### PR TITLE
HDDS-2374. Make Ozone Readme.txt point to the Ozone websites instead …

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,7 +1,8 @@
-For the latest information about Hadoop, please visit our website at:
+For the latest information about Apache Hadoop Ozone, please visit our website
+at:
 
-   http://hadoop.apache.org/
+   https://hadoop.apache.org/ozone/
 
 and our wiki, at:
 
-   https://cwiki.apache.org/confluence/display/HADOOP/
+   https://cwiki.apache.org/confluence/display/HADOOP/Ozone+Contributor+Guide


### PR DESCRIPTION
## What changes were proposed in this pull request?
Making the Readme.txt point to Apache Hadoop Ozone Webpage and Wiki.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2374

## How was this patch tested?

Just eyeballing the change.