### PR TITLE
HDDS-2381. In ExcludeList, add if not exist only.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/ExcludeList.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/ExcludeList.java
@@ -53,19 +53,25 @@ public class ExcludeList {
   }
 
   public void addDatanodes(Collection<DatanodeDetails> dns) {
-    datanodes.addAll(dns);
+    dns.forEach(dn -> addDatanode(dn));
   }
 
   public void addDatanode(DatanodeDetails dn) {
-    datanodes.add(dn);
+    if (!datanodes.contains(dn)) {
+      datanodes.add(dn);
+    }
   }
 
   public void addConatinerId(ContainerID containerId) {
-    containerIds.add(containerId);
+    if (!containerIds.contains(containerId)) {
+      containerIds.add(containerId);
+    }
   }
 
   public void addPipeline(PipelineID pipelineId) {
-    pipelineIds.add(pipelineId);
+    if (!pipelineIds.contains(pipelineId)) {
+      pipelineIds.add(pipelineId);
+    }
   }
 
   public List<PipelineID> getPipelineIds() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a check if not contains for addDatanode, addPipeline, addContainer.
Think of a case we have one pipeline in the cluster.(3 nodes)
As now when we have a single pipeline, it failed we add to pipelineIds, and we get a new pipeline from SCM, now SCM by excluding it will try and if there are no pipelines, it will return the same pipeline. And after some time in the client, we got an exception, and we try to add this pipeline again. When it is being added again, we should check if it already exists do nothing. To avoid this, added contains check.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2381


## How was this patch tested?
The check added will take care, and the log will not print same pipeline.