### PR TITLE
HDDS-2312. Fix typo in ozone command

### DIFF
--- a/hadoop-ozone/common/src/main/bin/ozone
+++ b/hadoop-ozone/common/src/main/bin/ozone
@@ -51,7 +51,7 @@ function hadoop_usage
   hadoop_add_subcommand "scmcli" client "run the CLI of the Storage Container Manager"
   hadoop_add_subcommand "sh" client "command line interface for object store operations"
   hadoop_add_subcommand "s3" client "command line interface for s3 related operations"
-  hadoop_add_subcommand "insight" client "tool to get runtime opeartion information"
+  hadoop_add_subcommand "insight" client "tool to get runtime operation information"
   hadoop_add_subcommand "version" client "print the version"
   hadoop_add_subcommand "dtutil" client "operations related to delegation tokens"
   hadoop_add_subcommand "upgrade" client "HDFS to Ozone in-place upgrade tool"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Trivial typo fix.

https://issues.apache.org/jira/browse/HDDS-2312

## How was this patch tested?

```
$ docker-compose exec scm ozone
...
insight       tool to get runtime operation information
...
```