### PR TITLE
HDDS-1987. Fix listStatus API

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -815,17 +815,17 @@ public class TestKeyManagerImpl {
     // Get entries in both TableCache and DB
     List<OzoneFileStatus> fileStatuses =
         keyManager.listStatus(rootDirArgs, true, "", 1000);
-    Assert.assertEquals(fileStatuses.size(),  100);
+    Assert.assertEquals(100, fileStatuses.size());
 
     // Get entries with startKey=prefixKeyInDB
     fileStatuses =
         keyManager.listStatus(rootDirArgs, true, prefixKeyInDB, 1000);
-    Assert.assertEquals(fileStatuses.size(),  50);
+    Assert.assertEquals(50, fileStatuses.size());
 
     // Get entries with startKey=prefixKeyInCache
     fileStatuses =
         keyManager.listStatus(rootDirArgs, true, prefixKeyInCache, 1000);
-    Assert.assertEquals(fileStatuses.size(),  100);
+    Assert.assertEquals(100, fileStatuses.size());
 
     // Clean up cache by marking those keys in cache as deleted
     for (int i = 1; i <= 100; i += 2) {
@@ -892,6 +892,17 @@ public class TestKeyManagerImpl {
     fileStatuses =
         keyManager.listStatus(rootDirArgs, true, "", 1000);
     Assert.assertEquals(10 + 3, fileStatuses.size());
+
+    // Clean up
+    for (int i = 1; i <= 10; i += 2) {
+      // Mark TableCache entries as deleted
+      // Note that DB entry clean up is handled by cleanupTest()
+      String key = metadataManager.getOzoneKey(
+          VOLUME_NAME, BUCKET_NAME,
+          keyNameDir1Subdir1 + OZONE_URI_DELIMITER + prefixKeyInCache + i);
+      metadataManager.getKeyTable().addCacheEntry(new CacheKey<>(key),
+          new CacheValue<>(Optional.absent(), 2L));
+    }
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1927,18 +1927,21 @@ public class KeyManagerImpl implements KeyManager {
       // and keep track of deleted OmKeys with deletedKeySet.
       int countEntries = 0;
       Table keyTable = metadataManager.getKeyTable();
-      Iterator<Map.Entry<CacheKey<String>, CacheValue<OzoneFileStatus>>>
+      Iterator<Map.Entry<CacheKey<String>, CacheValue<OmKeyInfo>>>
           cacheIter = keyTable.cacheIterator();
 
       // Similar to the logic in OmMetadataManagerImpl#listKeys
       while (cacheIter.hasNext() && numEntries - countEntries > 0) {
-        Map.Entry<CacheKey<String>, CacheValue<OzoneFileStatus>> entry =
+        Map.Entry<CacheKey<String>, CacheValue<OmKeyInfo>> entry =
             cacheIter.next();
         String key = entry.getKey().getCacheKey();
-        OzoneFileStatus fileStatus = entry.getValue().getCacheValue();
-        // fileStatus is null if an entry is deleted in cache.
-        if (fileStatus != null) {
+        OmKeyInfo keyInfo = entry.getValue().getCacheValue();
+        // keyInfo is null if an entry is deleted in cache.
+        if (keyInfo != null) {
           if (key.startsWith(startKey) && key.compareTo(startKey) >= 0) {
+            // Create OzoneFileStatus from OmKeyInfo
+            OzoneFileStatus fileStatus = new OzoneFileStatus(
+                keyInfo, scmBlockSize, !OzoneFSUtils.isFile(key));
             cacheKeyMap.put(key, fileStatus);
             countEntries++;
           }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1918,6 +1918,8 @@ public class KeyManagerImpl implements KeyManager {
           // Return the single file status directly if OmKey points to a file
           return Collections.singletonList(fileStatus);
         }
+        // Append '/' to startKey if it doesn't have it
+        startKey = OzoneFSUtils.addTrailingSlashIfNeeded(keyName);
       }
 
       int countEntries = 0;
@@ -1925,8 +1927,9 @@ public class KeyManagerImpl implements KeyManager {
       Iterator<Map.Entry<CacheKey<String>, CacheValue<OmKeyInfo>>>
           cacheIter = keyTable.cacheIterator();
       String startCacheKey = OZONE_URI_DELIMITER + volumeName +
-          OZONE_URI_DELIMITER + bucketName + OZONE_URI_DELIMITER + startKey;
-      // Note: startKey shouldn't begin with '/'
+          OZONE_URI_DELIMITER + bucketName + OZONE_URI_DELIMITER +
+          ((startKey.equals(OZONE_URI_DELIMITER)) ? "" : startKey);
+      // Note: eliminate the case where startCacheKey could end with '//'
 
       // First, iterate TableCache
       // Limit number of result to numEntries, append result to cacheKeyMap,
@@ -1951,8 +1954,6 @@ public class KeyManagerImpl implements KeyManager {
         }
       }
 
-      // Append '/' to startKey if it doesn't have it
-      startKey = OzoneFSUtils.addTrailingSlashIfNeeded(keyName);
       // Find key in db
       String seekKeyInDb =
           metadataManager.getOzoneKey(volumeName, bucketName, startKey);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -37,6 +37,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension;
 import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension.EncryptedKeyVersion;
@@ -1943,6 +1944,16 @@ public class KeyManagerImpl implements KeyManager {
         if (cacheOmKeyInfo != null) {
           if (cacheKey.startsWith(startCacheKey) &&
               cacheKey.compareTo(startCacheKey) >= 0) {
+            // Respect recursive
+            if (!recursive) {
+              // Remove trailing '/', if any
+              String remainingKeyPart = StringUtils.stripEnd(
+                  cacheKey.substring(startCacheKey.length()),
+                  OZONE_URI_DELIMITER);
+              if (remainingKeyPart.contains(OZONE_URI_DELIMITER)) {
+                continue;
+              }
+            }
             // Create OzoneFileStatus from OmKeyInfo
             OzoneFileStatus fileStatus = new OzoneFileStatus(
                 cacheOmKeyInfo, scmBlockSize, !OzoneFSUtils.isFile(cacheKey));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1961,13 +1961,13 @@ public class KeyManagerImpl implements KeyManager {
           iterator = keyTable.iterator();
       iterator.seek(seekKeyInDb);
 
+      int countEntries = 0;
       if (iterator.hasNext()) {
         if (iterator.key().equals(keyInDb)) {
           // Skip the key itself (when listing a directory)
           iterator.next();
         }
         // Iterate through seek results
-        int countEntries = 0;
         while (iterator.hasNext() && numEntries - countEntries > 0) {
           String entryInDb = iterator.key();
           OmKeyInfo value = iterator.value().getValue();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1917,7 +1917,6 @@ public class KeyManagerImpl implements KeyManager {
         startKey = OzoneFSUtils.addTrailingSlashIfNeeded(keyName);
       }
 
-      int countEntries = 0;
       Table keyTable = metadataManager.getKeyTable();
       Iterator<Map.Entry<CacheKey<String>, CacheValue<OmKeyInfo>>>
           cacheIter = keyTable.cacheIterator();
@@ -1927,7 +1926,7 @@ public class KeyManagerImpl implements KeyManager {
       // Note: eliminating the case where startCacheKey could end with '//'
 
       // First, find key in TableCache
-      while (cacheIter.hasNext() && numEntries - countEntries > 0) {
+      while (cacheIter.hasNext()) {
         Map.Entry<CacheKey<String>, CacheValue<OmKeyInfo>> entry =
             cacheIter.next();
         String cacheKey = entry.getKey().getCacheKey();
@@ -1947,7 +1946,6 @@ public class KeyManagerImpl implements KeyManager {
             OzoneFileStatus fileStatus = new OzoneFileStatus(
                 cacheOmKeyInfo, scmBlockSize, !OzoneFSUtils.isFile(cacheKey));
             cacheKeyMap.put(cacheKey, fileStatus);
-            countEntries++;
           }
         } else {
           deletedKeySet.add(cacheKey);
@@ -1969,7 +1967,7 @@ public class KeyManagerImpl implements KeyManager {
           iterator.next();
         }
         // Iterate through seek results
-        countEntries = 0;
+        int countEntries = 0;
         while (iterator.hasNext() && numEntries - countEntries > 0) {
           String entryInDb = iterator.key();
           OmKeyInfo value = iterator.value().getValue();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -191,10 +191,6 @@ public class TestOmMetadataManager {
   }
 
   @Test
-  public void testListStatus() throws Exception {
-  }
-
-  @Test
   public void testListKeys() throws Exception {
 
     String volumeNameA = "volumeA";

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -191,6 +191,10 @@ public class TestOmMetadataManager {
   }
 
   @Test
+  public void testListStatus() throws Exception {
+  }
+
+  @Test
   public void testListKeys() throws Exception {
 
     String volumeNameA = "volumeA";


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix listStatus API in HA code path.

In HA, we have an in-memory cache, where we put the result to in-memory cache and return the response. It will be picked by double buffer thread and flushed to disk later. So when user call listStatus, it should use both in-memory cache and rocksdb key table to return the correct result.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-1987

## How was this patch tested?

1. `TestOzoneFileSystem#testListStatus` passed (for correctness when not using TableCache for keyTable).
2. Added three new unit tests in `TestKeyManagerImpl `.