### PR TITLE
HDDS-2280. HddsUtils#CheckForException should not return null in case the ratis exception cause is not set 

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
@@ -306,7 +306,7 @@ public final class HddsClientUtils {
 
   public static Throwable checkForException(Exception e) {
     Throwable t = e;
-    while (t != null) {
+    while (t != null && t.getCause() != null) {
       for (Class<? extends Exception> cls : getExceptionList()) {
         if (cls.isInstance(t)) {
           return t;

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
@@ -304,6 +304,9 @@ public final class HddsClientUtils {
     return scmSecurityClient;
   }
 
+  // This will return the underlying exception after unwrapping
+  // the exception to see if it matches with expected exception
+  // list otherwise will return the exception back.
   public static Throwable checkForException(Exception e) {
     Throwable t = e;
     while (t != null && t.getCause() != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## What is the link to the Apache JIRA

(Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HDDS-XXXX. Fix a typo in YYY.)

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
