### PR TITLE
HDDS-2343. Add immutable entries in to the DoubleBuffer for Bucket requests.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -39,7 +39,8 @@ import com.google.common.base.Preconditions;
 /**
  * A class that encapsulates Bucket Info.
  */
-public final class OmBucketInfo extends WithMetadata implements Auditable {
+public final class OmBucketInfo extends WithMetadata implements Auditable,
+    Cloneable {
   /**
    * Name of the volume in which the bucket belongs to.
    */
@@ -212,6 +213,28 @@ public final class OmBucketInfo extends WithMetadata implements Auditable {
         (this.storageType != null) ? this.storageType.name() : null);
     auditMap.put(OzoneConsts.CREATION_TIME, String.valueOf(this.creationTime));
     return auditMap;
+  }
+
+  @Override
+  public Object clone() {
+    OmBucketInfo.Builder builder = new OmBucketInfo.Builder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setAcls(acls.stream().map(acl -> new OzoneAcl(acl.getType(),
+            acl.getName(), acl.getAclBitSet(), acl.getAclScope()))
+            .collect(Collectors.toList()))
+        .setStorageType(storageType)
+        .setIsVersionEnabled(isVersionEnabled)
+        .setCreationTime(creationTime)
+        .setBucketEncryptionKey(bekInfo != null ?
+            new BucketEncryptionKeyInfo(bekInfo.getVersion(),
+                bekInfo.getSuite(), bekInfo.getKeyName()) : null);
+
+    if (metadata != null) {
+      metadata.forEach((k, v) -> builder.addMetadata(k, v));
+    }
+    return builder.build();
+
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -178,7 +178,8 @@ public class OMBucketCreateRequest extends OMClientRequest {
 
       omResponse.setCreateBucketResponse(
           CreateBucketResponse.newBuilder().build());
-      omClientResponse = new OMBucketCreateResponse(omBucketInfo,
+      omClientResponse =
+          new OMBucketCreateResponse((OmBucketInfo) omBucketInfo.clone(),
           omResponse.build());
     } catch (IOException ex) {
       exception = ex;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -168,8 +168,9 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
 
       omResponse.setSetBucketPropertyResponse(
           SetBucketPropertyResponse.newBuilder().build());
-      omClientResponse = new OMBucketSetPropertyResponse(omBucketInfo,
-        omResponse.build());
+      omClientResponse =
+          new OMBucketSetPropertyResponse((OmBucketInfo) omBucketInfo.clone(),
+              omResponse.build());
     } catch (IOException ex) {
       exception = ex;
       omClientResponse = new OMBucketSetPropertyResponse(omBucketInfo,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
@@ -109,7 +109,8 @@ public abstract class OMBucketAclRequest extends OMClientRequest {
             new CacheValue<>(Optional.of(omBucketInfo), transactionLogIndex));
       }
 
-      omClientResponse = onSuccess(omResponse, omBucketInfo, operationResult);
+      omClientResponse = onSuccess(omResponse,
+          (OmBucketInfo) omBucketInfo.clone(), operationResult);
 
     } catch (IOException ex) {
       exception = ex;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
@@ -51,7 +51,6 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
   }
 
 
-
   @Test
   public void testValidateAndUpdateCache() throws Exception {
     String volumeName = UUID.randomUUID().toString();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
@@ -19,8 +19,11 @@
 
 package org.apache.hadoop.ozone.om.request.bucket;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.UUID;
 
+import org.apache.hadoop.ozone.om.response.bucket.OMBucketCreateResponse;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -49,6 +52,7 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
     String bucketName = UUID.randomUUID().toString();
     doPreExecute(volumeName, bucketName);
   }
+
 
 
   @Test
@@ -150,6 +154,17 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
     OMClientResponse omClientResponse =
         omBucketCreateRequest.validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
+
+    OmBucketInfo omBucketInfoRes =
+        ((OMBucketCreateResponse) omClientResponse).getOmBucketInfo();
+
+    OmBucketInfo omBucketInfoCache =
+        omMetadataManager.getBucketTable().get(bucketKey);
+
+    omBucketInfoCache.setMetadata(new HashMap<>());
+
+    System.out.println(omBucketInfoCache.getMetadata());
+    System.out.println(omBucketInfoRes.getMetadata());
 
     // As now after validateAndUpdateCache it should add entry to cache, get
     // should return non null value.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
@@ -19,11 +19,8 @@
 
 package org.apache.hadoop.ozone.om.request.bucket;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.UUID;
 
-import org.apache.hadoop.ozone.om.response.bucket.OMBucketCreateResponse;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -154,17 +151,6 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
     OMClientResponse omClientResponse =
         omBucketCreateRequest.validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
-
-    OmBucketInfo omBucketInfoRes =
-        ((OMBucketCreateResponse) omClientResponse).getOmBucketInfo();
-
-    OmBucketInfo omBucketInfoCache =
-        omMetadataManager.getBucketTable().get(bucketKey);
-
-    omBucketInfoCache.setMetadata(new HashMap<>());
-
-    System.out.println(omBucketInfoCache.getMetadata());
-    System.out.println(omBucketInfoRes.getMetadata());
 
     // As now after validateAndUpdateCache it should add entry to cache, get
     // should return non null value.


### PR DESCRIPTION
## What changes were proposed in this pull request?

```
OMBucketCreateRequest.java L181:

omClientResponse =
new OMBucketCreateResponse(omBucketInfo,
omResponse.build());
```

 
We add this to double-buffer, and double-buffer flushThread which is running in the background when picks up, converts to protoBuf and to ByteArray and write to rocksDB tables. So, during this conversion(This conversion will be done without any lock acquire), if any other request changes internal structure(like acls list) of OMBucketInfo we might get ConcurrentModificationException.

In this Jira handled Bucket requests, when adding entries to doubleBuffer cloned them and added to it. 


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2343

## How was this patch tested?

Ran TestOzoneRpcClient which tests this code path.
