### PR TITLE
HDDS-2352. Client gets internal error instead of volume not found in secure cluster

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
@@ -52,6 +52,8 @@ RpcClient without scheme
 *** Keywords ***
 Test ozone shell
     [arguments]     ${protocol}         ${server}       ${volume}
+    ${result} =     Execute And Ignore Error    ozone sh volume info ${protocol}${server}/${volume}
+                    Should contain      ${result}       VOLUME_NOT_FOUND
     ${result} =     Execute             ozone sh volume create ${protocol}${server}/${volume} --quota 100TB
                     Should not contain  ${result}       Failed
     ${result} =     Execute             ozone sh volume list ${protocol}${server}/ | grep -Ev 'Removed|WARN|DEBUG|ERROR|INFO|TRACE' | jq -r '. | select(.name=="${volume}")'

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/VolumeManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/VolumeManagerImpl.java
@@ -695,6 +695,9 @@ public class VolumeManagerImpl implements VolumeManager {
       }
       return hasAccess;
     } catch (IOException ex) {
+      if (ex instanceof OMException) {
+        throw (OMException) ex;
+      }
       LOG.error("Check access operation failed for volume:{}", volume, ex);
       throw new OMException("Check access operation failed for " +
           "volume:" + volume, ex, ResultCodes.INTERNAL_ERROR);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Let `checkAccess` propagate original `OMException` with `VOLUME_NOT_FOUND` result code instead of new one with `INTERNAL_ERROR`.  This is similar to [existing logic](https://github.com/apache/hadoop-ozone/blob/59d078605fd54b320412f4882af9f90ffaea9456/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketManagerImpl.java#L578-L585) for buckets.

https://issues.apache.org/jira/browse/HDDS-2352

## How was this patch tested?

Tested original steps to reproduce:

```
$ cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonesecure
$ docker-compose exec scm bash
$ kinit -kt /etc/security/keytabs/testuser.keytab testuser/scm@EXAMPLE.COM
$ ozone freon ockg -n 1 -t 1
...
2019-10-23 18:52:25,424 [main] INFO       - Creating Volume: vol1, with testuser/scm@EXAMPLE.COM as owner.
2019-10-23 18:52:25,542 [main] INFO       - Creating Bucket: vol1/bucket1, with Versioning false and Storage Type set to DISK and Encryption set to false
...
Successful executions: 1
```

Also ran `ozonesecure` acceptance test.