### PR TITLE
HDDS-2349 QueryNode does not respect null values for opState or state

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -321,8 +321,14 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
       StorageContainerLocationProtocolProtos.NodeQueryRequestProto request)
       throws IOException {
 
-    HddsProtos.NodeState nodeState = request.getState();
-    HddsProtos.NodeOperationalState opState = request.getOpState();
+    HddsProtos.NodeOperationalState opState = null;
+    HddsProtos.NodeState nodeState = null;
+    if (request.hasState()) {
+      nodeState = request.getState();
+    }
+    if (request.hasOpState()) {
+      opState = request.getOpState();
+    }
     List<HddsProtos.Node> datanodes = impl.queryNode(opState, nodeState,
         request.getScope(), request.getPoolName());
     return NodeQueryResponseProto.newBuilder()


### PR DESCRIPTION
In HDDS-2197, the queryNode API call was changed to allow operational state (in_service, decommissioning etc) to be passed along with the node health state. This changed allowed for a null state to indicate a wildcard, so passing:

opState = null
healthState = HEALTHY

Allows one to find all the healthy nodes, irrespective of their opState.

However, for an enum protobuf field, if no value is specified, the first enum in the set is returned as the default. This means that when a null is passed for opState, only the IN_SERVICE nodes are returned. Similar for health state - passing a null will return only HEALTHY nodes.

This PR will fix this issue so the null value acts as a wildcard as intended.