### PR TITLE
HDDS-2345. Add a UT for newly added clone() in OmBucketInfo

### DIFF
--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
@@ -75,12 +75,16 @@ public class TestOmBucketInfo {
         IAccessAuthorizer.ACLType.WRITE_ACL,
         OzoneAcl.AclScope.ACCESS
     )));
-    Assert.assertNotEquals(omBucketInfo.getAcls().get(0), cloneBucketInfo.getAcls().get(0));
+    Assert.assertNotEquals(
+        omBucketInfo.getAcls().get(0),
+        cloneBucketInfo.getAcls().get(0));
 
     /* Clone acl & check equal. */
     cloneBucketInfo = omBucketInfo.copyObject();
     Assert.assertEquals(omBucketInfo, cloneBucketInfo);
-    Assert.assertEquals(omBucketInfo.getAcls().get(0), cloneBucketInfo.getAcls().get(0));
+    Assert.assertEquals(
+        omBucketInfo.getAcls().get(0),
+        cloneBucketInfo.getAcls().get(0));
 
     /* Remove acl & check. */
     omBucketInfo.removeAcl(new OzoneAcl(

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
@@ -19,9 +19,13 @@ package org.apache.hadoop.ozone.om.helpers;
 
 import org.apache.hadoop.hdds.protocol.StorageType;
 
+import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.junit.Assert;
 import org.junit.Test;
 import org.apache.hadoop.util.Time;
+
+import java.util.Collections;
 
 /**
  * Test BucketInfo.
@@ -52,11 +56,41 @@ public class TestOmBucketInfo {
         .setCreationTime(Time.now())
         .setIsVersionEnabled(false)
         .setStorageType(StorageType.ARCHIVE)
+        .setAcls(Collections.singletonList(new OzoneAcl(
+            IAccessAuthorizer.ACLIdentityType.USER,
+            "defaultUser",
+            IAccessAuthorizer.ACLType.WRITE_ACL,
+            OzoneAcl.AclScope.ACCESS
+        )))
         .build();
 
     /* Clone an omBucketInfo. */
     OmBucketInfo cloneBucketInfo = omBucketInfo.copyObject();
-
     Assert.assertEquals(omBucketInfo, cloneBucketInfo);
+
+    /* Reset acl & check not equal. */
+    omBucketInfo.setAcls(Collections.singletonList(new OzoneAcl(
+        IAccessAuthorizer.ACLIdentityType.USER,
+        "newUser",
+        IAccessAuthorizer.ACLType.WRITE_ACL,
+        OzoneAcl.AclScope.ACCESS
+    )));
+    Assert.assertNotEquals(omBucketInfo.getAcls().get(0), cloneBucketInfo.getAcls().get(0));
+
+    /* Clone acl & check equal. */
+    cloneBucketInfo = omBucketInfo.copyObject();
+    Assert.assertEquals(omBucketInfo, cloneBucketInfo);
+    Assert.assertEquals(omBucketInfo.getAcls().get(0), cloneBucketInfo.getAcls().get(0));
+
+    /* Remove acl & check. */
+    omBucketInfo.removeAcl(new OzoneAcl(
+        IAccessAuthorizer.ACLIdentityType.USER,
+        "newUser",
+        IAccessAuthorizer.ACLType.WRITE_ACL,
+        OzoneAcl.AclScope.ACCESS
+    ));
+    Assert.assertEquals((int) 0, omBucketInfo.getAcls().size());
+    Assert.assertEquals((int) 1, cloneBucketInfo.getAcls().size());
+
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmBucketInfo.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hdds.protocol.StorageType;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.apache.hadoop.util.Time;
 
 /**
  * Test BucketInfo.
@@ -41,6 +42,21 @@ public class TestOmBucketInfo {
         OmBucketInfo.getFromProtobuf(bucket.getProtobuf());
 
     Assert.assertEquals(bucket, afterSerialization);
+  }
 
+  @Test
+  public void testClone() {
+    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
+        .setBucketName("bucket")
+        .setVolumeName("vol1")
+        .setCreationTime(Time.now())
+        .setIsVersionEnabled(false)
+        .setStorageType(StorageType.ARCHIVE)
+        .build();
+
+    /* Clone an omBucketInfo. */
+    OmBucketInfo cloneBucketInfo = omBucketInfo.copyObject();
+
+    Assert.assertEquals(omBucketInfo, cloneBucketInfo);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add an UT in ```TestOmBucketInfo.java``` for testing ```copyObject()```

Ref to ```TestOmVolumeArgs#testClone```, 
but we don't test acl related,
cause the ```copyObject()``` in ```OmBucketInfo.java``` don't clone acl.
 
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2345

## How was this patch tested?
Ran the command in ```hadoop-ozone/```:
```mvn -Dtest=org.apache.hadoop.ozone.om.helpers.TestOmBucketInfo test```