### PR TITLE
HDDS-2311. Fix logic of RetryPolicy in OzoneClientSideTranslatorPB.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -411,10 +411,6 @@ public final class OzoneConfigKeys {
       "ozone.fs.isolated-classloader";
 
   // Ozone Client Retry and Failover configurations
-  public static final String OZONE_CLIENT_RETRY_MAX_ATTEMPTS_KEY =
-      "ozone.client.retry.max.attempts";
-  public static final int OZONE_CLIENT_RETRY_MAX_ATTEMPTS_DEFAULT =
-      10;
   public static final String OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY =
       "ozone.client.failover.max.attempts";
   public static final int OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_DEFAULT =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2162,18 +2162,13 @@
     </description>
   </property>
   <property>
-    <name>ozone.client.retry.max.attempts</name>
-    <value>10</value>
-    <description>
-      Max retry attempts for Ozone RpcClient talking to OzoneManagers.
-    </description>
-  </property>
-  <property>
     <name>ozone.client.failover.max.attempts</name>
     <value>15</value>
     <description>
-      Expert only. The number of client failover attempts that should be
-      made before the failover is considered failed.
+      Expert only. Ozone RpcClient attempts talking to each OzoneManager
+      ipc.client.connect.max.retries (default = 10) number of times before
+      failing over to another OzoneManager, if available. This parameter
+      represents the number of times the client will failover before giving up.
     </description>
   </property>
   <property>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/NotLeaderException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/NotLeaderException.java
@@ -19,6 +19,9 @@
 package org.apache.hadoop.ozone.om.exceptions;
 
 import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.ratis.protocol.RaftPeerId;
 
 /**
  * Exception thrown by
@@ -29,20 +32,43 @@ public class NotLeaderException extends IOException {
 
   private final String currentPeerId;
   private final String leaderPeerId;
+  private static final Pattern CURRENT_PEER_ID_PATTERN =
+      Pattern.compile("OM:(.*) is not the leader[.]+.*", Pattern.DOTALL);
+  private static final Pattern SUGGESTED_LEADER_PATTERN =
+      Pattern.compile(".*Suggested leader is OM:([^.]*).*", Pattern.DOTALL);
 
-  public NotLeaderException(String currentPeerIdStr) {
-    super("OM " + currentPeerIdStr + " is not the leader. Could not " +
+  public NotLeaderException(RaftPeerId currentPeerId) {
+    super("OM:" + currentPeerId + " is not the leader. Could not " +
         "determine the leader node.");
-    this.currentPeerId = currentPeerIdStr;
+    this.currentPeerId = currentPeerId.toString();
     this.leaderPeerId = null;
   }
 
-  public NotLeaderException(String currentPeerIdStr,
-      String suggestedLeaderPeerIdStr) {
-    super("OM " + currentPeerIdStr + " is not the leader. Suggested leader is "
-        + suggestedLeaderPeerIdStr);
-    this.currentPeerId = currentPeerIdStr;
-    this.leaderPeerId = suggestedLeaderPeerIdStr;
+  public NotLeaderException(RaftPeerId currentPeerId,
+      RaftPeerId suggestedLeaderPeerId) {
+    super("OM:" + currentPeerId + " is not the leader. Suggested leader is" +
+        " OM:" + suggestedLeaderPeerId + ".");
+    this.currentPeerId = currentPeerId.toString();
+    this.leaderPeerId = suggestedLeaderPeerId.toString();
+  }
+
+  public NotLeaderException(String message) {
+    super(message);
+
+    Matcher currentLeaderMatcher = CURRENT_PEER_ID_PATTERN.matcher(message);
+    if (currentLeaderMatcher.matches()) {
+      this.currentPeerId = currentLeaderMatcher.group(1);
+
+      Matcher suggestedLeaderMatcher = SUGGESTED_LEADER_PATTERN.matcher(message);
+      if (suggestedLeaderMatcher.matches()) {
+        this.leaderPeerId = suggestedLeaderMatcher.group(1);
+      } else {
+        this.leaderPeerId = null;
+      }
+    } else {
+      this.currentPeerId = null;
+      this.leaderPeerId = null;
+    }
   }
 
   public String getSuggestedLeaderNodeId() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/NotLeaderException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/NotLeaderException.java
@@ -59,7 +59,8 @@ public class NotLeaderException extends IOException {
     if (currentLeaderMatcher.matches()) {
       this.currentPeerId = currentLeaderMatcher.group(1);
 
-      Matcher suggestedLeaderMatcher = SUGGESTED_LEADER_PATTERN.matcher(message);
+      Matcher suggestedLeaderMatcher =
+          SUGGESTED_LEADER_PATTERN.matcher(message);
       if (suggestedLeaderMatcher.matches()) {
         this.leaderPeerId = suggestedLeaderMatcher.group(1);
       } else {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -232,8 +232,9 @@ public class OMFailoverProxyProvider implements
   @Override
   public void performFailover(OzoneManagerProtocolPB currentProxy) {
     if (LOG.isDebugEnabled()) {
+      int currentIndex = getCurrentProxyIndex();
       LOG.debug("Failing over OM proxy to index: {}, nodeId: {}",
-          currentProxyIndex, omNodeIDList.get(currentProxyIndex));
+          currentIndex, omNodeIDList.get(currentIndex));
     }
   }
 
@@ -289,6 +290,10 @@ public class OMFailoverProxyProvider implements
       }
     }
     return false;
+  }
+
+  private synchronized int getCurrentProxyIndex() {
+    return currentProxyIndex;
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.retry.FailoverProxyProvider;
+import org.apache.hadoop.io.retry.RetryInvocationHandler;
 import org.apache.hadoop.ipc.Client;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
@@ -30,6 +31,7 @@ import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
+import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -205,17 +207,60 @@ public class OMFailoverProxyProvider implements
     return new Text(rpcAddress.toString());
   }
 
-
+  @Override
+  public Class<OzoneManagerProtocolPB> getInterface() {
+    return OzoneManagerProtocolPB.class;
+  }
 
   /**
    * Called whenever an error warrants failing over. It is determined by the
    * retry policy.
+   *
+   * This is a dummy call from {@link RetryInvocationHandler}. The actual
+   * failover should be performed using either
+   * {@link OMFailoverProxyProvider#performFailoverIfRequired(String)} or
+   * {@link OMFailoverProxyProvider#performFailoverToNextProxy()}.
+   *
+   * In {@link OzoneManagerProtocolClientSideTranslatorPB}, we first
+   * manually failover and then call the RetryAction FAILOVER_AND_RETRY. This
+   * is done because we do not want to always failover to the next proxy. If we
+   * get a NotLeaderException with a suggested leader, then we want to
+   * failover to that OM proxy instead. Hence, we failover manually and the
+   * {@link FailoverProxyProvider#performFailover(Object)} call should not do
+   * failover again.
    */
   @Override
   public void performFailover(OzoneManagerProtocolPB currentProxy) {
-    int newProxyIndex = incrementProxyIndex();
     if (LOG.isDebugEnabled()) {
       LOG.debug("Failing over OM proxy to index: {}, nodeId: {}",
+          currentProxyIndex, omNodeIDList.get(currentProxyIndex));
+    }
+  }
+
+  /**
+   * Performs failover if the leaderOMNodeId returned through OMReponse does
+   * not match the current leaderOMNodeId cached by the proxy provider.
+   */
+  public void performFailoverIfRequired(String newLeaderOMNodeId) {
+    if (newLeaderOMNodeId == null) {
+      LOG.debug("No suggested leader nodeId. Performing failover to next peer" +
+          " node");
+      performFailoverToNextProxy();
+    } else {
+      if (updateLeaderOMNodeId(newLeaderOMNodeId)) {
+        LOG.debug("Failing over OM proxy to nodeId: {}", newLeaderOMNodeId);
+      }
+    }
+  }
+
+  /**
+   * Performs failover if the leaderOMNodeId returned through OMReponse does
+   * not match the current leaderOMNodeId cached by the proxy provider.
+   */
+  public void performFailoverToNextProxy() {
+    int newProxyIndex = incrementProxyIndex();
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Incrementing OM proxy index to {}, nodeId: {}",
           newProxyIndex, omNodeIDList.get(newProxyIndex));
     }
   }
