### PR TITLE
HDDS-2373 Move isUseRatis getFactor and getType from XCeiverClientManager

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
@@ -71,7 +71,6 @@ public class XceiverClientManager implements Closeable {
   //TODO : change this to SCM configuration class
   private final Configuration conf;
   private final Cache<String, XceiverClientSpi> clientCache;
-  private final boolean useRatis;
   private X509Certificate caCert;
 
   private static XceiverClientMetrics metrics;
@@ -94,9 +93,6 @@ public class XceiverClientManager implements Closeable {
     Preconditions.checkNotNull(clientConf);
     Preconditions.checkNotNull(conf);
     long staleThresholdMs = clientConf.getStaleThreshold(MILLISECONDS);
-    this.useRatis = conf.getBoolean(
-        ScmConfigKeys.DFS_CONTAINER_RATIS_ENABLED_KEY,
-        ScmConfigKeys.DFS_CONTAINER_RATIS_ENABLED_DEFAULT);
     this.conf = conf;
     this.isSecurityEnabled = OzoneSecurityUtil.isSecurityEnabled(conf);
     if (isSecurityEnabled) {
@@ -278,38 +274,6 @@ public class XceiverClientManager implements Closeable {
     if (metrics != null) {
       metrics.unRegister();
     }
-  }
-
-  /**
-   * Tells us if Ratis is enabled for this cluster.
-   * @return True if Ratis is enabled.
-   */
-  public boolean isUseRatis() {
-    return useRatis;
-  }
-
-  /**
-   * Returns hard coded 3 as replication factor.
-   * @return 3
-   */
-  public  HddsProtos.ReplicationFactor getFactor() {
-    if(isUseRatis()) {
-      return HddsProtos.ReplicationFactor.THREE;
-    }
-    return HddsProtos.ReplicationFactor.ONE;
-  }
-
-  /**
-   * Returns the default replication type.
-   * @return Ratis or Standalone
-   */
-  public HddsProtos.ReplicationType getType() {
-    // TODO : Fix me and make Ratis default before release.
-    // TODO: Remove this as replication factor and type are pipeline properties
-    if(isUseRatis()) {
-      return HddsProtos.ReplicationType.RATIS;
-    }
-    return HddsProtos.ReplicationType.STAND_ALONE;
   }
 
   public Function<ByteBuffer, ByteString> byteBufferToByteStringConversion(){

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/ContainerOperationClient.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/ContainerOperationClient.java
@@ -93,20 +93,20 @@ public class ContainerOperationClient implements ScmClient {
 
   private XceiverClientManager newXCeiverClientManager(Configuration conf)
       throws IOException {
-    XceiverClientManager xceiverClientManager;
+    XceiverClientManager manager;
     if (OzoneSecurityUtil.isSecurityEnabled(conf)) {
       SecurityConfig securityConfig = new SecurityConfig(conf);
       SCMSecurityProtocol scmSecurityProtocolClient = getScmSecurityClient(
           (OzoneConfiguration) securityConfig.getConfiguration());
       String caCertificate =
           scmSecurityProtocolClient.getCACertificate();
-      xceiverClientManager = new XceiverClientManager(conf,
+      manager = new XceiverClientManager(conf,
           OzoneConfiguration.of(conf).getObject(XceiverClientManager
               .ScmClientConfig.class), caCertificate);
     } else {
-      xceiverClientManager = new XceiverClientManager(conf);
+      manager = new XceiverClientManager(conf);
     }
-    return xceiverClientManager;
+    return manager;
   }
 
   private StorageContainerLocationProtocol newContainerRpcClient(

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/ContainerOperationClient.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/ContainerOperationClient.java
@@ -18,12 +18,19 @@
 package org.apache.hadoop.hdds.scm.client;
 
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.StorageUnit;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
+import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
+import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolPB;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
     .ContainerDataProto;
@@ -32,11 +39,26 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerLocationProtocolProtos.ObjectStageChangeRequestProto;
+import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.hdds.tracing.TracingUtil;
+import org.apache.hadoop.ipc.Client;
+import org.apache.hadoop.ipc.ProtobufRpcEngine;
+import org.apache.hadoop.ipc.RPC;
+import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.ozone.OzoneSecurityUtil;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.SocketFactory;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.List;
+
+import static org.apache.hadoop.hdds.HddsUtils.getScmAddressForClients;
+import static org.apache.hadoop.hdds.HddsUtils.getScmSecurityClient;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT;
 
 /**
  * This class provides the client-facing APIs of container operations.
@@ -45,37 +67,70 @@ public class ContainerOperationClient implements ScmClient {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(ContainerOperationClient.class);
-  private static long containerSizeB = -1;
+  private final long containerSizeB;
+  private final HddsProtos.ReplicationFactor replicationFactor;
+  private final HddsProtos.ReplicationType replicationType;
   private final StorageContainerLocationProtocol
       storageContainerLocationClient;
   private final XceiverClientManager xceiverClientManager;
 
-  public ContainerOperationClient(
-      StorageContainerLocationProtocol
-          storageContainerLocationClient,
-      XceiverClientManager xceiverClientManager) {
-    this.storageContainerLocationClient = storageContainerLocationClient;
-    this.xceiverClientManager = xceiverClientManager;
+  public ContainerOperationClient(Configuration conf) throws IOException {
+    storageContainerLocationClient = newContainerRpcClient(conf);
+    xceiverClientManager = newXCeiverClientManager(conf);
+    containerSizeB = (int) conf.getStorageSize(OZONE_SCM_CONTAINER_SIZE,
+        OZONE_SCM_CONTAINER_SIZE_DEFAULT, StorageUnit.BYTES);
+    boolean useRatis = conf.getBoolean(
+        ScmConfigKeys.DFS_CONTAINER_RATIS_ENABLED_KEY,
+        ScmConfigKeys.DFS_CONTAINER_RATIS_ENABLED_DEFAULT);
+    if (useRatis) {
+      replicationFactor = HddsProtos.ReplicationFactor.THREE;
+      replicationType = HddsProtos.ReplicationType.RATIS;
+    } else {
+      replicationFactor = HddsProtos.ReplicationFactor.ONE;
+      replicationType = HddsProtos.ReplicationType.STAND_ALONE;
+    }
   }
 
-  /**
-   * Return the capacity of containers. The current assumption is that all
-   * containers have the same capacity. Therefore one static is sufficient for
-   * any container.
-   * @return The capacity of one container in number of bytes.
-   */
-  public static long getContainerSizeB() {
-    return containerSizeB;
+  private XceiverClientManager newXCeiverClientManager(Configuration conf)
+      throws IOException {
+    XceiverClientManager xceiverClientManager;
+    if (OzoneSecurityUtil.isSecurityEnabled(conf)) {
+      SecurityConfig securityConfig = new SecurityConfig(conf);
+      SCMSecurityProtocol scmSecurityProtocolClient = getScmSecurityClient(
+          (OzoneConfiguration) securityConfig.getConfiguration());
+      String caCertificate =
+          scmSecurityProtocolClient.getCACertificate();
+      xceiverClientManager = new XceiverClientManager(conf,
+          OzoneConfiguration.of(conf).getObject(XceiverClientManager
+              .ScmClientConfig.class), caCertificate);
+    } else {
+      xceiverClientManager = new XceiverClientManager(conf);
+    }
+    return xceiverClientManager;
   }
 
-  /**
-   * Set the capacity of container. Should be exactly once on system start.
-   * @param size Capacity of one container in number of bytes.
-   */
-  public static void setContainerSizeB(long size) {
-    containerSizeB = size;
-  }
+  private StorageContainerLocationProtocol newContainerRpcClient(
+      Configuration conf) throws IOException {
 
+    Class<StorageContainerLocationProtocolPB> protocol =
+        StorageContainerLocationProtocolPB.class;
+
+    RPC.setProtocolEngine(conf, protocol, ProtobufRpcEngine.class);
+    long version = RPC.getProtocolVersion(protocol);
+    InetSocketAddress scmAddress = getScmAddressForClients(conf);
+    UserGroupInformation user = UserGroupInformation.getCurrentUser();
+    SocketFactory socketFactory = NetUtils.getDefaultSocketFactory(conf);
+    int rpcTimeOut = Client.getRpcTimeout(conf);
+
+    StorageContainerLocationProtocolPB rpcProxy =
+        RPC.getProxy(protocol, version, scmAddress, user, conf,
+            socketFactory, rpcTimeOut);
+
+    StorageContainerLocationProtocolClientSideTranslatorPB client =
+        new StorageContainerLocationProtocolClientSideTranslatorPB(rpcProxy);
+    return TracingUtil.createProxy(
+        client, StorageContainerLocationProtocol.class, conf);
+  }
 
   @Override
   public ContainerWithPipeline createContainer(String owner)
@@ -83,9 +138,9 @@ public class ContainerOperationClient implements ScmClient {
     XceiverClientSpi client = null;
     try {
       ContainerWithPipeline containerWithPipeline =
-          storageContainerLocationClient.allocateContainer(
-              xceiverClientManager.getType(),
-              xceiverClientManager.getFactor(), owner);
+          storageContainerLocationClient.
+              allocateContainer(replicationType, replicationFactor, owner);
+
       Pipeline pipeline = containerWithPipeline.getPipeline();
       client = xceiverClientManager.acquireClient(pipeline);
 
@@ -449,11 +504,7 @@ public class ContainerOperationClient implements ScmClient {
   public long getContainerSize(long containerID) throws IOException {
     // TODO : Fix this, it currently returns the capacity
     // but not the current usage.
-    long size = getContainerSizeB();
-    if (size == -1) {
-      throw new IOException("Container size unknown!");
-    }
-    return size;
+    return containerSizeB;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/SCMTestUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/SCMTestUtils.java
@@ -24,7 +24,9 @@ import java.net.ServerSocket;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageContainerDatanodeProtocolService;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
@@ -123,6 +125,26 @@ public final class SCMTestUtils {
 
   public static OzoneConfiguration getOzoneConf() {
     return new OzoneConfiguration();
+  }
+
+  public static HddsProtos.ReplicationType getReplicationType(
+      Configuration conf) {
+    return isUseRatis(conf) ?
+        HddsProtos.ReplicationType.RATIS :
+        HddsProtos.ReplicationType.STAND_ALONE;
+  }
+
+  public static HddsProtos.ReplicationFactor getReplicationFactor(
+      Configuration conf) {
+    return isUseRatis(conf) ?
+        HddsProtos.ReplicationFactor.THREE :
+        HddsProtos.ReplicationFactor.ONE;
+  }
+
+  private static boolean isUseRatis(Configuration c) {
+    return c.getBoolean(
+        ScmConfigKeys.DFS_CONTAINER_RATIS_ENABLED_KEY,
+        ScmConfigKeys.DFS_CONTAINER_RATIS_ENABLED_DEFAULT);
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestSCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestSCMContainerManager.java
@@ -71,6 +71,8 @@ public class TestSCMContainerManager {
   private static XceiverClientManager xceiverClientManager;
   private static String containerOwner = "OZONE";
   private static Random random;
+  private static HddsProtos.ReplicationFactor replicationFactor;
+  private static HddsProtos.ReplicationType replicationType;
 
   private static final long TIMEOUT = 10000;
 
@@ -98,6 +100,8 @@ public class TestSCMContainerManager {
     containerManager = new SCMContainerManager(conf, nodeManager,
         pipelineManager, new EventQueue());
     xceiverClientManager = new XceiverClientManager(conf);
+    replicationFactor = SCMTestUtils.getReplicationFactor(conf);
+    replicationType = SCMTestUtils.getReplicationType(conf);
     random = new Random();
   }
 
@@ -120,9 +124,7 @@ public class TestSCMContainerManager {
   @Test
   public void testallocateContainer() throws Exception {
     ContainerInfo containerInfo = containerManager.allocateContainer(
-        xceiverClientManager.getType(),
-        xceiverClientManager.getFactor(),
-        containerOwner);
+        replicationType, replicationFactor, containerOwner);
     Assert.assertNotNull(containerInfo);
   }
 
@@ -137,9 +139,7 @@ public class TestSCMContainerManager {
     Set<UUID> pipelineList = new TreeSet<>();
     for (int x = 0; x < 30; x++) {
       ContainerInfo containerInfo = containerManager.allocateContainer(
-          xceiverClientManager.getType(),
-          xceiverClientManager.getFactor(),
-          containerOwner);
+          replicationType, replicationFactor, containerOwner);
 
       Assert.assertNotNull(containerInfo);
       Assert.assertNotNull(containerInfo.getPipelineID());
@@ -164,8 +164,8 @@ public class TestSCMContainerManager {
       CompletableFuture.supplyAsync(() -> {
         try {
           ContainerInfo containerInfo = containerManager
-              .allocateContainer(xceiverClientManager.getType(),
-                  xceiverClientManager.getFactor(), containerOwner);
+              .allocateContainer(replicationType, replicationFactor,
+                  containerOwner);
 
           Assert.assertNotNull(containerInfo);
           Assert.assertNotNull(containerInfo.getPipelineID());
@@ -190,9 +190,7 @@ public class TestSCMContainerManager {
   @Test
   public void testGetContainer() throws IOException {
     ContainerInfo containerInfo = containerManager.allocateContainer(
-        xceiverClientManager.getType(),
-        xceiverClientManager.getFactor(),
-        containerOwner);
+        replicationType, replicationFactor, containerOwner);
     Assert.assertNotNull(containerInfo);
     Pipeline pipeline  = pipelineManager
         .getPipeline(containerInfo.getPipelineID());
@@ -204,8 +202,8 @@ public class TestSCMContainerManager {
   @Test
   public void testGetContainerWithPipeline() throws Exception {
     ContainerInfo contInfo = containerManager
-        .allocateContainer(xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+        .allocateContainer(replicationType, replicationFactor,
+            containerOwner);
     // Add dummy replicas for container.
     Iterator<DatanodeDetails> nodes = pipelineManager
         .getPipeline(contInfo.getPipelineID()).getNodes().iterator();
@@ -311,8 +309,7 @@ public class TestSCMContainerManager {
       throws IOException {
     nodeManager.setSafemode(false);
     return containerManager
-        .allocateContainer(xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+        .allocateContainer(replicationType, replicationFactor, containerOwner);
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestContainerPlacement.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestContainerPlacement.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hdds.scm.pipeline.SCMPipelineManager;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.test.PathUtils;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -158,13 +159,13 @@ public class TestContainerPlacement {
       assertEquals(remaining * nodeCount,
           (long) nodeManager.getStats().getRemaining().get());
 
-      xceiverClientManager= new XceiverClientManager(new OzoneConfiguration());
+      xceiverClientManager= new XceiverClientManager(conf);
 
       ContainerInfo container = containerManager
           .allocateContainer(
-          xceiverClientManager.getType(),
-          xceiverClientManager.getFactor(), "OZONE");
-      assertEquals(xceiverClientManager.getFactor().getNumber(),
+              SCMTestUtils.getReplicationType(conf),
+              SCMTestUtils.getReplicationFactor(conf), "OZONE");
+      assertEquals(SCMTestUtils.getReplicationFactor(conf).getNumber(),
           containerManager.getContainerReplicas(
               container.containerID()).size());
     } finally {

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SCMCLI.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SCMCLI.java
@@ -17,45 +17,25 @@
  */
 package org.apache.hadoop.hdds.scm.cli;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.
+    OZONE_SCM_CLIENT_ADDRESS_KEY;
 
-import org.apache.hadoop.conf.StorageUnit;
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
-import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.cli.container.ContainerCommands;
 import org.apache.hadoop.hdds.scm.cli.pipeline.PipelineCommands;
 import org.apache.hadoop.hdds.scm.client.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
-import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
-import org.apache.hadoop.hdds.scm.protocolPB
-    .StorageContainerLocationProtocolClientSideTranslatorPB;
-import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolPB;
-import org.apache.hadoop.hdds.security.x509.SecurityConfig;
-import org.apache.hadoop.hdds.tracing.TracingUtil;
-import org.apache.hadoop.ipc.Client;
-import org.apache.hadoop.ipc.ProtobufRpcEngine;
-import org.apache.hadoop.ipc.RPC;
-import org.apache.hadoop.net.NetUtils;
-import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.hadoop.ozone.OzoneSecurityUtil;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.NativeCodeLoader;
 
 import org.apache.commons.lang3.StringUtils;
-import static org.apache.hadoop.hdds.HddsUtils.getScmAddressForClients;
-import static org.apache.hadoop.hdds.HddsUtils.getScmSecurityClient;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys
-    .OZONE_SCM_CLIENT_ADDRESS_KEY;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys
-    .OZONE_SCM_CONTAINER_SIZE_DEFAULT;
 import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
@@ -107,55 +87,12 @@ public class SCMCLI extends GenericCli {
 
   public ScmClient createScmClient()
       throws IOException {
-
     OzoneConfiguration ozoneConf = createOzoneConfiguration();
-    if (StringUtils.isNotEmpty(scm)) {
-      ozoneConf.set(OZONE_SCM_CLIENT_ADDRESS_KEY, scm);
-    }
-    if (!HddsUtils.getHostNameFromConfigKeys(ozoneConf,
-        ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY).isPresent()) {
-
-      throw new IllegalArgumentException(
-          ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY
-              + " should be set in ozone-site.xml or with the --scm option");
-    }
-
-    long version = RPC.getProtocolVersion(
-        StorageContainerLocationProtocolPB.class);
-    InetSocketAddress scmAddress =
-        getScmAddressForClients(ozoneConf);
-    int containerSizeGB = (int) ozoneConf.getStorageSize(
-        OZONE_SCM_CONTAINER_SIZE, OZONE_SCM_CONTAINER_SIZE_DEFAULT,
-        StorageUnit.GB);
-    ContainerOperationClient
-        .setContainerSizeB(containerSizeGB * OzoneConsts.GB);
-
-    RPC.setProtocolEngine(ozoneConf, StorageContainerLocationProtocolPB.class,
-        ProtobufRpcEngine.class);
-    StorageContainerLocationProtocol client =
-        TracingUtil.createProxy(
-        new StorageContainerLocationProtocolClientSideTranslatorPB(
-            RPC.getProxy(StorageContainerLocationProtocolPB.class, version,
-                scmAddress, UserGroupInformation.getCurrentUser(), ozoneConf,
-                NetUtils.getDefaultSocketFactory(ozoneConf),
-                Client.getRpcTimeout(ozoneConf))),
-            StorageContainerLocationProtocol.class, ozoneConf);
-
-    XceiverClientManager xceiverClientManager = null;
-    if (OzoneSecurityUtil.isSecurityEnabled(ozoneConf)) {
-      SecurityConfig securityConfig = new SecurityConfig(ozoneConf);
-      SCMSecurityProtocol scmSecurityProtocolClient = getScmSecurityClient(
-          (OzoneConfiguration) securityConfig.getConfiguration());
-      String caCertificate =
-          scmSecurityProtocolClient.getCACertificate();
-      xceiverClientManager = new XceiverClientManager(ozoneConf,
-          OzoneConfiguration.of(ozoneConf).getObject(XceiverClientManager
-              .ScmClientConfig.class), caCertificate);
-    } else {
-      xceiverClientManager = new XceiverClientManager(ozoneConf);
-    }
-    return new ContainerOperationClient(client, xceiverClientManager);
+    checkAndSetSCMAddressArg(ozoneConf);
+    return new ContainerOperationClient(ozoneConf);
   }
+
+
 
   public void checkContainerExists(ScmClient scmClient, long containerId)
       throws IOException {
@@ -165,4 +102,16 @@ public class SCMCLI extends GenericCli {
     }
   }
 
+  private void checkAndSetSCMAddressArg(Configuration conf) {
+    if (StringUtils.isNotEmpty(scm)) {
+      conf.set(OZONE_SCM_CLIENT_ADDRESS_KEY, scm);
+    }
+    if (!HddsUtils.getHostNameFromConfigKeys(conf,
+        ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY).isPresent()) {
+
+      throw new IllegalArgumentException(
+          ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY
+              + " should be set in ozone-site.xml or with the --scm option");
+    }
+  }
 }

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/BaseInsightPoint.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/BaseInsightPoint.java
@@ -18,36 +18,20 @@
 package org.apache.hadoop.ozone.insight;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
-import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.client.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
-import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
-import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
-import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolPB;
 import org.apache.hadoop.hdds.server.PrometheusMetricsSink;
-import org.apache.hadoop.hdds.tracing.TracingUtil;
-import org.apache.hadoop.ipc.Client;
-import org.apache.hadoop.ipc.ProtobufRpcEngine;
-import org.apache.hadoop.ipc.RPC;
-import org.apache.hadoop.net.NetUtils;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.insight.LoggerSource.Level;
-import org.apache.hadoop.security.UserGroupInformation;
 
 import com.google.protobuf.ProtocolMessageEnum;
-import static org.apache.hadoop.hdds.HddsUtils.getScmAddressForClients;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT;
 
 /**
  * Default implementation of Insight point logic.

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/BaseInsightPoint.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/BaseInsightPoint.java
@@ -86,7 +86,6 @@ public abstract class BaseInsightPoint implements InsightPoint {
    */
   public ScmClient createScmClient(OzoneConfiguration ozoneConf)
       throws IOException {
-
     if (!HddsUtils.getHostNameFromConfigKeys(ozoneConf,
         ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY).isPresent()) {
 
@@ -95,29 +94,7 @@ public abstract class BaseInsightPoint implements InsightPoint {
               + " should be set in ozone-site.xml");
     }
 
-    long version = RPC.getProtocolVersion(
-        StorageContainerLocationProtocolPB.class);
-    InetSocketAddress scmAddress =
-        getScmAddressForClients(ozoneConf);
-    int containerSizeGB = (int) ozoneConf.getStorageSize(
-        OZONE_SCM_CONTAINER_SIZE, OZONE_SCM_CONTAINER_SIZE_DEFAULT,
-        StorageUnit.GB);
-    ContainerOperationClient
-        .setContainerSizeB(containerSizeGB * OzoneConsts.GB);
-
-    RPC.setProtocolEngine(ozoneConf, StorageContainerLocationProtocolPB.class,
-        ProtobufRpcEngine.class);
-    StorageContainerLocationProtocol client =
-        TracingUtil.createProxy(
-            new StorageContainerLocationProtocolClientSideTranslatorPB(
-                RPC.getProxy(StorageContainerLocationProtocolPB.class, version,
-                    scmAddress, UserGroupInformation.getCurrentUser(),
-                    ozoneConf,
-                    NetUtils.getDefaultSocketFactory(ozoneConf),
-                    Client.getRpcTimeout(ozoneConf))),
-            StorageContainerLocationProtocol.class, ozoneConf);
-    return new ContainerOperationClient(
-        client, new XceiverClientManager(ozoneConf));
+    return new ContainerOperationClient(ozoneConf);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
+import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.junit.After;
 import org.junit.Assert;
@@ -94,28 +95,29 @@ public class TestContainerStateManagerIntegration {
   public void testAllocateContainer() throws IOException {
     // Allocate a container and verify the container info
     ContainerWithPipeline container1 = scm.getClientProtocolServer()
-        .allocateContainer(xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+        .allocateContainer(SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf), containerOwner);
     ContainerInfo info = containerManager
         .getMatchingContainer(OzoneConsts.GB * 3, containerOwner,
             container1.getPipeline());
     Assert.assertNotEquals(container1.getContainerInfo().getContainerID(),
         info.getContainerID());
     Assert.assertEquals(containerOwner, info.getOwner());
-    Assert.assertEquals(xceiverClientManager.getType(),
+    Assert.assertEquals(SCMTestUtils.getReplicationType(conf),
         info.getReplicationType());
-    Assert.assertEquals(xceiverClientManager.getFactor(),
+    Assert.assertEquals(SCMTestUtils.getReplicationFactor(conf),
         info.getReplicationFactor());
     Assert.assertEquals(HddsProtos.LifeCycleState.OPEN, info.getState());
 
     // Check there are two containers in ALLOCATED state after allocation
     ContainerWithPipeline container2 = scm.getClientProtocolServer()
         .allocateContainer(
-            xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+            SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf), containerOwner);
     int numContainers = containerStateManager
         .getMatchingContainerIDs(containerOwner,
-            xceiverClientManager.getType(), xceiverClientManager.getFactor(),
+            SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf),
             HddsProtos.LifeCycleState.OPEN).size();
     Assert.assertNotEquals(container1.getContainerInfo().getContainerID(),
         container2.getContainerInfo().getContainerID());
@@ -127,8 +129,8 @@ public class TestContainerStateManagerIntegration {
 
     // Allocate a container and verify the container info
     ContainerWithPipeline container1 = scm.getClientProtocolServer()
-        .allocateContainer(xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+        .allocateContainer(SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf), containerOwner);
     ContainerInfo info = containerManager
         .getMatchingContainer(OzoneConsts.GB * 3, containerOwner,
             container1.getPipeline());
@@ -136,8 +138,8 @@ public class TestContainerStateManagerIntegration {
 
     String newContainerOwner = "OZONE_NEW";
     ContainerWithPipeline container2 = scm.getClientProtocolServer()
-        .allocateContainer(xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), newContainerOwner);
+        .allocateContainer(SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf), newContainerOwner);
     ContainerInfo info2 = containerManager
         .getMatchingContainer(OzoneConsts.GB * 3, newContainerOwner,
             container1.getPipeline());
@@ -155,8 +157,8 @@ public class TestContainerStateManagerIntegration {
 
       ContainerWithPipeline container = scm.getClientProtocolServer()
           .allocateContainer(
-              xceiverClientManager.getType(),
-              xceiverClientManager.getFactor(), containerOwner);
+              SCMTestUtils.getReplicationType(conf),
+              SCMTestUtils.getReplicationFactor(conf), containerOwner);
       if (i >= 5) {
         scm.getContainerManager().updateContainerState(container
                 .getContainerInfo().containerID(),
@@ -173,9 +175,10 @@ public class TestContainerStateManagerIntegration {
         .filter(info ->
             info.getOwner().equals(containerOwner))
         .filter(info ->
-            info.getReplicationType() == xceiverClientManager.getType())
+            info.getReplicationType() == SCMTestUtils.getReplicationType(conf))
         .filter(info ->
-            info.getReplicationFactor() == xceiverClientManager.getFactor())
+            info.getReplicationFactor() ==
+                SCMTestUtils.getReplicationFactor(conf))
         .filter(info ->
             info.getState() == HddsProtos.LifeCycleState.OPEN)
         .count();
@@ -184,9 +187,10 @@ public class TestContainerStateManagerIntegration {
         .filter(info ->
             info.getOwner().equals(containerOwner))
         .filter(info ->
-            info.getReplicationType() == xceiverClientManager.getType())
+            info.getReplicationType() == SCMTestUtils.getReplicationType(conf))
         .filter(info ->
-            info.getReplicationFactor() == xceiverClientManager.getFactor())
+            info.getReplicationFactor() ==
+                SCMTestUtils.getReplicationFactor(conf))
         .filter(info ->
             info.getState() == HddsProtos.LifeCycleState.CLOSING)
         .count();
@@ -197,8 +201,8 @@ public class TestContainerStateManagerIntegration {
   public void testGetMatchingContainer() throws IOException {
     long cid;
     ContainerWithPipeline container1 = scm.getClientProtocolServer().
-        allocateContainer(xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+        allocateContainer(SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf), containerOwner);
     cid = container1.getContainerInfo().getContainerID();
 
     // each getMatchingContainer call allocates a container in the
@@ -225,8 +229,8 @@ public class TestContainerStateManagerIntegration {
   public void testGetMatchingContainerWithExcludedList() throws IOException {
     long cid;
     ContainerWithPipeline container1 = scm.getClientProtocolServer().
-        allocateContainer(xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+        allocateContainer(SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf), containerOwner);
     cid = container1.getContainerInfo().getContainerID();
 
     // each getMatchingContainer call allocates a container in the
@@ -255,8 +259,8 @@ public class TestContainerStateManagerIntegration {
   public void testCreateContainerLogicWithExcludedList() throws IOException {
     long cid;
     ContainerWithPipeline container1 = scm.getClientProtocolServer().
-        allocateContainer(xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+        allocateContainer(SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf), containerOwner);
     cid = container1.getContainerInfo().getContainerID();
 
     for (int i = 1; i < numContainerPerOwnerInPipeline; i++) {
@@ -279,8 +283,8 @@ public class TestContainerStateManagerIntegration {
   public void testGetMatchingContainerMultipleThreads()
       throws IOException, InterruptedException {
     ContainerWithPipeline container1 = scm.getClientProtocolServer().
-        allocateContainer(xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+        allocateContainer(SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf), containerOwner);
     Map<Long, Long> container2MatchedCount = new ConcurrentHashMap<>();
 
     // allocate blocks using multiple threads
@@ -320,7 +324,8 @@ public class TestContainerStateManagerIntegration {
   public void testUpdateContainerState() throws IOException {
     NavigableSet<ContainerID> containerList = containerStateManager
         .getMatchingContainerIDs(containerOwner,
-            xceiverClientManager.getType(), xceiverClientManager.getFactor(),
+            SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf),
             HddsProtos.LifeCycleState.OPEN);
     int containers = containerList == null ? 0 : containerList.size();
     Assert.assertEquals(0, containers);
@@ -329,10 +334,11 @@ public class TestContainerStateManagerIntegration {
     // OPEN -> CLOSING -> CLOSED -> DELETING -> DELETED
     ContainerWithPipeline container1 = scm.getClientProtocolServer()
         .allocateContainer(
-            xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+            SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf), containerOwner);
     containers = containerStateManager.getMatchingContainerIDs(containerOwner,
-        xceiverClientManager.getType(), xceiverClientManager.getFactor(),
+        SCMTestUtils.getReplicationType(conf),
+        SCMTestUtils.getReplicationFactor(conf),
         HddsProtos.LifeCycleState.OPEN).size();
     Assert.assertEquals(1, containers);
 
@@ -340,7 +346,8 @@ public class TestContainerStateManagerIntegration {
         .updateContainerState(container1.getContainerInfo().containerID(),
             HddsProtos.LifeCycleEvent.FINALIZE);
     containers = containerStateManager.getMatchingContainerIDs(containerOwner,
-        xceiverClientManager.getType(), xceiverClientManager.getFactor(),
+        SCMTestUtils.getReplicationType(conf),
+        SCMTestUtils.getReplicationFactor(conf),
         HddsProtos.LifeCycleState.CLOSING).size();
     Assert.assertEquals(1, containers);
 
@@ -348,7 +355,8 @@ public class TestContainerStateManagerIntegration {
         .updateContainerState(container1.getContainerInfo().containerID(),
             HddsProtos.LifeCycleEvent.CLOSE);
     containers = containerStateManager.getMatchingContainerIDs(containerOwner,
-        xceiverClientManager.getType(), xceiverClientManager.getFactor(),
+        SCMTestUtils.getReplicationType(conf),
+        SCMTestUtils.getReplicationFactor(conf),
         HddsProtos.LifeCycleState.CLOSED).size();
     Assert.assertEquals(1, containers);
 
@@ -356,7 +364,8 @@ public class TestContainerStateManagerIntegration {
         .updateContainerState(container1.getContainerInfo().containerID(),
             HddsProtos.LifeCycleEvent.DELETE);
     containers = containerStateManager.getMatchingContainerIDs(containerOwner,
-        xceiverClientManager.getType(), xceiverClientManager.getFactor(),
+        SCMTestUtils.getReplicationType(conf),
+        SCMTestUtils.getReplicationFactor(conf),
         HddsProtos.LifeCycleState.DELETING).size();
     Assert.assertEquals(1, containers);
 
@@ -364,7 +373,8 @@ public class TestContainerStateManagerIntegration {
         .updateContainerState(container1.getContainerInfo().containerID(),
             HddsProtos.LifeCycleEvent.CLEANUP);
     containers = containerStateManager.getMatchingContainerIDs(containerOwner,
-        xceiverClientManager.getType(), xceiverClientManager.getFactor(),
+        SCMTestUtils.getReplicationType(conf),
+        SCMTestUtils.getReplicationFactor(conf),
         HddsProtos.LifeCycleState.DELETED).size();
     Assert.assertEquals(1, containers);
 
@@ -372,8 +382,8 @@ public class TestContainerStateManagerIntegration {
     // OPEN -> CLOSING -> CLOSED
     ContainerWithPipeline container3 = scm.getClientProtocolServer()
         .allocateContainer(
-            xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+            SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf), containerOwner);
     containerManager
         .updateContainerState(container3.getContainerInfo().containerID(),
             HddsProtos.LifeCycleEvent.FINALIZE);
@@ -381,7 +391,8 @@ public class TestContainerStateManagerIntegration {
         .updateContainerState(container3.getContainerInfo().containerID(),
             HddsProtos.LifeCycleEvent.CLOSE);
     containers = containerStateManager.getMatchingContainerIDs(containerOwner,
-        xceiverClientManager.getType(), xceiverClientManager.getFactor(),
+        SCMTestUtils.getReplicationType(conf),
+        SCMTestUtils.getReplicationFactor(conf),
         HddsProtos.LifeCycleState.CLOSED).size();
     Assert.assertEquals(1, containers);
   }
@@ -408,8 +419,8 @@ public class TestContainerStateManagerIntegration {
 
     ContainerWithPipeline container = scm.getClientProtocolServer()
         .allocateContainer(
-            xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+            SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf), containerOwner);
 
     ContainerID id = container.getContainerInfo().containerID();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerOperations.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerOperations.java
@@ -17,23 +17,20 @@
  */
 package org.apache.hadoop.ozone;
 
+import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
-import org.apache.hadoop.ipc.ProtobufRpcEngine;
-import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementCapacity;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
-import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.client.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
-import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
-import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolPB;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -48,19 +45,12 @@ public class TestContainerOperations {
 
   @BeforeClass
   public static void setup() throws Exception {
-    int containerSizeGB = 5;
-    ContainerOperationClient.setContainerSizeB(
-        containerSizeGB * OzoneConsts.GB);
     ozoneConf = new OzoneConfiguration();
     ozoneConf.setClass(ScmConfigKeys.OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY,
         SCMContainerPlacementCapacity.class, ContainerPlacementPolicy.class);
+    ozoneConf.setStorageSize(OZONE_SCM_CONTAINER_SIZE, 5, StorageUnit.GB);
     cluster = MiniOzoneCluster.newBuilder(ozoneConf).setNumDatanodes(1).build();
-    StorageContainerLocationProtocolClientSideTranslatorPB client =
-        cluster.getStorageContainerLocationClient();
-    RPC.setProtocolEngine(ozoneConf, StorageContainerLocationProtocolPB.class,
-        ProtobufRpcEngine.class);
-    storageClient = new ContainerOperationClient(
-        client, new XceiverClientManager(ozoneConf));
+    storageClient = new ContainerOperationClient(ozoneConf);
     cluster.waitForClusterToBeReady();
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
@@ -74,6 +74,7 @@ import org.apache.hadoop.net.DNSToSwitchMapping;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.net.StaticMapping;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
+import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
@@ -180,7 +181,7 @@ public class TestStorageContainerManager {
 
       try {
         ContainerWithPipeline container2 = mockClientServer
-            .allocateContainer(xceiverClientManager.getType(),
+            .allocateContainer(SCMTestUtils.getReplicationType(ozoneConf),
             HddsProtos.ReplicationFactor.ONE,  "OZONE");
         if (expectPermissionDenied) {
           fail("Operation should fail, expecting an IOException here.");
@@ -193,7 +194,7 @@ public class TestStorageContainerManager {
 
       try {
         ContainerWithPipeline container3 = mockClientServer
-            .allocateContainer(xceiverClientManager.getType(),
+            .allocateContainer(SCMTestUtils.getReplicationType(ozoneConf),
             HddsProtos.ReplicationFactor.ONE, "OZONE");
         if (expectPermissionDenied) {
           fail("Operation should fail, expecting an IOException here.");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestAllocateContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestAllocateContainer.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
+import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -66,8 +67,8 @@ public class TestAllocateContainer {
   public void testAllocate() throws Exception {
     ContainerWithPipeline container =
         storageContainerLocationClient.allocateContainer(
-            xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(),
+            SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf),
             containerOwner);
     Assert.assertNotNull(container);
     Assert.assertNotNull(container.getPipeline().getFirstNode());
@@ -78,7 +79,7 @@ public class TestAllocateContainer {
   public void testAllocateNull() throws Exception {
     thrown.expect(NullPointerException.class);
     storageContainerLocationClient.allocateContainer(
-        xceiverClientManager.getType(),
-        xceiverClientManager.getFactor(), null);
+        SCMTestUtils.getReplicationType(conf),
+        SCMTestUtils.getReplicationFactor(conf), null);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestContainerSmallFile.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestContainerSmallFile.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
+import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -80,7 +81,7 @@ public class TestContainerSmallFile {
   public void testAllocateWrite() throws Exception {
     ContainerWithPipeline container =
         storageContainerLocationClient.allocateContainer(
-            xceiverClientManager.getType(),
+            SCMTestUtils.getReplicationType(ozoneConfig),
             HddsProtos.ReplicationFactor.ONE, containerOwner);
     XceiverClientSpi client = xceiverClientManager
         .acquireClient(container.getPipeline());
@@ -102,7 +103,7 @@ public class TestContainerSmallFile {
   public void testInvalidBlockRead() throws Exception {
     ContainerWithPipeline container =
         storageContainerLocationClient.allocateContainer(
-            xceiverClientManager.getType(),
+            SCMTestUtils.getReplicationType(ozoneConfig),
             HddsProtos.ReplicationFactor.ONE, containerOwner);
     XceiverClientSpi client = xceiverClientManager
         .acquireClient(container.getPipeline());
@@ -125,7 +126,7 @@ public class TestContainerSmallFile {
     long nonExistContainerID = 8888L;
     ContainerWithPipeline container =
         storageContainerLocationClient.allocateContainer(
-            xceiverClientManager.getType(),
+            SCMTestUtils.getReplicationType(ozoneConfig),
             HddsProtos.ReplicationFactor.ONE, containerOwner);
     XceiverClientSpi client = xceiverClientManager
         .acquireClient(container.getPipeline());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestGetCommittedBlockLengthAndPutKey.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestGetCommittedBlockLengthAndPutKey.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
+import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -83,7 +84,7 @@ public class TestGetCommittedBlockLengthAndPutKey {
   public void tesGetCommittedBlockLength() throws Exception {
     ContainerProtos.GetCommittedBlockLengthResponseProto response;
     ContainerWithPipeline container = storageContainerLocationClient
-        .allocateContainer(xceiverClientManager.getType(),
+        .allocateContainer(SCMTestUtils.getReplicationType(ozoneConfig),
             HddsProtos.ReplicationFactor.ONE, containerOwner);
     long containerID = container.getContainerInfo().getContainerID();
     Pipeline pipeline = container.getPipeline();
@@ -116,7 +117,7 @@ public class TestGetCommittedBlockLengthAndPutKey {
   @Test
   public void testGetCommittedBlockLengthForInvalidBlock() throws Exception {
     ContainerWithPipeline container = storageContainerLocationClient
-        .allocateContainer(xceiverClientManager.getType(),
+        .allocateContainer(SCMTestUtils.getReplicationType(ozoneConfig),
             HddsProtos.ReplicationFactor.ONE, containerOwner);
     long containerID = container.getContainerInfo().getContainerID();
     XceiverClientSpi client = xceiverClientManager

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientManager.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.protocolPB
     .StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
+import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.After;
@@ -83,14 +84,17 @@ public class TestXceiverClientManager {
     XceiverClientManager clientManager = new XceiverClientManager(conf);
 
     ContainerWithPipeline container1 = storageContainerLocationClient
-        .allocateContainer(clientManager.getType(), clientManager.getFactor(),
+        .allocateContainer(SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf),
             containerOwner);
     XceiverClientSpi client1 = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, client1.getRefcount());
 
     ContainerWithPipeline container2 = storageContainerLocationClient
-        .allocateContainer(clientManager.getType(), clientManager.getFactor(),
+        .allocateContainer(
+            SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf),
             containerOwner);
     XceiverClientSpi client2 = clientManager
         .acquireClient(container2.getPipeline());
@@ -121,7 +125,8 @@ public class TestXceiverClientManager {
 
     ContainerWithPipeline container1 =
         storageContainerLocationClient.allocateContainer(
-            clientManager.getType(), HddsProtos.ReplicationFactor.ONE,
+            SCMTestUtils.getReplicationType(conf),
+            HddsProtos.ReplicationFactor.ONE,
             containerOwner);
     XceiverClientSpi client1 = clientManager
         .acquireClient(container1.getPipeline());
@@ -131,7 +136,7 @@ public class TestXceiverClientManager {
 
     ContainerWithPipeline container2 =
         storageContainerLocationClient.allocateContainer(
-            clientManager.getType(),
+            SCMTestUtils.getReplicationType(conf),
             HddsProtos.ReplicationFactor.ONE, containerOwner);
     XceiverClientSpi client2 = clientManager
         .acquireClient(container2.getPipeline());
@@ -179,8 +184,8 @@ public class TestXceiverClientManager {
 
     ContainerWithPipeline container1 =
         storageContainerLocationClient.allocateContainer(
-            clientManager.getType(),
-            clientManager.getFactor(), containerOwner);
+            SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf), containerOwner);
     XceiverClientSpi client1 = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, client1.getRefcount());
@@ -188,9 +193,10 @@ public class TestXceiverClientManager {
     clientManager.releaseClient(client1, false);
     Assert.assertEquals(0, client1.getRefcount());
 
-    ContainerWithPipeline container2 = storageContainerLocationClient
-        .allocateContainer(clientManager.getType(), clientManager.getFactor(),
-            containerOwner);
+    ContainerWithPipeline container2 =
+        storageContainerLocationClient.allocateContainer(
+            SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf), containerOwner);
     XceiverClientSpi client2 = clientManager
         .acquireClient(container2.getPipeline());
     Assert.assertEquals(1, client2.getRefcount());
@@ -227,8 +233,10 @@ public class TestXceiverClientManager {
         clientManager.getClientCache();
 
     // client is added in cache
-    ContainerWithPipeline container1 = storageContainerLocationClient
-        .allocateContainer(clientManager.getType(), clientManager.getFactor(),
+    ContainerWithPipeline container1 =
+        storageContainerLocationClient.allocateContainer(
+            SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf),
             containerOwner);
     XceiverClientSpi client1 =
         clientManager.acquireClient(container1.getPipeline());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientMetrics.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientMetrics;
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
+import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -86,8 +87,8 @@ public class TestXceiverClientMetrics {
     XceiverClientManager clientManager = new XceiverClientManager(conf);
 
     ContainerWithPipeline container = storageContainerLocationClient
-        .allocateContainer(clientManager.getType(), clientManager.getFactor(),
-            containerOwner);
+        .allocateContainer(SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf), containerOwner);
     XceiverClientSpi client = clientManager
         .acquireClient(container.getPipeline());
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestQueryNode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestQueryNode.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.scm.node;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.client.ContainerOperationClient;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
@@ -82,9 +81,7 @@ public class TestQueryNode {
         .setNumDatanodes(numOfDatanodes)
         .build();
     cluster.waitForClusterToBeReady();
-    scmClient = new ContainerOperationClient(cluster
-        .getStorageContainerLocationClient(),
-        new XceiverClientManager(conf));
+    scmClient = new ContainerOperationClient(conf);
   }
 
   @After


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR aims to remove the isUseRatis(), getType(), and getFactor methods from the XCeiverClientManager class, as the return values of these methods are dependent on a single configuration value (ScmConfigKeys.DFS_CONTAINER_RATIS_ENABLED_KEY).

The proposed solution moves the setup of the ContainerOperationClient setup to its constructor, with that the ContainerOperationClient class will be responsible to set up its internally used SCMClient, and XCeiverClientManager based on the configuration.
It also gets responsible to set up the container size limit based on the configuration, and it is not being set anymore via a static method.

To deal with the change, and to provide an easy way to get the values in JUnit tests, SCMTestUtil gets two new pubic static utility methods to get the ReplicationType, and ReplicationFactor based on the configuration. All accesses of the old methods on XCeiverClientManager are mapped to the new static utility methods.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2373 - Move isUseRatis getFactor and getType from XCeiverClientManager

## How was this patch tested?

As this is a refactoring without changing any outer logic, no new JUnit tests are needed, but all existent tests has to pass as before.