### PR TITLE
HDDS-2273. Avoid buffer copying in GrpcReplicationService

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcOutputStream.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcOutputStream.java
@@ -58,10 +58,10 @@ class GrpcOutputStream extends OutputStream {
   @Override
   public void write(int b) {
     try {
+      buffer.write(b);
       if (buffer.size() >= bufferSize) {
         flushBuffer(false);
       }
-      buffer.write(b);
     } catch (Exception ex) {
       responseObserver.onError(ex);
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcOutputStream.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcOutputStream.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.replication;
+
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CopyContainerResponseProto;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Adapter from {@code OutputStream} to gRPC {@code StreamObserver}.
+ * Data is buffered in a limited buffer of the specified size.
+ */
+class GrpcOutputStream extends OutputStream {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(GrpcOutputStream.class);
+
+  private final StreamObserver<CopyContainerResponseProto> responseObserver;
+
+  private final ByteString.Output buffer;
+
+  private final long containerId;
+
+  private final int bufferSize;
+
+  private int writtenBytes;
+
+  GrpcOutputStream(
+      StreamObserver<CopyContainerResponseProto> responseObserver,
+      long containerId, int bufferSize) {
+    this.responseObserver = responseObserver;
+    this.containerId = containerId;
+    this.bufferSize = bufferSize;
+    buffer = ByteString.newOutput(bufferSize);
+  }
+
+  @Override
+  public void write(int b) {
+    try {
+      if (buffer.size() >= bufferSize) {
+        flushBuffer(false);
+      }
+      buffer.write(b);
+    } catch (Exception ex) {
+      responseObserver.onError(ex);
+    }
+  }
+
+  @Override
+  public void write(@Nonnull byte[] data, int offset, int length) {
+    if ((offset < 0) || (offset > data.length) || (length < 0) ||
+        ((offset + length) > data.length) || ((offset + length) < 0)) {
+      throw new IndexOutOfBoundsException();
+    } else if (length == 0) {
+      return;
+    }
+
+    try {
+      if (buffer.size() >= bufferSize) {
+        flushBuffer(false);
+      }
+
+      int remaining = length;
+      int off = offset;
+      int len = Math.min(remaining, bufferSize - buffer.size());
+      while (remaining > 0) {
+        buffer.write(data, off, len);
+        if (buffer.size() >= bufferSize) {
+          flushBuffer(false);
+        }
+        off += len;
+        remaining -= len;
+        len = Math.min(bufferSize, remaining);
+      }
+    } catch (Exception ex) {
+      responseObserver.onError(ex);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    flushBuffer(true);
+    LOG.info("Sent {} bytes for container {}",
+        writtenBytes, containerId);
+    responseObserver.onCompleted();
+    buffer.close();
+  }
+
+  private void flushBuffer(boolean eof) {
+    int length = buffer.size();
+    if (length > 0) {
+      ByteString data = buffer.toByteString();
+      LOG.debug("Sending {} bytes (of type {}) for container {}",
+          length, data.getClass().getSimpleName(), containerId);
+      CopyContainerResponseProto response =
+          CopyContainerResponseProto.newBuilder()
+              .setContainerID(containerId)
+              .setData(data)
+              .setEof(eof)
+              .setReadOffset(writtenBytes)
+              .setLen(length)
+              .build();
+      responseObserver.onNext(response);
+      writtenBytes += length;
+      buffer.reset();
+    }
+  }
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcOutputStream.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcOutputStream.java
@@ -36,6 +36,7 @@ import java.util.Random;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -119,6 +120,19 @@ public class TestGrpcOutputStream {
     subject.close();
 
     verifyResponses(bytes);
+  }
+
+  @Test
+  public void bufferFlushedWhenFull() throws IOException {
+    byte[] bytes = getRandomBytes(bufferSize);
+
+    subject.write(bytes, 0, bufferSize-1);
+    subject.write(bytes[bufferSize-1]);
+    verify(observer).onNext(any());
+
+    subject.write(bytes[0]);
+    subject.write(bytes, 1, bufferSize-1);
+    verify(observer, times(2)).onNext(any());
   }
 
   @Test

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcOutputStream.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestGrpcOutputStream.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.replication;
+
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CopyContainerResponseProto;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@code GrpcOutputStream}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class TestGrpcOutputStream {
+
+  private static final Random RND = new Random();
+
+  private final long containerId = RND.nextLong();
+  private final int bufferSize = RND.nextInt(1024) + 128 + 1;
+
+  @Mock
+  private StreamObserver<CopyContainerResponseProto> observer;
+
+  private OutputStream subject;
+
+  @Before
+  public void setUp() throws Exception {
+    subject = new GrpcOutputStream(observer, containerId, bufferSize);
+  }
+
+  @Test
+  public void seriesOfBytesInSingleResponse() throws IOException {
+    byte[] bytes = getRandomBytes(5);
+    for (byte b : bytes) {
+      subject.write(b);
+    }
+    subject.close();
+
+    verifyResponses(bytes);
+  }
+
+  @Test
+  public void mixedBytesAndArraysInSingleResponse() throws IOException {
+    byte[] bytes = getRandomBytes(16);
+    subject.write(bytes[0]);
+    subject.write(bytes, 1, 14);
+    subject.write(bytes[15]);
+    subject.close();
+
+    verifyResponses(bytes);
+  }
+
+  @Test
+  public void mixedArraysAndBytesInSingleResponse() throws IOException {
+    byte[] bytes = getRandomBytes(10);
+
+    subject.write(bytes, 0, 5);
+    subject.write(bytes[5]);
+    subject.write(bytes, 6, 4);
+    subject.close();
+
+    verifyResponses(bytes);
+  }
+
+  @Test
+  public void seriesOfArraysInSingleResponse() throws IOException {
+    byte[] bytes = getRandomBytes(8);
+
+    subject.write(bytes, 0, 5);
+    subject.write(bytes, 5, 3);
+    subject.close();
+
+    verifyResponses(bytes);
+  }
+
+  @Test
+  public void seriesOfArraysExactlyFillBuffer() throws IOException {
+    int half = bufferSize / 2, otherHalf = bufferSize - half;
+    byte[] bytes = getRandomBytes(2 * bufferSize);
+
+    // fill buffer
+    subject.write(bytes, 0, half);
+    subject.write(bytes, half, otherHalf);
+    // fill buffer again
+    subject.write(bytes, bufferSize, half);
+    subject.write(bytes, bufferSize + half, otherHalf);
+    subject.close();
+
+    verifyResponses(bytes);
+  }
+
+  @Test
+  public void singleArraySpansMultipleResponses() throws IOException {
+    byte[] bytes = writeBytes(subject, 2 * bufferSize + bufferSize/2);
+    subject.close();
+
+    verifyResponses(bytes);
+  }
+
+  @Test
+  public void secondWriteSpillsToNextResponse() throws IOException {
+    byte[] bytes1 = writeBytes(subject, bufferSize / 2);
+    byte[] bytes2 = writeBytes(subject, 2 * bufferSize);
+    subject.close();
+
+    verifyResponses(concat(bytes1, bytes2));
+  }
+
+  private void verifyResponses(byte[] bytes) {
+    int expectedResponseCount = bytes.length / bufferSize;
+    if (bytes.length % bufferSize > 0) {
+      expectedResponseCount++;
+    }
+
+    ArgumentCaptor<CopyContainerResponseProto> captor =
+        ArgumentCaptor.forClass(CopyContainerResponseProto.class);
+    verify(observer, times(expectedResponseCount)).onNext(captor.capture());
+
+    List<CopyContainerResponseProto> responses =
+        new ArrayList<>(captor.getAllValues());
+    for (int i = 0; i < expectedResponseCount; i++) {
+      CopyContainerResponseProto response = responses.get(i);
+      assertEquals(containerId, response.getContainerID());
+
+      int expectedOffset = i * bufferSize;
+      assertEquals(expectedOffset, response.getReadOffset());
+
+      int size = Math.min(bufferSize, bytes.length - expectedOffset);
+      assertEquals(size, response.getLen());
+
+      byte[] part = new byte[size];
+      System.arraycopy(bytes, expectedOffset, part, 0, size);
+      ByteString data = response.getData();
+      assertArrayEquals(part, data.toByteArray());
+
+      // we don't want concatenated ByteStrings
+      assertEquals("LiteralByteString", data.getClass().getSimpleName());
+    }
+
+    verify(observer, times(1)).onCompleted();
+  }
+
+  private static byte[] concat(byte[]... parts) {
+    int length = Arrays.stream(parts).mapToInt(each -> each.length).sum();
+    byte[] bytes = new byte[length];
+    int pos = 0;
+    for (byte[] part : parts) {
+      System.arraycopy(part, 0, bytes, pos, part.length);
+      pos += part.length;
+    }
+    return bytes;
+  }
+
+  private static byte[] writeBytes(OutputStream subject, int size)
+      throws IOException {
+    byte[] bytes = getRandomBytes(size);
+    subject.write(bytes);
+    return bytes;
+  }
+
+  private static byte[] getRandomBytes(int size) {
+    byte[] bytes = new byte[size];
+    RND.nextBytes(bytes);
+    return bytes;
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use `ByteString.Output` stream instead of `ByteArrayOutputStream`.  Its initial size is configured to 1MB (same as previous buffer size), and is flushed when that size is reached.  This helps to avoid allocating multiple buffers as well as buffer copy when converting to `ByteString`.

https://issues.apache.org/jira/browse/HDDS-2273

## How was this patch tested?

Tested closed container replication manually with a 300MB container.  Verified that container is correctly replicated to other datanode.  Also verified that flush happens when buffer is full.

```
datanode_1  | - Streaming container data (1) to other datanode
datanode_1  | - Sending 1048576 bytes (of type LiteralByteString) for container 1
datanode_1  | - Sending 530637 bytes (of type LiteralByteString) for container 1
datanode_1  | - 1579213 bytes written to the rpc stream from container 1
...
datanode_5  | - Container is downloaded to /tmp/container-copy/container-1.tar.gz
datanode_5  | - Container 1 is downloaded, starting to import.
datanode_5  | - Container 1 is replicated successfully
datanode_5  | - Container 1 is replicated.
```