@@ -228,27 +273,6 @@ public class OMFailoverProxyProvider implements
     currentProxyIndex = (currentProxyIndex + 1) % omProxies.size();
     currentProxyOMNodeId = omNodeIDList.get(currentProxyIndex);
     return currentProxyIndex;
-  }
-
-  @Override
-  public Class<OzoneManagerProtocolPB> getInterface() {
-    return OzoneManagerProtocolPB.class;
-  }
-
-  /**
-   * Performs failover if the leaderOMNodeId returned through OMReponse does
-   * not match the current leaderOMNodeId cached by the proxy provider.
-   */
-  public void performFailoverIfRequired(String newLeaderOMNodeId) {
-    if (newLeaderOMNodeId == null) {
-      LOG.debug("No suggested leader nodeId. Performing failover to next peer" +
-          " node");
-      performFailover(null);
-    } else {
-      if (updateLeaderOMNodeId(newLeaderOMNodeId)) {
-        LOG.debug("Failing over OM proxy to nodeId: {}", newLeaderOMNodeId);
-      }
-    }
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.ozone.om.protocolPB;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -35,6 +34,7 @@ import org.apache.hadoop.io.retry.RetryPolicy;
 import org.apache.hadoop.io.retry.RetryProxy;
 import org.apache.hadoop.ipc.ProtobufHelper;
 import org.apache.hadoop.ipc.ProtocolTranslator;
+import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.NotLeaderException;
@@ -202,9 +202,6 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     this.omFailoverProxyProvider = new OMFailoverProxyProvider(conf, ugi,
         omServiceId);
 
-    int maxRetries = conf.getInt(
-        OzoneConfigKeys.OZONE_CLIENT_RETRY_MAX_ATTEMPTS_KEY,
-        OzoneConfigKeys.OZONE_CLIENT_RETRY_MAX_ATTEMPTS_DEFAULT);
     int maxFailovers = conf.getInt(
         OzoneConfigKeys.OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY,
         OzoneConfigKeys.OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_DEFAULT);
@@ -215,9 +212,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         OzoneConfigKeys.OZONE_CLIENT_FAILOVER_SLEEP_MAX_MILLIS_KEY,
         OzoneConfigKeys.OZONE_CLIENT_FAILOVER_SLEEP_MAX_MILLIS_DEFAULT);
 
