### PR TITLE
HDDS-2354. SCM log is full of AllocateBlock logs.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -176,8 +176,11 @@ public class SCMBlockProtocolServer implements
     auditMap.put("owner", owner);
     List<AllocatedBlock> blocks = new ArrayList<>(num);
     boolean auditSuccess = true;
-    LOG.info("Allocating {} blocks of size {}, with {}",
-        num, size, excludeList);
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Allocating {} blocks of size {}, with {}",
+          num, size, excludeList);
+    }
     try {
       for (int i = 0; i < num; i++) {
         AllocatedBlock block = scm.getScmBlockManager()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make the below log statement debug log.
2019-10-24 03:17:43,087 INFO server.SCMBlockProtocolServer: Allocating 1 blocks of size 268435456, with ExcludeList {datanodes = [], containerIds = [], pipelineIds = []}

scm_1       | 2019-10-24 03:17:43,088 INFO server.SCMBlockProtocolServer: Allocating 1 blocks of size 268435456, with ExcludeList {datanodes = [], containerIds = [], pipelineIds = []}

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2354

## How was this patch tested?

Ran docker-compose cluster to verify.
