### PR TITLE
HDDS-2360. Update Ratis snapshot to d6d58d0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>0.5.0-ced7dbf-SNAPSHOT</ratis.version>
+    <ratis.version>0.5.0-d6d58d0-SNAPSHOT</ratis.version>
 
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update Ratis dependency version to snapshot [d6d58d0](https://github.com/apache/incubator-ratis/commit/d6d58d0), to fix memory issues ([RATIS-726](https://issues.apache.org/jira/browse/RATIS-726), [RATIS-728](https://issues.apache.org/jira/browse/RATIS-728)).

Thanks @szetszwo and @bshashikant for the fixes, and @mukul1987 for creating the snapshot release.

https://issues.apache.org/jira/browse/HDDS-2360

## How was this patch tested?

Tested with Freon using 1MB and 16MB keys.