### PR TITLE
HDDS-2318. Avoid proto::tostring in preconditions to save CPU cycles.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -146,7 +146,8 @@ public final class OzoneManagerRatisUtils {
     case GetS3Secret:
       return new S3GetSecretRequest(omRequest);
     default:
-      return null;
+      throw new IllegalStateException("Unrecognized write command " +
+          "type request" + cmdType);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -113,8 +113,6 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
           try {
             OMClientRequest omClientRequest =
                 OzoneManagerRatisUtils.createClientRequest(request);
-            Preconditions.checkState(omClientRequest != null,
-                "Unrecognized write command type request" + request.toString());
             request = omClientRequest.preExecute(ozoneManager);
           } catch (IOException ex) {
             // As some of the preExecute returns error. So handle here.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoiding proto::toString in OzoneManagerServerSideTranslatorPB.java

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2318

## How was this patch tested?

Ran TestOzoneRpcClient which executes this code path.
