### PR TITLE
HDDS-2297. Enable Opentracing for new Freon tests

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -43,6 +43,8 @@ import org.apache.hadoop.security.UserGroupInformation;
 
 import com.codahale.metrics.ConsoleReporter;
 import com.codahale.metrics.MetricRegistry;
+import io.opentracing.Scope;
+import io.opentracing.util.GlobalTracer;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.ratis.protocol.ClientId;
@@ -123,7 +125,13 @@ public class BaseFreonGenerator {
 
       final long counter = i;
 
+      //provider is usually a lambda, print out only the owner class name:
+      String spanName = provider.getClass().getSimpleName().split("\\$")[0];
+
       executor.execute(() -> {
+        Scope scope =
+            GlobalTracer.get().buildSpan(spanName)
+                .startActive(true);
         try {
 
           //in case of an other failed test, we shouldn't execute more tasks.
@@ -134,8 +142,11 @@ public class BaseFreonGenerator {
           provider.executeNextTask(counter);
           successCounter.incrementAndGet();
         } catch (Exception e) {
+          scope.span().setTag("failure", true);
           failureCounter.incrementAndGet();
           LOG.error("Error on executing task", e);
+        } finally {
+          scope.close();
         }
       });
     }
@@ -323,6 +334,7 @@ public class BaseFreonGenerator {
   public OzoneConfiguration createOzoneConfiguration() {
     return freonCommand.createOzoneConfiguration();
   }
+
   /**
    * Simple contract to execute a new step during a freon test.
    */


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-2022 introduced new freon tests, but the initial root span of opentracing is not created before the test execution. We need to enable opentracing to get better view about the executions of the new freon test.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2297

## How this patch can be tested?

Start an ozoneperf cluster:

```
cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozoneperf/
docker-compose up -d --scale datanode=3
```

If HDDS-2296 is not yet merged, stop old-style freon:

```
docker-compose stop freon
```

Start new freon test:

```
docker-compose exec scm bash
ozone freon ockg -n 10
```

Open the jaeger web ui: http://localhost:16686/

Choose _freon_ under the service and click to the _search_.

On the right side you should see results with the name _freon: OzoneClientKeyGenerator_ and with multiple sub-spans. 

Without the patch you can see entries with strange name (...span without root...) 