### PR TITLE
HDDS-2313. Duplicate release of lock in OMKeyCommitRequest

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -131,8 +131,8 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       String dbOpenKey = omMetadataManager.getOpenKey(volumeName, bucketName,
           keyName, commitKeyRequest.getClientID());
 
-      bucketLockAcquired = omMetadataManager.getLock().acquireLock(BUCKET_LOCK,
-          volumeName, bucketName);
+      bucketLockAcquired = omMetadataManager.getLock()
+          .acquireWriteLock(BUCKET_LOCK, volumeName, bucketName);
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
       omKeyInfo = omMetadataManager.getOpenKeyTable().get(dbOpenKey);
@@ -169,13 +169,11 @@ public class OMKeyCommitRequest extends OMKeyRequest {
         omClientResponse.setFlushFuture(
             ozoneManagerDoubleBufferHelper.add(omClientResponse,
                 transactionLogIndex));
-        if(bucketLockAcquired) {
-          omMetadataManager.getLock().releaseLock(BUCKET_LOCK, volumeName,
+        if (bucketLockAcquired) {
+          omMetadataManager.getLock().releaseWriteLock(BUCKET_LOCK, volumeName,
               bucketName);
         }
       }
-      omMetadataManager.getLock().releaseWriteLock(BUCKET_LOCK, volumeName,
-          bucketName);
     }
 
     // Performing audit logging outside of the lock.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -169,10 +169,11 @@ public class OMKeyCommitRequest extends OMKeyRequest {
         omClientResponse.setFlushFuture(
             ozoneManagerDoubleBufferHelper.add(omClientResponse,
                 transactionLogIndex));
-        if (bucketLockAcquired) {
-          omMetadataManager.getLock().releaseWriteLock(BUCKET_LOCK, volumeName,
-              bucketName);
-        }
+      }
+
+      if (bucketLockAcquired) {
+        omMetadataManager.getLock().releaseWriteLock(BUCKET_LOCK, volumeName,
+            bucketName);
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix duplicate release of lock (apparently a merge issue, the original change (#24) was fine), which causes acceptance test failures:

```
ozone-basic :: Smoketest ozone cluster startup
==============================================================================
Check webui static resources                                          | PASS |
------------------------------------------------------------------------------
Start freon testing                                                   | FAIL |
255 != 0
------------------------------------------------------------------------------
ozone-basic :: Smoketest ozone cluster startup                        | FAIL |
2 critical tests, 1 passed, 1 failed
2 tests total, 1 passed, 1 failed
```

https://issues.apache.org/jira/browse/HDDS-2313

## How was this patch tested?

Ran `ozone` acceptance test.

```
$ cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozone
$ ./test.sh
...
ozone-basic :: Smoketest ozone cluster startup
==============================================================================
Check webui static resources                                          | PASS |
------------------------------------------------------------------------------
Start freon testing                                                   | PASS |
------------------------------------------------------------------------------
ozone-basic :: Smoketest ozone cluster startup                        | PASS |
2 critical tests, 2 passed, 0 failed
```