### PR TITLE
HDDS-2334. Dummy chunk manager fails with length mismatch error

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
@@ -77,15 +77,8 @@ public final class ChunkUtils {
       ByteBuffer data, VolumeIOStats volumeIOStats, boolean sync)
       throws StorageContainerException, ExecutionException,
       InterruptedException, NoSuchAlgorithmException {
-    final int bufferSize = data.remaining();
     Logger log = LoggerFactory.getLogger(ChunkManagerImpl.class);
-    if (bufferSize != chunkInfo.getLen()) {
-      String err = String.format("data array does not match the length " +
-              "specified. DataLen: %d Byte Array: %d",
-          chunkInfo.getLen(), bufferSize);
-      log.error(err);
-      throw new StorageContainerException(err, INVALID_WRITE_SIZE);
-    }
+    final int bufferSize = validateBufferSize(chunkInfo, data, log);
 
     Path path = chunkFile.toPath();
     long startTime = Time.monotonicNow();
@@ -128,6 +121,20 @@ public final class ChunkUtils {
       log.debug("Write Chunk completed for chunkFile: {}, size {}", chunkFile,
           bufferSize);
     }
+  }
+
+  public static int validateBufferSize(
+      ChunkInfo chunkInfo, ByteBuffer data, Logger log)
+      throws StorageContainerException {
+    final int bufferSize = data.remaining();
+    if (bufferSize != chunkInfo.getLen()) {
+      String err = String.format("data array does not match the length " +
+              "specified. DataLen: %d Byte Array: %d",
+          chunkInfo.getLen(), bufferSize);
+      log.error(err);
+      throw new StorageContainerException(err, INVALID_WRITE_SIZE);
+    }
+    return bufferSize;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDummyImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDummyImpl.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.ozone.container.common.transport.server.ratis.Dispatche
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.VolumeIOStats;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
+import org.apache.hadoop.ozone.container.keyvalue.helpers.ChunkUtils;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +42,7 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
  * Chunks are not written to disk, Reads are returned with zero-filled buffers
  */
 public class ChunkManagerDummyImpl extends ChunkManagerImpl {
-  static final Logger LOG = LoggerFactory.getLogger(
+  private static final Logger LOG = LoggerFactory.getLogger(
       ChunkManagerDummyImpl.class);
 
   public ChunkManagerDummyImpl(boolean sync) {
@@ -67,25 +68,15 @@ public class ChunkManagerDummyImpl extends ChunkManagerImpl {
     Preconditions.checkNotNull(dispatcherContext);
     DispatcherContext.WriteChunkStage stage = dispatcherContext.getStage();
 
-    Logger log = LoggerFactory.getLogger(ChunkManagerImpl.class);
-
     try {
       KeyValueContainerData containerData =
           (KeyValueContainerData) container.getContainerData();
       HddsVolume volume = containerData.getVolume();
       VolumeIOStats volumeIOStats = volume.getVolumeIOStats();
-      int bufferSize;
 
       switch (stage) {
       case WRITE_DATA:
-        bufferSize = data.capacity();
-        if (bufferSize != info.getLen()) {
-          String err = String.format("data array does not match the length "
-                  + "specified. DataLen: %d Byte Array: %d",
-              info.getLen(), bufferSize);
-          log.error(err);
-          throw new StorageContainerException(err, INVALID_WRITE_SIZE);
-        }
+        ChunkUtils.validateBufferSize(info, data, LOG);
 
         // Increment volumeIO stats here.
         volumeIOStats.incWriteTime(Time.monotonicNow() - writeTimeStart);
@@ -102,7 +93,7 @@ public class ChunkManagerDummyImpl extends ChunkManagerImpl {
         throw new IOException("Can not identify write operation.");
       }
     } catch (IOException ex) {
-      LOG.error("write data failed. error: {}", ex);
+      LOG.error("write data failed", ex);
       throw new StorageContainerException("Internal error: ", ex,
           CONTAINER_INTERNAL_ERROR);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Data size validation logic was recently [changed](https://github.com/apache/hadoop-ozone/commit/e70ea7b66ca3326c3b00ddc3e4af7144d48ea5f5#diff-92341865368a6b82a1430bcb40bd4264R83) for real `ChunkManager`, but not for the dummy implementation.  This change extracts the validation logic and reuses it for the dummy one, too.  This restores the ability to skip writing data to disk (for performance testing).

https://issues.apache.org/jira/browse/HDDS-2334

## How was this patch tested?

Changed existing unit test to use a buffer with additional "header" at the beginning.  Added test cases for dummy implementation.

Tested on compose cluster with the following additional configs:

```
OZONE-SITE.XML_hdds.container.chunk.persistdata=false
OZONE-SITE.XML_ozone.client.verify.checksum=false
```

```
$ ozone sh volume create vol1
$ ozone sh bucket create vol1/buck1;
$ ozone sh key put vol1/buck1/key1 /etc/passwd
$ ozone sh key get vol1/buck1/key1 asdf
$ ls -l /etc/passwd
-rw-r--r-- 1 root root 671 Jun 17 15:33 /etc/passwd
$ wc asdf
  0   0 671 asdf
```

Also tested regular, "persistent" chunk manager:

```
$ docker-compose exec scm ozone freon rk --numOfThreads 1 --numOfVolumes 1 --numOfBuckets 1 --replicationType RATIS --factor ONE --validateWrites --keySize 1024 --numOfKeys 10 --bufferSize 1024
...
Status: Success
Git Base Revision: e97acb3bd8f3befd27418996fa5d4b50bf2e17bf
Number of Volumes created: 1
Number of Buckets created: 1
Number of Keys added: 10
Ratis replication factor: ONE
Ratis replication type: RATIS
Average Time spent in volume creation: 00:00:00,182
Average Time spent in bucket creation: 00:00:00,030
Average Time spent in key creation: 00:00:00,290
Average Time spent in key write: 00:00:02,379
Total bytes written: 10240
Total number of writes validated: 10
Writes validated: 100.0 %
Successful validation: 10
Unsuccessful validation: 0
Total Execution time: 00:00:09,389
```