### PR TITLE
HDDS-2370.Support HddsDatanodeService run as DataNode Plugin

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -502,9 +502,9 @@ public final class HddsUtils {
     MetricsSystem metricsSystem = DefaultMetricsSystem.initialize(serverName);
     try {
       JvmMetrics.create(serverName,
-           configuration.get(DFSConfigKeys.DFS_METRICS_SESSION_ID_KEY),
-           DefaultMetricsSystem.instance());
-    }catch (MetricsException e) {
+          configuration.get(DFSConfigKeys.DFS_METRICS_SESSION_ID_KEY),
+          DefaultMetricsSystem.instance());
+    } catch (MetricsException e) {
         LOG.info("Metrics source JvmMetrics already added to DataNode.");
     }
     return metricsSystem;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.io.retry.RetryPolicy;
 import org.apache.hadoop.ipc.Client;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
+import org.apache.hadoop.metrics2.MetricsException;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.source.JvmMetrics;
@@ -499,9 +500,13 @@ public final class HddsUtils {
   public static MetricsSystem initializeMetrics(
       OzoneConfiguration configuration, String serverName) {
     MetricsSystem metricsSystem = DefaultMetricsSystem.initialize(serverName);
-    JvmMetrics.create(serverName,
-        configuration.get(DFSConfigKeys.DFS_METRICS_SESSION_ID_KEY),
-        DefaultMetricsSystem.instance());
+    try {
+      JvmMetrics.create(serverName,
+           configuration.get(DFSConfigKeys.DFS_METRICS_SESSION_ID_KEY),
+           DefaultMetricsSystem.instance());
+    }catch (MetricsException e) {
+        LOG.info("Metrics source JvmMetrics already added to DataNode.");
+    }
     return metricsSystem;
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -505,7 +505,7 @@ public final class HddsUtils {
           configuration.get(DFSConfigKeys.DFS_METRICS_SESSION_ID_KEY),
           DefaultMetricsSystem.instance());
     } catch (MetricsException e) {
-        LOG.info("Metrics source JvmMetrics already added to DataNode.");
+      LOG.info("Metrics source JvmMetrics already added to DataNode.");
     }
     return metricsSystem;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -87,6 +87,10 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
   private String[] args;
   private volatile AtomicBoolean isStopped = new AtomicBoolean(false);
 
+  public HddsDatanodeService(){
+    this(false, new String[] {});
+  }
+
   public HddsDatanodeService(boolean printBanner, String[] args) {
     this.printBanner = printBanner;
     this.args = args != null ? Arrays.copyOf(args, args.length) : null;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -87,9 +87,8 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
   private String[] args;
   private volatile AtomicBoolean isStopped = new AtomicBoolean(false);
 
-  public HddsDatanodeService(){
-    this(false, new String[] {});
-  }
+  //Constructor for DataNode PluginService
+  public HddsDatanodeService(){}
 
   public HddsDatanodeService(boolean printBanner, String[] args) {
     this.printBanner = printBanner;

--- a/hadoop-hdds/docs/content/beyond/RunningWithHDFS.md
+++ b/hadoop-hdds/docs/content/beyond/RunningWithHDFS.md
@@ -42,10 +42,10 @@ be activated as part of the normal HDFS Datanode bootstrap.
 </property>
 {{< /highlight >}}
 
-You also need to add the ozone-datanode-plugin jar file to the classpath:
+You also need to add the jar file under path /opt/ozone/share/ozone/lib/ to the classpath:
 
 {{< highlight bash >}}
-export HADOOP_CLASSPATH=/opt/ozone/share/hadoop/ozoneplugin/hadoop-ozone-datanode-plugin.jar
+export HADOOP_CLASSPATH=/opt/ozone/share/ozone/lib/*.jar
 {{< /highlight >}}
 
 

--- a/hadoop-ozone/dist/src/main/compose/ozone-hdfs/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-hdfs/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
          - ../..:/opt/ozone
       command: ["hdfs","datanode"]
       environment:
-         HADOOP_CLASSPATH: /opt/ozone/share/hadoop/ozoneplugin/*.jar
+         HADOOP_CLASSPATH: /opt/ozone/share/hadoop/ozone/lib/*.jar
       env_file:
         - ./docker-config
    om:

--- a/hadoop-ozone/dist/src/main/compose/ozone-hdfs/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-hdfs/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
          - ../..:/opt/ozone
       command: ["hdfs","datanode"]
       environment:
-         HADOOP_CLASSPATH: /opt/ozone/share/hadoop/ozone/lib/*.jar
+         HADOOP_CLASSPATH: /opt/ozone/share/ozone/lib/*.jar
       env_file:
         - ./docker-config
    om:

--- a/hadoop-ozone/dist/src/main/compose/ozone-hdfs/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-hdfs/docker-config
@@ -23,7 +23,6 @@ OZONE-SITE.XML_ozone.scm.block.client.address=scm
 OZONE-SITE.XML_ozone.metadata.dirs=/data/metadata
 OZONE-SITE.XML_ozone.scm.client.address=scm
 OZONE-SITE.XML_ozone.replication=1
-OZONE-SITE.XML_hdds.datanode.plugins=org.apache.hadoop.ozone.web.OzoneHddsDatanodeService
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 
 HDFS-SITE.XML_dfs.datanode.plugins=org.apache.hadoop.ozone.HddsDatanodeService


### PR DESCRIPTION
## What changes were proposed in this pull request?

With cuuent version, cannot run hddsdatanodeservice as hdfs datanode pulgin, as there is no constructor without parameters.
` java.lang.NoSuchMethodException: org.apache.hadoop.ozone.HddsDatanodeService.<init>()`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2370

## How was this patch tested?

refer to RunningWithHDFS.md, config and run hddsdatanodeservice as datanode plugin, function go well with ozone.
