### PR TITLE
HDDS-2375. Refactor BlockOutputStream to allow flexible buffering.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerExcep
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.ozone.common.ChecksumData;
+import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.common.OzoneChecksumException;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
@@ -40,7 +41,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
@@ -87,7 +87,7 @@ public class BlockOutputStream extends OutputStream {
   private int chunkSize;
   private final long streamBufferFlushSize;
   private final long streamBufferMaxSize;
-  private BufferPool bufferPool;
+  private final BufferPool bufferPool;
   // The IOException will be set by response handling thread in case there is an
   // exception received in the response. If the exception is set, the next
   // request will fail upfront.
@@ -106,7 +106,7 @@ public class BlockOutputStream extends OutputStream {
   // when the watchForCommit acknowledges a putBlock logIndex has been
   // committed on all datanodes. This list will be a  place holder for buffers
   // which got written between successive putBlock calls.
-  private List<ByteBuffer> bufferList;
+  private List<ChunkBuffer> bufferList;
 
   // This object will maintain the commitIndexes and byteBufferList in order
   // Also, corresponding to the logIndex, the corresponding list of buffers will
@@ -199,7 +199,7 @@ public class BlockOutputStream extends OutputStream {
   }
 
   @VisibleForTesting
-  public Map<Long, List<ByteBuffer>> getCommitIndex2flushedDataMap() {
+  public Map<Long, List<ChunkBuffer>> getCommitIndex2flushedDataMap() {
     return commitWatcher.getCommitIndex2flushedDataMap();
   }
 
@@ -230,7 +230,7 @@ public class BlockOutputStream extends OutputStream {
       // Allocate a buffer if needed. The buffer will be allocated only
       // once as needed and will be reused again for multiple blockOutputStream
       // entries.
-      ByteBuffer  currentBuffer = bufferPool.allocateBufferIfNeeded();
+      final ChunkBuffer currentBuffer = bufferPool.allocateBufferIfNeeded();
       int pos = currentBuffer.position();
       writeLen =
           Math.min(chunkSize - pos % chunkSize, len);
@@ -366,7 +366,7 @@ public class BlockOutputStream extends OutputStream {
     checkOpen();
     long flushPos = totalDataFlushedLength;
     Preconditions.checkNotNull(bufferList);
-    List<ByteBuffer> byteBufferList = bufferList;
+    final List<ChunkBuffer> byteBufferList = bufferList;
     bufferList = null;
     Preconditions.checkNotNull(byteBufferList);
 
@@ -440,7 +440,7 @@ public class BlockOutputStream extends OutputStream {
   }
 
 
-  private void writeChunk(ByteBuffer buffer)
+  private void writeChunk(ChunkBuffer buffer)
       throws IOException {
     // This data in the buffer will be pushed to datanode and a reference will
     // be added to the bufferList. Once putBlock gets executed, this list will
@@ -451,15 +451,7 @@ public class BlockOutputStream extends OutputStream {
       bufferList = new ArrayList<>();
     }
     bufferList.add(buffer);
-    // Please note : We are not flipping the slice when we write since
-    // the slices are pointing the currentBuffer start and end as needed for
-    // the chunk write. Also please note, Duplicate does not create a
-    // copy of data, it only creates metadata that points to the data
-    // stream.
-    ByteBuffer chunk = buffer.duplicate();
-    chunk.position(0);
-    chunk.limit(buffer.position());
-    writeChunkToContainer(chunk);
+    writeChunkToContainer(buffer.duplicate(0, buffer.position()));
   }
 
   private void handleFlush()
@@ -467,7 +459,7 @@ public class BlockOutputStream extends OutputStream {
     checkOpen();
     // flush the last chunk data residing on the currentBuffer
     if (totalDataFlushedLength < writtenDataLength) {
-      ByteBuffer currentBuffer = bufferPool.getCurrentBuffer();
+      final ChunkBuffer currentBuffer = bufferPool.getCurrentBuffer();
       Preconditions.checkArgument(currentBuffer.position() > 0);
       if (currentBuffer.position() != chunkSize) {
         writeChunk(currentBuffer);
@@ -587,9 +579,10 @@ public class BlockOutputStream extends OutputStream {
    * @throws OzoneChecksumException if there is an error while computing
    * checksum
    */
-  private void writeChunkToContainer(ByteBuffer chunk) throws IOException {
+  private void writeChunkToContainer(ChunkBuffer chunk) throws IOException {
     int effectiveChunkSize = chunk.remaining();
-    ByteString data = bufferPool.byteStringConversion().apply(chunk);
+    final ByteString data = chunk.toByteString(
+        bufferPool.byteStringConversion());
     Checksum checksum = new Checksum(checksumType, bytesPerChecksum);
     ChecksumData checksumData = checksum.computeChecksum(chunk);
     ChunkInfo chunkInfo = ChunkInfo.newBuilder()

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.storage;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.scm.ByteStringConversion;
+import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 
 import java.nio.ByteBuffer;
@@ -32,7 +33,7 @@ import java.util.function.Function;
  */
 public class BufferPool {
 
-  private List<ByteBuffer> bufferList;
+  private List<ChunkBuffer> bufferList;
   private int currentBufferIndex;
   private final int bufferSize;
   private final int capacity;
@@ -56,7 +57,7 @@ public class BufferPool {
     return byteStringConversion;
   }
 
-  public ByteBuffer getCurrentBuffer() {
+  ChunkBuffer getCurrentBuffer() {
     return currentBufferIndex == -1 ? null : bufferList.get(currentBufferIndex);
   }
 
@@ -70,15 +71,15 @@ public class BufferPool {
    * chunk size.
    *
    */
-  public ByteBuffer allocateBufferIfNeeded() {
-    ByteBuffer buffer = getCurrentBuffer();
+  public ChunkBuffer allocateBufferIfNeeded() {
+    ChunkBuffer buffer = getCurrentBuffer();
     if (buffer != null && buffer.hasRemaining()) {
       return buffer;
     }
     if (currentBufferIndex < bufferList.size() - 1) {
       buffer = getBuffer(currentBufferIndex + 1);
     } else {
-      buffer = ByteBuffer.allocate(bufferSize);
+      buffer = ChunkBuffer.allocate(bufferSize);
       bufferList.add(buffer);
     }
     Preconditions.checkArgument(bufferList.size() <= capacity);
@@ -89,11 +90,11 @@ public class BufferPool {
     return buffer;
   }
 
-  public void releaseBuffer(ByteBuffer byteBuffer) {
+  void releaseBuffer(ChunkBuffer chunkBuffer) {
     // always remove from head of the list and append at last
-    ByteBuffer buffer = bufferList.remove(0);
+    final ChunkBuffer buffer = bufferList.remove(0);
     // Ensure the buffer to be removed is always at the head of the list.
-    Preconditions.checkArgument(buffer.equals(byteBuffer));
+    Preconditions.checkArgument(buffer.equals(chunkBuffer));
     buffer.clear();
     bufferList.add(buffer);
     Preconditions.checkArgument(currentBufferIndex >= 0);
@@ -118,7 +119,7 @@ public class BufferPool {
     return bufferList.size();
   }
 
-  public ByteBuffer getBuffer(int index) {
+  public ChunkBuffer getBuffer(int index) {
     return bufferList.get(index);
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ContainerCommandRequestMessage.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ContainerCommandRequestMessage.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerC
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.PutSmallFileRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.WriteChunkRequestProto;
+import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
@@ -90,7 +91,7 @@ public final class ContainerCommandRequestMessage implements Message {
 
   private ByteString buildContent() {
     final ByteString headerBytes = header.toByteString();
-    return RatisHelper.int2ByteString(headerBytes.size())
+    return Checksum.int2ByteString(headerBytes.size())
         .concat(headerBytes)
         .concat(data);
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.hdds.ratis;
 
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -275,16 +274,5 @@ public interface RatisHelper {
       Collection<RaftProtos.CommitInfoProto> commitInfos) {
     return commitInfos.stream().map(RaftProtos.CommitInfoProto::getCommitIndex)
         .min(Long::compareTo).orElse(null);
-  }
-
-  static ByteString int2ByteString(int n) {
-    final ByteString.Output out = ByteString.newOutput();
-    try(DataOutputStream dataOut = new DataOutputStream(out)) {
-      dataOut.writeInt(n);
-    } catch (IOException e) {
-      throw new IllegalStateException(
-          "Failed to write integer n = " + n + " to a ByteString.", e);
-    }
-    return out.toByteString();
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBuffer.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.common;
+
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+
+import java.nio.ByteBuffer;
+import java.util.function.Function;
+
+/** Buffer for a block chunk. */
+public interface ChunkBuffer {
+
+  /** Similar to {@link ByteBuffer#allocate(int)}. */
+  static ChunkBuffer allocate(int capacity) {
+    return new ChunkBufferImplWithByteBuffer(ByteBuffer.allocate(capacity));
+  }
+
+  /** Wrap the given {@link ByteBuffer} as a {@link ChunkBuffer}. */
+  static ChunkBuffer wrap(ByteBuffer buffer) {
+    return new ChunkBufferImplWithByteBuffer(buffer);
+  }
+
+  /** Similar to {@link ByteBuffer#position()}. */
+  int position();
+
+  /** Similar to {@link ByteBuffer#remaining()}. */
+  int remaining();
+
+  /** Similar to {@link ByteBuffer#hasRemaining()}. */
+  default boolean hasRemaining() {
+    return remaining() > 0;
+  }
+
+  /** Similar to {@link ByteBuffer#clear()}. */
+  void clear();
+
+  /** Similar to {@link ByteBuffer#put(ByteBuffer)}. */
+  void put(ByteBuffer b);
+
+  /** Similar to {@link ByteBuffer#put(byte[], int, int)}. */
+  default void put(byte[] b, int offset, int length) {
+    put(ByteBuffer.wrap(b, offset, length));
+  }
+
+  /** The same as put(b.asReadOnlyByteBuffer()). */
+  default void put(ByteString b) {
+    put(b.asReadOnlyByteBuffer());
+  }
+
+  /**
+   * Duplicate and then set the position and limit on the duplicated buffer.
+   *
+   * @see ByteBuffer#duplicate()
+   */
+  ChunkBuffer duplicate(int newPosition, int newLimit);
+
+  /**
+   * Iterate the buffer from the current position to the current limit.
+   *
+   * Upon the iteration complete,
+   * the buffer's position will be equal to its limit.
+   */
+  Iterable<ByteBuffer> iterate(int bytesPerChecksum);
+
+  /**
+   * Convert this buffer to a {@link ByteString}.
+   * The position and limit of this {@link ChunkBuffer} remains unchanged
+   * as long as the given function preserves the position and limit
+   * of the input {@link ByteBuffer}.
+   */
+  ByteString toByteString(Function<ByteBuffer, ByteString> function);
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBuffer.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.common;
+
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.function.Function;
+
+/** {@link ChunkBuffer} implementation using a single {@link ByteBuffer}. */
+public final class ChunkBufferImplWithByteBuffer implements ChunkBuffer {
+  private final ByteBuffer buffer;
+
+  ChunkBufferImplWithByteBuffer(ByteBuffer buffer) {
+    this.buffer = Objects.requireNonNull(buffer, "buffer == null");
+  }
+
+  @Override
+  public int position() {
+    return buffer.position();
+  }
+
+  @Override
+  public int remaining() {
+    return buffer.remaining();
+  }
+
+  @Override
+  public Iterable<ByteBuffer> iterate(int bytesPerChecksum) {
+    return () -> new Iterator<ByteBuffer>() {
+      @Override
+      public boolean hasNext() {
+        return buffer.hasRemaining();
+      }
+
+      @Override
+      public ByteBuffer next() {
+        final ByteBuffer duplicated = buffer.duplicate();
+        final int min = Math.min(
+            buffer.position() + bytesPerChecksum, buffer.limit());
+        duplicated.limit(min);
+        buffer.position(min);
+        return duplicated;
+      }
+    };
+  }
+
+  @Override
+  public ChunkBuffer duplicate(int newPosition, int newLimit) {
+    final ByteBuffer duplicated = buffer.duplicate();
+    duplicated.position(newPosition).limit(newLimit);
+    return new ChunkBufferImplWithByteBuffer(duplicated);
+  }
+
+  @Override
+  public void put(ByteBuffer b) {
+    buffer.put(b);
+  }
+
+  @Override
+  public void clear() {
+    buffer.clear();
+  }
+
+  @Override
+  public ByteString toByteString(Function<ByteBuffer, ByteString> function) {
+    return function.apply(buffer);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!(obj instanceof ChunkBufferImplWithByteBuffer)) {
+      return false;
+    }
+    final ChunkBufferImplWithByteBuffer that
+        = (ChunkBufferImplWithByteBuffer)obj;
+    return this.buffer.equals(that.buffer);
+  }
+
+  @Override
+  public int hashCode() {
+    return buffer.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName() + ":limit=" + buffer.limit();
+  }
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestContainerCommandRequestMessage.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestContainerCommandRequestMessage.java
@@ -41,17 +41,17 @@ import java.util.function.BiFunction;
 public class TestContainerCommandRequestMessage {
   static final Random RANDOM = new Random();
 
-  static ByteString newData(int length, Random random) {
+  static ByteString newData(int length) {
     final ByteString.Output out = ByteString.newOutput();
     for(int i = 0; i < length; i++) {
-      out.write(random.nextInt());
+      out.write(RANDOM.nextInt());
     }
     return out.toByteString();
   }
 
   static ChecksumData checksum(ByteString data) {
     try {
-      return new Checksum().computeChecksum(data.toByteArray());
+      return new Checksum().computeChecksum(data.asReadOnlyByteBuffer());
     } catch (OzoneChecksumException e) {
       throw new IllegalStateException(e);
     }
@@ -140,7 +140,7 @@ public class TestContainerCommandRequestMessage {
       throws Exception {
     System.out.println("length=" + length);
     final BlockID blockID = new BlockID(RANDOM.nextLong(), RANDOM.nextLong());
-    final ByteString data = newData(length, RANDOM);
+    final ByteString data = newData(length);
 
     final ContainerCommandRequestProto original = method.apply(blockID, data);
     final ContainerCommandRequestMessage message

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChunkBuffer.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChunkBuffer.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.common;
+
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Test {@link ChunkBuffer} implementations.
+ */
+public class TestChunkBuffer {
+  private static int nextInt(int n) {
+    return ThreadLocalRandom.current().nextInt(n);
+  }
+
+  @Test(timeout = 1_000)
+  public void testImplWithByteBuffer() {
+    runTestImplWithByteBuffer(1);
+    runTestImplWithByteBuffer(1 << 10);
+    for(int i = 0; i < 10; i++) {
+      runTestImplWithByteBuffer(nextInt(100) + 1);
+    }
+  }
+
+  private static void runTestImplWithByteBuffer(int n) {
+    final byte[] expected = new byte[n];
+    ThreadLocalRandom.current().nextBytes(expected);
+    runTestImpl(expected, 0, ChunkBuffer.allocate(n));
+  }
+
+  private static void runTestImpl(byte[] expected, int bpc, ChunkBuffer impl) {
+    final int n = expected.length;
+    System.out.println("n=" + n + ", impl=" + impl);
+
+    // check position, remaining
+    Assert.assertEquals(0, impl.position());
+    Assert.assertEquals(n, impl.remaining());
+
+    impl.put(expected, 0, expected.length);
+    Assert.assertEquals(n, impl.position());
+    Assert.assertEquals(0, impl.remaining());
+
+    // duplicate
+    assertDuplicate(expected, impl);
+
+    // test iterate
+    if (bpc > 0) {
+      assertIterate(expected, impl, bpc);
+    } else {
+      for (int d = 1; d < 5; d++) {
+        final int bytesPerChecksum = n/d;
+        if (bytesPerChecksum > 0) {
+          assertIterate(expected, impl, bytesPerChecksum);
+        }
+      }
+      for (int d = 1; d < 10; d++) {
+        final int bytesPerChecksum = nextInt(n) + 1;
+        assertIterate(expected, impl, bytesPerChecksum);
+      }
+    }
+  }
+
+  private static void assertDuplicate(byte[] expected, ChunkBuffer impl) {
+    final int n = expected.length;
+    assertToByteString(expected, 0, n, impl);
+    for(int i = 0; i < 10; i++) {
+      final int offset = nextInt(n);
+      final int length = nextInt(n - offset + 1);
+      assertToByteString(expected, offset, length, impl);
+    }
+  }
+
+  private static void assertIterate(
+      byte[] expected, ChunkBuffer impl, int bpc) {
+    final int n = expected.length;
+    final ChunkBuffer duplicated = impl.duplicate(0, n);
+    Assert.assertEquals(0, duplicated.position());
+    Assert.assertEquals(n, duplicated.remaining());
+
+    final int numChecksums = (n + bpc - 1) / bpc;
+    final Iterator<ByteBuffer> i = duplicated.iterate(bpc).iterator();
+    int count = 0;
+    for(int j = 0; j < numChecksums; j++) {
+      final ByteBuffer b = i.next();
+      final int expectedRemaining = j < numChecksums - 1?
+          bpc : n - bpc *(numChecksums - 1);
+      Assert.assertEquals(expectedRemaining, b.remaining());
+
+      final int offset = j* bpc;
+      for(int k = 0; k < expectedRemaining; k++) {
+        Assert.assertEquals(expected[offset + k], b.get());
+        count++;
+      }
+    }
+    Assert.assertEquals(n, count);
+  }
+
+  private static void assertToByteString(
+      byte[] expected, int offset, int length, ChunkBuffer impl) {
+    final ChunkBuffer duplicated = impl.duplicate(offset, offset + length);
+    Assert.assertEquals(offset, duplicated.position());
+    Assert.assertEquals(length, duplicated.remaining());
+    final ByteString computed = duplicated.toByteString(buffer -> {
+      buffer.mark();
+      final ByteString string = ByteString.copyFrom(buffer);
+      buffer.reset();
+      return string;
+    });
+    Assert.assertEquals(offset, duplicated.position());
+    Assert.assertEquals(length, duplicated.remaining());
+    Assert.assertEquals("offset=" + offset + ", length=" + length,
+        ByteString.copyFrom(expected, offset, length), computed);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitWatcher.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitWatcher.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -44,7 +45,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -140,7 +140,7 @@ public class TestCommitWatcher {
     XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
     CommitWatcher watcher = new CommitWatcher(bufferPool, ratisClient, 10000);
     BlockID blockID = ContainerTestHelper.getTestBlockID(containerId);
-    List<ByteBuffer> bufferList = new ArrayList<>();
+    final List<ChunkBuffer> bufferList = new ArrayList<>();
     List<XceiverClientReply> replies = new ArrayList<>();
     long length = 0;
     List<CompletableFuture<ContainerProtos.ContainerCommandResponseProto>>
@@ -151,8 +151,8 @@ public class TestCommitWatcher {
           ContainerTestHelper
               .getWriteChunkRequest(pipeline, blockID, chunkSize, null);
       // add the data to the buffer pool
-      ByteBuffer byteBuffer = bufferPool.allocateBufferIfNeeded().put(
-          writeChunkRequest.getWriteChunk().getData().asReadOnlyByteBuffer());
+      final ChunkBuffer byteBuffer = bufferPool.allocateBufferIfNeeded();
+      byteBuffer.put(writeChunkRequest.getWriteChunk().getData());
       ratisClient.sendCommandAsync(writeChunkRequest);
       ContainerProtos.ContainerCommandRequestProto putBlockRequest =
           ContainerTestHelper
@@ -216,7 +216,7 @@ public class TestCommitWatcher {
     XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
     CommitWatcher watcher = new CommitWatcher(bufferPool, ratisClient, 10000);
     BlockID blockID = ContainerTestHelper.getTestBlockID(containerId);
-    List<ByteBuffer> bufferList = new ArrayList<>();
+    final List<ChunkBuffer> bufferList = new ArrayList<>();
     List<XceiverClientReply> replies = new ArrayList<>();
     long length = 0;
     List<CompletableFuture<ContainerProtos.ContainerCommandResponseProto>>
@@ -227,8 +227,8 @@ public class TestCommitWatcher {
           ContainerTestHelper
               .getWriteChunkRequest(pipeline, blockID, chunkSize, null);
       // add the data to the buffer pool
-      ByteBuffer byteBuffer = bufferPool.allocateBufferIfNeeded().put(
-          writeChunkRequest.getWriteChunk().getData().asReadOnlyByteBuffer());
+      final ChunkBuffer byteBuffer = bufferPool.allocateBufferIfNeeded();
+      byteBuffer.put(writeChunkRequest.getWriteChunk().getData());
       ratisClient.sendCommandAsync(writeChunkRequest);
       ContainerProtos.ContainerCommandRequestProto putBlockRequest =
           ContainerTestHelper


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/HDDS-2375