### PR TITLE
HDDS-2326. Http server of Freon is not started for new Freon tests

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -174,6 +174,8 @@ public class BaseFreonGenerator {
    */
   public void init() {
 
+    freonCommand.startHttpServer();
+
     successCounter = new AtomicLong(0);
     failureCounter = new AtomicLong(0);
 
@@ -188,7 +190,14 @@ public class BaseFreonGenerator {
     pathSchema = new PathSchema(prefix);
 
     Runtime.getRuntime().addShutdownHook(
-        new Thread(this::printReport));
+        new Thread(() -> {
+          try {
+            freonCommand.stopHttpServer();
+          } catch (Exception ex) {
+            LOG.error("HTTP server can't be stopped.", ex);
+          }
+          printReport();
+        }));
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-2022 introduced new Freon tests but the Freon http server is not started for the new tests.

Freon includes a http server which can be turned on with the `–server` flag. It helps to monitor and profile the freon as the http server contains by default the prometheus and profiler servlets.

The server should be started if it's requested.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2326

## How was this patch tested?

You need a cluster and login to the scm:

```
cd compose/ozone
docker-compose up -d --scale datanode=3
docker-compose exec scm bash
```

Now start a new style freon test:

```
ozone freon --server ockg -n 10000000
```

You should see the http server on the std output:

```
2019-10-18 10:13:26,464 INFO server.AbstractConnector: Started ServerConnector@40dd3977{HTTP/1.1,[http/1.1]}{0.0.0.0:9884}
```

And you can access the standard servlets (while freon is running)

```
curl http://localhost:9884/jmx
```