### PR TITLE
HDDS-2348.Remove log4j properties for package org.apache.hadoop.ozone

### DIFF
--- a/hadoop-ozone/dist/src/main/conf/log4j.properties
+++ b/hadoop-ozone/dist/src/main/conf/log4j.properties
@@ -128,7 +128,7 @@ log4j.logger.com.amazonaws.http.AmazonHttpClient=ERROR
 log4j.appender.EventCounter=org.apache.hadoop.log.metrics.EventCounter
 
 
-log4j.logger.org.apache.hadoop.ozone=DEBUG,OZONE,FILE
+#log4j.logger.org.apache.hadoop.ozone=DEBUG,OZONE,FILE
 
 # Do not log into datanode logs. Remove this line to have single log.
 log4j.additivity.org.apache.hadoop.ozone=false

--- a/hadoop-ozone/dist/src/main/conf/log4j.properties
+++ b/hadoop-ozone/dist/src/main/conf/log4j.properties
@@ -128,27 +128,6 @@ log4j.logger.com.amazonaws.http.AmazonHttpClient=ERROR
 log4j.appender.EventCounter=org.apache.hadoop.log.metrics.EventCounter
 
 
-#log4j.logger.org.apache.hadoop.ozone=DEBUG,OZONE,FILE
-
-# Do not log into datanode logs. Remove this line to have single log.
-log4j.additivity.org.apache.hadoop.ozone=false
-
-# For development purposes, log both to console and log file.
-log4j.appender.OZONE=org.apache.log4j.ConsoleAppender
-log4j.appender.OZONE.Threshold=info
-log4j.appender.OZONE.layout=org.apache.log4j.PatternLayout
-log4j.appender.OZONE.layout.ConversionPattern=%d{ISO8601} [%t] %-5p \
- %X{component} %X{function} %X{resource} %X{user} %X{request} - %m%n
-
-# Real ozone logger that writes to ozone.log
-log4j.appender.FILE=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.FILE.File=${hadoop.log.dir}/ozone.log
-log4j.appender.FILE.Threshold=debug
-log4j.appender.FILE.layout=org.apache.log4j.PatternLayout
-log4j.appender.FILE.layout.ConversionPattern=%d{ISO8601} [%t] %-5p \
-(%F:%L) %X{function} %X{resource} %X{user} %X{request} - \
-%m%n
-
 # Log levels of third-party libraries
 log4j.logger.org.apache.commons.beanutils=WARN
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove log4j config for package org.apache.hadoop.ozone, as it cause the log in this package cannot be written to .log file . For example , the OM startup_msg was written to file om.out and ozone.log ; in addition, The OZONE and FILE appender is for development purpose.

## What is the link to the Apache JIRA


https://issues.apache.org/jira/browse/HDDS-2348

## How was this patch tested?

Restart OzoneManager , check the STARTUP_MSG in om.log
