### PR TITLE
HDDS-2254. Fix flaky unit test TestContainerStateMachine#testRatisSn…

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachine.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachine.java
@@ -37,9 +37,9 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -61,21 +61,21 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTER
 
 public class TestContainerStateMachine {
 
-  private static MiniOzoneCluster cluster;
-  private static OzoneConfiguration conf = new OzoneConfiguration();
-  private static OzoneClient client;
-  private static ObjectStore objectStore;
-  private static String volumeName;
-  private static String bucketName;
-  private static String path;
+  private MiniOzoneCluster cluster;
+  private OzoneConfiguration conf = new OzoneConfiguration();
+  private OzoneClient client;
+  private ObjectStore objectStore;
+  private String volumeName;
+  private String bucketName;
+  private String path;
 
   /**
    * Create a MiniDFSCluster for testing.
    *
    * @throws IOException
    */
-  @BeforeClass
-  public static void init() throws Exception {
+  @Before
+  public void setup() throws Exception {
     path = GenericTestUtils
         .getTempPath(TestContainerStateMachine.class.getSimpleName());
     File baseDir = new File(path);
@@ -112,8 +112,8 @@ public class TestContainerStateMachine {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @AfterClass
-  public static void shutdown() {
+  @After
+  public void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
     }


### PR DESCRIPTION
…apshotRetention.

## What changes were proposed in this pull request?
On locally trying out repeated runs of the unit test, the unit test failed intermittently while asserting "Null" value for CSM snapshot. This assertion is not valid when the other unit test in the class executes before and creates keys in the cluster/container. Hence, moved to a model where each unit test creates its own cluster.

https://issues.apache.org/jira/browse/HDDS-2254

## How was this patch tested?
Ran the unit tests in the IDE and command line.