### PR TITLE
HDDS-2341. Validate tar entry path during extraction

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -24,6 +24,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.nio.file.Path;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.HashSet;
@@ -32,6 +33,7 @@ import java.util.Optional;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.base.Preconditions;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
@@ -501,5 +503,26 @@ public final class HddsUtils {
         configuration.get(DFSConfigKeys.DFS_METRICS_SESSION_ID_KEY),
         DefaultMetricsSystem.instance());
     return metricsSystem;
+  }
+
+  /**
+   * Basic validation for {@code path}: checks that it is a descendant of
+   * (or the same as) the given {@code ancestor}.
+   * @param path the path to be validated
+   * @param ancestor a trusted path that is supposed to be the ancestor of
+   *     {@code path}
+   * @throws NullPointerException if either {@code path} or {@code ancestor} is
+   *     null
+   * @throws IllegalArgumentException if {@code ancestor} is not really the
+   *     ancestor of {@code path}
+   */
+  public static void validatePath(Path path, Path ancestor) {
+    Preconditions.checkNotNull(path,
+        "Path should not be null");
+    Preconditions.checkNotNull(ancestor,
+        "Ancestor should not be null");
+    Preconditions.checkArgument(
+        path.normalize().startsWith(ancestor.normalize()),
+        "Path should be a descendant of " + ancestor);
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
@@ -17,8 +17,10 @@
  */
 package org.apache.hadoop.hdds;
 
+import java.nio.file.Paths;
 import java.util.Optional;
 
+import org.apache.hadoop.test.LambdaTestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,6 +39,25 @@ public class TestHddsUtils {
 
     Assert.assertEquals(Optional.empty(),
         HddsUtils.getHostName(":1234"));
+  }
+
+  @Test
+  public void validatePath() throws Exception {
+    HddsUtils.validatePath(Paths.get("/"), Paths.get("/"));
+    HddsUtils.validatePath(Paths.get("/a"), Paths.get("/"));
+    HddsUtils.validatePath(Paths.get("/a"), Paths.get("/a"));
+    HddsUtils.validatePath(Paths.get("/a/b"), Paths.get("/a"));
+    HddsUtils.validatePath(Paths.get("/a/b/c"), Paths.get("/a"));
+    HddsUtils.validatePath(Paths.get("/a/../a/b"), Paths.get("/a"));
+
+    LambdaTestUtils.intercept(IllegalArgumentException.class,
+        () -> HddsUtils.validatePath(Paths.get("/b/c"), Paths.get("/a")));
+    LambdaTestUtils.intercept(IllegalArgumentException.class,
+        () -> HddsUtils.validatePath(Paths.get("/"), Paths.get("/a")));
+    LambdaTestUtils.intercept(IllegalArgumentException.class,
+        () -> HddsUtils.validatePath(Paths.get("/a/.."), Paths.get("/a")));
+    LambdaTestUtils.intercept(IllegalArgumentException.class,
+        () -> HddsUtils.validatePath(Paths.get("/a/../b"), Paths.get("/a")));
   }
 
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
@@ -30,7 +30,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.stream.Collectors;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
@@ -116,11 +115,13 @@ public class TarContainerPacker
     }
   }
 
