### PR TITLE
HDDS-2335. Params not included in AuditMessage

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditMessage.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditMessage.java
@@ -120,7 +120,7 @@ public class AuditMessage implements Message {
     public AuditMessage build(){
       AuditMessage auditMessage = new AuditMessage();
       auditMessage.message = "user=" + this.user + " | ip=" + this.ip + " | " +
-          "op=" + this.op + " | " + "ret=" + this.ret;
+          "op=" + this.op + " " + this.params + " | " + "ret=" + this.ret;
       auditMessage.throwable = this.throwable;
       return auditMessage;
     }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
@@ -48,10 +48,13 @@ public class TestOzoneAuditLogger {
   private static final Map<String, String> PARAMS =
       new DummyEntity().toAuditMap();
 
+  private static final String IP_ADDRESS = "192.168.0.1";
+  private static final String USER = "john";
+
   private static final AuditMessage WRITE_FAIL_MSG =
       new AuditMessage.Builder()
-          .setUser("john")
-          .atIp("192.168.0.1")
+          .setUser(USER)
+          .atIp(IP_ADDRESS)
           .forOperation(DummyAction.CREATE_VOLUME.name())
           .withParams(PARAMS)
           .withResult(FAILURE)
@@ -59,8 +62,8 @@ public class TestOzoneAuditLogger {
 
   private static final AuditMessage WRITE_SUCCESS_MSG =
       new AuditMessage.Builder()
-          .setUser("john")
-          .atIp("192.168.0.1")
+          .setUser(USER)
+          .atIp(IP_ADDRESS)
           .forOperation(DummyAction.CREATE_VOLUME.name())
           .withParams(PARAMS)
           .withResult(SUCCESS)
@@ -68,8 +71,8 @@ public class TestOzoneAuditLogger {
 
   private static final AuditMessage READ_FAIL_MSG =
       new AuditMessage.Builder()
-          .setUser("john")
-          .atIp("192.168.0.1")
+          .setUser(USER)
+          .atIp(IP_ADDRESS)
           .forOperation(DummyAction.READ_VOLUME.name())
           .withParams(PARAMS)
           .withResult(FAILURE)
@@ -77,8 +80,8 @@ public class TestOzoneAuditLogger {
 
   private static final AuditMessage READ_SUCCESS_MSG =
       new AuditMessage.Builder()
-          .setUser("john")
-          .atIp("192.168.0.1")
+          .setUser(USER)
+          .atIp(IP_ADDRESS)
           .forOperation(DummyAction.READ_VOLUME.name())
           .withParams(PARAMS)
           .withResult(SUCCESS)
@@ -120,6 +123,16 @@ public class TestOzoneAuditLogger {
     String expected =
         "ERROR | OMAudit | " + WRITE_FAIL_MSG.getFormattedMessage();
     verifyLog(expected);
+  }
+
+  @Test
+  public void messageIncludesAllParts() {
+    String message = WRITE_FAIL_MSG.getMessage();
+    assertTrue(message, message.contains(USER));
+    assertTrue(message, message.contains(IP_ADDRESS));
+    assertTrue(message, message.contains(DummyAction.CREATE_VOLUME.name()));
+    assertTrue(message, message.contains(PARAMS.toString()));
+    assertTrue(message, message.contains(FAILURE));
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Include operation parameters in audit messages like before [HDDS-2323](https://github.com/apache/hadoop-ozone/commit/b9618834c9902fc8fd9ae12872092cfb1e5c1be3).

https://issues.apache.org/jira/browse/HDDS-2335

## How was this patch tested?

Added unit test.

Verified Findbugs violation is fixed.

Tested using Freon:

```
2019-10-20 08:54:19,437 | INFO  | OMAudit | user=hadoop | ip=192.168.144.3 | op=CREATE_VOLUME {admin=hadoop, owner=hadoop, volume=vol-0-52867, creationTime=1571561659397, quotaInBytes=1152921504606846976, objectID=1, updateID=1} | ret=SUCCESS |
2019-10-20 08:54:19,497 | INFO  | OMAudit | user=hadoop | ip=192.168.144.3 | op=CREATE_BUCKET {volume=vol-0-52867, bucket=bucket-0-43473, gdprEnabled=null, acls=[user:hadoop:a[ACCESS], group:users:a[ACCESS]], isVersionEnabled=false, storageType=DISK, creationTime=1571561659483} | ret=SUCCESS |
```