### PR TITLE
HDDS-2377. Speed up TestOzoneManagerHA#testOMRetryProxy and #testTwoOMNodesDown

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -73,6 +73,10 @@ import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.VolumeArgs;
 import org.apache.hadoop.util.Time;
 
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic
+    .IPC_CLIENT_CONNECT_MAX_RETRIES_KEY;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic
+    .IPC_CLIENT_CONNECT_RETRY_INTERVAL_KEY;
 
 import static org.apache.hadoop.ozone.MiniOzoneHAClusterImpl
     .NODE_FAILURE_TIMEOUT;
@@ -107,6 +111,9 @@ public class TestOzoneManagerHA {
   private int numOfOMs = 3;
   private static final long SNAPSHOT_THRESHOLD = 50;
   private static final int LOG_PURGE_GAP = 50;
+  /* Reduce max number of retries to speed up unit test. */
+  private static final int OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS = 5;
+  private static final int IPC_CLIENT_CONNECT_MAX_RETRIES = 4;
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
@@ -131,7 +138,12 @@ public class TestOzoneManagerHA {
     conf.set(OzoneConfigKeys.OZONE_ADMINISTRATORS,
         OZONE_ADMINISTRATORS_WILDCARD);
     conf.setInt(OZONE_OPEN_KEY_EXPIRE_THRESHOLD_SECONDS, 2);
-    conf.setInt(OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY, 6);
+    conf.setInt(OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY,
+        OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS);
+    conf.setInt(IPC_CLIENT_CONNECT_MAX_RETRIES_KEY,
+        IPC_CLIENT_CONNECT_MAX_RETRIES);
+    /* Reduce IPC retry interval to speed up unit test. */
+    conf.setInt(IPC_CLIENT_CONNECT_RETRY_INTERVAL_KEY, 200);
     conf.setLong(
         OMConfigKeys.OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_KEY,
         SNAPSHOT_THRESHOLD);
@@ -717,8 +729,7 @@ public class TestOzoneManagerHA {
 
   @Test
   public void testOMRetryProxy() throws Exception {
-    // Stop all the OMs. After making 5 (set maxRetries value) attempts at
-    // connection, the RpcClient should give up.
+    // Stop all the OMs.
     for (int i = 0; i < numOfOMs; i++) {
       cluster.stopOzoneManager(i);
     }
@@ -729,19 +740,26 @@ public class TestOzoneManagerHA {
 
     try {
       createVolumeTest(true);
+      // After making N (set maxRetries value) connection attempts to OMs,
+      // the RpcClient should give up.
       fail("TestOMRetryProxy should fail when there are no OMs running");
     } catch (ConnectException e) {
-      // Each retry attempt tries upto 10 times to connect. So there should be
-      // 10 * OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY "Retrying connect to
-      // server" messages. Also, the first call will result in EOFException.
-      // That will result in another 10 retry attempts.
-      Assert.assertEquals(70,
+      // Each retry attempt tries IPC_CLIENT_CONNECT_MAX_RETRIES times.
+      // So there should be at least
+      // OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS * IPC_CLIENT_CONNECT_MAX_RETRIES
+      // "Retrying connect to server" messages.
+      // Also, the first call will result in EOFException.
+      // That will result in another IPC_CLIENT_CONNECT_MAX_RETRIES attempts.
+      Assert.assertEquals(
+          (OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS + 1) *
+              IPC_CLIENT_CONNECT_MAX_RETRIES,
           appender.countLinesWithMessage("Retrying connect to server:"));
 
       Assert.assertEquals(1,
           appender.countLinesWithMessage("Failed to connect to OMs:"));
       Assert.assertEquals(1,
-          appender.countLinesWithMessage("Attempted 6 failovers."));
+          appender.countLinesWithMessage("Attempted " +
+              OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS + " failovers."));
     }
   }
 
@@ -1268,6 +1286,7 @@ public class TestOzoneManagerHA {
 
     // Stop leader OM, and then validate list parts.
     stopLeaderOM();
+    Thread.sleep(NODE_FAILURE_TIMEOUT * 2);
 
     validateListParts(ozoneBucket, keyName, uploadID, partsMap);
 
@@ -1293,6 +1312,7 @@ public class TestOzoneManagerHA {
 
     // Stop leader OM, and then validate list volumes for user.
     stopLeaderOM();
+    Thread.sleep(NODE_FAILURE_TIMEOUT * 2);
 
     validateVolumesList(userName, expectedVolumes);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Goal: Reduce the time to run TestOzoneManagerHA.

From Marton's comment:
https://github.com/apache/hadoop-ozone/pull/30#pullrequestreview-302465440

Out of curiosity, I ran entire TestOzoneManagerHA locally. The entire test class finished in 10m 30s. I discovered testOMRetryProxy and testTwoOMNodesDown are taking the most time (2m and 2m 30s respectively) to finish. Most time are wasted on retry and wait. We could reasonably reduce the amount of time on the wait.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2377

## How was this patch tested?

As I tested, with the patch, testOMRetryProxy and testTwoOMNodesDown finish in 20 sec each, saving almost 4 min runtime on those two tests alone. The whole TestOzoneManagerHA test finishes in 5m 44s with the patch.

All TestOzoneManagerHA tests passed locally.