### PR TITLE
HDDS-2298. Fix maven warning about duplicated metrics-core jar

### DIFF
--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -77,11 +77,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>activation</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-      <version>3.2.4</version>
-    </dependency>
-    <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
       <version>1.19</version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Maven build of Ozone is starting with a warning:

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.apache.hadoop:hadoop-ozone-tools:jar:0.5.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.dropwizard.metrics:metrics-core:jar -> version 3.2.4 vs (?) @ line 94, column 17
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
 ```

It's better to avoid it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2298

## How this patch can be tested?

```
mvn clean install | head -n 20
```

Without patch: there are warnings.