### PR TITLE
HDDS-2240. Command line tool for OM Admin

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -42,6 +42,7 @@ import java.util.Map;
 
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.security.KerberosInfo;
@@ -57,6 +58,13 @@ import org.apache.hadoop.security.token.Token;
  */
 @KerberosInfo(serverPrincipal = OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY)
 public interface ClientProtocol {
+
+  /**
+   * List of OM node Ids and their Ratis server roles.
+   * @return List of OM server roles
+   * @throws IOException
+   */
+  List<OMRoleInfo> getOmRoleInfos() throws IOException;
 
   /**
    * Creates a new Volume.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -64,6 +64,7 @@ import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
+import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.protocolPB
@@ -72,6 +73,7 @@ import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import org.apache.hadoop.ozone.security.GDPRSymmetricKey;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType;
@@ -221,6 +223,23 @@ public class RpcClient implements ClientProtocol {
     topologyAwareReadEnabled = conf.getBoolean(
         OzoneConfigKeys.OZONE_NETWORK_TOPOLOGY_AWARE_READ_KEY,
         OzoneConfigKeys.OZONE_NETWORK_TOPOLOGY_AWARE_READ_DEFAULT);
+  }
+
+  @Override
+  public List<OMRoleInfo> getOmRoleInfos() throws IOException {
+
+    List<ServiceInfo> serviceList = ozoneManagerClient.getServiceList();
+    List<OMRoleInfo> roleInfos = new ArrayList<>();
+
+    for (ServiceInfo serviceInfo : serviceList) {
+      if (serviceInfo.getNodeType().equals(HddsProtos.NodeType.OM)) {
+        OMRoleInfo omRoleInfo = serviceInfo.getOmRoleInfo();
+        if (omRoleInfo != null) {
+          roleInfos.add(omRoleInfo);
+        }
+      }
+    }
+    return roleInfos;
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/bin/ozone
+++ b/hadoop-ozone/common/src/main/bin/ozone
@@ -55,6 +55,7 @@ function hadoop_usage
   hadoop_add_subcommand "version" client "print the version"
   hadoop_add_subcommand "dtutil" client "operations related to delegation tokens"
   hadoop_add_subcommand "upgrade" client "HDFS to Ozone in-place upgrade tool"
+  hadoop_add_subcommand "admin" client "Ozone admin tool"
 
   hadoop_generate_usage "${HADOOP_SHELL_EXECNAME}" false
 }
@@ -206,6 +207,10 @@ function ozonecmd_case
     upgrade)
       HADOOP_CLASSNAME=org.apache.hadoop.ozone.upgrade.InPlaceUpgrade
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-upgrade"
+    ;;
+    admin)
+      HADOOP_CLASSNAME=org.apache.hadoop.ozone.admin.OzoneAdmin
+      OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-tools"
     ;;
     *)
       HADOOP_CLASSNAME="${subcmd}"

--- a/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
+++ b/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
@@ -903,10 +903,16 @@ message ServicePort {
     required uint32 value = 2;
 }
 
+message OMRoleInfo {
+    required string nodeId = 1;
+    required string serverRole = 2;
+}
+
 message ServiceInfo {
     required hadoop.hdds.NodeType nodeType = 1;
     required string hostname = 2;
     repeated ServicePort servicePorts = 3;
+    optional OMRoleInfo omRole = 4;
 }
 
 message S3CreateBucketRequest {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/OzoneAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/OzoneAdmin.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.admin;
+
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.admin.om.OMAdmin;
+import org.apache.hadoop.util.NativeCodeLoader;
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+import picocli.CommandLine;
+
+/**
+ * Ozone Admin Command line tool.
+ */
+@CommandLine.Command(name = "ozone admin",
+    hidden = true,
+    description = "Developer tools for Ozone Admin operations",
+    versionProvider = HddsVersionProvider.class,
+    subcommands = {
+        OMAdmin.class
+    },
+    mixinStandardHelpOptions = true)
+public class OzoneAdmin extends GenericCli {
+  private OzoneConfiguration ozoneConf;
+
+  public OzoneConfiguration getOzoneConf() {
+    if (ozoneConf == null) {
+      ozoneConf = createOzoneConfiguration();
+    }
+    return ozoneConf;
+  }
+
+  /**
+   * Main for the Ozone Admin shell Command handling.
+   *
+   * @param argv - System Args Strings[]
+   * @throws Exception
+   */
+  public static void main(String[] argv) throws Exception {
+    LogManager.resetConfiguration();
+    Logger.getRootLogger().setLevel(Level.WARN);
+    Logger.getRootLogger()
+        .addAppender(new ConsoleAppender(new PatternLayout("%m%n")));
+    Logger.getLogger(NativeCodeLoader.class).setLevel(Level.ERROR);
+
+    new OzoneAdmin().run(argv);
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.admin.om;
+
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
+import picocli.CommandLine;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * Handler of om get-service-roles command.
+ */
+@CommandLine.Command(
+    name = "getserviceroles",
+    description = "List all OMs and their respective Ratis server roles",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class)
+public class GetServiceRolesSubcommand implements Callable<Void> {
+
+  @CommandLine.ParentCommand
+  private OMAdmin parent;
+
+  @CommandLine.Option(names = {"-id", "--service-id"},
+      description = "OM Service ID",
+      required = true)
+  private String omServiceId;
+
+  @Override
+  public Void call() throws Exception {
+    ClientProtocol client = parent.createClient(omServiceId);
+    getOmServerRoles(client.getOmRoleInfos());
+    return null;
+  }
+
+  private void getOmServerRoles(List<OMRoleInfo> roleInfos) {
+    for (OMRoleInfo roleInfo : roleInfos) {
+      System.out.println(
+          roleInfo.getNodeId() + " : " + roleInfo.getServerRole());
+    }
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.admin.om;
+
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.cli.MissingSubcommandException;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.admin.OzoneAdmin;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
+import picocli.CommandLine;
+
+import java.io.IOException;
+
+/**
+ * Subcommand for admin operations related to OM.
+ */
+@CommandLine.Command(
+    name = "om",
+    description = "Ozone Manager specific admin operations",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class,
+    subcommands = {
+        GetServiceRolesSubcommand.class
+    })
+public class OMAdmin extends GenericCli {
+
+  @CommandLine.ParentCommand
+  private OzoneAdmin parent;
+
+  public OzoneAdmin getParent() {
+    return parent;
+  }
+
+  @Override
+  public Void call() throws Exception {
+    throw new MissingSubcommandException(
+        this.parent.getCmd().getSubcommands().get("om"));
+  }
+
+  public ClientProtocol createClient(String omServiceId) throws IOException {
+    OzoneConfiguration conf = parent.getOzoneConf();
+    return OzoneClientFactory.getRpcClient(omServiceId, conf).getObjectStore()
+        .getClientProxy();
+
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/package-info.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <p>
+ * SCM related cli tools.
+ */
+
+/**
+ * OM related Admin tools.
+ */
+package org.apache.hadoop.ozone.admin.om;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/package-info.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <p>
+ * SCM related cli tools.
+ */
+
+/**
+ * Ozone Admin tools.
+ */
+package org.apache.hadoop.ozone.admin;


### PR DESCRIPTION
A command line tool (ozone omha) to get information related to OM HA. 
This Jira proposes to add the getServiceState option for OM HA which lists all the OMs in the service and their corresponding Ratis server roles (LEADER/ FOLLOWER). 
We can later add more options to this tool.

Migrated from https://github.com/apache/hadoop/pull/1586