### PR TITLE
HDDS-2316. Support to skip recon and/or ozonefs during the build

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -44,7 +44,8 @@
               <goal>copy</goal>
             </goals>
             <configuration>
-              <outputDirectory>target/ozone-${ozone.version}/share/ozone/classpath
+              <outputDirectory>
+                target/ozone-${ozone.version}/share/ozone/classpath
               </outputDirectory>
               <artifactItems>
                 <artifactItem>
@@ -119,14 +120,6 @@
                   <classifier>classpath</classifier>
                   <type>cp</type>
                   <destFileName>hadoop-ozone-datanode.classpath</destFileName>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.apache.hadoop</groupId>
-                  <artifactId>hadoop-ozone-recon</artifactId>
-                  <version>${ozone.version}</version>
-                  <classifier>classpath</classifier>
-                  <type>cp</type>
-                  <destFileName>hadoop-ozone-recon.classpath</destFileName>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.apache.hadoop</groupId>
@@ -308,23 +301,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-ozone-filesystem-lib-current</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-ozone-filesystem-lib-legacy</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-ozone-common</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-ozone-datanode</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-ozone-recon</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -340,6 +321,73 @@
     </dependency>
   </dependencies>
   <profiles>
+    <profile>
+      <id>build-with-ozonefs</id>
+      <activation>
+        <property>
+          <name>!skipShade</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-ozone-filesystem-lib-current</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-ozone-filesystem-lib-legacy</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>build-with-recon</id>
+      <activation>
+        <property>
+          <name>!skipRecon</name>
+        </property>
+      </activation>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-recon-classpath-file</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>
+                    target/ozone-${ozone.version}/share/ozone/classpath
+                  </outputDirectory>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.apache.hadoop</groupId>
+                      <artifactId>hadoop-ozone-recon</artifactId>
+                      <version>${ozone.version}</version>
+                      <classifier>classpath</classifier>
+                      <type>cp</type>
+                      <destFileName>hadoop-ozone-recon.classpath</destFileName>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-ozone-recon</artifactId>
+        </dependency>
+      </dependencies>
+
+    </profile>
     <profile>
       <id>docker-build</id>
       <build>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -39,16 +39,11 @@
     <module>common</module>
     <module>client</module>
     <module>ozone-manager</module>
-    <module>ozonefs</module>
-    <module>ozonefs-lib-current</module>
-    <module>ozonefs-lib-legacy</module>
     <module>tools</module>
     <module>integration-test</module>
     <module>datanode</module>
     <module>s3gateway</module>
     <module>dist</module>
-    <module>recon</module>
-    <module>recon-codegen</module>
     <module>upgrade</module>
     <module>csi</module>
     <module>fault-injection-test</module>
@@ -362,6 +357,31 @@
       <properties>
         <docker.image>${user.name}/ozone:${project.version}</docker.image>
       </properties>
+    </profile>
+    <profile>
+      <id>build-with-ozonefs</id>
+      <activation>
+        <property>
+          <name>!skipShade</name>
+        </property>
+      </activation>
+      <modules>
+        <module>ozonefs</module>
+        <module>ozonefs-lib-current</module>
+        <module>ozonefs-lib-legacy</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>build-with-recon</id>
+      <activation>
+        <property>
+          <name>!skipRecon</name>
+        </property>
+      </activation>
+      <modules>
+        <module>recon</module>
+        <module>recon-codegen</module>
+      </modules>
     </profile>
     <profile>
       <id>parallel-tests</id>


### PR DESCRIPTION
## What changes were proposed in this pull request?

 The two slowest part of Ozone build as of now:

    * The (multiple) shading of ozonefs
    * And the frontend build/obfuscation of ozone recon

@anuengineer suggested to introduce options to skip them as they are not required for the build all the time.

This patch introduces `-DskipRecon` and `-DskipShade` options to provide a faster way to create a partial build.

## What is the link to the Apache JIRA

https://github.com/elek/hadoop-ozone/pull/new/HDDS-2316

## How this patch can be tested?

```
mvn clean install -DskipShade -DskipRecon -DskipTests
```

```
mvn clean install -DskipShade -DskipTests
```