### PR TITLE
HDDS-2285. GetBlock and ReadChunk command from the client should be s…

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -61,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -111,7 +112,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
         OzoneConfigKeys.OZONE_NETWORK_TOPOLOGY_AWARE_READ_KEY,
         OzoneConfigKeys.OZONE_NETWORK_TOPOLOGY_AWARE_READ_DEFAULT);
     this.caCert = caCert;
-    this.getBlockDNcache = new HashMap<>();
+    this.getBlockDNcache = new ConcurrentHashMap<>();
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/GetKeyHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/GetKeyHandler.java
@@ -86,7 +86,7 @@ public class GetKeyHandler extends Handler {
 
     if (dataFile.exists()) {
       throw new OzoneClientException(
-          fileName + "exists. Download will overwrite an "
+          fileName + " exists. Download will overwrite an "
               + "existing file. Aborting.");
     }
 


### PR DESCRIPTION
It can be observed that the GetBlock and ReadChunk command is sent to 2 different datanodes. It should be sent to the same datanode to re-use the connection.

```
19/10/10 00:43:42 INFO scm.XceiverClientGrpc: Send command GetBlock to datanode 172.26.32.224
19/10/10 00:43:42 INFO scm.XceiverClientGrpc: Send command ReadChunk to datanode 172.26.32.231
```
