### PR TITLE
HDDS-2302. Manage common pom versions in one common place

### DIFF
--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -41,14 +41,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </modules>
 
   <properties>
-    <!-- version for hdds/ozone components -->
-    <hdds.version>0.5.0-SNAPSHOT</hdds.version>
-
-    <!-- Apache Ratis version -->
-    <ratis.version>0.5.0-3f446aa-SNAPSHOT</ratis.version>
-
-    <bouncycastle.version>1.60</bouncycastle.version>
-
     <protobuf-maven-plugin.version>0.5.1</protobuf-maven-plugin.version>
     <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
 

--- a/hadoop-ozone/dev-support/checks/acceptance.sh
+++ b/hadoop-ozone/dev-support/checks/acceptance.sh
@@ -19,7 +19,7 @@ cd "$DIR/../../.." || exit 1
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/acceptance"}
 mkdir -p "$REPORT_DIR"
 
-OZONE_VERSION=$(grep "<ozone.version>" "$DIR/../../pom.xml" | sed 's/<[^>]*>//g'|  sed 's/^[ \t]*//')
+OZONE_VERSION=$(grep "<ozone.version>" "pom.xml" | sed 's/<[^>]*>//g'|  sed 's/^[ \t]*//')
 DIST_DIR="$DIR/../../dist/target/ozone-$OZONE_VERSION"
 
 if [ ! -d "$DIST_DIR" ]; then

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -25,14 +25,6 @@
   <packaging>pom</packaging>
 
   <properties>
-    <hdds.version>0.5.0-SNAPSHOT</hdds.version>
-    <ozone.version>0.5.0-SNAPSHOT</ozone.version>
-    <ratis.version>0.5.0-3f446aa-SNAPSHOT</ratis.version>
-    <bouncycastle.version>1.60</bouncycastle.version>
-    <ozone.release>Crater Lake</ozone.release>
-    <declared.ozone.version>${ozone.version}</declared.ozone.version>
-    <maven-surefire-plugin.version>3.0.0-M1</maven-surefire-plugin.version>
-    <guice.version>4.0</guice.version>
     <docker.image>apache/ozone:${project.version}</docker.image>
   </properties>
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,15 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <properties>
     <hadoop.version>3.2.0</hadoop.version>
 
+    <!-- version for hdds/ozone components -->
+    <hdds.version>${ozone.version}</hdds.version>
+    <ozone.version>0.5.0-SNAPSHOT</ozone.version>
+    <ozone.release>Crater Lake</ozone.release>
+    <declared.ozone.version>${ozone.version}</declared.ozone.version>
+
+    <!-- Apache Ratis version -->
+    <ratis.version>0.5.0-3f446aa-SNAPSHOT</ratis.version>
+
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>
     <distMgmtSnapshotsUrl>https://repository.apache.org/content/repositories/snapshots</distMgmtSnapshotsUrl>
@@ -117,6 +126,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- avro version -->
     <avro.version>1.7.7</avro.version>
 
+    <bouncycastle.version>1.60</bouncycastle.version>
+
     <!-- jersey version -->
     <jersey.version>1.19</jersey.version>
 
@@ -155,8 +166,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <apacheds.version>2.0.0-M21</apacheds.version>
     <ldap-api.version>1.0.0-M33</ldap-api.version>
 
-    <!-- Apache Ratis version -->
-    <ratis.version>0.5.0-3f446aa-SNAPSHOT</ratis.version>
     <jcache.version>1.0-alpha-1</jcache.version>
     <ehcache.version>3.3.1</ehcache.version>
     <hikari.version>2.4.12</hikari.version>
@@ -182,7 +191,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <!-- Plugin versions and config -->
     <maven-surefire-plugin.argLine>-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError</maven-surefire-plugin.argLine>
-    <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M1</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>${maven-surefire-plugin.version}</maven-surefire-report-plugin.version>
     <maven-failsafe-plugin.version>${maven-surefire-plugin.version}</maven-failsafe-plugin.version>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some of the versions (eg. ozone.version, hdds.version, ratis.version) are required for both ozone and hdds subprojects. As we have a common pom.xml it can be safer to manage them in one common place at the root pom.xml instead of managing them multiple times.

I would move some of the properties to the root pom.xml to make it easier to manage/change them. (For example change the ratis.version at only one place)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2302

## How this patch can be tested?

Do a normal build.