### PR TITLE
HDDS-2299. BlockManager should allocate a block in excluded pipelines if none other left

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/ExcludeList.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/ExcludeList.java
@@ -103,6 +103,11 @@ public class ExcludeList {
     return excludeList;
   }
 
+  public boolean isEmpty() {
+    return datanodes.isEmpty() && containerIds.isEmpty() && pipelineIds
+        .isEmpty();
+  }
+
   public void clear() {
     datanodes.clear();
     containerIds.clear();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
@@ -185,6 +185,12 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
               .getPipelines(type, factor, Pipeline.PipelineState.OPEN,
                   excludeList.getDatanodes(), excludeList.getPipelineIds());
       Pipeline pipeline = null;
+      if (availablePipelines.size() == 0 && !excludeList.isEmpty()) {
+        // if no pipelines can be found, try finding pipeline without
+        // exclusion
+        availablePipelines = pipelineManager
+            .getPipelines(type, factor, Pipeline.PipelineState.OPEN);
+      }
       if (availablePipelines.size() == 0) {
         try {
           // TODO: #CLUTIL Remove creation logic when all replication types and
@@ -196,6 +202,12 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
           availablePipelines = pipelineManager
               .getPipelines(type, factor, Pipeline.PipelineState.OPEN,
                   excludeList.getDatanodes(), excludeList.getPipelineIds());
+          if (availablePipelines.size() == 0 && !excludeList.isEmpty()) {
+            // if no pipelines can be found, try finding pipeline without
+            // exclusion
+            availablePipelines = pipelineManager
+                .getPipelines(type, factor, Pipeline.PipelineState.OPEN);
+          }
           if (availablePipelines.size() == 0) {
             LOG.info("Could not find available pipeline of type:{} and " +
                 "factor:{} even after retrying", type, factor);


### PR DESCRIPTION
In SCM, BlockManager#allocateBlock does not allocate a block in the excluded pipelines or datanodes if requested by the client. But there can be cases where excluded pipelines or datanodes are the only ones left. In such a case SCM should allocate a block in such pipelines and return to the client. The client can choose to use or discard the block.