-  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
   private void extractEntry(TarArchiveInputStream tarInput, long size,
                             Path ancestor, Path path) throws IOException {
     HddsUtils.validatePath(path, ancestor);
-    Files.createDirectories(path.getParent());
+    Path parent = path.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
     try (BufferedOutputStream bos = new BufferedOutputStream(
         new FileOutputStream(path.toAbsolutePath().toString()))) {
       int bufferSize = 1024;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.container.keyvalue;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
@@ -30,7 +31,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.commons.compress.archivers.ArchiveOutputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.CompressorOutputStream;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerPacker;
 
@@ -41,11 +46,13 @@ import org.apache.commons.compress.compressors.CompressorInputStream;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.test.LambdaTestUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.compress.compressors.CompressorStreamFactory.GZIP;
 
 /**
  * Test the tar/untar for a given container.
@@ -62,13 +69,16 @@ public class TestTarContainerPacker {
 
   private static final String TEST_DESCRIPTOR_FILE_CONTENT = "descriptor";
 
-  private ContainerPacker packer = new TarContainerPacker();
+  private final ContainerPacker<KeyValueContainerData> packer
+      = new TarContainerPacker();
 
   private static final Path SOURCE_CONTAINER_ROOT =
       Paths.get("target/test/data/packer-source-dir");
 
   private static final Path DEST_CONTAINER_ROOT =
       Paths.get("target/test/data/packer-dest-dir");
+
+  private static final AtomicInteger CONTAINER_ID = new AtomicInteger(1);
 
   @BeforeClass
   public static void init() throws IOException {
@@ -80,11 +90,11 @@ public class TestTarContainerPacker {
     if (path.toFile().exists()) {
       FileUtils.deleteDirectory(path.toFile());
     }
-    path.toFile().mkdirs();
+    Files.createDirectories(path);
   }
 
-  private KeyValueContainerData createContainer(long id, Path dir,
-      OzoneConfiguration conf) throws IOException {
+  private KeyValueContainerData createContainer(Path dir) throws IOException {
+    long id = CONTAINER_ID.getAndIncrement();
 
     Path containerDir = dir.resolve("container" + id);
     Path dbDir = containerDir.resolve("db");
@@ -98,7 +108,6 @@ public class TestTarContainerPacker {
     containerData.setMetadataPath(dbDir.getParent().toString());
     containerData.setDbFile(dbDir.toFile());
 
-
     return containerData;
   }
 
@@ -109,32 +118,19 @@ public class TestTarContainerPacker {
     OzoneConfiguration conf = new OzoneConfiguration();
 
     KeyValueContainerData sourceContainerData =
-        createContainer(1L, SOURCE_CONTAINER_ROOT, conf);
+        createContainer(SOURCE_CONTAINER_ROOT);
 
     KeyValueContainer sourceContainer =
         new KeyValueContainer(sourceContainerData, conf);
 
     //sample db file in the metadata directory
-    try (FileWriter writer = new FileWriter(
-        sourceContainerData.getDbFile().toPath()
-            .resolve(TEST_DB_FILE_NAME)
-            .toFile())) {
-      IOUtils.write(TEST_DB_FILE_CONTENT, writer);
-    }
+    writeDbFile(sourceContainerData, TEST_DB_FILE_NAME);
 
     //sample chunk file in the chunk directory
-    try (FileWriter writer = new FileWriter(
-        Paths.get(sourceContainerData.getChunksPath())
-            .resolve(TEST_CHUNK_FILE_NAME)
-            .toFile())) {
-      IOUtils.write(TEST_CHUNK_FILE_CONTENT, writer);
-    }
+    writeChunkFile(sourceContainerData, TEST_CHUNK_FILE_NAME);
 
     //sample container descriptor file
-    try (FileWriter writer = new FileWriter(
-        sourceContainer.getContainerFile())) {
-      IOUtils.write(TEST_DESCRIPTOR_FILE_CONTENT, writer);
-    }
+    writeDescriptor(sourceContainer);
 
     Path targetFile =
         SOURCE_CONTAINER_ROOT.getParent().resolve("container.tar.gz");
@@ -147,7 +143,7 @@ public class TestTarContainerPacker {
     //THEN: check the result
     try (FileInputStream input = new FileInputStream(targetFile.toFile())) {
       CompressorInputStream uncompressed = new CompressorStreamFactory()
-          .createCompressorInputStream(CompressorStreamFactory.GZIP, input);
+          .createCompressorInputStream(GZIP, input);
       TarArchiveInputStream tarStream = new TarArchiveInputStream(uncompressed);
 
       TarArchiveEntry entry;
@@ -169,12 +165,12 @@ public class TestTarContainerPacker {
     }
 
     KeyValueContainerData destinationContainerData =
-        createContainer(2L, DEST_CONTAINER_ROOT, conf);
+        createContainer(DEST_CONTAINER_ROOT);
 
     KeyValueContainer destinationContainer =
         new KeyValueContainer(destinationContainerData, conf);
 
-    String descriptor = "";
+    String descriptor;
 
     //unpackContainerData
     try (FileInputStream input = new FileInputStream(targetFile.toFile())) {
@@ -188,13 +184,139 @@ public class TestTarContainerPacker {
     assertExampleChunkFileIsGood(
         Paths.get(destinationContainerData.getChunksPath()));
     Assert.assertFalse(
-        "Descriptor file should not been exctarcted by the "
+        "Descriptor file should not have been extracted by the "
             + "unpackContainerData Call",
         destinationContainer.getContainerFile().exists());
     Assert.assertEquals(TEST_DESCRIPTOR_FILE_CONTENT, descriptor);
-
   }
 
+  @Test
+  public void unpackContainerDataWithValidRelativeDbFilePath()
+      throws Exception {
+    //GIVEN
+    KeyValueContainerData sourceContainerData =
+        createContainer(SOURCE_CONTAINER_ROOT);
+
+    String fileName = "sub/dir/" + TEST_DB_FILE_NAME;
+    File file = writeDbFile(sourceContainerData, fileName);
+    String entryName = TarContainerPacker.DB_DIR_NAME + "/" + fileName;
+
+    File containerFile = packContainerWithSingleFile(file, entryName);
+
+    // WHEN
+    unpackContainerData(containerFile);
+
+    // THEN
+    assertExampleMetadataDbIsGood(file.toPath().getParent());
+  }
+
+  @Test
+  public void unpackContainerDataWithValidRelativeChunkFilePath()
+      throws Exception {
+    //GIVEN
+    KeyValueContainerData sourceContainerData =
+        createContainer(SOURCE_CONTAINER_ROOT);
+
+    String fileName = "sub/dir/" + TEST_CHUNK_FILE_NAME;
+    File file = writeChunkFile(sourceContainerData, fileName);
+    String entryName = TarContainerPacker.CHUNKS_DIR_NAME + "/" + fileName;
+
+    File containerFile = packContainerWithSingleFile(file, entryName);
+
+    // WHEN
+    unpackContainerData(containerFile);
+
+    // THEN
+    assertExampleChunkFileIsGood(file.toPath().getParent());
+  }
+
+  @Test
+  public void unpackContainerDataWithInvalidRelativeDbFilePath()
+      throws Exception {
+    //GIVEN
+    KeyValueContainerData sourceContainerData =
+        createContainer(SOURCE_CONTAINER_ROOT);
+
+    String fileName = "../db_file";
+    File file = writeDbFile(sourceContainerData, fileName);
+    String entryName = TarContainerPacker.DB_DIR_NAME + "/" + fileName;
+
+    File containerFile = packContainerWithSingleFile(file, entryName);
+
+    LambdaTestUtils.intercept(IllegalArgumentException.class,
+        () -> unpackContainerData(containerFile));
+  }
+
+  @Test
+  public void unpackContainerDataWithInvalidRelativeChunkFilePath()
+      throws Exception {
+    //GIVEN
+    KeyValueContainerData sourceContainerData =
+        createContainer(SOURCE_CONTAINER_ROOT);
+
+    String fileName = "../chunk_file";
+    File file = writeChunkFile(sourceContainerData, fileName);
+    String entryName = TarContainerPacker.CHUNKS_DIR_NAME + "/" + fileName;
+
+    File containerFile = packContainerWithSingleFile(file, entryName);
+
+    LambdaTestUtils.intercept(IllegalArgumentException.class,
+        () -> unpackContainerData(containerFile));
+  }
+
+  private void unpackContainerData(File containerFile) throws IOException {
+    try (FileInputStream input = new FileInputStream(containerFile)) {
+      OzoneConfiguration conf = new OzoneConfiguration();
+      KeyValueContainerData data = createContainer(DEST_CONTAINER_ROOT);
+      KeyValueContainer container = new KeyValueContainer(data, conf);
+      packer.unpackContainerData(container, input);
+    }
+  }
+
+  private void writeDescriptor(KeyValueContainer container) throws IOException {
+    try (FileWriter writer = new FileWriter(container.getContainerFile())) {
+      IOUtils.write(TEST_DESCRIPTOR_FILE_CONTENT, writer);
+    }
+  }
+
+  private File writeChunkFile(
+      KeyValueContainerData containerData, String chunkFileName)
+      throws IOException {
+    Path path = Paths.get(containerData.getChunksPath())
+        .resolve(chunkFileName);
+    Files.createDirectories(path.getParent());
+    File file = path.toFile();
+    try (FileWriter writer = new FileWriter(file)) {
+      IOUtils.write(TEST_CHUNK_FILE_CONTENT, writer);
+    }
+    return file;
+  }
+
+  private File writeDbFile(
+      KeyValueContainerData containerData, String dbFileName)
+      throws IOException {
+    Path path = containerData.getDbFile().toPath()
+        .resolve(dbFileName);
+    Files.createDirectories(path.getParent());
+    File file = path.toFile();
+    try (FileWriter writer = new FileWriter(file)) {
+      IOUtils.write(TEST_DB_FILE_CONTENT, writer);
+    }
+    return file;
+  }
+
+  private File packContainerWithSingleFile(File file, String entryName)
+      throws Exception {
+    File targetFile = SOURCE_CONTAINER_ROOT.getParent()
+        .resolve("container.tar.gz").toFile();
+    try (FileOutputStream output = new FileOutputStream(targetFile);
+         CompressorOutputStream gzipped = new CompressorStreamFactory()
+             .createCompressorOutputStream(GZIP, output);
+         ArchiveOutputStream archive = new TarArchiveOutputStream(gzipped)) {
+      TarContainerPacker.includeFile(file, entryName, archive);
+    }
+    return targetFile;
+  }
 
   private void assertExampleMetadataDbIsGood(Path dbPath)
       throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a check to verify tar entries during extraction: they should not be able to escape (by using `../` or absolute directory names) from the expected archive directory.

https://issues.apache.org/jira/browse/HDDS-2341

## How was this patch tested?

Added unit test.

Verified in docker-compose cluster that container replication still works normally.