### PR TITLE
HDDS-2380. Use the Table.isExist() API instead of get() API while checking for presence of key.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -60,7 +60,7 @@ public final class OMFileRequest {
       String dbDirKeyName = omMetadataManager.getOzoneDirKey(volumeName,
           bucketName, pathName);
 
-      if (omMetadataManager.getKeyTable().get(dbKeyName) != null) {
+      if (omMetadataManager.getKeyTable().isExist(dbKeyName)) {
         // Found a file in the given path.
         // Check if this is actual file or a file in the given path
         if (dbKeyName.equals(fileNameFromDetails)) {
@@ -68,7 +68,7 @@ public final class OMFileRequest {
         } else {
           return OMDirectoryResult.FILE_EXISTS_IN_GIVENPATH;
         }
-      } else if (omMetadataManager.getKeyTable().get(dbDirKeyName) != null) {
+      } else if (omMetadataManager.getKeyTable().isExist(dbDirKeyName)) {
         // Found a directory in the given path.
         // Check if this is actual directory or a directory in the given path
         if (dbDirKeyName.equals(dirNameFromDetails)) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImpl.java
@@ -185,7 +185,7 @@ public class ContainerDBServiceProviderImpl
    */
   @Override
   public boolean doesContainerExists(Long containerID) throws IOException {
-    return containerKeyCountTable.get(containerID) != null;
+    return containerKeyCountTable.isExist(containerID);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, when OM creates a file/directory, it checks the absence of all prefix paths of the key in its RocksDB. Since we don't care about the deserialization of the actual value from the DB, we should use the isExist API added in org.apache.hadoop.hdds.utils.db.Table which internally uses the more performant keyMayExist API of RocksDB. More documentation on the keyMayExist API can be found [here](https://github.com/facebook/rocksdb/blob/7a8d7358bb40b13a06c2c6adc62e80295d89ed05/java/src/main/java/org/rocksdb/RocksDB.java#L2184) This API was already used in the old OM create file flow. This patch adds it to the new OM code flow that uses Double buffering. 
There is a similar check in Recon container DB. Refactored that as well.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2380

## How was this patch tested?
Manually tested.