-    this.rpcProxy =
-        createRetryProxy(omFailoverProxyProvider, maxRetries, maxFailovers,
-            sleepBase, sleepMax);
+    this.rpcProxy = createRetryProxy(omFailoverProxyProvider, maxFailovers,
+        sleepBase, sleepMax);
     this.clientID = clientId;
   }
 
@@ -228,32 +224,39 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
    */
   private OzoneManagerProtocolPB createRetryProxy(
       OMFailoverProxyProvider failoverProxyProvider,
-      int maxRetries, int maxFailovers, int delayMillis, int maxDelayBase) {
+      int maxFailovers, int delayMillis, int maxDelayBase) {
 
     RetryPolicy retryPolicyOnNetworkException = RetryPolicies
         .failoverOnNetworkException(RetryPolicies.TRY_ONCE_THEN_FAIL,
-            maxFailovers, maxRetries, delayMillis, maxDelayBase);
+            maxFailovers, maxFailovers, delayMillis, maxDelayBase);
 
+    // Client attempts contacting each OM ipc.client.connect.max.retries
+    // (default = 10) times before failing over to the next OM, if
+    // available.
+    // Client will attempt upto maxFailovers number of failovers between
+    // available OMs before throwing exception.
     RetryPolicy retryPolicy = new RetryPolicy() {
       @Override
       public RetryAction shouldRetry(Exception exception, int retries,
           int failovers, boolean isIdempotentOrAtMostOnce)
           throws Exception {
-
         if (exception instanceof ServiceException) {
-          Throwable cause = exception.getCause();
-          if (cause instanceof NotLeaderException) {
-            NotLeaderException notLeaderException = (NotLeaderException) cause;
+          NotLeaderException notLeaderException =
+              getNotLeaderException(exception);
+          if (notLeaderException != null &&
+              notLeaderException.getSuggestedLeaderNodeId() != null) {
+            // We need to failover manually to the suggested Leader OM Node.
+            // OMFailoverProxyProvider#performFailover() is a dummy call and
+            // does not perform any failover.
             omFailoverProxyProvider.performFailoverIfRequired(
                 notLeaderException.getSuggestedLeaderNodeId());
-            return getRetryAction(RetryAction.RETRY, retries, failovers);
-          } else {
-            return getRetryAction(RetryAction.FAILOVER_AND_RETRY, retries,
-                failovers);
+            return getRetryAction(RetryAction.FAILOVER_AND_RETRY, failovers);
           }
-        } else if (exception instanceof EOFException) {
-          return getRetryAction(RetryAction.FAILOVER_AND_RETRY, retries,
-              failovers);
+          // We need to failover manually to the next OM Node proxy.
+          // OMFailoverProxyProvider#performFailover() is a dummy call and
+          // does not perform any failover.
+          omFailoverProxyProvider.performFailoverToNextProxy();
+          return getRetryAction(RetryAction.FAILOVER_AND_RETRY, failovers);
         } else {
           return retryPolicyOnNetworkException.shouldRetry(
               exception, retries, failovers, isIdempotentOrAtMostOnce);
@@ -261,12 +264,13 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
       }
 
       private RetryAction getRetryAction(RetryAction fallbackAction,
-          int retries, int failovers) {
-        if (retries < maxRetries && failovers < maxFailovers) {
+          int failovers) {
+        if (failovers <= maxFailovers) {
           return fallbackAction;
         } else {
-          FAILOVER_PROXY_PROVIDER_LOG.error("Failed to connect to OM. " +
-              "Attempted {} retries and {} failovers", retries, failovers);
+          FAILOVER_PROXY_PROVIDER_LOG.error("Failed to connect to OMs: {}. " +
+              "Attempted {} failovers.",
+              omFailoverProxyProvider.getOMProxyInfos(), maxFailovers);
           return RetryAction.FAIL;
         }
       }
@@ -275,6 +279,22 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     OzoneManagerProtocolPB proxy = (OzoneManagerProtocolPB) RetryProxy.create(
         OzoneManagerProtocolPB.class, failoverProxyProvider, retryPolicy);
     return proxy;
+  }
+
+  /**
+   * Check if exception is a NotLeaderException.
+   * @return NotLeaderException.
+   */
+  private NotLeaderException getNotLeaderException(Exception exception) {
+    Throwable cause = exception.getCause();
+    if (cause != null && cause instanceof RemoteException) {
+      IOException ioException =
+          ((RemoteException) cause).unwrapRemoteException();
+      if (ioException instanceof NotLeaderException) {
+        return (NotLeaderException) ioException;
+      }
+    }
+    return null;
   }
 
   @VisibleForTesting
@@ -347,7 +367,13 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
 
       return omResponse;
     } catch (ServiceException e) {
-      throw ProtobufHelper.getRemoteException(e);
+//      throw ProtobufHelper.getRemoteException(e);
+      NotLeaderException notLeaderException = getNotLeaderException(e);
+      if (notLeaderException == null) {
+        throw ProtobufHelper.getRemoteException(e);
+      } else {
+        throw new IOException("Could not determine or connect to OM Leader.");
+      }
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -67,7 +67,6 @@ import org.apache.hadoop.ozone.om.ha.OMFailoverProxyProvider;
 import org.apache.hadoop.ozone.om.ha.OMProxyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
-import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
@@ -85,8 +84,6 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys
     .OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys
     .OZONE_CLIENT_FAILOVER_SLEEP_BASE_MILLIS_DEFAULT;
-import static org.apache.hadoop.ozone.OzoneConfigKeys
-    .OZONE_CLIENT_RETRY_MAX_ATTEMPTS_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys
     .OZONE_OPEN_KEY_EXPIRE_THRESHOLD_SECONDS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_ALREADY_EXISTS;
@@ -134,8 +131,7 @@ public class TestOzoneManagerHA {
     conf.set(OzoneConfigKeys.OZONE_ADMINISTRATORS,
         OZONE_ADMINISTRATORS_WILDCARD);
     conf.setInt(OZONE_OPEN_KEY_EXPIRE_THRESHOLD_SECONDS, 2);
-    conf.setInt(OZONE_CLIENT_RETRY_MAX_ATTEMPTS_KEY, 10);
-    conf.setInt(OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY, 10);
+    conf.setInt(OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY, 6);
     conf.setLong(
         OMConfigKeys.OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_KEY,
         SNAPSHOT_THRESHOLD);
@@ -700,8 +696,7 @@ public class TestOzoneManagerHA {
 
     // Perform a manual failover of the proxy provider to move the
     // currentProxyIndex to a node other than the leader OM.
-    omFailoverProxyProvider.performFailover(
-        (OzoneManagerProtocolPB) omFailoverProxyProvider.getProxy().proxy);
+    omFailoverProxyProvider.performFailoverToNextProxy();
 
     String newProxyNodeId = omFailoverProxyProvider.getCurrentProxyOMNodeId();
     Assert.assertNotEquals(leaderOMNodeId, newProxyNodeId);
@@ -737,13 +732,15 @@ public class TestOzoneManagerHA {
       fail("TestOMRetryProxy should fail when there are no OMs running");
     } catch (ConnectException e) {
       // Each retry attempt tries upto 10 times to connect. So there should be
-      // 10*10 "Retrying connect to server" messages
-      Assert.assertEquals(100,
+      // 10 * OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY "Retrying connect to
+      // server" messages
+      Assert.assertEquals(60,
           appender.countLinesWithMessage("Retrying connect to server:"));
 
       Assert.assertEquals(1,
-          appender.countLinesWithMessage("Failed to connect to OM. Attempted " +
-              "10 retries and 10 failovers"));
+          appender.countLinesWithMessage("Failed to connect to OMs:"));
+      Assert.assertEquals(1,
+          appender.countLinesWithMessage("Attempted 6 failovers."));
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -733,8 +733,9 @@ public class TestOzoneManagerHA {
     } catch (ConnectException e) {
       // Each retry attempt tries upto 10 times to connect. So there should be
       // 10 * OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY "Retrying connect to
-      // server" messages
-      Assert.assertEquals(60,
+      // server" messages. Also, the first call will result in EOFException.
+      // That will result in another 10 retry attempts.
+      Assert.assertEquals(70,
           appender.countLinesWithMessage("Retrying connect to server:"));
 
       Assert.assertEquals(1,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -183,11 +183,11 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
         .getCachedLeaderPeerId();
 
     NotLeaderException notLeaderException;
-    if (!leaderRaftPeerId.isPresent()) {
-      notLeaderException = new NotLeaderException(raftPeerId.toString());
-    } else {
+    if (leaderRaftPeerId.isPresent()) {
       notLeaderException = new NotLeaderException(
-          raftPeerId.toString(), leaderRaftPeerId.get().toString());
+          raftPeerId, leaderRaftPeerId.get());
+    } else {
+      notLeaderException = new NotLeaderException(raftPeerId);
     }
 
     if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
OzoneManagerProtocolClientSideTranslatorPB.java

L251: if (cause instanceof NotLeaderException)

{ NotLeaderException notLeaderException = (NotLeaderException) cause; omFailoverProxyProvider.performFailoverIfRequired( notLeaderException.getSuggestedLeaderNodeId()); return getRetryAction(RetryAction.RETRY, retries, failovers); }
 

The suggested leader returned from Server is not used during failOver, as the cause is a type of RemoteException. So with current code, it does not use suggested leader for failOver at all and by default with each OM, it tries max retries.