### PR TITLE
HDDS-2208. Propagate System Exceptions from OM transaction apply phase. Contributed by Supratim Deka

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -193,7 +193,7 @@ public abstract class OMClientRequest implements RequestAuditor {
     if (ex instanceof OMException) {
       return ex.getMessage();
     } else {
-        return org.apache.hadoop.util.StringUtils.stringifyException(ex);
+      return org.apache.hadoop.util.StringUtils.stringifyException(ex);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.ozone.audit.AuditEventStatus;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.AuditMessage;
 import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -180,11 +181,20 @@ public abstract class OMClientRequest implements RequestAuditor {
       @Nonnull OMResponse.Builder omResponse, @Nonnull IOException ex) {
 
     omResponse.setSuccess(false);
-    if (ex.getMessage() != null) {
-      omResponse.setMessage(ex.getMessage());
+    String errorMsg = exceptionErrorMessage(ex);
+    if (errorMsg != null) {
+      omResponse.setMessage(errorMsg);
     }
     omResponse.setStatus(OzoneManagerRatisUtils.exceptionToResponseStatus(ex));
     return omResponse.build();
+  }
+
+  private String exceptionErrorMessage(IOException ex) {
+    if (ex instanceof OMException) {
+      return ex.getMessage();
+    } else {
+        return org.apache.hadoop.util.StringUtils.stringifyException(ex);
+    }
   }
 
   /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-2208

This is a follow-up to the patch for HDDS-2206
https://github.com/apache/hadoop-ozone/pull/12

The change propagates complete stacktraces for system exceptions encountered during the Ratis phase of the OM request handling.

However, this patch does not consider the configuration parameter introduced earlier in the patch for HDDS-2206. Controlling the behaviour using a configuration parameter requires a much greater footprint in the code. Because at this point, there is no clear requirement for such a config parameter - going ahead without the config param.
Will update the patch for HDDS-2206 as well - will remove the configuration that was introduced.