### PR TITLE
HDDS-2296. ozoneperf compose cluster shouln't start freon by default

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozoneperf/README.md
+++ b/hadoop-ozone/dist/src/main/compose/ozoneperf/README.md
@@ -31,7 +31,25 @@ Start the cluster with `docker-compose`
 docker-compose up -d
 ```
 
-Note: The freon test will be started after 30 seconds.
+Scale datanodes up:
+
+```
+docker-compose up -d --scale datanode=3
+```
+
+You can enter to the SCM container and start a freon test:
+
+```
+docker-compose exec scm bash
+ozone freon ockg -n1000
+```
+
+Or you can start freon instances in containers (to make it possible to scale them up):
+If all the datanodes are started, start the freon instance:
+
+```
+docker-compose -f docker-compose.yaml -f freon-ockg.yaml up --scale datanode=3 -d
+```
 
 ## How to use
 

--- a/hadoop-ozone/dist/src/main/compose/ozoneperf/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozoneperf/docker-compose.yaml
@@ -60,15 +60,6 @@ services:
      command: ["--config.file","/etc/prometheus.yml"]
      ports:
         - 9090:9090
-   freon:
-      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
-      volumes:
-         - ../..:/opt/hadoop
-      environment:
-         SLEEP_SECONDS: 30
-      env_file:
-         - ./docker-config
-      command: ["ozone","freon","rk"]
    grafana:
       image: grafana/grafana
       volumes:

--- a/hadoop-ozone/dist/src/main/compose/ozoneperf/freon-ockg.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozoneperf/freon-ockg.yaml
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3"
+services:
+   freon:
+      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      volumes:
+         - ../..:/opt/hadoop
+      env_file:
+         - ./docker-config
+      command: ["ozone","freon","ockg","-n100000"]

--- a/hadoop-ozone/dist/src/main/compose/ozoneperf/freon-rk.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozoneperf/freon-rk.yaml
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3"
+services:
+   freon:
+      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      volumes:
+         - ../..:/opt/hadoop
+      env_file:
+         - ./docker-config
+      command: ["ozone","freon","rk"]


### PR DESCRIPTION
## What changes were proposed in this pull request?

During the original creation of the `compose/ozoneperf` we added an example freon execution to make it clean how the data can be generated. This freon process starts all the time when ozoneperf cluster is started (usually I notice it when my CPU starts to use 100% of the available resources).

Since the creation of this cluster definition we implemented multiple type of freon tests and it's hard predict which tests should be executed. I propose to remove the default execution of the random key generation but keep the opportunity to run any of the tests.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2296

## How this patch can be tested?

Go to the `compose/ozoneperf` dir and follow the updated README ;-)

(TLDR; start the cluster, wait, start freon with the documented command)