### PR TITLE
HDDS-2071. Support filters in ozone insight point

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneProtocolMessageDispatcher.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneProtocolMessageDispatcher.java
@@ -59,7 +59,7 @@ public class OzoneProtocolMessageDispatcher<REQUEST, RESPONSE> {
     try {
       if (logger.isTraceEnabled()) {
         logger.trace(
-            "{} {} request is received: <json>{}</json>",
+            "[service={}] [type={}] request is received: <json>{}</json>",
             serviceName,
             type.toString(),
             request.toString().replaceAll("\n", "\\\\n"));
@@ -73,7 +73,7 @@ public class OzoneProtocolMessageDispatcher<REQUEST, RESPONSE> {
 
       if (logger.isTraceEnabled()) {
         logger.trace(
-            "{} {} request is processed. Response: "
+            "[service={}] [type={}] request is processed. Response: "
                 + "<json>{}</json>",
             serviceName,
             type.toString(),

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/EventQueue.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/EventQueue.java
@@ -163,12 +163,12 @@ public class EventQueue implements EventPublisher, AutoCloseable {
           queuedCount.incrementAndGet();
           if (LOG.isDebugEnabled()) {
             LOG.debug(
-                "Delivering event {} to executor/handler {}: <json>{}</json>",
+                "Delivering [event={}] to executor/handler {}: <json>{}</json>",
                 event.getName(),
                 executorAndHandlers.getKey().getName(),
                 TRACING_SERIALIZER.toJson(payload).replaceAll("\n", "\\\\n"));
           } else if (LOG.isDebugEnabled()) {
-            LOG.debug("Delivering event {} to executor/handler {}: {}",
+            LOG.debug("Delivering [event={}] to executor/handler {}: {}",
                 event.getName(),
                 executorAndHandlers.getKey().getName(),
                 payload.getClass().getSimpleName());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -142,7 +142,6 @@ public class SCMNodeManager implements NodeManager {
     }
   }
 
-
   /**
    * Returns all datanode that are in the given state. This function works by
    * taking a snapshot of the current collection and then returning the list
@@ -154,7 +153,7 @@ public class SCMNodeManager implements NodeManager {
   @Override
   public List<DatanodeDetails> getNodes(NodeState nodestate) {
     return nodeStateManager.getNodes(nodestate).stream()
-        .map(node -> (DatanodeDetails)node).collect(Collectors.toList());
+        .map(node -> (DatanodeDetails) node).collect(Collectors.toList());
   }
 
   /**
@@ -165,7 +164,7 @@ public class SCMNodeManager implements NodeManager {
   @Override
   public List<DatanodeDetails> getAllNodes() {
     return nodeStateManager.getAllNodes().stream()
-        .map(node -> (DatanodeDetails)node).collect(Collectors.toList());
+        .map(node -> (DatanodeDetails) node).collect(Collectors.toList());
   }
 
   /**
@@ -229,11 +228,11 @@ public class SCMNodeManager implements NodeManager {
    * SCM.
    *
    * @param datanodeDetails - Send datanodeDetails with Node info.
-   *                   This function generates and assigns new datanode ID
-   *                   for the datanode. This allows SCM to be run independent
-   *                   of Namenode if required.
-   * @param nodeReport NodeReport.
-   *
+   *                        This function generates and assigns new datanode ID
+   *                        for the datanode. This allows SCM to be run
+   *                        independent
+   *                        of Namenode if required.
+   * @param nodeReport      NodeReport.
    * @return SCMHeartbeatResponseProto
    */
   @Override
@@ -338,7 +337,7 @@ public class SCMNodeManager implements NodeManager {
    */
   @Override
   public void processNodeReport(DatanodeDetails datanodeDetails,
-                                NodeReportProto nodeReport) {
+      NodeReportProto nodeReport) {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Processing node report from [datanode={}]",
           datanodeDetails.getHostName());
@@ -363,6 +362,7 @@ public class SCMNodeManager implements NodeManager {
 
   /**
    * Returns the aggregated node stats.
+   *
    * @return the aggregated node stats.
    */
   @Override
@@ -381,6 +381,7 @@ public class SCMNodeManager implements NodeManager {
 
   /**
    * Return a map of node stats.
+   *
    * @return a map of individual node stats (live/stale but not dead).
    */
   @Override
@@ -388,7 +389,7 @@ public class SCMNodeManager implements NodeManager {
 
     final Map<DatanodeDetails, SCMNodeStat> nodeStats = new HashMap<>();
 
-    final List<DatanodeInfo> healthyNodes =  nodeStateManager
+    final List<DatanodeInfo> healthyNodes = nodeStateManager
         .getNodes(NodeState.HEALTHY);
     final List<DatanodeInfo> staleNodes = nodeStateManager
         .getNodes(NodeState.STALE);
@@ -406,6 +407,7 @@ public class SCMNodeManager implements NodeManager {
 
   /**
    * Return the node stat of the specified datanode.
+   *
    * @param datanodeDetails - datanode ID.
    * @return node stat if it is live/stale, null if it is decommissioned or
    * doesn't exist.
@@ -442,7 +444,7 @@ public class SCMNodeManager implements NodeManager {
   @Override
   public Map<String, Integer> getNodeCount() {
     Map<String, Integer> nodeCountMap = new HashMap<String, Integer>();
-    for(NodeState state : NodeState.values()) {
+    for (NodeState state : NodeState.values()) {
       nodeCountMap.put(state.toString(), getNodeCount(state));
     }
     return nodeCountMap;
@@ -460,7 +462,7 @@ public class SCMNodeManager implements NodeManager {
     long ssdUsed = 0L;
     long ssdRemaining = 0L;
 
-    List<DatanodeInfo> healthyNodes =  nodeStateManager
+    List<DatanodeInfo> healthyNodes = nodeStateManager
         .getNodes(NodeState.HEALTHY);
     List<DatanodeInfo> staleNodes = nodeStateManager
         .getNodes(NodeState.STALE);
@@ -496,9 +498,9 @@ public class SCMNodeManager implements NodeManager {
     return nodeInfo;
   }
 
-
   /**
    * Get set of pipelines a datanode is part of.
+   *
    * @param datanodeDetails - datanodeID
    * @return Set of PipelineID
    */
@@ -507,9 +509,9 @@ public class SCMNodeManager implements NodeManager {
     return nodeStateManager.getPipelineByDnID(datanodeDetails.getUuid());
   }
 
-
   /**
    * Add pipeline information in the NodeManager.
+   *
    * @param pipeline - Pipeline to be added
    */
   @Override
@@ -519,6 +521,7 @@ public class SCMNodeManager implements NodeManager {
 
   /**
    * Remove a pipeline information from the NodeManager.
+   *
    * @param pipeline - Pipeline to be removed
    */
   @Override
@@ -528,17 +531,18 @@ public class SCMNodeManager implements NodeManager {
 
   @Override
   public void addContainer(final DatanodeDetails datanodeDetails,
-                           final ContainerID containerId)
+      final ContainerID containerId)
       throws NodeNotFoundException {
     nodeStateManager.addContainer(datanodeDetails.getUuid(), containerId);
   }
 
   /**
    * Update set of containers available on a datanode.
+   *
    * @param datanodeDetails - DatanodeID
-   * @param containerIds - Set of containerIDs
+   * @param containerIds    - Set of containerIDs
    * @throws NodeNotFoundException - if datanode is not known. For new datanode
-   *                        use addDatanodeInContainerMap call.
+   *                               use addDatanodeInContainerMap call.
    */
   @Override
   public void setContainers(DatanodeDetails datanodeDetails,
@@ -549,6 +553,7 @@ public class SCMNodeManager implements NodeManager {
 
   /**
    * Return set of containerIDs available on a datanode.
+   *
    * @param datanodeDetails - DatanodeID
    * @return - set of containerIDs
    */
@@ -572,7 +577,7 @@ public class SCMNodeManager implements NodeManager {
    * DATANODE_COMMAND to the Queue.
    *
    * @param commandForDatanode DatanodeCommand
-   * @param ignored publisher
+   * @param ignored            publisher
    */
   @Override
   public void onMessage(CommandForDatanode commandForDatanode,
@@ -657,6 +662,7 @@ public class SCMNodeManager implements NodeManager {
 
   /**
    * Test utility to stop heartbeat check process.
+   *
    * @return ScheduledFuture of next scheduled check that got cancelled.
    */
   @VisibleForTesting
@@ -666,6 +672,7 @@ public class SCMNodeManager implements NodeManager {
 
   /**
    * Test utility to resume the paused heartbeat check process.
+   *
    * @return ScheduledFuture of the next scheduled check
    */
   @VisibleForTesting
@@ -675,6 +682,7 @@ public class SCMNodeManager implements NodeManager {
 
   /**
    * Test utility to get the count of skipped heartbeat check iterations.
+   *
    * @return count of skipped heartbeat check iterations
    */
   @VisibleForTesting

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/BaseInsightPoint.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/BaseInsightPoint.java
@@ -22,6 +22,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.HddsUtils;
@@ -185,4 +186,18 @@ public abstract class BaseInsightPoint implements InsightPoint {
     metrics.add(performance);
   }
 
+  @Override
+  public boolean filterLog(Map<String, String> filters, String logLine) {
+    if (filters == null) {
+      return true;
+    }
+    boolean result = true;
+    for (Entry<String, String> entry : filters.entrySet()) {
+      if (!logLine.matches(
+          String.format(".*\\[%s=%s\\].*", entry.getKey(), entry.getValue()))) {
+        result = result & false;
+      }
+    }
+    return result;
+  }
 }

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/BaseInsightPoint.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/BaseInsightPoint.java
@@ -195,9 +195,9 @@ public abstract class BaseInsightPoint implements InsightPoint {
     for (Entry<String, String> entry : filters.entrySet()) {
       if (!logLine.matches(
           String.format(".*\\[%s=%s\\].*", entry.getKey(), entry.getValue()))) {
-        result = result & false;
+        return false;
       }
     }
-    return result;
+    return true;
   }
 }

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/InsightPoint.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/InsightPoint.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.insight;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Definition of a specific insight points.
@@ -44,6 +45,9 @@ public interface InsightPoint {
    */
   List<Class> getConfigurationClasses();
 
-
+  /**
+   * Decide if the specific log should be displayed or not..
+   */
+  boolean filterLog(Map<String, String> filters, String logLine);
 
 }

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/datanode/RatisInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/datanode/RatisInsight.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.insight.datanode;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -72,4 +73,8 @@ public class RatisInsight extends BaseInsightPoint implements InsightPoint {
     return "More information about one ratis datanode ring.";
   }
 
+  @Override
+  public boolean filterLog(Map<String, String> filters, String logLine) {
+    return true;
+  }
 }

--- a/hadoop-ozone/insight/src/test/java/org/apache/hadoop/ozone/insight/TestBaseInsightPoint.java
+++ b/hadoop-ozone/insight/src/test/java/org/apache/hadoop/ozone/insight/TestBaseInsightPoint.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.insight;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+/**
+ * Test common insight point utility methods.
+ */
+public class TestBaseInsightPoint {
+
+  @Test
+  public void filterLog() {
+
+    BaseInsightPoint insightPoint = new BaseInsightPoint() {
+      @Override
+      public String getDescription() {
+        return "test";
+      }
+    };
+
+    //with simple filter
+    Map<String, String> filters = new HashMap<>();
+    filters.put("datanode", "123");
+
+    Assert.assertTrue(insightPoint
+        .filterLog(filters, "This a log specific to [datanode=123]"));
+
+    Assert.assertFalse(insightPoint
+        .filterLog(filters, "This a log specific to [datanode=234]"));
+
+    //with empty filters
+    Assert.assertTrue(insightPoint
+        .filterLog(new HashMap<>(), "This a log specific to [datanode=234]"));
+
+    //with multiple filters
+    filters.clear();
+    filters.put("datanode", "123");
+    filters.put("pipeline", "abcd");
+
+    Assert.assertFalse(insightPoint
+        .filterLog(filters, "This a log specific to [datanode=123]"));
+
+    Assert.assertTrue(insightPoint
+        .filterLog(filters,
+            "This a log specific to [datanode=123] [pipeline=abcd]"));
+
+    Assert.assertFalse(insightPoint
+        .filterLog(filters,
+            "This a log specific to [datanode=456] [pipeline=abcd]"));
+
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Extent the existing ozone insight command with support additional log filtering. For example if you are interested about 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2071

## How was this patch tested?

```
#start a cluster
cd hadoop-ozone/dist/target/ozone-*/compose/ozone
docker-compose up -d --scale datanode=3

# go to scm
docker-compose exec scm bash
```

insight without filter (wait until the next node report, ~ 30 s)

```
ozone insight logs -v scm.node-manager

#Example output
[SCM] 2019-10-13 08:34:29,920 [TRACE|org.apache.hadoop.hdds.scm.node.SCMNodeManager|SCMNodeManager] HB is received from [datanode=ozone_datanode_2.ozone_default]: 
storageReport {
  storageUuid: "DS-36d38c09-4306-4a30-b48c-b3b612d4eb00"
  storageLocation: "/data/hdds"
  capacity: 485541425152
  scmUsed: 4096
  remaining: 128080560128
  storageType: DISK
  failed: false
}
```

insight WITH filter (wait until the next node report, ~ 30 s)
```
ozone insight logs -v scm.node-manager -f datanode=ozone_datanode_2.ozone_default
```
You should see only the node reports from datanode_2