### PR TITLE
HDDS-1985. Fix listVolumes API

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -185,11 +185,11 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
         .getCachedLeaderPeerId();
 
     NotLeaderException notLeaderException;
-    if (leaderRaftPeerId.isPresent()) {
+    if (!leaderRaftPeerId.isPresent()) {
       notLeaderException = new NotLeaderException(raftPeerId.toString());
     } else {
       notLeaderException = new NotLeaderException(
-          raftPeerId.toString(), leaderRaftPeerId.toString());
+          raftPeerId.toString(), leaderRaftPeerId.get().toString());
     }
 
     if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-1985

No fix is required for this, as the information is retrieved from the MPU Key table, this information is not retrieved through RocksDB Table iteration. (As when we use get() this checks from cache first, and then it checks table)

 

Used this Jira to add an integration test to verify the behavior.

(This has cumulative changes required for HDDS-1988 and HDDS-1985)