### PR TITLE
HDDS-2320. Negative value seen for OM NumKeys Metric in JMX.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -198,6 +198,7 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
     if (exception == null) {
       LOG.debug("Directory is successfully created for Key: {} in " +
               "volume/bucket:{}/{}", keyName, volumeName, bucketName);
+      omMetrics.incNumKeys();
       return omClientResponse;
     } else {
       LOG.error("CreateDirectory failed for Key: {} in volume/bucket:{}/{}",

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
@@ -378,13 +378,11 @@ public class TestOMDirectoryCreateRequest {
         omDirectoryCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertTrue(omClientResponse.getOMResponse().getStatus()
-        == OzoneManagerProtocolProtos.Status.OK);
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omClientResponse.getOMResponse().getStatus());
 
-    // Key should exist in DB
-    Assert.assertTrue(omMetadataManager.getKeyTable().get(
-        omMetadataManager.getOzoneDirKey(
-            volumeName, bucketName, keyName)) != null);
+    Assert.assertNotNull(omMetadataManager.getKeyTable().get(
+        omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName)));
 
     Assert.assertEquals(1L, omMetrics.getNumKeys());
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

After running teragen, I noticed that the NumKeys metric in OzoneManager JMX had a negative value. On investigation, it was seen that we decrease the numkeys metric while deleting any key (including directory), but do not increment NumKeys when we create a directory. To keep it consistent, the change proposes increasing NumKeys while creating directories as well. This essentially means that the "NumKeys" is a pure OM metric that tracks the number of entries it manages as opposed to the number of files that are managed by SCM and Ratis. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2320

## How was this patch tested?
Manually tested on cluster. Added unit test. 