### PR TITLE
HDDS-2379. OM terminates with RocksDB error while continuously writing keys.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -129,21 +129,22 @@ public class OzoneManagerDoubleBuffer {
       try {
         if (canFlush()) {
           setReadyBuffer();
-          final BatchOperation batchOperation = omMetadataManager.getStore()
-              .initBatchOperation();
+          try(BatchOperation batchOperation = omMetadataManager.getStore()
+              .initBatchOperation()) {
 
-          readyBuffer.iterator().forEachRemaining((entry) -> {
-            try {
-              entry.getResponse().addToDBBatch(omMetadataManager,
-                  batchOperation);
-            } catch (IOException ex) {
-              // During Adding to RocksDB batch entry got an exception.
-              // We should terminate the OM.
-              terminate(ex);
-            }
-          });
+            readyBuffer.iterator().forEachRemaining((entry) -> {
+              try {
+                entry.getResponse().addToDBBatch(omMetadataManager,
+                    batchOperation);
+              } catch (IOException ex) {
+                // During Adding to RocksDB batch entry got an exception.
+                // We should terminate the OM.
+                terminate(ex);
+              }
+            });
 
-          omMetadataManager.getStore().commitBatchOperation(batchOperation);
+            omMetadataManager.getStore().commitBatchOperation(batchOperation);
+          }
 
           // Complete futures first and then do other things. So, that
           // handler threads will be released.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Close the BatchOperation, by using try with the resource. As this is not cleaning up the underlying native references, this occurs randomly.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2379

## How was this patch tested?
Ran a few of Integration tests and also after this patch on a cluster testing we are not seeing this error, which we used to see very frequently. Thank You @avijayanhwx for the testing it on the cluster.

And also the below rocksdb issue link has the same error, once after following memory management the issue was resolved is the solution proposed. Followed the same to resolve this issue.
https://github.com/facebook/rocksdb/issues/5068
