### PR TITLE
HDDS-2197. Extend SCMCLI Topology command to print node Operational States

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/ContainerOperationClient.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/ContainerOperationClient.java
@@ -198,18 +198,23 @@ public class ContainerOperationClient implements ScmClient {
   /**
    * Returns a set of Nodes that meet a query criteria.
    *
-   * @param nodeStatuses - Criteria that we want the node to have.
+   * @param opState - The operational state we want the node to have
+   *                eg IN_SERVICE, DECOMMISSIONED, etc
+   * @param nodeState - The health we want the node to have, eg HEALTHY, STALE,
+   *                  etc
    * @param queryScope - Query scope - Cluster or pool.
    * @param poolName - if it is pool, a pool name is required.
    * @return A set of nodes that meet the requested criteria.
    * @throws IOException
    */
   @Override
-  public List<HddsProtos.Node> queryNode(HddsProtos.NodeState
-      nodeStatuses, HddsProtos.QueryScope queryScope, String poolName)
+  public List<HddsProtos.Node> queryNode(
+      HddsProtos.NodeOperationalState opState,
+      HddsProtos.NodeState nodeState,
+      HddsProtos.QueryScope queryScope, String poolName)
       throws IOException {
-    return storageContainerLocationClient.queryNode(nodeStatuses, queryScope,
-        poolName);
+    return storageContainerLocationClient.queryNode(opState, nodeState,
+        queryScope, poolName);
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
@@ -151,15 +151,20 @@ public interface ScmClient extends Closeable {
       String owner) throws IOException;
 
   /**
-   * Returns a set of Nodes that meet a query criteria.
-   * @param nodeStatuses - Criteria that we want the node to have.
+   * Returns a set of Nodes that meet a query criteria. Passing null for opState
+   * or nodeState acts like a wild card, returning all nodes in that state.
+   * @param opState - Operational State of the node, eg IN_SERVICE,
+   *                DECOMMISSIONED, etc
+   * @param nodeState - Health of the nodeCriteria that we want the node to
+   *                  have, eg HEALTHY, STALE etc
    * @param queryScope - Query scope - Cluster or pool.
    * @param poolName - if it is pool, a pool name is required.
    * @return A set of nodes that meet the requested criteria.
    * @throws IOException
    */
-  List<HddsProtos.Node> queryNode(HddsProtos.NodeState nodeStatuses,
-      HddsProtos.QueryScope queryScope, String poolName) throws IOException;
+  List<HddsProtos.Node> queryNode(HddsProtos.NodeOperationalState opState,
+      HddsProtos.NodeState nodeState, HddsProtos.QueryScope queryScope,
+      String poolName) throws IOException;
 
   /**
    * Allows a list of hosts to be decommissioned. The hosts are identified

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -105,12 +105,15 @@ public interface StorageContainerLocationProtocol extends Closeable {
   void deleteContainer(long containerID) throws IOException;
 
   /**
-   *  Queries a list of Node Statuses.
-   * @param state
+   *  Queries a list of Node Statuses. Passing a null for either opState or
+   *  state acts like a wildcard returning all nodes in that state.
+   * @param opState The node operational state
+   * @param state The node health
    * @return List of Datanodes.
    */
-  List<HddsProtos.Node> queryNode(HddsProtos.NodeState state,
-      HddsProtos.QueryScope queryScope, String poolName) throws IOException;
+  List<HddsProtos.Node> queryNode(HddsProtos.NodeOperationalState opState,
+      HddsProtos.NodeState state, HddsProtos.QueryScope queryScope,
+      String poolName) throws IOException;
 
   void decommissionNodes(List<String> nodes) throws IOException;
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -240,23 +240,34 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
   }
 
   /**
-   * Queries a list of Node Statuses.
+   * Queries a list of Nodes based on their operational state or health state.
+   * Passing a null for either value acts as a wildcard for that state.
+   *
+   * @param opState The operation state of the node
+   * @param nodeState The health of the node
+   * @return List of Datanodes.
    */
   @Override
-  public List<HddsProtos.Node> queryNode(HddsProtos.NodeState
-      nodeStatuses, HddsProtos.QueryScope queryScope, String poolName)
+  public List<HddsProtos.Node> queryNode(
+      HddsProtos.NodeOperationalState opState, HddsProtos.NodeState
+      nodeState, HddsProtos.QueryScope queryScope, String poolName)
       throws IOException {
     // TODO : We support only cluster wide query right now. So ignoring checking
     // queryScope and poolName
-    Preconditions.checkNotNull(nodeStatuses);
-    NodeQueryRequestProto request = NodeQueryRequestProto.newBuilder()
-        .setState(nodeStatuses)
+    NodeQueryRequestProto.Builder builder = NodeQueryRequestProto.newBuilder()
         .setTraceID(TracingUtil.exportCurrentSpan())
-        .setScope(queryScope).setPoolName(poolName).build();
+        .setScope(queryScope).setPoolName(poolName);
+    if (opState != null) {
+      builder.setOpState(opState);
+    }
+    if (nodeState != null) {
+      builder.setState(nodeState);
+    }
+    NodeQueryRequestProto request = builder.build();
     NodeQueryResponseProto response = submitRequest(Type.QueryNode,
-        builder -> builder.setNodeQueryRequest(request)).getNodeQueryResponse();
+        builder1 -> builder1.setNodeQueryRequest(request))
+        .getNodeQueryResponse();
     return response.getDatanodesList();
-
   }
 
   /**

--- a/hadoop-hdds/common/src/main/proto/StorageContainerLocationProtocol.proto
+++ b/hadoop-hdds/common/src/main/proto/StorageContainerLocationProtocol.proto
@@ -223,10 +223,11 @@ message ObjectStageChangeResponseProto {
  match the NodeState that we are requesting.
 */
 message NodeQueryRequestProto {
-  required NodeState state = 1;
+  optional NodeState state = 1;
   required QueryScope scope = 2;
   optional string poolName = 3; // if scope is pool, then pool name is needed.
   optional string traceID = 4;
+  optional NodeOperationalState opState = 5;
 }
 
 message NodeQueryResponseProto {

--- a/hadoop-hdds/common/src/main/proto/hdds.proto
+++ b/hadoop-hdds/common/src/main/proto/hdds.proto
@@ -118,6 +118,7 @@ enum QueryScope {
 message Node {
     required DatanodeDetailsProto nodeID = 1;
     repeated NodeState nodeStates = 2;
+    repeated NodeOperationalState nodeOperationalStates = 3;
 }
 
 message NodePool {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -18,7 +18,6 @@ package org.apache.hadoop.hdds.scm.node;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
@@ -165,6 +164,13 @@ public class NodeDecommissionManager {
     this.nodeManager = nodeManager;
     this.pipeLineManager = pipelineManager;
     this.containerManager = containerManager;
+
+    // TODO these 3 lines are only here to silence findbugs for now, as they
+    // will be used in a later patch or removed, but for now they should stay
+    // here.
+    conf.get("test.test");
+    pipeLineManager.getPipelines();
+    containerManager.getContainers();
 
     useHostnames = conf.getBoolean(
         DFSConfigKeys.DFS_DATANODE_USE_DN_HOSTNAME,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -40,9 +40,9 @@ import java.util.List;
 public class NodeDecommissionManager {
 
   private NodeManager nodeManager;
-  private PipelineManager pipeLineManager;
-  private ContainerManager containerManager;
-  private OzoneConfiguration conf;
+ // private PipelineManager pipeLineManager;
+ // private ContainerManager containerManager;
+ // private OzoneConfiguration conf;
   private boolean useHostnames;
 
   private List<DatanodeDetails> pendingNodes = new LinkedList<>();
@@ -160,17 +160,10 @@ public class NodeDecommissionManager {
   public NodeDecommissionManager(OzoneConfiguration conf,
       NodeManager nodeManager, PipelineManager pipelineManager,
       ContainerManager containerManager) {
-    this.conf = conf;
     this.nodeManager = nodeManager;
-    this.pipeLineManager = pipelineManager;
-    this.containerManager = containerManager;
-
-    // TODO these 3 lines are only here to silence findbugs for now, as they
-    // will be used in a later patch or removed, but for now they should stay
-    // here.
-    conf.get("test.test");
-    pipeLineManager.getPipelines();
-    containerManager.getContainers();
+    //this.conf = conf;
+    //this.pipeLineManager = pipelineManager;
+    //this.containerManager = containerManager;
 
     useHostnames = conf.getBoolean(
         DFSConfigKeys.DFS_DATANODE_USE_DN_HOSTNAME,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -322,12 +322,12 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
       throws IOException {
 
     HddsProtos.NodeState nodeState = request.getState();
-    List<HddsProtos.Node> datanodes = impl.queryNode(nodeState,
+    HddsProtos.NodeOperationalState opState = request.getOpState();
+    List<HddsProtos.Node> datanodes = impl.queryNode(opState, nodeState,
         request.getScope(), request.getPoolName());
     return NodeQueryResponseProto.newBuilder()
         .addAllDatanodes(datanodes)
         .build();
-
   }
 
   public ObjectStageChangeResponseProto notifyObjectStageChange(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -347,7 +347,8 @@ public class SCMClientProtocolServer implements
   }
 
   @Override
-  public List<HddsProtos.Node> queryNode(HddsProtos.NodeState state,
+  public List<HddsProtos.Node> queryNode(
+      HddsProtos.NodeOperationalState opState, HddsProtos.NodeState state,
       HddsProtos.QueryScope queryScope, String poolName) throws
       IOException {
 
@@ -356,9 +357,11 @@ public class SCMClientProtocolServer implements
     }
 
     List<HddsProtos.Node> result = new ArrayList<>();
-    queryNode(state).forEach(node -> result.add(HddsProtos.Node.newBuilder()
+    queryNode(opState, state)
+        .forEach(node -> result.add(HddsProtos.Node.newBuilder()
         .setNodeID(node.getProtoBufMessage())
         .addNodeStates(state)
+        .addNodeOperationalStates(opState)
         .build()));
 
     return result;
@@ -565,12 +568,14 @@ public class SCMClientProtocolServer implements
    * operation between the
    * operators.
    *
-   * @param state - NodeStates.
+   * @param opState - NodeOperational State
+   * @param state - NodeState.
    * @return List of Datanodes.
    */
-  public List<DatanodeDetails> queryNode(HddsProtos.NodeState state) {
+  public List<DatanodeDetails> queryNode(
+      HddsProtos.NodeOperationalState opState, HddsProtos.NodeState state) {
     Preconditions.checkNotNull(state, "Node Query set cannot be null");
-    return new ArrayList<>(queryNodeState(state));
+    return new ArrayList<>(queryNodeState(opState, state));
   }
 
   @VisibleForTesting
@@ -589,14 +594,15 @@ public class SCMClientProtocolServer implements
   /**
    * Query the System for Nodes.
    *
+   * @params opState - The node operational state
    * @param nodeState - NodeState that we are interested in matching.
    * @return Set of Datanodes that match the NodeState.
    */
-  private Set<DatanodeDetails> queryNodeState(HddsProtos.NodeState nodeState) {
+  private Set<DatanodeDetails> queryNodeState(
+      HddsProtos.NodeOperationalState opState, HddsProtos.NodeState nodeState) {
     Set<DatanodeDetails> returnSet = new TreeSet<>();
-    // TODO - decomm states needed
     List<DatanodeDetails> tmp = scm.getScmNodeManager()
-        .getNodes(null, nodeState);
+        .getNodes(opState, nodeState);
     if ((tmp != null) && (tmp.size() > 0)) {
       returnSet.addAll(tmp);
     }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/TopologySubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/TopologySubcommand.java
@@ -65,7 +65,7 @@ public class TopologySubcommand implements Callable<Void> {
   public Void call() throws Exception {
     try (ScmClient scmClient = parent.createScmClient()) {
       for (HddsProtos.NodeState state : stateArray) {
-        List<HddsProtos.Node> nodes = scmClient.queryNode(state,
+        List<HddsProtos.Node> nodes = scmClient.queryNode(null, state,
             HddsProtos.QueryScope.CLUSTER, "");
         if (nodes != null && nodes.size() > 0) {
           // show node state
@@ -83,36 +83,37 @@ public class TopologySubcommand implements Callable<Void> {
 
   // Format
   // Location: rack1
-  //  ipAddress(hostName)
+  //  ipAddress(hostName) OperationalState
   private void printOrderedByLocation(List<HddsProtos.Node> nodes) {
-    HashMap<String, TreeSet<DatanodeDetails>> tree =
+    HashMap<String, TreeSet<HddsProtos.Node>> tree =
         new HashMap<>();
     for (HddsProtos.Node node : nodes) {
       String location = node.getNodeID().getNetworkLocation();
       if (location != null && !tree.containsKey(location)) {
         tree.put(location, new TreeSet<>());
       }
-      tree.get(location).add(DatanodeDetails.getFromProtoBuf(node.getNodeID()));
+      tree.get(location).add(node);
     }
     ArrayList<String> locations = new ArrayList<>(tree.keySet());
     Collections.sort(locations);
 
     locations.forEach(location -> {
       System.out.println("Location: " + location);
-      tree.get(location).forEach(node -> {
+      tree.get(location).forEach(n -> {
+        DatanodeDetails node = DatanodeDetails.getFromProtoBuf(n.getNodeID());
         System.out.println(" " + node.getIpAddress() + "(" + node.getHostName()
-            + ")");
+            + ") "+n.getNodeOperationalStates(0));
       });
     });
   }
 
 
-  // Format "ipAddress(hostName)    networkLocation"
+  // Format "ipAddress(hostName)    OperationalState    networkLocation"
   private void printNodesWithLocation(Collection<HddsProtos.Node> nodes) {
     nodes.forEach(node -> {
       System.out.print(" " + node.getNodeID().getIpAddress() + "(" +
           node.getNodeID().getHostName() + ")");
-      System.out.println("    " +
+      System.out.println("    " + node.getNodeOperationalStates(0) + "    " +
           (node.getNodeID().getNetworkLocation() != null ?
               node.getNodeID().getNetworkLocation() : "NA"));
     });

--- a/hadoop-ozone/dist/src/main/smoketest/topology/scmcli.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/topology/scmcli.robot
@@ -25,8 +25,8 @@ Resource            ../commonlib.robot
 *** Test Cases ***
 Run printTopology
     ${output} =         Execute          ozone scmcli printTopology
-                        Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net)    /rack2
+                        Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net)    IN_SERVICE    /rack2
 Run printTopology -o
     ${output} =         Execute          ozone scmcli printTopology -o
                         Should contain   ${output}         Location: /rack2
-                        Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net)
+                        Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net) IN_SERVICE

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2394,8 +2394,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
             .setType(ServicePort.Type.RPC)
             .setValue(scmAddr.getPort()).build());
     services.add(scmServiceInfoBuilder.build());
-
-    List<HddsProtos.Node> nodes = scmContainerClient.queryNode(HEALTHY,
+    List<HddsProtos.Node> nodes = scmContainerClient.queryNode(
+        HddsProtos.NodeOperationalState.IN_SERVICE, HEALTHY,
         HddsProtos.QueryScope.CLUSTER, "");
 
     for (HddsProtos.Node node : nodes) {


### PR DESCRIPTION
The scmcli topology command only consider the node health (healthy, stale or dead). With decommission and maintenance stages, we need to also consider the operational states and display them with this command.

The current topology command prints details in the format:
```
State = HEALTHY
 IpAddress(hostName)    networkLocation
 IpAddress(hostName) networkLocation
 IpAddress(hostName) networkLocation

State = STALE
  ...

State = DEAD
  ... 
```
Alternatively, it prints the details ordered by network location
```
State = HEALTHY
Location: somelocation
 ipAddress(hostName)
 ipAddress(hostName)
 ipAddress(hostName)
Location: otherlocation
 ipAddress(hostName)
 ipAddress(hostName)
 ipAddress(hostName) 

State = STALE
Location: someLocation
 ...
 ...
```

In this PR, I propose we simple add the operational state into the existing output, and keep the ordering and formatting as is:

```
State = HEALTHY
 IpAddress(hostName) IN_SERVICE networkLocation
 IpAddress(hostName) IN_SERVICE networkLocation
 IpAddress(hostName) DECOMMISSIONING networkLocation

State = STALE
 ...

State = DEAD
 ...  
```
Or
```
State = HEALTHY
Location: somelocation
 ipAddress(hostName) IN_SERVICE
 ipAddress(hostName) IN_SERVICE
 ipAddress(hostName) DECOMMISSIONED
Location: otherlocation
 ipAddress(hostName) IN_SERVICE
 ipAddress(hostName) IN_MAINTENANE
 ipAddress(hostName) IN_SERVIE

State = STALE
Location: someLocation
 ...
 ...
```