### PR TITLE
HDDS-2322. DoubleBuffer flush termination and OM shutdown's after that. Make entry returned from cache a new copy.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/OmKeyInfoCodec.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/OmKeyInfoCodec.java
@@ -52,7 +52,7 @@ public class OmKeyInfoCodec implements Codec<OmKeyInfo> {
 
   @Override
   public OmKeyInfo copyObject(OmKeyInfo omKeyInfo) {
-    return omKeyInfo;
+    return omKeyInfo.copyObject();
   }
 
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/OmMultipartKeyInfoCodec.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/OmMultipartKeyInfoCodec.java
@@ -59,6 +59,6 @@ public class OmMultipartKeyInfoCodec implements Codec<OmMultipartKeyInfo> {
 
   @Override
   public OmMultipartKeyInfo copyObject(OmMultipartKeyInfo object) {
-    return object;
+    return object.copyObject();
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/OmPrefixInfoCodec.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/codec/OmPrefixInfoCodec.java
@@ -53,6 +53,6 @@ public class OmPrefixInfoCodec implements Codec<OmPrefixInfo> {
 
   @Override
   public OmPrefixInfo copyObject(OmPrefixInfo object) {
-    return object;
+    return object.copyObject();
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -18,9 +18,10 @@
 package org.apache.hadoop.ozone.om.helpers;
 
 
+import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -221,15 +222,16 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
     OmBucketInfo.Builder builder = new OmBucketInfo.Builder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
-        .setAcls(acls.stream().map(acl -> new OzoneAcl(acl.getType(),
-            acl.getName(), acl.getAclBitSet(), acl.getAclScope()))
-            .collect(Collectors.toList()))
         .setStorageType(storageType)
         .setIsVersionEnabled(isVersionEnabled)
         .setCreationTime(creationTime)
         .setBucketEncryptionKey(bekInfo != null ?
             new BucketEncryptionKeyInfo(bekInfo.getVersion(),
                 bekInfo.getSuite(), bekInfo.getKeyName()) : null);
+
+    acls.stream().map(acl -> builder.addAcl(new OzoneAcl(acl.getType(),
+        acl.getName(), (BitSet) acl.getAclBitSet().clone(),
+        acl.getAclScope())));
 
     if (metadata != null) {
       metadata.forEach((k, v) -> builder.addMetadata(k, v));
@@ -253,7 +255,7 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
 
     public Builder() {
       //Default values
-      this.acls = new LinkedList<>();
+      this.acls = new ArrayList<>();
       this.isVersionEnabled = false;
       this.storageType = StorageType.DISK;
       this.metadata = new HashMap<>();
@@ -272,6 +274,13 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
     public Builder setAcls(List<OzoneAcl> listOfAcls) {
       if (listOfAcls != null) {
         this.acls.addAll(listOfAcls);
+      }
+      return this;
+    }
+
+    public Builder addAcl(OzoneAcl ozoneAcl) {
+      if (ozoneAcl != null) {
+        this.acls.add(ozoneAcl);
       }
       return this;
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -229,7 +229,7 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
             new BucketEncryptionKeyInfo(bekInfo.getVersion(),
                 bekInfo.getSuite(), bekInfo.getKeyName()) : null);
 
-    acls.stream().map(acl -> builder.addAcl(new OzoneAcl(acl.getType(),
+    acls.forEach(acl -> builder.addAcl(new OzoneAcl(acl.getType(),
         acl.getName(), (BitSet) acl.getAclBitSet().clone(),
         acl.getAclScope())));
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.helpers;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -288,7 +289,17 @@ public final class OmKeyInfo extends WithMetadata {
 
     public Builder setOmKeyLocationInfos(
         List<OmKeyLocationInfoGroup> omKeyLocationInfoList) {
-      this.omKeyLocationInfoGroups = omKeyLocationInfoList;
+      if (omKeyLocationInfoList != null) {
+        this.omKeyLocationInfoGroups.addAll(omKeyLocationInfoList);
+      }
+      return this;
+    }
+
+    public Builder addOmKeyLocationInfoGroup(OmKeyLocationInfoGroup
+        omKeyLocationInfoGroup) {
+      if (omKeyLocationInfoGroup != null) {
+        this.omKeyLocationInfoGroups.add(omKeyLocationInfoGroup);
+      }
       return this;
     }
 
@@ -335,6 +346,13 @@ public final class OmKeyInfo extends WithMetadata {
     public Builder setAcls(List<OzoneAcl> listOfAcls) {
       if (listOfAcls != null) {
         this.acls.addAll(listOfAcls);
+      }
+      return this;
+    }
+
+    public Builder addAcl(OzoneAcl ozoneAcl) {
+      if (ozoneAcl != null) {
+        this.acls.add(ozoneAcl);
       }
       return this;
     }
@@ -417,5 +435,38 @@ public final class OmKeyInfo extends WithMetadata {
   @Override
   public int hashCode() {
     return Objects.hash(volumeName, bucketName, keyName);
+  }
+
+  /**
+   * Return a new copy of the object.
+   */
+  public OmKeyInfo copyObject() {
+    OmKeyInfo.Builder builder = new OmKeyInfo.Builder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setCreationTime(creationTime)
+        .setModificationTime(modificationTime)
+        .setDataSize(dataSize)
+        .setReplicationType(type)
+        .setReplicationFactor(factor)
+        .setFileEncryptionInfo(encInfo);
+
+    keyLocationVersions.forEach(keyLocationVersion -> {
+      List<OmKeyLocationInfo> keyLocationInfos = new ArrayList<>();
+      keyLocationInfos.addAll(keyLocationVersion.getLocationList());
+      builder.addOmKeyLocationInfoGroup(new OmKeyLocationInfoGroup(
+          keyLocationVersion.getVersion(), keyLocationInfos));
+    });
+
+    acls.stream().map(acl -> builder.addAcl(new OzoneAcl(acl.getType(),
+            acl.getName(), (BitSet) acl.getAclBitSet().clone(),
+        acl.getAclScope())));
+
+    if (metadata != null) {
+      metadata.forEach((k, v) -> builder.addMetadata(k, v));
+    }
+
+    return builder.build();
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -459,7 +459,7 @@ public final class OmKeyInfo extends WithMetadata {
           keyLocationVersion.getVersion(), keyLocationInfos));
     });
 
-    acls.stream().map(acl -> builder.addAcl(new OzoneAcl(acl.getType(),
+    acls.forEach(acl -> builder.addAcl(new OzoneAcl(acl.getType(),
             acl.getName(), (BitSet) acl.getAclBitSet().clone(),
         acl.getAclScope())));
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartKeyInfo.java
@@ -126,4 +126,11 @@ public class OmMultipartKeyInfo {
     return uploadID.hashCode();
   }
 
+  public OmMultipartKeyInfo copyObject() {
+    // For partKeyInfoList we can do shallow copy here, as the PartKeyInfo is
+    // immutable here.
+    return new OmMultipartKeyInfo(uploadID, creationTime, replicationType,
+        replicationFactor, new TreeMap<>(partKeyInfoList));
+  }
+
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmPrefixInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmPrefixInfo.java
@@ -22,11 +22,13 @@ import com.google.common.base.Preconditions;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrefixInfo;
 
+import java.util.BitSet;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Wrapper class for Ozone prefix path info, currently mainly target for ACL but
@@ -178,6 +180,22 @@ public final class OmPrefixInfo extends WithMetadata {
   @Override
   public int hashCode() {
     return Objects.hash(name);
+  }
+
+  /**
+   * Return a new copy of the object.
+   */
+  public OmPrefixInfo copyObject() {
+    List<OzoneAcl> aclList = acls.stream().map(acl ->
+        new OzoneAcl(acl.getType(), acl.getName(),
+            (BitSet) acl.getAclBitSet().clone(), acl.getAclScope()))
+        .collect(Collectors.toList());
+
+    Map<String, String> metadataList = new HashMap<>();
+    if (metadata != null) {
+      metadata.forEach((k, v) -> metadataList.put(k, v));
+    }
+    return new OmPrefixInfo(name, aclList, metadataList);
   }
 }
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -17,12 +17,26 @@
  */
 package org.apache.hadoop.ozone.om.helpers;
 
+import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo.Builder;
 
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
+import org.apache.hadoop.util.Time;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 
 /**
  * Test OmKeyInfo.
@@ -48,5 +62,74 @@ public class TestOmKeyInfo {
         OmKeyInfo.getFromProtobuf(key.getProtobuf());
 
     Assert.assertEquals(key, keyAfterSerialization);
+  }
+
+  @Test
+  public void testCopyObject() {
+    OmKeyInfo key = new Builder()
+        .setKeyName("key1")
+        .setBucketName("bucket")
+        .setVolumeName("vol1")
+        .setCreationTime(Time.now())
+        .setModificationTime(Time.now())
+        .setDataSize(100L)
+        .setReplicationFactor(ReplicationFactor.THREE)
+        .setReplicationType(ReplicationType.RATIS)
+        .addMetadata("key1", "value1")
+        .addMetadata("key2", "value2")
+        .setOmKeyLocationInfos(
+            Collections.singletonList(createOmKeyLocationInfoGroup()))
+        .build();
+
+    OmKeyInfo cloneKey = key.copyObject();
+
+    // Because for OmKeyLocationInfoGroup we have not implemented equals()
+    // method, so it checks only references.
+    Assert.assertNotEquals(key, cloneKey);
+
+
+    key.setAcls(Arrays.asList(new OzoneAcl(
+        IAccessAuthorizer.ACLIdentityType.USER, "user1",
+        IAccessAuthorizer.ACLType.WRITE, ACCESS)));
+
+    // Change acls and check.
+    Assert.assertNotEquals(key, cloneKey);
+
+    Assert.assertNotEquals(key.getAcls(), cloneKey.getAcls());
+
+    // clone now again
+    cloneKey = key.copyObject();
+
+    Assert.assertEquals(key.getAcls(), cloneKey.getAcls());
+
+
+  }
+
+  private OmKeyLocationInfoGroup createOmKeyLocationInfoGroup() {
+    List<OmKeyLocationInfo> omKeyLocationInfos = new ArrayList<>();
+    omKeyLocationInfos.add(getOmKeyLocationInfo(new BlockID(100L, 101L),
+        getPipeline()));
+    omKeyLocationInfos.add(getOmKeyLocationInfo(new BlockID(101L, 100L),
+        getPipeline()));
+    return new OmKeyLocationInfoGroup(0, omKeyLocationInfos);
+
+  }
+
+  Pipeline getPipeline() {
+    return Pipeline.newBuilder()
+        .setFactor(HddsProtos.ReplicationFactor.ONE)
+        .setId(PipelineID.randomId())
+        .setNodes(Collections.EMPTY_LIST)
+        .setState(Pipeline.PipelineState.OPEN)
+        .setType(HddsProtos.ReplicationType.STAND_ALONE)
+        .build();
+  }
+
+  OmKeyLocationInfo getOmKeyLocationInfo(BlockID blockID,
+      Pipeline pipeline) {
+    return new OmKeyLocationInfo.Builder()
+        .setBlockID(blockID)
+        .setPipeline(pipeline)
+        .build();
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartKeyInfo.java
@@ -44,9 +44,18 @@ public class TestOmMultipartKeyInfo {
 
     Assert.assertEquals(cloneMultipartKeyInfo, omMultipartKeyInfo);
 
-    omMultipartKeyInfo.addPartKeyInfo(1, PartKeyInfo.newBuilder()
-            .setPartKeyInfo(KeyInfo.newBuilder().getDefaultInstanceForType())
-        .build());
+    // Just setting dummy values for this test.
+    omMultipartKeyInfo.addPartKeyInfo(1,
+        PartKeyInfo.newBuilder().setPartNumber(1).setPartName("/path")
+            .setPartKeyInfo(KeyInfo.newBuilder()
+        .setVolumeName(UUID.randomUUID().toString())
+        .setBucketName(UUID.randomUUID().toString())
+        .setKeyName(UUID.randomUUID().toString())
+        .setDataSize(100L) // Just set dummy size for testing
+        .setCreationTime(Time.now())
+        .setModificationTime(Time.now())
+        .setType(HddsProtos.ReplicationType.RATIS)
+        .setFactor(HddsProtos.ReplicationFactor.ONE).build()).build());
 
     Assert.assertEquals(0, cloneMultipartKeyInfo.getPartKeyInfoMap().size());
     Assert.assertEquals(1, omMultipartKeyInfo.getPartKeyInfoMap().size());

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartKeyInfo.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PartKeyInfo;
+import org.apache.hadoop.util.Time;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+/**
+ * Class to test OmMultipartKeyInfo.
+ */
+public class TestOmMultipartKeyInfo {
+
+  @Test
+  public void testCopyObject() {
+    OmMultipartKeyInfo omMultipartKeyInfo = new OmMultipartKeyInfo(
+        UUID.randomUUID().toString(), Time.now(),
+        HddsProtos.ReplicationType.RATIS, HddsProtos.ReplicationFactor.THREE,
+        new HashMap<>());
+
+    OmMultipartKeyInfo cloneMultipartKeyInfo = omMultipartKeyInfo.copyObject();
+
+    Assert.assertEquals(cloneMultipartKeyInfo, omMultipartKeyInfo);
+
+    omMultipartKeyInfo.addPartKeyInfo(1, PartKeyInfo.newBuilder()
+            .setPartKeyInfo(KeyInfo.newBuilder().getDefaultInstanceForType())
+        .build());
+
+    Assert.assertEquals(0, cloneMultipartKeyInfo.getPartKeyInfoMap().size());
+    Assert.assertEquals(1, omMultipartKeyInfo.getPartKeyInfoMap().size());
+
+  }
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmPrefixInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmPrefixInfo.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
+
+/**
+ * Class to test OmPrefixInfo.
+ */
+public class TestOmPrefixInfo {
+
+  @Test
+  public void testCopyObject() {
+    OmPrefixInfo omPrefixInfo = new OmPrefixInfo("/path",
+        Collections.singletonList(new OzoneAcl(
+        IAccessAuthorizer.ACLIdentityType.USER, "user1",
+        IAccessAuthorizer.ACLType.WRITE, ACCESS)), new HashMap<>());
+
+    OmPrefixInfo clonePrefixInfo = omPrefixInfo.copyObject();
+
+    Assert.assertEquals(omPrefixInfo, clonePrefixInfo);
+
+
+    // Change acls and check.
+    omPrefixInfo.addAcl(new OzoneAcl(
+        IAccessAuthorizer.ACLIdentityType.USER, "user1",
+        IAccessAuthorizer.ACLType.READ, ACCESS));
+
+    Assert.assertNotEquals(omPrefixInfo, clonePrefixInfo);
+
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Whenever value is returned from cache, it returns a copy object. So, that when doubleBuffer flushes, we don't see random ConcurrentModificationException errors like this.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2322

Please replace this section with the link to the Apache JIRA)

Ran freon tests with 100K Keys multiple times, now I am not seeing the error given in Jira description. Without this patch, we will see the error. (If you are not seeing error run multiple times in non-HA or just enable ozone.om.ratis.enable, and you will see the error in the first run)

## How was this patch tested?
**Command used for testing:**
ozone freon rk --numOfBuckets=1 --numOfVolumes=1 --numOfKeys=100000 --keySize=0
