### PR TITLE
HDDS-2344. Add immutable entries in to the DoubleBuffer for Volume requests.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Codec.java
@@ -40,4 +40,10 @@ public interface Codec<T> {
    * @param rawData Byte array from the key/value store. Should not be null.
    */
   T fromPersistedFormat(byte[] rawData) throws IOException;
+
+  /**
+   * Copy Object from the provided object, and returns a new object.
+   * @param object
+   */
+  T copyObject(T object);
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecRegistry.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecRegistry.java
@@ -55,6 +55,22 @@ public class CodecRegistry {
   }
 
   /**
+   * Copy object, and return a new object.
+   * @param object
+   * @param format
+   * @param <T>
+   * @return new object copied from the given object.
+   * @throws IOException
+   */
+  public <T> T copyObject(T object, Class<T> format) throws IOException {
+    if (object == null) {
+      return null;
+    }
+    Codec codec = getCodec(format);
+    return (T) codec.copyObject(object);
+  }
+
+  /**
    * Convert strongly typed object to raw data to store it in the kv store.
    *
    * @param object typed object.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/IntegerCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/IntegerCodec.java
@@ -35,4 +35,9 @@ public class IntegerCodec implements Codec<Integer> {
   public Integer fromPersistedFormat(byte[] rawData) throws IOException {
     return Ints.fromByteArray(rawData);
   }
+
+  @Override
+  public Integer copyObject(Integer object) {
+    return object;
+  }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/LongCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/LongCodec.java
@@ -43,4 +43,9 @@ public class LongCodec implements Codec<Long> {
       return null;
     }
   }
+
+  @Override
+  public Long copyObject(Long object) {
+    return object;
+  }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/StringCodec.java
@@ -43,4 +43,9 @@ public class StringCodec implements Codec<String> {
       return null;
     }
   }
+
+  @Override
+  public String copyObject(String object) {
+    return object;
+  }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -167,7 +167,8 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
         cache.lookup(new CacheKey<>(key));
 
     if (cacheResult.getCacheStatus() == EXISTS) {
-      return cacheResult.getValue().getCacheValue();
+      return codecRegistry.copyObject(cacheResult.getValue().getCacheValue(),
+          valueType);
     } else if (cacheResult.getCacheStatus() == NOT_EXIST) {
       return null;
     } else {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/BigIntegerCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/BigIntegerCodec.java
@@ -36,4 +36,9 @@ public class BigIntegerCodec implements Codec<BigInteger> {
   public BigInteger fromPersistedFormat(byte[] rawData) throws IOException {
     return new BigInteger(rawData);
   }
+
+  @Override
+  public BigInteger copyObject(BigInteger object) {
+    return object;
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/DeletedBlocksTransactionCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/DeletedBlocksTransactionCodec.java
@@ -47,4 +47,9 @@ public class DeletedBlocksTransactionCodec
           "Can't convert rawBytes to DeletedBlocksTransaction.", e);
     }
   }
+
+  @Override
+  public DeletedBlocksTransaction copyObject(DeletedBlocksTransaction object) {
+    return object;
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/LongCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/LongCodec.java
@@ -37,4 +37,9 @@ public class LongCodec implements Codec<Long> {
   public Long fromPersistedFormat(byte[] rawData) throws IOException {
     return Longs.fromByteArray(rawData);
   }
+
+  @Override
+  public Long copyObject(Long object) {
+    return object;
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/X509CertificateCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/X509CertificateCodec.java
@@ -51,4 +51,9 @@ public class X509CertificateCodec implements Codec<X509Certificate> {
       throw new IOException(exp);
     }
   }
+
+  @Override
+  public X509Certificate copyObject(X509Certificate object) {
+    return object;
+  }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/OmBucketInfoCodec.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/OmBucketInfoCodec.java
@@ -50,4 +50,8 @@ public class OmBucketInfoCodec implements Codec<OmBucketInfo> {
     }
   }
 
+  @Override
+  public OmBucketInfo copyObject(OmBucketInfo object) {
+    return object.copyObject();
+  }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/OmKeyInfoCodec.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/OmKeyInfoCodec.java
@@ -50,4 +50,9 @@ public class OmKeyInfoCodec implements Codec<OmKeyInfo> {
     }
   }
 
+  @Override
+  public OmKeyInfo copyObject(OmKeyInfo omKeyInfo) {
+    return omKeyInfo;
+  }
+
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/OmMultipartKeyInfoCodec.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/OmMultipartKeyInfoCodec.java
@@ -56,4 +56,9 @@ public class OmMultipartKeyInfoCodec implements Codec<OmMultipartKeyInfo> {
           "Can't encode the the raw data from the byte array", e);
     }
   }
+
+  @Override
+  public OmMultipartKeyInfo copyObject(OmMultipartKeyInfo object) {
+    return object;
+  }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/OmPrefixInfoCodec.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/OmPrefixInfoCodec.java
@@ -50,4 +50,9 @@ public class OmPrefixInfoCodec implements Codec<OmPrefixInfo> {
           "Can't encode the the raw data from the byte array", e);
     }
   }
+
+  @Override
+  public OmPrefixInfo copyObject(OmPrefixInfo object) {
+    return object;
+  }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/OmVolumeArgsCodec.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/OmVolumeArgsCodec.java
@@ -50,4 +50,8 @@ public class OmVolumeArgsCodec implements Codec<OmVolumeArgs> {
     }
   }
 
+  @Override
+  public OmVolumeArgs copyObject(OmVolumeArgs omVolumeArgs) {
+    return omVolumeArgs.copyObject();
+  }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/RepeatedOmKeyInfoCodec.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/RepeatedOmKeyInfoCodec.java
@@ -49,4 +49,9 @@ public class RepeatedOmKeyInfoCodec implements Codec<RepeatedOmKeyInfo> {
           "Can't encode the the raw data from the byte array", e);
     }
   }
+
+  @Override
+  public RepeatedOmKeyInfo copyObject(RepeatedOmKeyInfo object) {
+    return object;
+  }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/S3SecretValueCodec.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/S3SecretValueCodec.java
@@ -54,4 +54,9 @@ public class S3SecretValueCodec implements Codec<S3SecretValue> {
           "Can't encode the the raw data from the byte array", e);
     }
   }
+
+  @Override
+  public S3SecretValue copyObject(S3SecretValue object) {
+    return object;
+  }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/TokenIdentifierCodec.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/TokenIdentifierCodec.java
@@ -49,4 +49,8 @@ public class TokenIdentifierCodec implements Codec<OzoneTokenIdentifier> {
     }
   }
 
+  @Override
+  public OzoneTokenIdentifier copyObject(OzoneTokenIdentifier object) {
+    return object;
+  }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/UserVolumeInfoCodec.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/UserVolumeInfoCodec.java
@@ -50,4 +50,8 @@ public class UserVolumeInfoCodec implements Codec<UserVolumeInfo> {
     }
   }
 
+  @Override
+  public UserVolumeInfo copyObject(UserVolumeInfo object) {
+    return object;
+  }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -367,6 +367,7 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
     return obib.build();
   }
 
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -39,8 +39,7 @@ import com.google.common.base.Preconditions;
 /**
  * A class that encapsulates Bucket Info.
  */
-public final class OmBucketInfo extends WithMetadata implements Auditable,
-    Cloneable {
+public final class OmBucketInfo extends WithMetadata implements Auditable{
   /**
    * Name of the volume in which the bucket belongs to.
    */
@@ -215,8 +214,10 @@ public final class OmBucketInfo extends WithMetadata implements Auditable,
     return auditMap;
   }
 
-  @Override
-  public Object clone() {
+  /**
+   * Return a new copy of the object.
+   */
+  public OmBucketInfo copyObject() {
     OmBucketInfo.Builder builder = new OmBucketInfo.Builder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
@@ -366,7 +367,6 @@ public final class OmBucketInfo extends WithMetadata implements Auditable,
     return obib.build();
   }
 
-  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmOzoneAclMap.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmOzoneAclMap.java
@@ -62,6 +62,12 @@ public class OmOzoneAclMap {
     }
   }
 
+  OmOzoneAclMap(List<OzoneAclInfo> defaultAclList,
+      ArrayList<Map<String, BitSet>> accessAclMap) {
+    this.defaultAclList = defaultAclList;
+    this.accessAclMap = accessAclMap;
+  }
+
   private Map<String, BitSet> getAccessAclMap(OzoneAclType type) {
     return accessAclMap.get(type.ordinal());
   }
@@ -297,5 +303,30 @@ public class OmOzoneAclMap {
 
   public List<OzoneAclInfo> getDefaultAclList() {
     return defaultAclList;
+  }
+
+  /**
+   * Return a new copy of the object.
+   */
+  public OmOzoneAclMap copyObject() {
+    ArrayList<Map<String, BitSet>> accessMap = new ArrayList<>();
+
+    // Initialize.
+    for (OzoneAclType aclType : OzoneAclType.values()) {
+      accessMap.add(aclType.ordinal(), new HashMap<>());
+    }
+
+    // Add from original accessAclMap to accessMap.
+    for (OzoneAclType aclType : OzoneAclType.values()) {
+      final int ordinal = aclType.ordinal();
+      accessAclMap.get(ordinal).forEach((k, v) ->
+          accessMap.get(ordinal).put(k, (BitSet) v.clone()));
+    }
+
+    // We can do shallow copy here, as OzoneAclInfo is immutable structure.
+    ArrayList<OzoneAclInfo> defaultList = new ArrayList<>();
+    defaultList.addAll(defaultAclList);
+
+    return new OmOzoneAclMap(defaultList, accessMap);
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmVolumeArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmVolumeArgs.java
@@ -244,19 +244,21 @@ public final class OmVolumeArgs extends WithMetadata implements Auditable {
      * Sets the Object ID for this Object.
      * Object ID are unique and immutable identifier for each object in the
      * System.
-     * @param objectID - long
+     * @param id - long
      */
-    public void setObjectID(long objectID) {
-      this.objectID = objectID;
+    public Builder setObjectID(long id) {
+      this.objectID = id;
+      return this;
     }
 
     /**
      * Sets the update ID for this Object. Update IDs are monotonically
      * increasing values which are updated each time there is an update.
-     * @param updateID - long
+     * @param id - long
      */
-    public void setUpdateID(long updateID) {
-      this.updateID = updateID;
+    public Builder setUpdateID(long id) {
+      this.updateID = id;
+      return this;
     }
 
 
@@ -355,5 +357,20 @@ public final class OmVolumeArgs extends WithMetadata implements Auditable {
         volInfo.getCreationTime(),
         volInfo.getObjectID(),
         volInfo.getUpdateID());
+  }
+
+  /**
+   * Return a new copy of the object.
+   */
+  public OmVolumeArgs copyObject() {
+    Map<String, String> cloneMetadata = new HashMap<>();
+    if (metadata != null) {
+      metadata.forEach((k, v) -> cloneMetadata.put(k, v));
+    }
+
+    OmOzoneAclMap cloneAclMap = aclMap.copyObject();
+
+    return new OmVolumeArgs(adminName, ownerName, volume, quotaInBytes,
+        cloneMetadata, cloneAclMap, creationTime, objectID, updateID);
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmVolumeArgs.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmVolumeArgs.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import java.util.Collections;
+
+import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.util.Time;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
+
+/**
+ * Class to test {@link OmVolumeArgs}.
+ */
+public class TestOmVolumeArgs {
+
+  @Test
+  public void testClone() throws Exception {
+    String volumeName = "vol1";
+    String admin = "admin";
+    String owner = UserGroupInformation.getCurrentUser().getUserName();
+    OmVolumeArgs omVolumeArgs = new OmVolumeArgs.Builder().setVolume(volumeName)
+        .setAdminName(admin).setCreationTime(Time.now()).setOwnerName(owner)
+        .setObjectID(1L).setUpdateID(1L).setQuotaInBytes(100L).addMetadata(
+            "key1", "value1").addMetadata("key2", "value2")
+        .addOzoneAcls(OzoneAcl.toProtobuf(
+            new OzoneAcl(IAccessAuthorizer.ACLIdentityType.USER, "user1",
+                IAccessAuthorizer.ACLType.READ, ACCESS))).build();
+
+    OmVolumeArgs cloneVolumeArgs = omVolumeArgs.copyObject();
+
+    Assert.assertEquals(omVolumeArgs, cloneVolumeArgs);
+
+    // add user acl to write.
+    omVolumeArgs.addAcl(new OzoneAcl(
+        IAccessAuthorizer.ACLIdentityType.USER, "user1",
+        IAccessAuthorizer.ACLType.WRITE, ACCESS));
+
+    // Now check clone acl
+    Assert.assertNotEquals(cloneVolumeArgs.getAclMap().getAcl().get(0),
+        omVolumeArgs.getAclMap().getAcl().get(0));
+
+    // Set user acl to Write_ACL.
+    omVolumeArgs.setAcls(Collections.singletonList(new OzoneAcl(
+        IAccessAuthorizer.ACLIdentityType.USER, "user1",
+        IAccessAuthorizer.ACLType.WRITE_ACL, ACCESS)));
+
+    Assert.assertNotEquals(cloneVolumeArgs.getAclMap().getAcl().get(0),
+        omVolumeArgs.getAclMap().getAcl().get(0));
+
+    // Now clone and check. It should have same as original acl.
+    cloneVolumeArgs = (OmVolumeArgs) omVolumeArgs.copyObject();
+
+    Assert.assertEquals(omVolumeArgs, cloneVolumeArgs);
+    Assert.assertEquals(cloneVolumeArgs.getAclMap().getAcl().get(0),
+        omVolumeArgs.getAclMap().getAcl().get(0));
+
+    omVolumeArgs.removeAcl(new OzoneAcl(
+        IAccessAuthorizer.ACLIdentityType.USER, "user1",
+        IAccessAuthorizer.ACLType.WRITE_ACL, ACCESS));
+
+    // Removing acl, in original omVolumeArgs it should have no acls.
+    Assert.assertEquals(0, omVolumeArgs.getAclMap().getAcl().size());
+    Assert.assertEquals(1, cloneVolumeArgs.getAclMap().getAcl().size());
+
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -178,8 +178,7 @@ public class OMBucketCreateRequest extends OMClientRequest {
 
       omResponse.setCreateBucketResponse(
           CreateBucketResponse.newBuilder().build());
-      omClientResponse =
-          new OMBucketCreateResponse((OmBucketInfo) omBucketInfo.clone(),
+      omClientResponse = new OMBucketCreateResponse(omBucketInfo,
           omResponse.build());
     } catch (IOException ex) {
       exception = ex;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -169,8 +169,7 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
       omResponse.setSetBucketPropertyResponse(
           SetBucketPropertyResponse.newBuilder().build());
       omClientResponse =
-          new OMBucketSetPropertyResponse((OmBucketInfo) omBucketInfo.clone(),
-              omResponse.build());
+          new OMBucketSetPropertyResponse(omBucketInfo, omResponse.build());
     } catch (IOException ex) {
       exception = ex;
       omClientResponse = new OMBucketSetPropertyResponse(omBucketInfo,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
@@ -109,8 +109,7 @@ public abstract class OMBucketAclRequest extends OMClientRequest {
             new CacheValue<>(Optional.of(omBucketInfo), transactionLogIndex));
       }
 
-      omClientResponse = onSuccess(omResponse,
-          (OmBucketInfo) omBucketInfo.clone(), operationResult);
+      omClientResponse = onSuccess(omResponse, omBucketInfo, operationResult);
 
     } catch (IOException ex) {
       exception = ex;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerKeyPrefixCodec.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerKeyPrefixCodec.java
@@ -84,4 +84,9 @@ public class ContainerKeyPrefixCodec implements Codec<ContainerKeyPrefix>{
     long version = ByteBuffer.wrap(versionBytes).getLong();
     return new ContainerKeyPrefix(containerIdFromDB, keyPrefix, version);
   }
+
+  @Override
+  public ContainerKeyPrefix copyObject(ContainerKeyPrefix object) {
+    return object;
+  }
 }


### PR DESCRIPTION
…quests.

## What changes were proposed in this pull request?

OMVolumeCreateRequest.java L159:

omClientResponse =
 new OMVolumeCreateResponse(omVolumeArgs,volumeList, omResponse.build());
 

We add this to double-buffer, and double-buffer flushThread which is running in the background when picks up, converts to protoBuf and to ByteArray and write to rocksDB tables. So, during this conversion(This conversion will be done without any lock acquire), if any other request changes internal structure(like acls list) of OmVolumeArgs we might get ConcurrentModificationException.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2344



## How was this patch tested?

Ran TestOzoneRpcClient which tests this code path and also added a new test for clone method.
