### PR TITLE
HDDS-2310. Add support to add ozone ranger plugin to Ozone Manager cl…

### DIFF
--- a/hadoop-ozone/common/src/main/shellprofile.d/hadoop-ozone-manager.sh
+++ b/hadoop-ozone/common/src/main/shellprofile.d/hadoop-ozone-manager.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [[ "${HADOOP_SHELL_EXECNAME}" == ozone ]]; then
+   hadoop_add_profile ozone_manager
+fi
+
+_ozone_manager_hadoop_finalize() {
+  if [[ "${HADOOP_CLASSNAME}" == "org.apache.hadoop.ozone.om.OzoneManagerStarter" ]]; then
+   echo "Ozone Manager classpath extended by ${OZONE_MANAGER_CLASSPATH}"
+   hadoop_add_classpath ${OZONE_MANAGER_CLASSPATH}
+  fi
+}

--- a/hadoop-ozone/common/src/main/shellprofile.d/hadoop-ozone-manager.sh
+++ b/hadoop-ozone/common/src/main/shellprofile.d/hadoop-ozone-manager.sh
@@ -21,6 +21,6 @@ fi
 _ozone_manager_hadoop_finalize() {
   if [[ "${HADOOP_CLASSNAME}" == "org.apache.hadoop.ozone.om.OzoneManagerStarter" ]]; then
    echo "Ozone Manager classpath extended by ${OZONE_MANAGER_CLASSPATH}"
-   hadoop_add_classpath ${OZONE_MANAGER_CLASSPATH}
+   hadoop_add_classpath "${OZONE_MANAGER_CLASSPATH}"
   fi
 }


### PR DESCRIPTION
…asspath.

## What changes were proposed in this pull request?

This PR adds a new hadoop shell profile for ozone manager to be able to extend Ozone Manager's classpath. It is implemented in a generic way and is not exclusive to ranger plugin. Any path can be added to Ozone Manager classpath by setting the env variable `OZONE_MANAGER_CLASSPATH`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2310

## How was this patch tested?

Tested by running ozone manager locally with the above mentioned env set to some path.
```
 export OZONE_MANAGER_CLASSPATH=/tmp/*
./hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/bin/ozone --debug om
```
