### PR TITLE
HDDS-2301. Write path: Reduce read contention in rocksDB.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -88,6 +88,10 @@ public final class OMConfigKeys {
       "ozone.om.save.metrics.interval";
   public static final String OZONE_OM_METRICS_SAVE_INTERVAL_DEFAULT = "5m";
 
+  public static final String OZONE_OM_KEY_PREFIX_CREATE =
+      "ozone.om.key.prefix.create";
+  public static final boolean OZONE_OM_KEY_PREFIX_CREATE_DEFAULT =
+      true;
   /**
    * OM Ratis related configurations.
    */

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -138,7 +138,7 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
       if (keyName.length() == 0) {
         return new OMDirectoryCreateResponse(null, null,
             omResponse.setCreateDirectoryResponse(
-                CreateDirectoryResponse.newBuilder()).build());
+                CreateDirectoryResponse.newBuilder()).build(), false);
       }
       // acquire lock
       acquiredLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
@@ -194,12 +194,13 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
       omResponse.setCreateDirectoryResponse(
           CreateDirectoryResponse.newBuilder());
       omClientResponse = new OMDirectoryCreateResponse(dirKeyInfo,
-          missingParentInfos, omResponse.build());
+          missingParentInfos, omResponse.build(),
+          ozoneManager.createPrefixRecursive());
 
     } catch (IOException ex) {
       exception = ex;
       omClientResponse = new OMDirectoryCreateResponse(null,null,
-          createErrorOMResponse(omResponse, exception));
+          createErrorOMResponse(omResponse, exception), false);
     } finally {
       if (omClientResponse != null) {
         omClientResponse.setFlushFuture(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -162,6 +162,8 @@ public class OMFileCreateRequest extends OMKeyRequest {
     // directories does not exist.
     boolean isRecursive = createFileRequest.getIsRecursive();
 
+    boolean createPrefixRecursive = ozoneManager.createPrefixRecursive();
+
     // if isOverWrite is true, file would be over written.
     boolean isOverWrite = createFileRequest.getIsOverwrite();
 
@@ -244,7 +246,13 @@ public class OMFileCreateRequest extends OMKeyRequest {
         // unnecessary check which is not required for those cases.
         if (omDirectoryResult == NONE ||
             omDirectoryResult == DIRECTORY_EXISTS_IN_GIVENPATH) {
-          boolean canBeCreated = missingParents.isEmpty();
+          boolean canBeCreated;
+          if (createPrefixRecursive) {
+            canBeCreated = missingParents.isEmpty();
+          } else {
+            canBeCreated = checkKeysUnderPath(omMetadataManager, volumeName,
+                bucketName, keyName);
+          }
           if (!canBeCreated) {
             throw new OMException("Can not create file: " + keyName + "as one" +
                 " of parent directory is not created",

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -20,10 +20,20 @@ package org.apache.hadoop.ozone.om.request.file;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
+import com.google.common.base.Preconditions;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
+import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 
 import javax.annotation.Nonnull;
+
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_NOT_FOUND;
 
 /**
  * Base class for file requests.
@@ -82,6 +92,56 @@ public final class OMFileRequest {
 
     // Found no files/ directories in the given path.
     return OMDirectoryResult.NONE;
+  }
+
+  /**
+   * Return list of missing parent directories in the given path.
+   * @param omMetadataManager
+   * @param volumeName
+   * @param bucketName
+   * @param keyName
+   * @return List of keys representing non-existent parent dirs
+   * @throws IOException
+   */
+  public static List<String> getMissingParents(
+      @Nonnull OMMetadataManager omMetadataManager,
+      @Nonnull String volumeName,
+      @Nonnull String bucketName,
+      @Nonnull String keyName) throws IOException {
+    Path path = Paths.get(keyName);
+    int parents = path.getNameCount() - 1;
+    List<String> missing = new ArrayList<>();
+
+    int index = 1;
+    String parentKey;
+    while (index <= parents) {
+      Path subpath = path.subpath(0, index);
+      parentKey =
+          OzoneFSUtils.addTrailingSlashIfNeeded(subpath.toString());
+
+      OmKeyInfo keyInfo = getKeyInfo(omMetadataManager,
+          volumeName, bucketName, parentKey);
+      if (keyInfo == null) {
+        missing.add(parentKey);
+      }
+
+      index++;
+    }
+
+    return missing;
+  }
+
+  private static OmKeyInfo getKeyInfo(
+      @Nonnull OMMetadataManager omMetadataManager,
+      @Nonnull String volumeName,
+      @Nonnull String bucketName,
+      @Nonnull String keyName) throws IOException {
+
+    if (omMetadataManager.getKeyTable().isExist(keyName)) {
+      return omMetadataManager.getKeyTable().get(keyName);
+    } else {
+      return null;
+    }
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -183,17 +183,18 @@ public class OMKeyCreateRequest extends OMKeyRequest {
           omMetadataManager.getOzoneKey(volumeName, bucketName, keyName),
           keyArgs.getDataSize(), locations, encryptionInfo.orNull(),
           ozoneManager.getPrefixManager(), bucketInfo);
-      omClientResponse = prepareCreateKeyResponse(keyArgs, omKeyInfo,
+      omClientResponse = prepareCreateKeyResponse(keyArgs, omKeyInfo, null,
           locations, encryptionInfo.orNull(), exception,
           createKeyRequest.getClientID(), transactionLogIndex, volumeName,
           bucketName, keyName, ozoneManager, OMAction.ALLOCATE_KEY,
           ozoneManager.getPrefixManager(), bucketInfo);
     } catch (IOException ex) {
       exception = ex;
-      omClientResponse = prepareCreateKeyResponse(keyArgs, omKeyInfo, locations,
-          encryptionInfo.orNull(), exception, createKeyRequest.getClientID(),
-          transactionLogIndex, volumeName, bucketName, keyName, ozoneManager,
-          OMAction.ALLOCATE_KEY, ozoneManager.getPrefixManager(), null);
+      omClientResponse = prepareCreateKeyResponse(keyArgs, omKeyInfo, null,
+          locations, encryptionInfo.orNull(), exception,
+          createKeyRequest.getClientID(), transactionLogIndex, volumeName,
+          bucketName, keyName, ozoneManager, OMAction.ALLOCATE_KEY,
+          ozoneManager.getPrefixManager(), null);
     } finally {
       if (omClientResponse != null) {
         omClientResponse.setFlushFuture(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -315,7 +315,8 @@ public abstract class OMKeyRequest extends OMClientRequest {
                   .setOpenVersion(openVersion).build());
           omResponse.setCmdType(CreateFile);
           omClientResponse = new OMFileCreateResponse(omKeyInfo,
-              parentKeyInfos, clientID, omResponse.build());
+              parentKeyInfos, clientID, omResponse.build(),
+              ozoneManager.createPrefixRecursive());
         } else {
           omResponse.setCreateKeyResponse(CreateKeyResponse.newBuilder()
               .setKeyInfo(omKeyInfo.getProtobuf())
@@ -323,7 +324,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
               .build());
           omResponse.setCmdType(CreateKey);
           omClientResponse = new OMKeyCreateResponse(omKeyInfo, null, clientID,
-              omResponse.build());
+              omResponse.build(), ozoneManager.createPrefixRecursive());
         }
       }
 
@@ -490,12 +491,12 @@ public abstract class OMKeyRequest extends OMClientRequest {
       omMetrics.incNumCreateFileFails();
       omResponse.setCmdType(CreateFile);
       return new OMFileCreateResponse(null, null, -1L,
-          createErrorOMResponse(omResponse, exception));
+          createErrorOMResponse(omResponse, exception), false);
     } else {
       omMetrics.incNumKeyAllocateFails();
       omResponse.setCmdType(CreateKey);
       return new OMKeyCreateResponse(null, null,-1L,
-          createErrorOMResponse(omResponse, exception));
+          createErrorOMResponse(omResponse, exception), false);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -251,7 +251,8 @@ public abstract class OMKeyRequest extends OMClientRequest {
    */
   @SuppressWarnings("parameternumber")
   protected OMClientResponse prepareCreateKeyResponse(@Nonnull KeyArgs keyArgs,
-      OmKeyInfo omKeyInfo, @Nonnull List<OmKeyLocationInfo> locations,
+      OmKeyInfo omKeyInfo, @Nullable List<OmKeyInfo> parentKeyInfos,
+      @Nonnull List<OmKeyLocationInfo> locations,
       FileEncryptionInfo encryptionInfo, @Nullable IOException exception,
       long clientID, long transactionLogIndex, @Nonnull String volumeName,
       @Nonnull String bucketName, @Nonnull String keyName,
@@ -313,15 +314,15 @@ public abstract class OMKeyRequest extends OMClientRequest {
                   .setID(clientID)
                   .setOpenVersion(openVersion).build());
           omResponse.setCmdType(CreateFile);
-          omClientResponse = new OMFileCreateResponse(omKeyInfo, clientID,
-              omResponse.build());
+          omClientResponse = new OMFileCreateResponse(omKeyInfo,
+              parentKeyInfos, clientID, omResponse.build());
         } else {
           omResponse.setCreateKeyResponse(CreateKeyResponse.newBuilder()
               .setKeyInfo(omKeyInfo.getProtobuf())
               .setID(clientID).setOpenVersion(openVersion)
               .build());
           omResponse.setCmdType(CreateKey);
-          omClientResponse = new OMKeyCreateResponse(omKeyInfo, clientID,
+          omClientResponse = new OMKeyCreateResponse(omKeyInfo, null, clientID,
               omResponse.build());
         }
       }
@@ -488,12 +489,12 @@ public abstract class OMKeyRequest extends OMClientRequest {
     if (omAction == OMAction.CREATE_FILE) {
       omMetrics.incNumCreateFileFails();
       omResponse.setCmdType(CreateFile);
-      return new OMFileCreateResponse(null, -1L,
+      return new OMFileCreateResponse(null, null, -1L,
           createErrorOMResponse(omResponse, exception));
     } else {
       omMetrics.incNumKeyAllocateFails();
       omResponse.setCmdType(CreateKey);
-      return new OMKeyCreateResponse(null, -1L,
+      return new OMKeyCreateResponse(null, null,-1L,
           createErrorOMResponse(omResponse, exception));
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponse.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Response for create directory request.
@@ -40,11 +41,14 @@ public class OMDirectoryCreateResponse extends OMClientResponse {
   public static final Logger LOG =
       LoggerFactory.getLogger(OMDirectoryCreateResponse.class);
   private OmKeyInfo dirKeyInfo;
+  private List<OmKeyInfo> parentKeyInfos;
 
   public OMDirectoryCreateResponse(@Nullable OmKeyInfo dirKeyInfo,
+      @Nullable List<OmKeyInfo> parentKeyInfos,
       @Nonnull OMResponse omResponse) {
     super(omResponse);
     this.dirKeyInfo = dirKeyInfo;
+    this.parentKeyInfos = parentKeyInfos;
   }
 
   @Override
@@ -62,6 +66,18 @@ public class OMDirectoryCreateResponse extends OMClientResponse {
         // not an error, in this case dirKeyInfo will be null.
         LOG.debug("Response Status is OK, dirKeyInfo is null in " +
             "OMDirectoryCreateResponse");
+      }
+
+      if (parentKeyInfos != null) {
+        for (OmKeyInfo parentKeyInfo : parentKeyInfos) {
+          String parentKey = omMetadataManager.getOzoneDirKey(
+              parentKeyInfo.getVolumeName(),
+              parentKeyInfo.getBucketName(),
+              parentKeyInfo.getKeyName());
+          LOG.debug("putWithBatch parent : key {} info : {}", parentKey, parentKeyInfo);
+          omMetadataManager.getKeyTable().putWithBatch(batchOperation,
+              parentKey, parentKeyInfo);
+        }
       }
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponse.java
@@ -42,13 +42,16 @@ public class OMDirectoryCreateResponse extends OMClientResponse {
       LoggerFactory.getLogger(OMDirectoryCreateResponse.class);
   private OmKeyInfo dirKeyInfo;
   private List<OmKeyInfo> parentKeyInfos;
+  private boolean createPrefix;
 
   public OMDirectoryCreateResponse(@Nullable OmKeyInfo dirKeyInfo,
       @Nullable List<OmKeyInfo> parentKeyInfos,
-      @Nonnull OMResponse omResponse) {
+      @Nonnull OMResponse omResponse,
+      boolean createPrefix) {
     super(omResponse);
     this.dirKeyInfo = dirKeyInfo;
     this.parentKeyInfos = parentKeyInfos;
+    this.createPrefix = createPrefix;
   }
 
   @Override
@@ -68,15 +71,17 @@ public class OMDirectoryCreateResponse extends OMClientResponse {
             "OMDirectoryCreateResponse");
       }
 
-      if (parentKeyInfos != null) {
-        for (OmKeyInfo parentKeyInfo : parentKeyInfos) {
-          String parentKey = omMetadataManager.getOzoneDirKey(
-              parentKeyInfo.getVolumeName(),
-              parentKeyInfo.getBucketName(),
-              parentKeyInfo.getKeyName());
-          LOG.debug("putWithBatch parent : key {} info : {}", parentKey, parentKeyInfo);
-          omMetadataManager.getKeyTable().putWithBatch(batchOperation,
-              parentKey, parentKeyInfo);
+      if (createPrefix) {
+        if (parentKeyInfos != null) {
+          for (OmKeyInfo parentKeyInfo : parentKeyInfos) {
+            String parentKey = omMetadataManager
+                .getOzoneDirKey(parentKeyInfo.getVolumeName(), parentKeyInfo.getBucketName(),
+                    parentKeyInfo.getKeyName());
+            LOG.debug("putWithBatch parent : key {} info : {}", parentKey,
+                parentKeyInfo);
+            omMetadataManager.getKeyTable()
+                .putWithBatch(batchOperation, parentKey, parentKeyInfo);
+          }
         }
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponse.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.ozone.om.response.key.OMKeyCreateResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 
-
+import java.util.List;
 
 /**
  * Response for crate file request.
@@ -34,8 +34,9 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 public class OMFileCreateResponse extends OMKeyCreateResponse {
 
   public OMFileCreateResponse(@Nullable OmKeyInfo omKeyInfo,
+      @Nullable List<OmKeyInfo> parentKeyInfos,
       long openKeySessionID, @Nonnull OMResponse omResponse) {
-    super(omKeyInfo, openKeySessionID, omResponse);
+    super(omKeyInfo, parentKeyInfos, openKeySessionID, omResponse);
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponse.java
@@ -35,8 +35,10 @@ public class OMFileCreateResponse extends OMKeyCreateResponse {
 
   public OMFileCreateResponse(@Nullable OmKeyInfo omKeyInfo,
       @Nullable List<OmKeyInfo> parentKeyInfos,
-      long openKeySessionID, @Nonnull OMResponse omResponse) {
-    super(omKeyInfo, parentKeyInfos, openKeySessionID, omResponse);
+      long openKeySessionID, @Nonnull OMResponse omResponse,
+      boolean createPrefixRecursive) {
+    super(omKeyInfo, parentKeyInfos, openKeySessionID, omResponse,
+        createPrefixRecursive);
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
@@ -77,7 +77,7 @@ public class TestOMDirectoryCreateResponse {
             .build();
 
     OMDirectoryCreateResponse omDirectoryCreateResponse =
-        new OMDirectoryCreateResponse(omKeyInfo, omResponse);
+        new OMDirectoryCreateResponse(omKeyInfo, null, omResponse);
 
     omDirectoryCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
 
@@ -107,7 +107,7 @@ public class TestOMDirectoryCreateResponse {
         .build();
 
     OMDirectoryCreateResponse omDirectoryCreateResponse =
-        new OMDirectoryCreateResponse(null, omResponse);
+        new OMDirectoryCreateResponse(null, null, omResponse);
 
     omDirectoryCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
@@ -77,7 +77,7 @@ public class TestOMDirectoryCreateResponse {
             .build();
 
     OMDirectoryCreateResponse omDirectoryCreateResponse =
-        new OMDirectoryCreateResponse(omKeyInfo, null, omResponse);
+        new OMDirectoryCreateResponse(omKeyInfo, null, omResponse, false);
 
     omDirectoryCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
 
@@ -107,7 +107,7 @@ public class TestOMDirectoryCreateResponse {
         .build();
 
     OMDirectoryCreateResponse omDirectoryCreateResponse =
-        new OMDirectoryCreateResponse(null, null, omResponse);
+        new OMDirectoryCreateResponse(null, null, omResponse, false);
 
     omDirectoryCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
@@ -48,7 +48,7 @@ public class TestOMKeyCreateResponse extends TestOMKeyResponse {
             .build();
 
     OMKeyCreateResponse omKeyCreateResponse =
-        new OMKeyCreateResponse(omKeyInfo, clientID, omResponse);
+        new OMKeyCreateResponse(omKeyInfo, null, clientID, omResponse);
 
     String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,
         keyName, clientID);
@@ -73,7 +73,7 @@ public class TestOMKeyCreateResponse extends TestOMKeyResponse {
         .build();
 
     OMKeyCreateResponse omKeyCreateResponse =
-        new OMKeyCreateResponse(omKeyInfo, clientID, omResponse);
+        new OMKeyCreateResponse(omKeyInfo, null, clientID, omResponse);
 
     // Before calling addToDBBatch
     String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
@@ -48,7 +48,7 @@ public class TestOMKeyCreateResponse extends TestOMKeyResponse {
             .build();
 
     OMKeyCreateResponse omKeyCreateResponse =
-        new OMKeyCreateResponse(omKeyInfo, null, clientID, omResponse);
+        new OMKeyCreateResponse(omKeyInfo, null, clientID, omResponse, false);
 
     String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,
         keyName, clientID);
@@ -73,7 +73,7 @@ public class TestOMKeyCreateResponse extends TestOMKeyResponse {
         .build();
 
     OMKeyCreateResponse omKeyCreateResponse =
-        new OMKeyCreateResponse(omKeyInfo, null, clientID, omResponse);
+        new OMKeyCreateResponse(omKeyInfo, null, clientID, omResponse, false);
 
     // Before calling addToDBBatch
     String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-2301

This change introduces 'mkdir -p' behaviour in these 2 OM Requests:
1. create directory and 
2. create (file)

The idea is to avoid iteration of the key table when creating new files with a path. Without the patch,  during file create - checking the existence of each parent directory requires a slow DB iterator. With the patch, this check becomes a point lookup which can be accelerated by the bloom filters in RocksDB.

This patch is a work-in-progress and the following functionality is broken:
1. interoperability with S3
2. ACLs (setting correct ACLs for the parent directories created in the path)
3. rename

Soliciting early feedback.
