### PR TITLE
HDDS-2378 - Change OZONE as string used in the code where OzoneConsts.OZONE is suitable

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDataYaml.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDataYaml.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.fs.FileSystemTestHelper;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.test.GenericTestUtils;
@@ -48,6 +49,9 @@ public class TestContainerDataYaml {
   private static final long MAXSIZE = (long) StorageUnit.GB.toBytes(5);
   private static final Instant SCAN_TIME = Instant.now();
 
+  private static final String VOLUMEOWNER = "hdfs";
+  private static final String CONTAINERDBTYPE = "RocksDB";
+
   /**
    * Creates a .container file. cleanup() should be called at the end of the
    * test when container file is created.
@@ -60,7 +64,7 @@ public class TestContainerDataYaml {
     KeyValueContainerData keyValueContainerData = new KeyValueContainerData(
         containerID, MAXSIZE, UUID.randomUUID().toString(),
         UUID.randomUUID().toString());
-    keyValueContainerData.setContainerDBType("RocksDB");
+    keyValueContainerData.setContainerDBType(CONTAINERDBTYPE);
     keyValueContainerData.setMetadataPath(testRoot);
     keyValueContainerData.setChunksPath(testRoot);
     keyValueContainerData.updateDataScanTime(SCAN_TIME);
@@ -93,7 +97,7 @@ public class TestContainerDataYaml {
     assertEquals(containerID, kvData.getContainerID());
     assertEquals(ContainerProtos.ContainerType.KeyValueContainer, kvData
         .getContainerType());
-    assertEquals("RocksDB", kvData.getContainerDBType());
+    assertEquals(CONTAINERDBTYPE, kvData.getContainerDBType());
     assertEquals(containerFile.getParent(), kvData.getMetadataPath());
     assertEquals(containerFile.getParent(), kvData.getChunksPath());
     assertEquals(ContainerProtos.ContainerDataProto.State.OPEN, kvData
@@ -108,8 +112,8 @@ public class TestContainerDataYaml {
         kvData.getDataScanTimestamp().longValue());
 
     // Update ContainerData.
-    kvData.addMetadata("VOLUME", "hdfs");
-    kvData.addMetadata("OWNER", "ozone");
+    kvData.addMetadata(OzoneConsts.VOLUME, VOLUMEOWNER);
+    kvData.addMetadata(OzoneConsts.OWNER, OzoneConsts.OZONE);
     kvData.setState(ContainerProtos.ContainerDataProto.State.CLOSED);
 
 
@@ -124,15 +128,16 @@ public class TestContainerDataYaml {
     assertEquals(containerID, kvData.getContainerID());
     assertEquals(ContainerProtos.ContainerType.KeyValueContainer, kvData
         .getContainerType());
-    assertEquals("RocksDB", kvData.getContainerDBType());
+    assertEquals(CONTAINERDBTYPE, kvData.getContainerDBType());
     assertEquals(containerFile.getParent(), kvData.getMetadataPath());
     assertEquals(containerFile.getParent(), kvData.getChunksPath());
     assertEquals(ContainerProtos.ContainerDataProto.State.CLOSED, kvData
         .getState());
     assertEquals(1, kvData.getLayOutVersion());
     assertEquals(2, kvData.getMetadata().size());
-    assertEquals("hdfs", kvData.getMetadata().get("VOLUME"));
-    assertEquals("ozone", kvData.getMetadata().get("OWNER"));
+    assertEquals(VOLUMEOWNER, kvData.getMetadata().get(OzoneConsts.VOLUME));
+    assertEquals(OzoneConsts.OZONE,
+        kvData.getMetadata().get(OzoneConsts.OWNER));
     assertEquals(MAXSIZE, kvData.getMaxSize());
     assertTrue(kvData.lastDataScanTime().isPresent());
     assertEquals(SCAN_TIME, kvData.lastDataScanTime().get());
@@ -176,7 +181,7 @@ public class TestContainerDataYaml {
       //Checking the Container file data is consistent or not
       assertEquals(ContainerProtos.ContainerDataProto.State.CLOSED, kvData
           .getState());
-      assertEquals("RocksDB", kvData.getContainerDBType());
+      assertEquals(CONTAINERDBTYPE, kvData.getContainerDBType());
       assertEquals(ContainerProtos.ContainerType.KeyValueContainer, kvData
           .getContainerType());
       assertEquals(9223372036854775807L, kvData.getContainerID());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestBlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestBlockManagerImpl.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
@@ -91,8 +92,9 @@ public class TestBlockManagerImpl {
     // Creating BlockData
     blockID = new BlockID(1L, 1L);
     blockData = new BlockData(blockID);
-    blockData.addMetadata("VOLUME", "ozone");
-    blockData.addMetadata("OWNER", "hdfs");
+    blockData.addMetadata(OzoneConsts.VOLUME, OzoneConsts.OZONE);
+    blockData.addMetadata(OzoneConsts.OWNER,
+        OzoneConsts.OZONE_SIMPLE_HDFS_USER);
     List<ContainerProtos.ChunkInfo> chunkList = new ArrayList<>();
     ChunkInfo info = new ChunkInfo(String.format("%d.data.%d", blockID
         .getLocalID(), 0), 0, 1024);
@@ -156,8 +158,9 @@ public class TestBlockManagerImpl {
     for (long i = 2; i <= 10; i++) {
       blockID = new BlockID(1L, i);
       blockData = new BlockData(blockID);
-      blockData.addMetadata("VOLUME", "ozone");
-      blockData.addMetadata("OWNER", "hdfs");
+      blockData.addMetadata(OzoneConsts.VOLUME, OzoneConsts.OZONE);
+      blockData.addMetadata(OzoneConsts.OWNER,
+          OzoneConsts.OZONE_SIMPLE_HDFS_USER);
       List<ContainerProtos.ChunkInfo> chunkList = new ArrayList<>();
       ChunkInfo info = new ChunkInfo(String.format("%d.data.%d", blockID
           .getLocalID(), 0), 0, 1024);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers
     .StorageContainerException;
 import org.apache.hadoop.hdds.utils.MetadataStoreBuilder;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.impl.ContainerDataYaml;
@@ -138,8 +139,9 @@ public class TestKeyValueContainer {
         // Creating BlockData
         BlockID blockID = new BlockID(containerId, i);
         BlockData blockData = new BlockData(blockID);
-        blockData.addMetadata("VOLUME", "ozone");
-        blockData.addMetadata("OWNER", "hdfs");
+        blockData.addMetadata(OzoneConsts.VOLUME, OzoneConsts.OZONE);
+        blockData.addMetadata(OzoneConsts.OWNER,
+            OzoneConsts.OZONE_SIMPLE_HDFS_USER);
         List<ContainerProtos.ChunkInfo> chunkList = new ArrayList<>();
         ChunkInfo info = new ChunkInfo(String.format("%d.data.%d", blockID
             .getLocalID(), 0), 0, 1024);
@@ -350,8 +352,8 @@ public class TestKeyValueContainer {
   public void testUpdateContainer() throws IOException {
     keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
     Map<String, String> metadata = new HashMap<>();
-    metadata.put("VOLUME", "ozone");
-    metadata.put("OWNER", "hdfs");
+    metadata.put(OzoneConsts.VOLUME, OzoneConsts.OZONE);
+    metadata.put(OzoneConsts.OWNER, OzoneConsts.OZONE_SIMPLE_HDFS_USER);
     keyValueContainer.update(metadata, true);
 
     keyValueContainerData = keyValueContainer
@@ -376,7 +378,7 @@ public class TestKeyValueContainer {
       keyValueContainer = new KeyValueContainer(keyValueContainerData, conf);
       keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
       Map<String, String> metadata = new HashMap<>();
-      metadata.put("VOLUME", "ozone");
+      metadata.put(OzoneConsts.VOLUME, OzoneConsts.OZONE);
       keyValueContainer.update(metadata, false);
       fail("testUpdateContainerUnsupportedRequest failed");
     } catch (StorageContainerException ex) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/metrics/SCMContainerManagerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/metrics/SCMContainerManagerMetrics.java
@@ -22,11 +22,12 @@ import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+import org.apache.hadoop.ozone.OzoneConsts;
 
 /**
  * Class contains metrics related to ContainerManager.
  */
-@Metrics(about = "SCM ContainerManager metrics", context = "ozone")
+@Metrics(about = "SCM ContainerManager metrics", context = OzoneConsts.OZONE)
 public final class SCMContainerManagerMetrics {
 
   private static final String SOURCE_NAME =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementMetrics.java
@@ -28,11 +28,12 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+import org.apache.hadoop.ozone.OzoneConsts;
 
 /**
  * This class is for maintaining Topology aware container placement statistics.
  */
-@Metrics(about="SCM Container Placement Metrics", context = "ozone")
+@Metrics(about="SCM Container Placement Metrics", context = OzoneConsts.OZONE)
 public class SCMContainerPlacementMetrics implements MetricsSource {
   public static final String SOURCE_NAME =
       SCMContainerPlacementMetrics.class.getSimpleName();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeMetrics.java
@@ -37,12 +37,13 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+import org.apache.hadoop.ozone.OzoneConsts;
 
 /**
  * This class maintains Node related metrics.
  */
 @InterfaceAudience.Private
-@Metrics(about = "SCM NodeManager Metrics", context = "ozone")
+@Metrics(about = "SCM NodeManager Metrics", context = OzoneConsts.OZONE)
 public final class SCMNodeMetrics implements MetricsSource {
 
   private static final String SOURCE_NAME =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineMetrics.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+import org.apache.hadoop.ozone.OzoneConsts;
 
 import java.util.Map;
 import java.util.Optional;
@@ -38,7 +39,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * This class maintains Pipeline related metrics.
  */
 @InterfaceAudience.Private
-@Metrics(about = "SCM PipelineManager Metrics", context = "ozone")
+@Metrics(about = "SCM PipelineManager Metrics", context = OzoneConsts.OZONE)
 public final class SCMPipelineMetrics implements MetricsSource {
 
   private static final String SOURCE_NAME =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMContainerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMContainerMetrics.java
@@ -33,12 +33,13 @@ import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.Interns;
+import org.apache.hadoop.ozone.OzoneConsts;
 
 /**
  * Metrics source to report number of containers in different states.
  */
 @InterfaceAudience.Private
-@Metrics(about = "SCM Container Manager Metrics", context = "ozone")
+@Metrics(about = "SCM Container Manager Metrics", context = OzoneConsts.OZONE)
 public class SCMContainerMetrics implements MetricsSource {
 
   private final SCMMXBean scmmxBean;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.hdds.scm.pipeline.SCMPipelineManager;
 import org.apache.hadoop.hdds.scm.server.SCMConfigurator;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventQueue;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
@@ -73,7 +74,6 @@ public class TestBlockManager {
   private final static long DEFAULT_BLOCK_SIZE = 128 * MB;
   private static HddsProtos.ReplicationFactor factor;
   private static HddsProtos.ReplicationType type;
-  private static String containerOwner = "OZONE";
   private static EventQueue eventQueue;
   private int numContainerPerOwnerInPipeline;
   private OzoneConfiguration conf;
@@ -137,7 +137,7 @@ public class TestBlockManager {
       return !blockManager.isScmInSafeMode();
     }, 10, 1000 * 5);
     AllocatedBlock block = blockManager.allocateBlock(DEFAULT_BLOCK_SIZE,
-        type, factor, containerOwner, new ExcludeList());
+        type, factor, OzoneConsts.OZONE, new ExcludeList());
     Assert.assertNotNull(block);
   }
 
@@ -157,7 +157,7 @@ public class TestBlockManager {
     excludeList
         .addPipeline(pipelineManager.getPipelines(type, factor).get(0).getId());
     AllocatedBlock block = blockManager
-        .allocateBlock(DEFAULT_BLOCK_SIZE, type, factor, containerOwner,
+        .allocateBlock(DEFAULT_BLOCK_SIZE, type, factor, OzoneConsts.OZONE,
             excludeList);
     Assert.assertNotNull(block);
     Assert.assertNotEquals(block.getPipeline().getId(),
@@ -167,7 +167,7 @@ public class TestBlockManager {
       excludeList.addPipeline(pipeline.getId());
     }
     block = blockManager
-        .allocateBlock(DEFAULT_BLOCK_SIZE, type, factor, containerOwner,
+        .allocateBlock(DEFAULT_BLOCK_SIZE, type, factor, OzoneConsts.OZONE,
             excludeList);
     Assert.assertNotNull(block);
     Assert.assertTrue(
@@ -193,7 +193,8 @@ public class TestBlockManager {
       CompletableFuture.supplyAsync(() -> {
         try {
           future.complete(blockManager
-              .allocateBlock(DEFAULT_BLOCK_SIZE, type, factor, containerOwner,
+              .allocateBlock(DEFAULT_BLOCK_SIZE, type, factor,
+                  OzoneConsts.OZONE,
                   new ExcludeList()));
         } catch (IOException e) {
           future.completeExceptionally(e);
@@ -220,7 +221,7 @@ public class TestBlockManager {
     long size = 6 * GB;
     thrown.expectMessage("Unsupported block size");
     AllocatedBlock block = blockManager.allocateBlock(size,
-        type, factor, containerOwner, new ExcludeList());
+        type, factor, OzoneConsts.OZONE, new ExcludeList());
   }
 
 
@@ -235,7 +236,7 @@ public class TestBlockManager {
     thrown.expectMessage("SafeModePrecheck failed for "
         + "allocateBlock");
     blockManager.allocateBlock(DEFAULT_BLOCK_SIZE,
-        type, factor, containerOwner, new ExcludeList());
+        type, factor, OzoneConsts.OZONE, new ExcludeList());
   }
 
   @Test
@@ -246,7 +247,7 @@ public class TestBlockManager {
       return !blockManager.isScmInSafeMode();
     }, 10, 1000 * 5);
     Assert.assertNotNull(blockManager.allocateBlock(DEFAULT_BLOCK_SIZE,
-        type, factor, containerOwner, new ExcludeList()));
+        type, factor, OzoneConsts.OZONE, new ExcludeList()));
   }
 
   @Test(timeout = 10000)
@@ -260,13 +261,13 @@ public class TestBlockManager {
     pipelineManager.createPipeline(type, factor);
 
     AllocatedBlock allocatedBlock = blockManager
-        .allocateBlock(DEFAULT_BLOCK_SIZE, type, factor, containerOwner,
+        .allocateBlock(DEFAULT_BLOCK_SIZE, type, factor, OzoneConsts.OZONE,
             new ExcludeList());
     // block should be allocated in different pipelines
     GenericTestUtils.waitFor(() -> {
       try {
         AllocatedBlock block = blockManager
-            .allocateBlock(DEFAULT_BLOCK_SIZE, type, factor, containerOwner,
+            .allocateBlock(DEFAULT_BLOCK_SIZE, type, factor, OzoneConsts.OZONE,
                 new ExcludeList());
         return !block.getPipeline().getId()
             .equals(allocatedBlock.getPipeline().getId());
@@ -311,7 +312,7 @@ public class TestBlockManager {
     GenericTestUtils.waitFor(() -> {
       try {
         blockManager
-            .allocateBlock(DEFAULT_BLOCK_SIZE, type, factor, containerOwner,
+            .allocateBlock(DEFAULT_BLOCK_SIZE, type, factor, OzoneConsts.OZONE,
                 new ExcludeList());
       } catch (IOException e) {
       }
@@ -335,7 +336,7 @@ public class TestBlockManager {
     GenericTestUtils.waitFor(() -> {
       try {
         blockManager
-            .allocateBlock(DEFAULT_BLOCK_SIZE, type, factor, containerOwner,
+            .allocateBlock(DEFAULT_BLOCK_SIZE, type, factor, OzoneConsts.OZONE,
                 new ExcludeList());
       } catch (IOException e) {
       }
@@ -356,7 +357,7 @@ public class TestBlockManager {
     }
     Assert.assertEquals(0, pipelineManager.getPipelines(type, factor).size());
     Assert.assertNotNull(blockManager
-        .allocateBlock(DEFAULT_BLOCK_SIZE, type, factor, containerOwner,
+        .allocateBlock(DEFAULT_BLOCK_SIZE, type, factor, OzoneConsts.OZONE,
             new ExcludeList()));
     Assert.assertEquals(1, pipelineManager.getPipelines(type, factor).size());
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.scm.pipeline.MockRatisPipelineProvider;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineProvider;
 import org.apache.hadoop.hdds.scm.pipeline.SCMPipelineManager;
 import org.apache.hadoop.hdds.server.events.EventQueue;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.AfterClass;
@@ -118,7 +119,7 @@ public class TestCloseContainerEventHandler {
 
     ContainerInfo container = containerManager
         .allocateContainer(HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.ONE, "ozone");
+            HddsProtos.ReplicationFactor.ONE, OzoneConsts.OZONE);
     ContainerID id = container.containerID();
     DatanodeDetails datanode = pipelineManager
         .getPipeline(container.getPipelineID()).getFirstNode();
@@ -138,7 +139,7 @@ public class TestCloseContainerEventHandler {
         .captureLogs(CloseContainerEventHandler.LOG);
     ContainerInfo container = containerManager
         .allocateContainer(HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.THREE, "ozone");
+            HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
     ContainerID id = container.containerID();
     int[] closeCount = new int[3];
     eventQueue.fireEvent(CLOSE_CONTAINER, id);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestSCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestSCMContainerManager.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdds.protocol.proto
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.pipeline.SCMPipelineManager;
 import org.apache.hadoop.hdds.server.events.EventQueue;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.AfterClass;
@@ -69,7 +70,6 @@ public class TestSCMContainerManager {
   private static PipelineManager pipelineManager;
   private static File testDir;
   private static XceiverClientManager xceiverClientManager;
-  private static String containerOwner = "OZONE";
   private static Random random;
 
   private static final long TIMEOUT = 10000;
@@ -121,8 +121,7 @@ public class TestSCMContainerManager {
   public void testallocateContainer() throws Exception {
     ContainerInfo containerInfo = containerManager.allocateContainer(
         xceiverClientManager.getType(),
-        xceiverClientManager.getFactor(),
-        containerOwner);
+        xceiverClientManager.getFactor(), OzoneConsts.OZONE);
     Assert.assertNotNull(containerInfo);
   }
 
@@ -138,8 +137,7 @@ public class TestSCMContainerManager {
     for (int x = 0; x < 30; x++) {
       ContainerInfo containerInfo = containerManager.allocateContainer(
           xceiverClientManager.getType(),
-          xceiverClientManager.getFactor(),
-          containerOwner);
+          xceiverClientManager.getFactor(), OzoneConsts.OZONE);
 
       Assert.assertNotNull(containerInfo);
       Assert.assertNotNull(containerInfo.getPipelineID());
@@ -165,7 +163,7 @@ public class TestSCMContainerManager {
         try {
           ContainerInfo containerInfo = containerManager
               .allocateContainer(xceiverClientManager.getType(),
-                  xceiverClientManager.getFactor(), containerOwner);
+                  xceiverClientManager.getFactor(), OzoneConsts.OZONE);
 
           Assert.assertNotNull(containerInfo);
           Assert.assertNotNull(containerInfo.getPipelineID());
@@ -191,8 +189,7 @@ public class TestSCMContainerManager {
   public void testGetContainer() throws IOException {
     ContainerInfo containerInfo = containerManager.allocateContainer(
         xceiverClientManager.getType(),
-        xceiverClientManager.getFactor(),
-        containerOwner);
+        xceiverClientManager.getFactor(), OzoneConsts.OZONE);
     Assert.assertNotNull(containerInfo);
     Pipeline pipeline  = pipelineManager
         .getPipeline(containerInfo.getPipelineID());
@@ -205,7 +202,7 @@ public class TestSCMContainerManager {
   public void testGetContainerWithPipeline() throws Exception {
     ContainerInfo contInfo = containerManager
         .allocateContainer(xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+            xceiverClientManager.getFactor(), OzoneConsts.OZONE);
     // Add dummy replicas for container.
     Iterator<DatanodeDetails> nodes = pipelineManager
         .getPipeline(contInfo.getPipelineID()).getNodes().iterator();
@@ -312,7 +309,7 @@ public class TestSCMContainerManager {
     nodeManager.setSafemode(false);
     return containerManager
         .allocateContainer(xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+            xceiverClientManager.getFactor(), OzoneConsts.OZONE);
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestContainerPlacement.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestContainerPlacement.java
@@ -163,7 +163,7 @@ public class TestContainerPlacement {
       ContainerInfo container = containerManager
           .allocateContainer(
           xceiverClientManager.getType(),
-          xceiverClientManager.getFactor(), "OZONE");
+          xceiverClientManager.getFactor(), OzoneConsts.OZONE);
       assertEquals(xceiverClientManager.getFactor().getNumber(),
           containerManager.getContainerReplicas(
               container.containerID()).size());

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/OzoneVersionInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/OzoneVersionInfo.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.util;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.util.ClassUtil;
 import org.apache.hadoop.hdds.utils.HddsVersionInfo;
 import org.apache.hadoop.hdds.utils.VersionInfo;
@@ -36,7 +37,7 @@ public final class OzoneVersionInfo {
       LoggerFactory.getLogger(OzoneVersionInfo.class);
 
   public static final VersionInfo OZONE_VERSION_INFO =
-      new VersionInfo("ozone");
+      new VersionInfo(OzoneConsts.OZONE);
 
   private OzoneVersionInfo() {}
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -63,7 +63,6 @@ public class TestContainerStateManagerIntegration {
   private StorageContainerManager scm;
   private ContainerManager containerManager;
   private ContainerStateManager containerStateManager;
-  private String containerOwner = "OZONE";
   private int numContainerPerOwnerInPipeline;
 
 
@@ -95,13 +94,13 @@ public class TestContainerStateManagerIntegration {
     // Allocate a container and verify the container info
     ContainerWithPipeline container1 = scm.getClientProtocolServer()
         .allocateContainer(xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+            xceiverClientManager.getFactor(), OzoneConsts.OZONE);
     ContainerInfo info = containerManager
-        .getMatchingContainer(OzoneConsts.GB * 3, containerOwner,
+        .getMatchingContainer(OzoneConsts.GB * 3, OzoneConsts.OZONE,
             container1.getPipeline());
     Assert.assertNotEquals(container1.getContainerInfo().getContainerID(),
         info.getContainerID());
-    Assert.assertEquals(containerOwner, info.getOwner());
+    Assert.assertEquals(OzoneConsts.OZONE, info.getOwner());
     Assert.assertEquals(xceiverClientManager.getType(),
         info.getReplicationType());
     Assert.assertEquals(xceiverClientManager.getFactor(),
@@ -112,9 +111,9 @@ public class TestContainerStateManagerIntegration {
     ContainerWithPipeline container2 = scm.getClientProtocolServer()
         .allocateContainer(
             xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+            xceiverClientManager.getFactor(), OzoneConsts.OZONE);
     int numContainers = containerStateManager
-        .getMatchingContainerIDs(containerOwner,
+        .getMatchingContainerIDs(OzoneConsts.OZONE,
             xceiverClientManager.getType(), xceiverClientManager.getFactor(),
             HddsProtos.LifeCycleState.OPEN).size();
     Assert.assertNotEquals(container1.getContainerInfo().getContainerID(),
@@ -128,9 +127,9 @@ public class TestContainerStateManagerIntegration {
     // Allocate a container and verify the container info
     ContainerWithPipeline container1 = scm.getClientProtocolServer()
         .allocateContainer(xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+            xceiverClientManager.getFactor(), OzoneConsts.OZONE);
     ContainerInfo info = containerManager
-        .getMatchingContainer(OzoneConsts.GB * 3, containerOwner,
+        .getMatchingContainer(OzoneConsts.GB * 3, OzoneConsts.OZONE,
             container1.getPipeline());
     Assert.assertNotNull(info);
 
@@ -156,7 +155,7 @@ public class TestContainerStateManagerIntegration {
       ContainerWithPipeline container = scm.getClientProtocolServer()
           .allocateContainer(
               xceiverClientManager.getType(),
-              xceiverClientManager.getFactor(), containerOwner);
+              xceiverClientManager.getFactor(), OzoneConsts.OZONE);
       if (i >= 5) {
         scm.getContainerManager().updateContainerState(container
                 .getContainerInfo().containerID(),
@@ -171,7 +170,7 @@ public class TestContainerStateManagerIntegration {
 
     long matchCount = result.stream()
         .filter(info ->
-            info.getOwner().equals(containerOwner))
+            info.getOwner().equals(OzoneConsts.OZONE))
         .filter(info ->
             info.getReplicationType() == xceiverClientManager.getType())
         .filter(info ->
@@ -182,7 +181,7 @@ public class TestContainerStateManagerIntegration {
     Assert.assertEquals(5, matchCount);
     matchCount = result.stream()
         .filter(info ->
-            info.getOwner().equals(containerOwner))
+            info.getOwner().equals(OzoneConsts.OZONE))
         .filter(info ->
             info.getReplicationType() == xceiverClientManager.getType())
         .filter(info ->
@@ -198,7 +197,7 @@ public class TestContainerStateManagerIntegration {
     long cid;
     ContainerWithPipeline container1 = scm.getClientProtocolServer().
         allocateContainer(xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+            xceiverClientManager.getFactor(), OzoneConsts.OZONE);
     cid = container1.getContainerInfo().getContainerID();
 
     // each getMatchingContainer call allocates a container in the
@@ -206,7 +205,7 @@ public class TestContainerStateManagerIntegration {
     // containers.
     for (int i = 1; i < numContainerPerOwnerInPipeline; i++) {
       ContainerInfo info = containerManager
-          .getMatchingContainer(OzoneConsts.GB * 3, containerOwner,
+          .getMatchingContainer(OzoneConsts.GB * 3, OzoneConsts.OZONE,
               container1.getPipeline());
       Assert.assertTrue(info.getContainerID() > cid);
       cid = info.getContainerID();
@@ -215,7 +214,7 @@ public class TestContainerStateManagerIntegration {
     // At this point there are already three containers in the pipeline.
     // next container should be the same as first container
     ContainerInfo info = containerManager
-        .getMatchingContainer(OzoneConsts.GB * 3, containerOwner,
+        .getMatchingContainer(OzoneConsts.GB * 3, OzoneConsts.OZONE,
             container1.getPipeline());
     Assert.assertEquals(container1.getContainerInfo().getContainerID(),
         info.getContainerID());
@@ -226,7 +225,7 @@ public class TestContainerStateManagerIntegration {
     long cid;
     ContainerWithPipeline container1 = scm.getClientProtocolServer().
         allocateContainer(xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+            xceiverClientManager.getFactor(), OzoneConsts.OZONE);
     cid = container1.getContainerInfo().getContainerID();
 
     // each getMatchingContainer call allocates a container in the
@@ -234,7 +233,7 @@ public class TestContainerStateManagerIntegration {
     // containers.
     for (int i = 1; i < numContainerPerOwnerInPipeline; i++) {
       ContainerInfo info = containerManager
-          .getMatchingContainer(OzoneConsts.GB * 3, containerOwner,
+          .getMatchingContainer(OzoneConsts.GB * 3, OzoneConsts.OZONE,
               container1.getPipeline());
       Assert.assertTrue(info.getContainerID() > cid);
       cid = info.getContainerID();
@@ -243,7 +242,7 @@ public class TestContainerStateManagerIntegration {
     // At this point there are already three containers in the pipeline.
     // next container should be the same as first container
     ContainerInfo info = containerManager
-        .getMatchingContainer(OzoneConsts.GB * 3, containerOwner,
+        .getMatchingContainer(OzoneConsts.GB * 3, OzoneConsts.OZONE,
             container1.getPipeline(), Collections.singletonList(new
                 ContainerID(1)));
     Assert.assertNotEquals(container1.getContainerInfo().getContainerID(),
@@ -256,19 +255,19 @@ public class TestContainerStateManagerIntegration {
     long cid;
     ContainerWithPipeline container1 = scm.getClientProtocolServer().
         allocateContainer(xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+            xceiverClientManager.getFactor(), OzoneConsts.OZONE);
     cid = container1.getContainerInfo().getContainerID();
 
     for (int i = 1; i < numContainerPerOwnerInPipeline; i++) {
       ContainerInfo info = containerManager
-          .getMatchingContainer(OzoneConsts.GB * 3, containerOwner,
+          .getMatchingContainer(OzoneConsts.GB * 3, OzoneConsts.OZONE,
               container1.getPipeline());
       Assert.assertTrue(info.getContainerID() > cid);
       cid = info.getContainerID();
     }
 
     ContainerInfo info = containerManager
-        .getMatchingContainer(OzoneConsts.GB * 3, containerOwner,
+        .getMatchingContainer(OzoneConsts.GB * 3, OzoneConsts.OZONE,
             container1.getPipeline(), Arrays.asList(new ContainerID(1), new
                 ContainerID(2), new ContainerID(3)));
     Assert.assertEquals(info.getContainerID(), 4);
@@ -280,7 +279,7 @@ public class TestContainerStateManagerIntegration {
       throws IOException, InterruptedException {
     ContainerWithPipeline container1 = scm.getClientProtocolServer().
         allocateContainer(xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+            xceiverClientManager.getFactor(), OzoneConsts.OZONE);
     Map<Long, Long> container2MatchedCount = new ConcurrentHashMap<>();
 
     // allocate blocks using multiple threads
@@ -288,7 +287,7 @@ public class TestContainerStateManagerIntegration {
     for (int i = 0; i < numBlockAllocates; i++) {
       CompletableFuture.supplyAsync(() -> {
         ContainerInfo info = containerManager
-            .getMatchingContainer(OzoneConsts.GB * 3, containerOwner,
+            .getMatchingContainer(OzoneConsts.GB * 3, OzoneConsts.OZONE,
                 container1.getPipeline());
         container2MatchedCount
             .compute(info.getContainerID(), (k, v) -> v == null ? 1L : v + 1);
@@ -319,7 +318,7 @@ public class TestContainerStateManagerIntegration {
   @Test
   public void testUpdateContainerState() throws IOException {
     NavigableSet<ContainerID> containerList = containerStateManager
-        .getMatchingContainerIDs(containerOwner,
+        .getMatchingContainerIDs(OzoneConsts.OZONE,
             xceiverClientManager.getType(), xceiverClientManager.getFactor(),
             HddsProtos.LifeCycleState.OPEN);
     int containers = containerList == null ? 0 : containerList.size();
@@ -330,8 +329,9 @@ public class TestContainerStateManagerIntegration {
     ContainerWithPipeline container1 = scm.getClientProtocolServer()
         .allocateContainer(
             xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
-    containers = containerStateManager.getMatchingContainerIDs(containerOwner,
+            xceiverClientManager.getFactor(), OzoneConsts.OZONE);
+    containers = containerStateManager.getMatchingContainerIDs(
+        OzoneConsts.OZONE,
         xceiverClientManager.getType(), xceiverClientManager.getFactor(),
         HddsProtos.LifeCycleState.OPEN).size();
     Assert.assertEquals(1, containers);
@@ -339,7 +339,8 @@ public class TestContainerStateManagerIntegration {
     containerManager
         .updateContainerState(container1.getContainerInfo().containerID(),
             HddsProtos.LifeCycleEvent.FINALIZE);
-    containers = containerStateManager.getMatchingContainerIDs(containerOwner,
+    containers = containerStateManager.getMatchingContainerIDs(
+        OzoneConsts.OZONE,
         xceiverClientManager.getType(), xceiverClientManager.getFactor(),
         HddsProtos.LifeCycleState.CLOSING).size();
     Assert.assertEquals(1, containers);
@@ -347,7 +348,8 @@ public class TestContainerStateManagerIntegration {
     containerManager
         .updateContainerState(container1.getContainerInfo().containerID(),
             HddsProtos.LifeCycleEvent.CLOSE);
-    containers = containerStateManager.getMatchingContainerIDs(containerOwner,
+    containers = containerStateManager.getMatchingContainerIDs(
+        OzoneConsts.OZONE,
         xceiverClientManager.getType(), xceiverClientManager.getFactor(),
         HddsProtos.LifeCycleState.CLOSED).size();
     Assert.assertEquals(1, containers);
@@ -355,7 +357,8 @@ public class TestContainerStateManagerIntegration {
     containerManager
         .updateContainerState(container1.getContainerInfo().containerID(),
             HddsProtos.LifeCycleEvent.DELETE);
-    containers = containerStateManager.getMatchingContainerIDs(containerOwner,
+    containers = containerStateManager.getMatchingContainerIDs(
+        OzoneConsts.OZONE,
         xceiverClientManager.getType(), xceiverClientManager.getFactor(),
         HddsProtos.LifeCycleState.DELETING).size();
     Assert.assertEquals(1, containers);
@@ -363,7 +366,8 @@ public class TestContainerStateManagerIntegration {
     containerManager
         .updateContainerState(container1.getContainerInfo().containerID(),
             HddsProtos.LifeCycleEvent.CLEANUP);
-    containers = containerStateManager.getMatchingContainerIDs(containerOwner,
+    containers = containerStateManager.getMatchingContainerIDs(
+        OzoneConsts.OZONE,
         xceiverClientManager.getType(), xceiverClientManager.getFactor(),
         HddsProtos.LifeCycleState.DELETED).size();
     Assert.assertEquals(1, containers);
@@ -373,14 +377,15 @@ public class TestContainerStateManagerIntegration {
     ContainerWithPipeline container3 = scm.getClientProtocolServer()
         .allocateContainer(
             xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+            xceiverClientManager.getFactor(), OzoneConsts.OZONE);
     containerManager
         .updateContainerState(container3.getContainerInfo().containerID(),
             HddsProtos.LifeCycleEvent.FINALIZE);
     containerManager
         .updateContainerState(container3.getContainerInfo().containerID(),
             HddsProtos.LifeCycleEvent.CLOSE);
-    containers = containerStateManager.getMatchingContainerIDs(containerOwner,
+    containers = containerStateManager.getMatchingContainerIDs(
+        OzoneConsts.OZONE,
         xceiverClientManager.getType(), xceiverClientManager.getFactor(),
         HddsProtos.LifeCycleState.CLOSED).size();
     Assert.assertEquals(1, containers);
@@ -409,7 +414,7 @@ public class TestContainerStateManagerIntegration {
     ContainerWithPipeline container = scm.getClientProtocolServer()
         .allocateContainer(
             xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(), containerOwner);
+            xceiverClientManager.getFactor(), OzoneConsts.OZONE);
 
     ContainerID id = container.getContainerInfo().containerID();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
@@ -50,7 +51,6 @@ public class TestSCMContainerManagerMetrics {
 
   private MiniOzoneCluster cluster;
   private StorageContainerManager scm;
-  private String containerOwner = "OZONE";
 
   @Before
   public void setup() throws Exception {
@@ -77,7 +77,7 @@ public class TestSCMContainerManagerMetrics {
 
     ContainerInfo containerInfo = containerManager.allocateContainer(
         HddsProtos.ReplicationType.RATIS,
-        HddsProtos.ReplicationFactor.ONE, containerOwner);
+        HddsProtos.ReplicationFactor.ONE, OzoneConsts.OZONE);
 
     metrics = getMetrics(SCMContainerManagerMetrics.class.getSimpleName());
     Assert.assertEquals(getLongCounter("NumSuccessfulCreateContainers",
@@ -86,7 +86,7 @@ public class TestSCMContainerManagerMetrics {
     try {
       containerManager.allocateContainer(
           HddsProtos.ReplicationType.RATIS,
-          HddsProtos.ReplicationFactor.THREE, containerOwner);
+          HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
       fail("testContainerOpsMetrics failed");
     } catch (IOException ex) {
       // Here it should fail, so it should have the old metric value.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerOperations.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerOperations.java
@@ -79,7 +79,7 @@ public class TestContainerOperations {
   public void testCreate() throws Exception {
     ContainerWithPipeline container = storageClient.createContainer(HddsProtos
         .ReplicationType.STAND_ALONE, HddsProtos.ReplicationFactor
-        .ONE, "OZONE");
+        .ONE, OzoneConsts.OZONE);
     assertEquals(container.getContainerInfo().getContainerID(), storageClient
         .getContainer(container.getContainerInfo().getContainerID())
         .getContainerID());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerStateMachineIdempotency.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerStateMachineIdempotency.java
@@ -54,7 +54,6 @@ public class TestContainerStateMachineIdempotency {
   private static StorageContainerLocationProtocolClientSideTranslatorPB
       storageContainerLocationClient;
   private static XceiverClientManager xceiverClientManager;
-  private static String containerOwner = "OZONE";
 
   @BeforeClass
   public static void init() throws Exception {
@@ -81,7 +80,7 @@ public class TestContainerStateMachineIdempotency {
   public void testContainerStateMachineIdempotency() throws Exception {
     ContainerWithPipeline container = storageContainerLocationClient
         .allocateContainer(HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.ONE, containerOwner);
+            HddsProtos.ReplicationFactor.ONE, OzoneConsts.OZONE);
     long containerID = container.getContainerInfo().getContainerID();
     Pipeline pipeline = container.getPipeline();
     XceiverClientSpi client = xceiverClientManager.acquireClient(pipeline);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
@@ -181,7 +181,7 @@ public class TestStorageContainerManager {
       try {
         ContainerWithPipeline container2 = mockClientServer
             .allocateContainer(xceiverClientManager.getType(),
-            HddsProtos.ReplicationFactor.ONE,  "OZONE");
+            HddsProtos.ReplicationFactor.ONE,  OzoneConsts.OZONE);
         if (expectPermissionDenied) {
           fail("Operation should fail, expecting an IOException here.");
         } else {
@@ -194,7 +194,7 @@ public class TestStorageContainerManager {
       try {
         ContainerWithPipeline container3 = mockClientServer
             .allocateContainer(xceiverClientManager.getType(),
-            HddsProtos.ReplicationFactor.ONE, "OZONE");
+            HddsProtos.ReplicationFactor.ONE, OzoneConsts.OZONE);
         if (expectPermissionDenied) {
           fail("Operation should fail, expecting an IOException here.");
         } else {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/Test2WayCommitInRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/Test2WayCommitInRatis.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
@@ -58,7 +59,6 @@ public class Test2WayCommitInRatis {
   private int blockSize;
   private StorageContainerLocationProtocolClientSideTranslatorPB
       storageContainerLocationClient;
-  private static String containerOwner = "OZONE";
 
   /**
    * Create a MiniDFSCluster for testing.
@@ -123,7 +123,7 @@ public class Test2WayCommitInRatis {
 
     ContainerWithPipeline container1 = storageContainerLocationClient
         .allocateContainer(HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.THREE, containerOwner);
+            HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
     XceiverClientSpi xceiverClient = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, xceiverClient.getRefcount());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitWatcher.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitWatcher.java
@@ -72,7 +72,6 @@ public class TestCommitWatcher {
   private static String keyString;
   private static StorageContainerLocationProtocolClientSideTranslatorPB
       storageContainerLocationClient;
-  private static String containerOwner = "OZONE";
 
   /**
    * Create a MiniDFSCluster for testing.
@@ -132,7 +131,7 @@ public class TestCommitWatcher {
     XceiverClientManager clientManager = new XceiverClientManager(conf);
     ContainerWithPipeline container = storageContainerLocationClient
         .allocateContainer(HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.THREE, containerOwner);
+            HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
     Pipeline pipeline = container.getPipeline();
     long containerId = container.getContainerInfo().getContainerID();
     XceiverClientSpi xceiverClient = clientManager.acquireClient(pipeline);
@@ -208,7 +207,7 @@ public class TestCommitWatcher {
     XceiverClientManager clientManager = new XceiverClientManager(conf);
     ContainerWithPipeline container = storageContainerLocationClient
         .allocateContainer(HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.THREE, containerOwner);
+            HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
     Pipeline pipeline = container.getPipeline();
     long containerId = container.getContainerInfo().getContainerID();
     XceiverClientSpi xceiverClient = clientManager.acquireClient(pipeline);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -406,7 +406,7 @@ public abstract class TestOzoneRpcClientAbstract {
   public void testCreateS3BucketMapping()
       throws IOException, OzoneClientException {
     long currentTime = Time.now();
-    String userName = "ozone";
+    String userName = OzoneConsts.OZONE;
     String bucketName = UUID.randomUUID().toString();
     store.createS3Bucket(userName, bucketName);
     String volumeName = store.getOzoneVolumeName(bucketName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolCli
 import org.apache.hadoop.hdds.scm.storage.BlockOutputStream;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
@@ -73,7 +74,6 @@ public class TestWatchForCommit {
   private int blockSize;
   private StorageContainerLocationProtocolClientSideTranslatorPB
       storageContainerLocationClient;
-  private static String containerOwner = "OZONE";
 
   /**
    * Create a MiniDFSCluster for testing.
@@ -279,7 +279,7 @@ public class TestWatchForCommit {
     XceiverClientManager clientManager = new XceiverClientManager(conf);
     ContainerWithPipeline container1 = storageContainerLocationClient
         .allocateContainer(HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.THREE, containerOwner);
+            HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
     XceiverClientSpi xceiverClient = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, xceiverClient.getRefcount());
@@ -321,7 +321,7 @@ public class TestWatchForCommit {
     XceiverClientManager clientManager = new XceiverClientManager(conf);
     ContainerWithPipeline container1 = storageContainerLocationClient
         .allocateContainer(HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.THREE, containerOwner);
+            HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
     XceiverClientSpi xceiverClient = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, xceiverClient.getRefcount());
@@ -369,7 +369,7 @@ public class TestWatchForCommit {
 
     ContainerWithPipeline container1 = storageContainerLocationClient
         .allocateContainer(HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.THREE, containerOwner);
+            HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
     XceiverClientSpi xceiverClient = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, xceiverClient.getRefcount());
@@ -417,7 +417,7 @@ public class TestWatchForCommit {
 
     ContainerWithPipeline container1 = storageContainerLocationClient
         .allocateContainer(HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.THREE, containerOwner);
+            HddsProtos.ReplicationFactor.THREE, OzoneConsts.OZONE);
     XceiverClientSpi xceiverClient = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, xceiverClient.getRefcount());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/ozShell/TestS3Shell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/ozShell/TestS3Shell.java
@@ -154,7 +154,7 @@ public class TestS3Shell {
 
     String s3Bucket = "bucket1";
     String commandOutput;
-    createS3Bucket("ozone", s3Bucket);
+    createS3Bucket(OzoneConsts.OZONE, s3Bucket);
 
     // WHEN
     String[] args =
@@ -200,7 +200,7 @@ public class TestS3Shell {
 
   private void createS3Bucket(String userName, String s3Bucket) {
     try {
-      client.createS3Bucket("ozone", s3Bucket);
+      client.createS3Bucket(OzoneConsts.OZONE, s3Bucket);
     } catch (IOException ex) {
       GenericTestUtils.assertExceptionContains("S3_BUCKET_ALREADY_EXISTS", ex);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestAllocateContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestAllocateContainer.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -40,7 +41,6 @@ public class TestAllocateContainer {
   private static StorageContainerLocationProtocolClientSideTranslatorPB
       storageContainerLocationClient;
   private static XceiverClientManager xceiverClientManager;
-  private static String containerOwner = "OZONE";
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
@@ -67,8 +67,7 @@ public class TestAllocateContainer {
     ContainerWithPipeline container =
         storageContainerLocationClient.allocateContainer(
             xceiverClientManager.getType(),
-            xceiverClientManager.getFactor(),
-            containerOwner);
+            xceiverClientManager.getFactor(), OzoneConsts.OZONE);
     Assert.assertNotNull(container);
     Assert.assertNotNull(container.getPipeline().getFirstNode());
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestContainerSmallFile.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestContainerSmallFile.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -53,7 +54,6 @@ public class TestContainerSmallFile {
   private static StorageContainerLocationProtocolClientSideTranslatorPB
       storageContainerLocationClient;
   private static XceiverClientManager xceiverClientManager;
-  private static String containerOwner = "OZONE";
 
   @BeforeClass
   public static void init() throws Exception {
@@ -81,7 +81,7 @@ public class TestContainerSmallFile {
     ContainerWithPipeline container =
         storageContainerLocationClient.allocateContainer(
             xceiverClientManager.getType(),
-            HddsProtos.ReplicationFactor.ONE, containerOwner);
+            HddsProtos.ReplicationFactor.ONE, OzoneConsts.OZONE);
     XceiverClientSpi client = xceiverClientManager
         .acquireClient(container.getPipeline());
     ContainerProtocolCalls.createContainer(client,
@@ -103,7 +103,7 @@ public class TestContainerSmallFile {
     ContainerWithPipeline container =
         storageContainerLocationClient.allocateContainer(
             xceiverClientManager.getType(),
-            HddsProtos.ReplicationFactor.ONE, containerOwner);
+            HddsProtos.ReplicationFactor.ONE, OzoneConsts.OZONE);
     XceiverClientSpi client = xceiverClientManager
         .acquireClient(container.getPipeline());
     ContainerProtocolCalls.createContainer(client,
@@ -126,7 +126,7 @@ public class TestContainerSmallFile {
     ContainerWithPipeline container =
         storageContainerLocationClient.allocateContainer(
             xceiverClientManager.getType(),
-            HddsProtos.ReplicationFactor.ONE, containerOwner);
+            HddsProtos.ReplicationFactor.ONE, OzoneConsts.OZONE);
     XceiverClientSpi client = xceiverClientManager
         .acquireClient(container.getPipeline());
     ContainerProtocolCalls.createContainer(client,
@@ -152,7 +152,7 @@ public class TestContainerSmallFile {
     ContainerWithPipeline container =
         storageContainerLocationClient.allocateContainer(
             HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.ONE, containerOwner);
+            HddsProtos.ReplicationFactor.ONE, OzoneConsts.OZONE);
     XceiverClientSpi client = xceiverClientManager
         .acquireClient(container.getPipeline());
     ContainerProtocolCalls.createContainer(client,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestGetCommittedBlockLengthAndPutKey.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestGetCommittedBlockLengthAndPutKey.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.hdds.scm.protocolPB.
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -56,7 +57,6 @@ public class TestGetCommittedBlockLengthAndPutKey {
   private static StorageContainerLocationProtocolClientSideTranslatorPB
       storageContainerLocationClient;
   private static XceiverClientManager xceiverClientManager;
-  private static String containerOwner = "OZONE";
 
   @BeforeClass
   public static void init() throws Exception {
@@ -84,7 +84,7 @@ public class TestGetCommittedBlockLengthAndPutKey {
     ContainerProtos.GetCommittedBlockLengthResponseProto response;
     ContainerWithPipeline container = storageContainerLocationClient
         .allocateContainer(xceiverClientManager.getType(),
-            HddsProtos.ReplicationFactor.ONE, containerOwner);
+            HddsProtos.ReplicationFactor.ONE, OzoneConsts.OZONE);
     long containerID = container.getContainerInfo().getContainerID();
     Pipeline pipeline = container.getPipeline();
     XceiverClientSpi client = xceiverClientManager.acquireClient(pipeline);
@@ -117,7 +117,7 @@ public class TestGetCommittedBlockLengthAndPutKey {
   public void testGetCommittedBlockLengthForInvalidBlock() throws Exception {
     ContainerWithPipeline container = storageContainerLocationClient
         .allocateContainer(xceiverClientManager.getType(),
-            HddsProtos.ReplicationFactor.ONE, containerOwner);
+            HddsProtos.ReplicationFactor.ONE, OzoneConsts.OZONE);
     long containerID = container.getContainerInfo().getContainerID();
     XceiverClientSpi client = xceiverClientManager
         .acquireClient(container.getPipeline());
@@ -142,7 +142,7 @@ public class TestGetCommittedBlockLengthAndPutKey {
     ContainerProtos.PutBlockResponseProto response;
     ContainerWithPipeline container = storageContainerLocationClient
         .allocateContainer(HddsProtos.ReplicationType.RATIS,
-            HddsProtos.ReplicationFactor.ONE, containerOwner);
+            HddsProtos.ReplicationFactor.ONE, OzoneConsts.OZONE);
     long containerID = container.getContainerInfo().getContainerID();
     Pipeline pipeline = container.getPipeline();
     XceiverClientSpi client = xceiverClientManager.acquireClient(pipeline);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientManager.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.protocolPB
     .StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.After;
@@ -49,7 +50,6 @@ public class TestXceiverClientManager {
   private static MiniOzoneCluster cluster;
   private static StorageContainerLocationProtocolClientSideTranslatorPB
       storageContainerLocationClient;
-  private static String containerOwner = "OZONE";
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
@@ -84,14 +84,14 @@ public class TestXceiverClientManager {
 
     ContainerWithPipeline container1 = storageContainerLocationClient
         .allocateContainer(clientManager.getType(), clientManager.getFactor(),
-            containerOwner);
+            OzoneConsts.OZONE);
     XceiverClientSpi client1 = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, client1.getRefcount());
 
     ContainerWithPipeline container2 = storageContainerLocationClient
         .allocateContainer(clientManager.getType(), clientManager.getFactor(),
-            containerOwner);
+            OzoneConsts.OZONE);
     XceiverClientSpi client2 = clientManager
         .acquireClient(container2.getPipeline());
     Assert.assertEquals(1, client2.getRefcount());
@@ -122,7 +122,7 @@ public class TestXceiverClientManager {
     ContainerWithPipeline container1 =
         storageContainerLocationClient.allocateContainer(
             clientManager.getType(), HddsProtos.ReplicationFactor.ONE,
-            containerOwner);
+            OzoneConsts.OZONE);
     XceiverClientSpi client1 = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, client1.getRefcount());
@@ -132,7 +132,7 @@ public class TestXceiverClientManager {
     ContainerWithPipeline container2 =
         storageContainerLocationClient.allocateContainer(
             clientManager.getType(),
-            HddsProtos.ReplicationFactor.ONE, containerOwner);
+            HddsProtos.ReplicationFactor.ONE, OzoneConsts.OZONE);
     XceiverClientSpi client2 = clientManager
         .acquireClient(container2.getPipeline());
     Assert.assertEquals(1, client2.getRefcount());
@@ -180,7 +180,7 @@ public class TestXceiverClientManager {
     ContainerWithPipeline container1 =
         storageContainerLocationClient.allocateContainer(
             clientManager.getType(),
-            clientManager.getFactor(), containerOwner);
+            clientManager.getFactor(), OzoneConsts.OZONE);
     XceiverClientSpi client1 = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, client1.getRefcount());
@@ -190,7 +190,7 @@ public class TestXceiverClientManager {
 
     ContainerWithPipeline container2 = storageContainerLocationClient
         .allocateContainer(clientManager.getType(), clientManager.getFactor(),
-            containerOwner);
+            OzoneConsts.OZONE);
     XceiverClientSpi client2 = clientManager
         .acquireClient(container2.getPipeline());
     Assert.assertEquals(1, client2.getRefcount());
@@ -229,7 +229,7 @@ public class TestXceiverClientManager {
     // client is added in cache
     ContainerWithPipeline container1 = storageContainerLocationClient
         .allocateContainer(clientManager.getType(), clientManager.getFactor(),
-            containerOwner);
+            OzoneConsts.OZONE);
     XceiverClientSpi client1 =
         clientManager.acquireClient(container1.getPipeline());
     clientManager.acquireClient(container1.getPipeline());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientMetrics.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientMetrics;
@@ -60,7 +61,6 @@ public class TestXceiverClientMetrics {
   private static MiniOzoneCluster cluster;
   private static StorageContainerLocationProtocolClientSideTranslatorPB
       storageContainerLocationClient;
-  private static String containerOwner = "OZONE";
 
   @BeforeClass
   public static void init() throws Exception {
@@ -87,7 +87,7 @@ public class TestXceiverClientMetrics {
 
     ContainerWithPipeline container = storageContainerLocationClient
         .allocateContainer(clientManager.getType(), clientManager.getFactor(),
-            containerOwner);
+            OzoneConsts.OZONE);
     XceiverClientSpi client = clientManager
         .acquireClient(container.getPipeline());
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestS3BucketManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestS3BucketManager.java
@@ -64,7 +64,7 @@ public class TestS3BucketManager {
   public void testOzoneVolumeNameForUser() throws IOException {
     S3BucketManager s3BucketManager = new S3BucketManagerImpl(conf, metaMgr,
         volumeManager, bucketManager);
-    String userName = "ozone";
+    String userName = OzoneConsts.OZONE;
     String volumeName = s3BucketManager.getOzoneVolumeNameForUser(userName);
     assertEquals(OzoneConsts.OM_S3_VOLUME_PREFIX + userName, volumeName);
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.AuditMessage;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
@@ -441,7 +442,7 @@ public class TestOzoneManagerDoubleBufferWithOMResponse {
   private OMClientResponse createVolume(String volumeName,
       long transactionId) {
 
-    String admin = "ozone";
+    String admin = OzoneConsts.OZONE;
     String owner = UUID.randomUUID().toString();
     OzoneManagerProtocolProtos.OMRequest omRequest =
         TestOMRequestUtils.createVolumeRequest(volumeName, admin, owner);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
@@ -23,6 +23,7 @@ package org.apache.hadoop.ozone.om.request.key;
 import java.util.List;
 import java.util.UUID;
 
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -146,7 +147,8 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
 
 
     // Added only volume to DB.
-    TestOMRequestUtils.addVolumeToDB(volumeName, "ozone", omMetadataManager);
+    TestOMRequestUtils.addVolumeToDB(volumeName, OzoneConsts.OZONE,
+        omMetadataManager);
 
     OMClientResponse omAllocateBlockResponse =
         omAllocateBlockRequest.validateAndUpdateCache(ozoneManager, 100L,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -154,7 +155,8 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         new OMKeyCommitRequest(modifiedOmRequest);
 
 
-    TestOMRequestUtils.addVolumeToDB(volumeName, "ozone", omMetadataManager);
+    TestOMRequestUtils.addVolumeToDB(volumeName, OzoneConsts.OZONE,
+        omMetadataManager);
     String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
         keyName);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.om.request.key;
 import java.util.List;
 import java.util.UUID;
 
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -210,7 +211,8 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,
         keyName, id);
 
-    TestOMRequestUtils.addVolumeToDB(volumeName, "ozone", omMetadataManager);
+    TestOMRequestUtils.addVolumeToDB(volumeName, OzoneConsts.OZONE,
+        omMetadataManager);
 
     // Before calling
     OmKeyInfo omKeyInfo = omMetadataManager.getOpenKeyTable().get(openKey);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/bucket/TestS3BucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/bucket/TestS3BucketDeleteRequest.java
@@ -22,6 +22,7 @@ package org.apache.hadoop.ozone.om.request.s3.bucket;
 import java.util.UUID;
 
 import org.apache.commons.lang.RandomStringUtils;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -52,7 +53,7 @@ public class TestS3BucketDeleteRequest extends TestS3BucketRequest {
     OMRequest omRequest = doPreExecute(s3BucketName);
 
     // Add s3Bucket to s3Bucket table.
-    TestOMRequestUtils.addS3BucketToDB("ozone", s3BucketName,
+    TestOMRequestUtils.addS3BucketToDB(OzoneConsts.OZONE, s3BucketName,
         omMetadataManager);
 
     S3BucketDeleteRequest s3BucketDeleteRequest =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/bucket/TestS3BucketDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/bucket/TestS3BucketDeleteResponse.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.response.s3.bucket;
 
 import java.util.UUID;
 
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -63,7 +64,7 @@ public class TestS3BucketDeleteResponse {
   @Test
   public void testAddToDBBatch() throws Exception {
     String s3BucketName = UUID.randomUUID().toString();
-    String userName = "ozone";
+    String userName = OzoneConsts.OZONE;
     String volumeName = S3BucketCreateRequest.formatOzoneVolumeName(userName);
     S3BucketCreateResponse s3BucketCreateResponse =
         TestOMResponseUtils.createS3BucketResponse(userName, volumeName,

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestAbortMultipartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestAbortMultipartUpload.java
@@ -19,6 +19,7 @@
  */
 package org.apache.hadoop.ozone.s3.endpoint;
 
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
@@ -43,10 +44,10 @@ public class TestAbortMultipartUpload {
   @Test
   public void testAbortMultipartUpload() throws Exception {
 
-    String bucket = "s3bucket";
-    String key = "key1";
+    String bucket = OzoneConsts.S3_BUCKET;
+    String key = OzoneConsts.KEY;
     OzoneClientStub client = new OzoneClientStub();
-    client.getObjectStore().createS3Bucket("ozone", bucket);
+    client.getObjectStore().createS3Bucket(OzoneConsts.OZONE, bucket);
 
     HttpHeaders headers = Mockito.mock(HttpHeaders.class);
     when(headers.getHeaderString(STORAGE_CLASS_HEADER)).thenReturn(

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketDelete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketDelete.java
@@ -22,6 +22,7 @@ package org.apache.hadoop.ozone.s3.endpoint;
 
 import javax.ws.rs.core.Response;
 
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.ObjectStoreStub;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
@@ -39,7 +40,7 @@ import org.junit.Test;
  */
 public class TestBucketDelete {
 
-  private String bucketName = "myBucket";
+  private String bucketName = OzoneConsts.BUCKET;
   private OzoneClientStub clientStub;
   private ObjectStore objectStoreStub;
   private BucketEndpoint bucketEndpoint;
@@ -51,7 +52,7 @@ public class TestBucketDelete {
     clientStub = new OzoneClientStub();
     objectStoreStub = clientStub.getObjectStore();
 
-    objectStoreStub.createS3Bucket("ozone", bucketName);
+    objectStoreStub.createS3Bucket(OzoneConsts.OZONE, bucketName);
 
     // Create HeadBucket and setClient to OzoneClientStub
     bucketEndpoint = new BucketEndpoint();
@@ -84,11 +85,9 @@ public class TestBucketDelete {
   @Test
   public void testDeleteWithBucketNotEmpty() throws Exception {
     try {
-      String bucket = "nonemptybucket";
-      objectStoreStub.createS3Bucket("ozone1", bucket);
       ObjectStoreStub stub = (ObjectStoreStub) objectStoreStub;
-      stub.setBucketEmptyStatus(bucket, false);
-      bucketEndpoint.delete(bucket);
+      stub.setBucketEmptyStatus(bucketName, false);
+      bucketEndpoint.delete(bucketName);
     } catch (OS3Exception ex) {
       assertEquals(S3ErrorTable.BUCKET_NOT_EMPTY.getCode(), ex.getCode());
       assertEquals(S3ErrorTable.BUCKET_NOT_EMPTY.getErrorMessage(),

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketHead.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketHead.java
@@ -22,6 +22,7 @@ package org.apache.hadoop.ozone.s3.endpoint;
 
 import javax.ws.rs.core.Response;
 
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 
@@ -35,8 +36,8 @@ import org.junit.Test;
  */
 public class TestBucketHead {
 
-  private String bucketName = "myBucket";
-  private String userName = "ozone";
+  private String bucketName = OzoneConsts.BUCKET;
+  private String userName = OzoneConsts.OZONE;
   private OzoneClientStub clientStub;
   private ObjectStore objectStoreStub;
   private BucketEndpoint bucketEndpoint;

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestInitiateMultipartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestInitiateMultipartUpload.java
@@ -20,6 +20,7 @@
 
 package org.apache.hadoop.ozone.s3.endpoint;
 
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.OzoneVolume;
@@ -43,13 +44,13 @@ public class TestInitiateMultipartUpload {
   @Test
   public void testInitiateMultipartUpload() throws Exception {
 
-    String bucket = "s3bucket";
-    String key = "key1";
+    String bucket = OzoneConsts.S3_BUCKET;
+    String key = OzoneConsts.KEY;
     OzoneClientStub client = new OzoneClientStub();
-    client.getObjectStore().createS3Bucket("ozone", bucket);
+    client.getObjectStore().createS3Bucket(OzoneConsts.OZONE, bucket);
     String volumeName = client.getObjectStore().getOzoneVolumeName(bucket);
     OzoneVolume volume = client.getObjectStore().getVolume(volumeName);
-    OzoneBucket ozoneBucket = volume.getBucket("s3bucket");
+    OzoneBucket ozoneBucket = volume.getBucket(OzoneConsts.S3_BUCKET);
 
 
     HttpHeaders headers = Mockito.mock(HttpHeaders.class);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestListParts.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestListParts.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.s3.endpoint;
 
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
@@ -43,15 +44,14 @@ public class TestListParts {
 
 
   private final static ObjectEndpoint REST = new ObjectEndpoint();
-  private final static String BUCKET = "s3bucket";
-  private final static String KEY = "key1";
   private static String uploadID;
 
   @BeforeClass
   public static void setUp() throws Exception {
 
     OzoneClientStub client = new OzoneClientStub();
-    client.getObjectStore().createS3Bucket("ozone", BUCKET);
+    client.getObjectStore().createS3Bucket(OzoneConsts.OZONE,
+        OzoneConsts.S3_BUCKET);
 
 
     HttpHeaders headers = Mockito.mock(HttpHeaders.class);
@@ -61,7 +61,8 @@ public class TestListParts {
     REST.setHeaders(headers);
     REST.setClient(client);
 
-    Response response = REST.initializeMultipartUpload(BUCKET, KEY);
+    Response response = REST.initializeMultipartUpload(OzoneConsts.S3_BUCKET,
+        OzoneConsts.KEY);
     MultipartUploadInitiateResponse multipartUploadInitiateResponse =
         (MultipartUploadInitiateResponse) response.getEntity();
     assertNotNull(multipartUploadInitiateResponse.getUploadID());
@@ -71,22 +72,26 @@ public class TestListParts {
 
     String content = "Multipart Upload";
     ByteArrayInputStream body = new ByteArrayInputStream(content.getBytes());
-    response = REST.put(BUCKET, KEY, content.length(), 1, uploadID, body);
+    response = REST.put(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
+        content.length(), 1, uploadID, body);
 
     assertNotNull(response.getHeaderString("ETag"));
 
-    response = REST.put(BUCKET, KEY, content.length(), 2, uploadID, body);
+    response = REST.put(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
+        content.length(), 2, uploadID, body);
 
     assertNotNull(response.getHeaderString("ETag"));
 
-    response = REST.put(BUCKET, KEY, content.length(), 3, uploadID, body);
+    response = REST.put(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
+        content.length(), 3, uploadID, body);
 
     assertNotNull(response.getHeaderString("ETag"));
   }
 
   @Test
   public void testListParts() throws Exception {
-    Response response = REST.get(BUCKET, KEY, uploadID, 3, "0", null);
+    Response response = REST.get(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
+        uploadID, 3, "0", null);
 
     ListPartsResponse listPartsResponse =
         (ListPartsResponse) response.getEntity();
@@ -98,7 +103,8 @@ public class TestListParts {
 
   @Test
   public void testListPartsContinuation() throws Exception {
-    Response response = REST.get(BUCKET, KEY, uploadID, 2, "0", null);
+    Response response = REST.get(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
+        uploadID, 2, "0", null);
     ListPartsResponse listPartsResponse =
         (ListPartsResponse) response.getEntity();
 
@@ -106,7 +112,7 @@ public class TestListParts {
     Assert.assertTrue(listPartsResponse.getPartList().size() == 2);
 
     // Continue
-    response = REST.get(BUCKET, KEY, uploadID, 2,
+    response = REST.get(OzoneConsts.S3_BUCKET, OzoneConsts.KEY, uploadID, 2,
         Integer.toString(listPartsResponse.getNextPartNumberMarker()), null);
     listPartsResponse = (ListPartsResponse) response.getEntity();
 
@@ -118,7 +124,8 @@ public class TestListParts {
   @Test
   public void testListPartsWithUnknownUploadID() throws Exception {
     try {
-      Response response = REST.get(BUCKET, KEY, uploadID, 2, "0", null);
+      Response response = REST.get(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
+          uploadID, 2, "0", null);
     } catch (OS3Exception ex) {
       Assert.assertEquals(S3ErrorTable.NO_SUCH_UPLOAD.getErrorMessage(),
           ex.getErrorMessage());

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadComplete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadComplete.java
@@ -20,6 +20,7 @@
 
 package org.apache.hadoop.ozone.s3.endpoint;
 
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
@@ -50,14 +51,13 @@ import static org.mockito.Mockito.when;
 public class TestMultipartUploadComplete {
 
   private final static ObjectEndpoint REST = new ObjectEndpoint();;
-  private final static String BUCKET = "s3bucket";
-  private final static String KEY = "key1";
   private final static OzoneClientStub CLIENT = new OzoneClientStub();
 
   @BeforeClass
   public static void setUp() throws Exception {
 
-    CLIENT.getObjectStore().createS3Bucket("ozone", BUCKET);
+    CLIENT.getObjectStore().createS3Bucket(OzoneConsts.OZONE,
+        OzoneConsts.S3_BUCKET);
 
 
     HttpHeaders headers = Mockito.mock(HttpHeaders.class);
@@ -70,7 +70,8 @@ public class TestMultipartUploadComplete {
 
   private String initiateMultipartUpload(String key) throws IOException,
       OS3Exception {
-    Response response = REST.initializeMultipartUpload(BUCKET, key);
+    Response response = REST.initializeMultipartUpload(OzoneConsts.S3_BUCKET,
+        key);
     MultipartUploadInitiateResponse multipartUploadInitiateResponse =
         (MultipartUploadInitiateResponse) response.getEntity();
     assertNotNull(multipartUploadInitiateResponse.getUploadID());
@@ -85,8 +86,8 @@ public class TestMultipartUploadComplete {
   private Part uploadPart(String key, String uploadID, int partNumber, String
       content) throws IOException, OS3Exception {
     ByteArrayInputStream body = new ByteArrayInputStream(content.getBytes());
-    Response response = REST.put(BUCKET, key, content.length(), partNumber,
-        uploadID, body);
+    Response response = REST.put(OzoneConsts.S3_BUCKET, key, content.length(),
+        partNumber, uploadID, body);
     assertEquals(response.getStatus(), 200);
     assertNotNull(response.getHeaderString("ETag"));
     Part part = new Part();
@@ -99,17 +100,19 @@ public class TestMultipartUploadComplete {
   private void completeMultipartUpload(String key,
       CompleteMultipartUploadRequest completeMultipartUploadRequest,
       String uploadID) throws IOException, OS3Exception {
-    Response response = REST.completeMultipartUpload(BUCKET, key, uploadID,
-        completeMultipartUploadRequest);
+    Response response = REST.completeMultipartUpload(OzoneConsts.S3_BUCKET, key,
+        uploadID, completeMultipartUploadRequest);
 
     assertEquals(response.getStatus(), 200);
 
     CompleteMultipartUploadResponse completeMultipartUploadResponse =
         (CompleteMultipartUploadResponse) response.getEntity();
 
-    assertEquals(completeMultipartUploadResponse.getBucket(), BUCKET);
-    assertEquals(completeMultipartUploadResponse.getKey(), KEY);
-    assertEquals(completeMultipartUploadResponse.getLocation(), BUCKET);
+    assertEquals(completeMultipartUploadResponse.getBucket(),
+        OzoneConsts.S3_BUCKET);
+    assertEquals(completeMultipartUploadResponse.getKey(), OzoneConsts.KEY);
+    assertEquals(completeMultipartUploadResponse.getLocation(),
+        OzoneConsts.S3_BUCKET);
     assertNotNull(completeMultipartUploadResponse.getETag());
   }
 
@@ -117,7 +120,7 @@ public class TestMultipartUploadComplete {
   public void testMultipart() throws Exception {
 
     // Initiate multipart upload
-    String uploadID = initiateMultipartUpload(KEY);
+    String uploadID = initiateMultipartUpload(OzoneConsts.KEY);
 
     List<Part> partsList = new ArrayList<>();
 
@@ -126,12 +129,12 @@ public class TestMultipartUploadComplete {
     String content = "Multipart Upload 1";
     int partNumber = 1;
 
-    Part part1 = uploadPart(KEY, uploadID, partNumber, content);
+    Part part1 = uploadPart(OzoneConsts.KEY, uploadID, partNumber, content);
     partsList.add(part1);
 
     content = "Multipart Upload 2";
     partNumber = 2;
-    Part part2 = uploadPart(KEY, uploadID, partNumber, content);
+    Part part2 = uploadPart(OzoneConsts.KEY, uploadID, partNumber, content);
     partsList.add(part2);
 
     // complete multipart upload
@@ -140,7 +143,7 @@ public class TestMultipartUploadComplete {
     completeMultipartUploadRequest.setPartList(partsList);
 
 
-    completeMultipartUpload(KEY, completeMultipartUploadRequest,
+    completeMultipartUpload(OzoneConsts.KEY, completeMultipartUploadRequest,
         uploadID);
 
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 
 import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
@@ -51,7 +52,7 @@ import static org.mockito.Mockito.when;
  */
 public class TestObjectPut {
   public static final String CONTENT = "0123456789";
-  private String userName = "ozone";
+  private String userName = OzoneConsts.OZONE;
   private String bucketName = "b1";
   private String keyName = "key1";
   private String destBucket = "b2";

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
@@ -20,6 +20,7 @@
 
 package org.apache.hadoop.ozone.s3.endpoint;
 
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.junit.BeforeClass;
@@ -45,14 +46,13 @@ import static org.mockito.Mockito.when;
 public class TestPartUpload {
 
   private final static ObjectEndpoint REST = new ObjectEndpoint();
-  private final static String BUCKET = "s3bucket";
-  private final static String KEY = "key1";
 
   @BeforeClass
   public static void setUp() throws Exception {
 
     OzoneClientStub client = new OzoneClientStub();
-    client.getObjectStore().createS3Bucket("ozone", BUCKET);
+    client.getObjectStore().createS3Bucket(OzoneConsts.OZONE,
+        OzoneConsts.S3_BUCKET);
 
 
     HttpHeaders headers = Mockito.mock(HttpHeaders.class);
@@ -67,7 +67,8 @@ public class TestPartUpload {
   @Test
   public void testPartUpload() throws Exception {
 
-    Response response = REST.initializeMultipartUpload(BUCKET, KEY);
+    Response response = REST.initializeMultipartUpload(OzoneConsts.S3_BUCKET,
+        OzoneConsts.KEY);
     MultipartUploadInitiateResponse multipartUploadInitiateResponse =
         (MultipartUploadInitiateResponse) response.getEntity();
     assertNotNull(multipartUploadInitiateResponse.getUploadID());
@@ -77,7 +78,8 @@ public class TestPartUpload {
 
     String content = "Multipart Upload";
     ByteArrayInputStream body = new ByteArrayInputStream(content.getBytes());
-    response = REST.put(BUCKET, KEY, content.length(), 1, uploadID, body);
+    response = REST.put(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
+        content.length(), 1, uploadID, body);
 
     assertNotNull(response.getHeaderString("ETag"));
 
@@ -86,7 +88,8 @@ public class TestPartUpload {
   @Test
   public void testPartUploadWithOverride() throws Exception {
 
-    Response response = REST.initializeMultipartUpload(BUCKET, KEY);
+    Response response = REST.initializeMultipartUpload(OzoneConsts.S3_BUCKET,
+        OzoneConsts.KEY);
     MultipartUploadInitiateResponse multipartUploadInitiateResponse =
         (MultipartUploadInitiateResponse) response.getEntity();
     assertNotNull(multipartUploadInitiateResponse.getUploadID());
@@ -96,7 +99,8 @@ public class TestPartUpload {
 
     String content = "Multipart Upload";
     ByteArrayInputStream body = new ByteArrayInputStream(content.getBytes());
-    response = REST.put(BUCKET, KEY, content.length(), 1, uploadID, body);
+    response = REST.put(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
+        content.length(), 1, uploadID, body);
 
     assertNotNull(response.getHeaderString("ETag"));
 
@@ -104,7 +108,8 @@ public class TestPartUpload {
 
     // Upload part again with same part Number, the ETag should be changed.
     content = "Multipart Upload Changed";
-    response = REST.put(BUCKET, KEY, content.length(), 1, uploadID, body);
+    response = REST.put(OzoneConsts.S3_BUCKET, OzoneConsts.KEY,
+        content.length(), 1, uploadID, body);
     assertNotNull(response.getHeaderString("ETag"));
     assertNotEquals(eTag, response.getHeaderString("ETag"));
 
@@ -116,7 +121,8 @@ public class TestPartUpload {
     try {
       String content = "Multipart Upload With Incorrect uploadID";
       ByteArrayInputStream body = new ByteArrayInputStream(content.getBytes());
-      REST.put(BUCKET, KEY, content.length(), 1, "random", body);
+      REST.put(OzoneConsts.S3_BUCKET, OzoneConsts.KEY, content.length(), 1,
+          "random", body);
       fail("testPartUploadWithIncorrectUploadID failed");
     } catch (OS3Exception ex) {
       assertEquals("NoSuchUpload", ex.getCode());

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestRootList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestRootList.java
@@ -20,6 +20,7 @@
 
 package org.apache.hadoop.ozone.s3.endpoint;
 
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.s3.header.AuthenticationHeaderParser;
@@ -37,7 +38,7 @@ public class TestRootList {
   private OzoneClientStub clientStub;
   private ObjectStore objectStoreStub;
   private RootEndpoint rootEndpoint;
-  private String userName = "ozone";
+  private String userName = OzoneConsts.OZONE;
 
   @Before
   public void setup() throws Exception {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkContainerStateMap.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkContainerStateMap.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.container.states.ContainerStateMap;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.util.Time;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Level;
@@ -73,7 +74,7 @@ public class BenchMarkContainerStateMap {
             .setUsedBytes(0)
             .setNumberOfKeys(0)
             .setStateEnterTime(Time.monotonicNow())
-            .setOwner("OZONE")
+            .setOwner(OzoneConsts.OZONE)
             .setContainerID(x)
             .setDeleteTransactionId(0)
             .build();
@@ -93,7 +94,7 @@ public class BenchMarkContainerStateMap {
             .setUsedBytes(0)
             .setNumberOfKeys(0)
             .setStateEnterTime(Time.monotonicNow())
-            .setOwner("OZONE")
+            .setOwner(OzoneConsts.OZONE)
             .setContainerID(y)
             .setDeleteTransactionId(0)
             .build();
@@ -112,7 +113,7 @@ public class BenchMarkContainerStateMap {
           .setUsedBytes(0)
           .setNumberOfKeys(0)
           .setStateEnterTime(Time.monotonicNow())
-          .setOwner("OZONE")
+          .setOwner(OzoneConsts.OZONE)
           .setContainerID(currentCount++)
           .setDeleteTransactionId(0)
           .build();
@@ -181,7 +182,7 @@ public class BenchMarkContainerStateMap {
         .setUsedBytes(0)
         .setNumberOfKeys(0)
         .setStateEnterTime(Time.monotonicNow())
-        .setOwner("OZONE")
+        .setOwner(OzoneConsts.OZONE)
         .setContainerID(cid)
         .setDeleteTransactionId(0)
         .build();
@@ -194,7 +195,7 @@ public class BenchMarkContainerStateMap {
       state.stateMap.addContainer(getContainerInfo(state));
     }
     bh.consume(state.stateMap
-        .getMatchingContainerIDs(OPEN, "OZONE", ReplicationFactor.ONE,
+        .getMatchingContainerIDs(OPEN, OzoneConsts.OZONE, ReplicationFactor.ONE,
             ReplicationType.STAND_ALONE));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In #95 review it came up that the tests could use the OzoneConsts.OZONE constant instead of using the "ozone" string literal, this PR is aiming to address this issue globally in the whole codebase.
As it is commented in the JIRA the changes were made in this PR where suitable in the following way:
There are some places where we use the string literal "Ozone" which I would not change, the places are:
- RocksDBStore, and RDBStore, where it is used to specify the name of jmx keys.
- ServerUtils uses it in a function parameter passed to a log message that seems fine.
- StorageContainerManager, and OzoneManager uses the full capital in InterfaceAudience annotation, that is fine.
- CommonHeadersContainerResponseFilter is using this in headers I would not change the protocol

In TestAuthorizationHeaderV4 we use "ozone" that is ok, as we provide a string to parse, and check elements provided, in this case I would not change to a constant makes it harder to read.

CreateSubcommand I am unsure, the default is specified with full capital I am not brave enough to change it to the lowercase version, though my instinct tells that it would be most likely ok.


Also while going through the S3 related tests, that were coming up with the query, I changed a few other literals to suitable constants, like:
"OWNER" -> OzoneConsts.OWNER (makes it lowercase)
"VOLUME" -> OzoneConsts.VOLUME (makes it lowercase)
"hdfs" -> OzoneConsts.OZONE_SIMPLE_HDFS_USER
"xxBucket" -> OzoneConsts.BUCKET
"s3Bucket" -> OzoneConsts.S3_BUCKET
"key1" -> OzoneConsts.KEY (in cases where only 1 key is used)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2378

## How was this patch tested?
There are no change in the code logic, mostly tests were changed, the expectation is that all the JUnit tests should run as they ran before. I have ran most of the changed tests locally, they seemed ok.
