### PR TITLE
HDDS-2357. Add replication factor option to new Freon tests

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmKeyGenerator.java
@@ -56,6 +56,12 @@ public class OmKeyGenerator extends BaseFreonGenerator
       defaultValue = "bucket1")
   private String bucketName;
 
+  @Option(names = { "-F", "--factor" },
+      description = "Replication factor (ONE, THREE)",
+      defaultValue = "THREE"
+  )
+  private ReplicationFactor factor = ReplicationFactor.THREE;
+
   private OzoneManagerProtocol ozoneManagerClient;
 
   private Timer timer;
@@ -84,7 +90,7 @@ public class OmKeyGenerator extends BaseFreonGenerator
         .setBucketName(bucketName)
         .setVolumeName(volumeName)
         .setType(ReplicationType.RATIS)
-        .setFactor(ReplicationFactor.THREE)
+        .setFactor(factor)
         .setKeyName(generateObjectName(counter))
         .setLocationInfoList(new ArrayList<>())
         .build();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
@@ -66,6 +66,12 @@ public class OzoneClientKeyGenerator extends BaseFreonGenerator
       defaultValue = "4096")
   private int bufferSize;
 
+  @Option(names = { "-F", "--factor" },
+      description = "Replication factor (ONE, THREE)",
+      defaultValue = "THREE"
+  )
+  private ReplicationFactor factor = ReplicationFactor.THREE;
+
   private Timer timer;
 
   private OzoneBucket bucket;
@@ -103,7 +109,7 @@ public class OzoneClientKeyGenerator extends BaseFreonGenerator
       try (OutputStream stream = bucket
           .createKey(generateObjectName(counter), keySize,
               ReplicationType.RATIS,
-              ReplicationFactor.THREE,
+              factor,
               new HashMap<>())) {
         contentGenerator.write(stream);
         stream.flush();


### PR DESCRIPTION
## What changes were proposed in this pull request?

New Freon generators (OCKG and OKG) use fixed replication factor of 3.  Sometimes it's useful to be able to test single-node replication.  This change proposes to add a command-line option to specify replication factor.

https://issues.apache.org/jira/browse/HDDS-2357

## How was this patch tested?

```
$ ozone freon ockg -t 1 -n 1 -p factor_default
$ ozone freon ockg -t 1 -n 1 -p factor_THREE   --factor THREE
$ ozone freon ockg -t 1 -n 1 -p factor_ONE     --factor ONE  
$ ozone sh key list vol1/bucket1
{
  "volumeName" : "vol1",
  "bucketName" : "bucket1",
  "name" : "factor_ONE/0",
  "dataSize" : 10240,
  "creationTime" : 1571908239786,
  "modificationTime" : 1571908241398,
  "replicationType" : "RATIS",
  "replicationFactor" : 1
}
{
  "volumeName" : "vol1",
  "bucketName" : "bucket1",
  "name" : "factor_THREE/0",
  "dataSize" : 10240,
  "creationTime" : 1571908232929,
  "modificationTime" : 1571908234605,
  "replicationType" : "RATIS",
  "replicationFactor" : 3
}
{
  "volumeName" : "vol1",
  "bucketName" : "bucket1",
  "name" : "factor_default/0",
  "dataSize" : 10240,
  "creationTime" : 1571908225134,
  "modificationTime" : 1571908227372,
  "replicationType" : "RATIS",
  "replicationFactor" : 3
}
```