### PR TITLE
HDDS-2361. Ozone Manager init & start command prints out unnecessary line in the beginning.

### DIFF
--- a/hadoop-ozone/common/src/main/shellprofile.d/hadoop-ozone-manager.sh
+++ b/hadoop-ozone/common/src/main/shellprofile.d/hadoop-ozone-manager.sh
@@ -19,7 +19,7 @@ if [[ "${HADOOP_SHELL_EXECNAME}" == ozone ]]; then
 fi
 
 _ozone_manager_hadoop_finalize() {
-  if [[ "${HADOOP_CLASSNAME}" == "org.apache.hadoop.ozone.om.OzoneManagerStarter" ]] &
+  if [[ "${HADOOP_CLASSNAME}" == "org.apache.hadoop.ozone.om.OzoneManagerStarter" ]] &&
      [[ -n ${OZONE_MANAGER_CLASSPATH} ]];
   then
        echo "Ozone Manager classpath extended by ${OZONE_MANAGER_CLASSPATH}"

--- a/hadoop-ozone/common/src/main/shellprofile.d/hadoop-ozone-manager.sh
+++ b/hadoop-ozone/common/src/main/shellprofile.d/hadoop-ozone-manager.sh
@@ -22,7 +22,7 @@ _ozone_manager_hadoop_finalize() {
   if [[ "${HADOOP_CLASSNAME}" == "org.apache.hadoop.ozone.om.OzoneManagerStarter" ]] &&
      [[ -n ${OZONE_MANAGER_CLASSPATH} ]];
   then
-       echo "Ozone Manager classpath extended by ${OZONE_MANAGER_CLASSPATH}"
-       hadoop_add_classpath "${OZONE_MANAGER_CLASSPATH}"
+    echo "Ozone Manager classpath extended by ${OZONE_MANAGER_CLASSPATH}"
+    hadoop_add_classpath "${OZONE_MANAGER_CLASSPATH}"
   fi
 }

--- a/hadoop-ozone/common/src/main/shellprofile.d/hadoop-ozone-manager.sh
+++ b/hadoop-ozone/common/src/main/shellprofile.d/hadoop-ozone-manager.sh
@@ -19,8 +19,10 @@ if [[ "${HADOOP_SHELL_EXECNAME}" == ozone ]]; then
 fi
 
 _ozone_manager_hadoop_finalize() {
-  if [[ "${HADOOP_CLASSNAME}" == "org.apache.hadoop.ozone.om.OzoneManagerStarter" ]]; then
-   echo "Ozone Manager classpath extended by ${OZONE_MANAGER_CLASSPATH}"
-   hadoop_add_classpath "${OZONE_MANAGER_CLASSPATH}"
+  if [[ "${HADOOP_CLASSNAME}" == "org.apache.hadoop.ozone.om.OzoneManagerStarter" ]] &
+     [[ -n ${OZONE_MANAGER_CLASSPATH} ]];
+  then
+       echo "Ozone Manager classpath extended by ${OZONE_MANAGER_CLASSPATH}"
+       hadoop_add_classpath "${OZONE_MANAGER_CLASSPATH}"
   fi
 }


### PR DESCRIPTION

## What changes were proposed in this pull request?

Modify the if-condition in ```hadoop-ozone-manager.sh```
 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2361


## How was this patch tested?

Ran the command in ```hadoop-ozone/```:
```mvn clean package -Pdist -Dtar -DskipTests```

And ran the commands after deployment
```ozone --daemon start om```
```ozone --daemon stop om```