### PR TITLE
HDDS-2295. Display log of freon on the standard output

### DIFF
--- a/hadoop-ozone/common/src/main/bin/ozone
+++ b/hadoop-ozone/common/src/main/bin/ozone
@@ -124,7 +124,7 @@ function ozonecmd_case
     ;;
     freon)
       HADOOP_CLASSNAME=org.apache.hadoop.ozone.freon.Freon
-      OZONE_FREON_OPTS="${OZONE_FREON_OPTS} -Dhadoop.log.file=ozone-freon.log -Dlog4j.configuration=file:${ozone_shell_log4j}"
+      OZONE_FREON_OPTS="${OZONE_FREON_OPTS}"
       HADOOP_OPTS="${HADOOP_OPTS} ${OZONE_FREON_OPTS}"
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-tools"
     ;;


### PR DESCRIPTION
 ## What changes were proposed in this pull request?

HDDS-2042 disabled the console logging for all of the ozone command line tools including freon.

But freon is different, it has a different error handling model. For freon we need all the log on the console.

 1. To follow all the different errors

 2. To get information about the used (random) prefix which can be reused during the validation phase.

I propose to restore the original behavior for Ozone.

 ## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2295

 ## How was this patch tested?

Start any of the docker compose cluster and do a 

```
ozone freon ockg -n10
```

You should see the logs (for example the notice about the used prefix)