### PR TITLE
HDDS-2347. XCeiverClientGrpc's parallel use leads to NPE

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -146,8 +146,11 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     connectToDatanode(dn, encodedToken);
   }
 
-  private void connectToDatanode(DatanodeDetails dn, String encodedToken)
-      throws IOException {
+  private synchronized void connectToDatanode(DatanodeDetails dn,
+      String encodedToken) throws IOException {
+    if (isConnected(dn)){
+      return;
+    }
     // read port from the data node, on failure use default configured
     // port.
     int port = dn.getPort(DatanodeDetails.Port.Name.STANDALONE).getValue();
@@ -202,7 +205,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
   }
 
   @Override
-  public void close() {
+  public synchronized void close() {
     closed = true;
     for (ManagedChannel channel : channels.values()) {
       channel.shutdownNow();
@@ -368,19 +371,9 @@ public class XceiverClientGrpc extends XceiverClientSpi {
 
   private XceiverClientReply sendCommandAsync(
       ContainerCommandRequestProto request, DatanodeDetails dn)
-      throws IOException, ExecutionException, InterruptedException {
-    if (closed) {
-      throw new IOException("This channel is not connected.");
-    }
-
+      throws IOException, InterruptedException {
+    checkOpen(dn, request.getEncodedToken());
     UUID dnId = dn.getUuid();
-    ManagedChannel channel = channels.get(dnId);
-    // If the channel doesn't exist for this specific datanode or the channel
-    // is closed, just reconnect
-    String token = request.getEncodedToken();
-    if (!isConnected(channel)) {
-      reconnect(dn, token);
-    }
     if (LOG.isDebugEnabled()) {
       LOG.debug("Send command {} to datanode {}",
           request.getCmdType().toString(), dn.getNetworkFullPath());
@@ -425,6 +418,21 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     requestObserver.onNext(request);
     requestObserver.onCompleted();
     return new XceiverClientReply(replyFuture);
+  }
+
+  private synchronized void checkOpen(DatanodeDetails dn, String encodedToken)
+      throws IOException{
+    if (closed) {
+      throw new IOException("This channel is not connected.");
+    }
+
+    ManagedChannel channel = channels.get(dn.getUuid());
+    // If the channel doesn't exist for this specific datanode or the channel
+    // is closed, just reconnect
+    if (!isConnected(channel)) {
+      reconnect(dn, encodedToken);
+    }
+
   }
 
   private void reconnect(DatanodeDetails dn, String encodedToken)

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
@@ -235,7 +235,6 @@ public class XceiverClientManager implements Closeable {
             case RATIS:
               client = XceiverClientRatis.newXceiverClientRatis(pipeline, conf,
                   caCert);
-              client.connect();
               break;
             case STAND_ALONE:
               client = new XceiverClientGrpc(pipeline, conf, caCert);
@@ -244,6 +243,7 @@ public class XceiverClientManager implements Closeable {
             default:
               throw new IOException("not implemented" + pipeline.getType());
             }
+            client.connect();
             return client;
           }
         });


### PR DESCRIPTION
## What changes were proposed in this pull request?
We found this issue during Hive TPCDS tests, the basis of the problem is that Hive starts up an arbitrary number of threads to work on the same file, and reads the file from multiple threads.
In this case, the same XCeiverClientGrpc is called, and there are certain scenarios, where the current client is not synchronized properly. This PR is to add necessary synchronization around the closed internal boolean state, and around the channels and asyncstubs structures.
A fundamental change in behaviour is that the XCeiverClientGrpc instances are served after connecting to the first DN in a synchronized fashion in the XCeiverClientManager, then reconnect if needed is done after checking wether the DN is connected properly, and if not then reconnect in a synchronized block.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2347

## How was this patch tested?
As this issue comes out intermittently, and reproduction depends on how the JVM schedules the code of different threads, I was not able to write any reliable tests so far.
Manually the patch was tested on a 42 node cluster, with the 100 tpcds queries on a scale 2 and scale 3 large data set generated by the tools here: https://github.com/fapifta/hive-testbench
These tools are coming from https://github.com/hortonworks/hive-testbench with some modification to be able to use Ozone and HDFS as filesystems in parallel.

After applying the patch on the cluster with current trunk, I have not seen the NPE in 3 runs of the 99 TPCDS queries, before the patch I was able to see 2-5 queries failing with the given NPE per run.