### PR TITLE
HDDS-2221. Monitor datanodes in ozoneperf compose cluster

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozoneperf/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozoneperf/docker-compose.yaml
@@ -56,7 +56,7 @@ services:
    prometheus:
      image: prom/prometheus
      volumes:
-       - "../common/prometheus/prometheus.yml:/etc/prometheus.yml"
+       - "./prometheus.yml:/etc/prometheus.yml"
      command: ["--config.file","/etc/prometheus.yml"]
      ports:
         - 9090:9090

--- a/hadoop-ozone/dist/src/main/compose/ozoneperf/prometheus.yml
+++ b/hadoop-ozone/dist/src/main/compose/ozoneperf/prometheus.yml
@@ -23,3 +23,13 @@ scrape_configs:
      - targets:
         - "scm:9876"
         - "om:9874"
+        - "ozoneperf_datanode_1:9882"
+        - "ozoneperf_datanode_2:9882"
+        - "ozoneperf_datanode_3:9882"
+        - "ozoneperf_datanode_4:9882"
+        - "ozoneperf_datanode_5:9882"
+        - "ozoneperf_datanode_6:9882"
+        - "ozoneperf_datanode_7:9882"
+        - "ozoneperf_datanode_8:9882"
+        - "ozoneperf_datanode_9:9882"
+        - "ozoneperf_datanode_10:9882"


### PR DESCRIPTION
# What changes were proposed in this pull request?

Enable promehteus monitoring for the datanodes in the compose/ozoneperf cluster definition

# What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2221

# How was this patch tested?

1. Start ozoneperf docker-compose cluster (scale up to 3 datanodes)

```
cd hadoop-ozone/dist/target/ozone-*/compose/ozoneperf
docker-compose down
docker-compose up -d --scale datanode=3
```

2. Check if the datanodes are reporting

http://localhost:9090/targets

(You should see green UP after the first 3 datanodes)

3. Check if you see any Ratis metrics in prometheus

Search for ratis in http://localhost:9090/graph
