### PR TITLE
HDDS-2395. Handle completeMPU scenarios to match with aws s3 behavior.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
@@ -210,7 +210,11 @@ public class OMException extends IOException {
     INVALID_PATH_IN_ACL_REQUEST, // Error code when path name is invalid during
     // acl requests.
 
-    USER_MISMATCH // Error code when requested user name passed is different
+    USER_MISMATCH, // Error code when requested user name passed is different
     // from remote user.
+
+    INVALID_PART,
+
+    INVALID_PART_ORDER
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
@@ -213,8 +213,10 @@ public class OMException extends IOException {
     USER_MISMATCH, // Error code when requested user name passed is different
     // from remote user.
 
-    INVALID_PART,
+    INVALID_PART, // When part name is not found or not matching with partname 
+    // in OM MPU partInfo.
 
-    INVALID_PART_ORDER
+    INVALID_PART_ORDER // When list of parts mentioned to complete MPU are not 
+    // given in ascending order.  
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartUploadCompleteList.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartUploadCompleteList.java
@@ -21,9 +21,9 @@ package org.apache.hadoop.ozone.om.helpers;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Part;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 /**
  * This class represents multipart list, which is required for
@@ -31,7 +31,7 @@ import java.util.TreeMap;
  */
 public class OmMultipartUploadCompleteList {
 
-  private final TreeMap<Integer, String> multipartMap;
+  private final LinkedHashMap<Integer, String> multipartMap;
 
   /**
    * Construct OmMultipartUploadCompleteList which holds multipart map which
@@ -39,14 +39,14 @@ public class OmMultipartUploadCompleteList {
    * @param partMap
    */
   public OmMultipartUploadCompleteList(Map<Integer, String> partMap) {
-    this.multipartMap = new TreeMap<>(partMap);
+    this.multipartMap = new LinkedHashMap<>(partMap);
   }
 
   /**
    * Return multipartMap which is a map of part number and part name.
    * @return multipartMap
    */
-  public TreeMap<Integer, String> getMultipartMap() {
+  public Map<Integer, String> getMultipartMap() {
     return multipartMap;
   }
 

--- a/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
+++ b/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
@@ -297,6 +297,9 @@ enum Status {
 
     USER_MISMATCH = 54; // Error code when requested user name passed is
     // different from remote user.
+
+    INVALID_PART = 55;
+    INVALID_PART_ORDER = 56;
 }
 
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1909,7 +1909,7 @@ public abstract class TestOzoneRpcClientAbstract {
     TreeMap<Integer, String> partsMap = new TreeMap<>();
     partsMap.put(1, UUID.randomUUID().toString());
 
-    OzoneTestUtils.expectOmException(ResultCodes.MISMATCH_MULTIPART_LIST,
+    OzoneTestUtils.expectOmException(ResultCodes.INVALID_PART,
         () -> completeMultipartUpload(bucket, keyName, uploadID, partsMap));
 
   }
@@ -1935,7 +1935,7 @@ public abstract class TestOzoneRpcClientAbstract {
     TreeMap<Integer, String> partsMap = new TreeMap<>();
     partsMap.put(1, UUID.randomUUID().toString());
 
-    OzoneTestUtils.expectOmException(ResultCodes.MISMATCH_MULTIPART_LIST,
+    OzoneTestUtils.expectOmException(ResultCodes.INVALID_PART,
         () -> completeMultipartUpload(bucket, keyName, uploadID, partsMap));
 
   }
@@ -1960,7 +1960,7 @@ public abstract class TestOzoneRpcClientAbstract {
     TreeMap<Integer, String> partsMap = new TreeMap<>();
     partsMap.put(3, "random");
 
-    OzoneTestUtils.expectOmException(ResultCodes.MISSING_UPLOAD_PARTS,
+    OzoneTestUtils.expectOmException(ResultCodes.INVALID_PART,
         () -> completeMultipartUpload(bucket, keyName, uploadID, partsMap));
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1094,9 +1094,6 @@ public class KeyManagerImpl implements KeyManager {
     try {
       String multipartKey = metadataManager.getMultipartKey(volumeName,
           bucketName, keyName, uploadID);
-      String ozoneKey = metadataManager.getOzoneKey(volumeName, bucketName,
-          keyName);
-      OmKeyInfo keyInfo = metadataManager.getKeyTable().get(ozoneKey);
 
       OmMultipartKeyInfo multipartKeyInfo = metadataManager
           .getMultipartInfoTable().get(multipartKey);
@@ -1105,119 +1102,10 @@ public class KeyManagerImpl implements KeyManager {
             volumeName + "bucket: " + bucketName + "key: " + keyName,
             ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR);
       }
-      TreeMap<Integer, PartKeyInfo> partKeyInfoMap = multipartKeyInfo
-          .getPartKeyInfoMap();
+      //TODO: Actual logic has been removed from this, and the old code has a
+      // bug. New code for this is in S3MultipartUploadCompleteRequest.
+      // This code will be cleaned up as part of HDDS-2353.
 
-      TreeMap<Integer, String> multipartMap = multipartUploadList
-          .getMultipartMap();
-
-      // Last key in the map should be having key value as size, as map's
-      // are sorted. Last entry in both maps should have partNumber as size
-      // of the map. As we have part entries 1, 2, 3, 4 and then we get
-      // complete multipart upload request so the map last entry should have 4,
-      // if it is having value greater or less than map size, then there is
-      // some thing wrong throw error.
-
-      Map.Entry<Integer, String> multipartMapLastEntry = multipartMap
-          .lastEntry();
-      Map.Entry<Integer, PartKeyInfo> partKeyInfoLastEntry = partKeyInfoMap
-          .lastEntry();
-      if (partKeyInfoMap.size() != multipartMap.size()) {
-        throw new OMException("Complete Multipart Upload Failed: volume: " +
-            volumeName + "bucket: " + bucketName + "key: " + keyName,
-            ResultCodes.MISMATCH_MULTIPART_LIST);
-      }
-
-      // Last entry part Number should be the size of the map, otherwise this
-      // means we have missing some parts but we got a complete request.
-      if (multipartMapLastEntry.getKey() != partKeyInfoMap.size() ||
-          partKeyInfoLastEntry.getKey() != partKeyInfoMap.size()) {
-        throw new OMException("Complete Multipart Upload Failed: volume: " +
-            volumeName + "bucket: " + bucketName + "key: " + keyName,
-            ResultCodes.MISSING_UPLOAD_PARTS);
-      }
-      ReplicationType type = partKeyInfoLastEntry.getValue().getPartKeyInfo()
-          .getType();
-      ReplicationFactor factor = partKeyInfoLastEntry.getValue()
-          .getPartKeyInfo().getFactor();
-      List<OmKeyLocationInfo> locations = new ArrayList<>();
-      long size = 0;
-      int partsCount =1;
-      int partsMapSize = partKeyInfoMap.size();
-      for(Map.Entry<Integer, PartKeyInfo> partKeyInfoEntry : partKeyInfoMap
-          .entrySet()) {
-        int partNumber = partKeyInfoEntry.getKey();
-        PartKeyInfo partKeyInfo = partKeyInfoEntry.getValue();
-        // Check we have all parts to complete multipart upload and also
-        // check partNames provided match with actual part names
-        String providedPartName = multipartMap.get(partNumber);
-        String actualPartName = partKeyInfo.getPartName();
-        if (partNumber == partsCount) {
-          if (!actualPartName.equals(providedPartName)) {
-            throw new OMException("Complete Multipart Upload Failed: volume: " +
-                volumeName + "bucket: " + bucketName + "key: " + keyName,
-                ResultCodes.MISMATCH_MULTIPART_LIST);
-          }
-          OmKeyInfo currentPartKeyInfo = OmKeyInfo
-              .getFromProtobuf(partKeyInfo.getPartKeyInfo());
-          // Check if any part size is less than 5mb, last part can be less
-          // than 5 mb.
-          if (partsCount != partsMapSize &&
-              currentPartKeyInfo.getDataSize() < OM_MULTIPART_MIN_SIZE) {
-            LOG.error("MultipartUpload: " + ozoneKey + "Part number: " +
-                partKeyInfo.getPartNumber() + "size " + currentPartKeyInfo
-                    .getDataSize() + " is less than minimum part size " +
-                OzoneConsts.OM_MULTIPART_MIN_SIZE);
-            throw new OMException("Complete Multipart Upload Failed: Entity " +
-                "too small: volume: " + volumeName + "bucket: " + bucketName
-                + "key: " + keyName, ResultCodes.ENTITY_TOO_SMALL);
-          }
-          // As all part keys will have only one version.
-          OmKeyLocationInfoGroup currentKeyInfoGroup = currentPartKeyInfo
-              .getKeyLocationVersions().get(0);
-          locations.addAll(currentKeyInfoGroup.getLocationList());
-          size += currentPartKeyInfo.getDataSize();
-        } else {
-          throw new OMException("Complete Multipart Upload Failed: volume: " +
-              volumeName + "bucket: " + bucketName + "key: " + keyName,
-              ResultCodes.MISSING_UPLOAD_PARTS);
-        }
-        partsCount++;
-      }
-      if (keyInfo == null) {
-        // This is a newly added key, it does not have any versions.
-        OmKeyLocationInfoGroup keyLocationInfoGroup = new
-            OmKeyLocationInfoGroup(0, locations);
-        // A newly created key, this is the first version.
-        keyInfo = new OmKeyInfo.Builder()
-            .setVolumeName(omKeyArgs.getVolumeName())
-            .setBucketName(omKeyArgs.getBucketName())
-            .setKeyName(omKeyArgs.getKeyName())
-            .setReplicationFactor(factor)
-            .setReplicationType(type)
-            .setCreationTime(Time.now())
-            .setModificationTime(Time.now())
-            .setDataSize(size)
-            .setOmKeyLocationInfos(
-                Collections.singletonList(keyLocationInfoGroup))
-            .setAcls(omKeyArgs.getAcls()).build();
-      } else {
-        // Already a version exists, so we should add it as a new version.
-        // But now as versioning is not supported, just following the commit
-        // key approach. When versioning support comes, then we can uncomment
-        // below code keyInfo.addNewVersion(locations);
-        keyInfo.updateLocationInfoList(locations);
-      }
-      DBStore store = metadataManager.getStore();
-      try (BatchOperation batch = store.initBatchOperation()) {
-        //Remove entry in multipart table and add a entry in to key table
-        metadataManager.getMultipartInfoTable().deleteWithBatch(batch,
-            multipartKey);
-        metadataManager.getKeyTable().putWithBatch(batch,
-            ozoneKey, keyInfo);
-        metadataManager.getOpenKeyTable().deleteWithBatch(batch, multipartKey);
-        store.commitBatchOperation(batch);
-      }
       return new OmMultipartUploadCompleteInfo(omKeyArgs.getVolumeName(),
           omKeyArgs.getBucketName(), omKeyArgs.getKeyName(), DigestUtils
               .sha256Hex(keyName));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -113,7 +113,6 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BL
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BLOCKS_MAX_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAULT;
-import static org.apache.hadoop.ozone.OzoneConsts.OM_MULTIPART_MIN_SIZE;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.DIRECTORY_NOT_FOUND;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
-import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteList;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
@@ -114,15 +113,8 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         .setSuccess(true);
     OMClientResponse omClientResponse = null;
     IOException exception = null;
-    OmMultipartUploadCompleteList multipartUploadList = null;
     try {
       // TODO to support S3 ACL later.
-      TreeMap<Integer, String> partsMap = new TreeMap<>();
-      for (OzoneManagerProtocolProtos.Part part : partsList) {
-        partsMap.put(part.getPartNumber(), part.getPartName());
-      }
-
-      multipartUploadList = new OmMultipartUploadCompleteList(partsMap);
 
       acquiredLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
           volumeName, bucketName);
@@ -146,122 +138,146 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
       TreeMap<Integer, PartKeyInfo> partKeyInfoMap =
           multipartKeyInfo.getPartKeyInfoMap();
 
-      TreeMap<Integer, String> multipartMap = multipartUploadList
-          .getMultipartMap();
+      if (partsList.size() > 0) {
+        if (partKeyInfoMap.size() == 0) {
+          LOG.error("Complete MultipartUpload failed for key {} , MPU Key has" +
+                  " no parts in OM, parts given to upload are {}", ozoneKey,
+              partsList);
+          throw new OMException("Complete Multipart Upload Failed: volume: " +
+              volumeName + "bucket: " + bucketName + "key: " + keyName,
+              OMException.ResultCodes.INVALID_PART);
+        }
 
-      // Last key in the map should be having key value as size, as map's
-      // are sorted. Last entry in both maps should have partNumber as size
-      // of the map. As we have part entries 1, 2, 3, 4 and then we get
-      // complete multipart upload request so the map last entry should have 4,
-      // if it is having value greater or less than map size, then there is
-      // some thing wrong throw error.
 
-      Map.Entry<Integer, String> multipartMapLastEntry = multipartMap
-          .lastEntry();
-      Map.Entry<Integer, PartKeyInfo> partKeyInfoLastEntry =
-          partKeyInfoMap.lastEntry();
-      if (partKeyInfoMap.size() != multipartMap.size()) {
-        throw new OMException("Complete Multipart Upload Failed: volume: " +
-            volumeName + "bucket: " + bucketName + "key: " + keyName,
-            OMException.ResultCodes.MISMATCH_MULTIPART_LIST);
-      }
+        // First Check for Invalid Part Order.
+        int prevPartNumber = partsList.get(0).getPartNumber();
+        List< Integer > partNumbers = new ArrayList<>();
+        int partsListSize = partsList.size();
+        partNumbers.add(prevPartNumber);
+        for (int i = 1; i < partsListSize; i++) {
+          int currentPartNumber = partsList.get(i).getPartNumber();
+          if (prevPartNumber >= currentPartNumber) {
+            LOG.error("PartNumber at index {} is {}, and its previous " +
+                    "partNumber at index {} is {} for ozonekey is " +
+                    "{}", i, currentPartNumber, i - 1, prevPartNumber,
+                ozoneKey);
+            throw new OMException("Complete Multipart Upload Failed: volume: " +
+                volumeName + "bucket: " + bucketName + "key: " + keyName +
+                "because parts are in Invalid order.",
+                OMException.ResultCodes.INVALID_PART_ORDER);
+          }
+          prevPartNumber = currentPartNumber;
+          partNumbers.add(prevPartNumber);
+        }
 
-      // Last entry part Number should be the size of the map, otherwise this
-      // means we have missing some parts but we got a complete request.
-      if (multipartMapLastEntry.getKey() != partKeyInfoMap.size() ||
-          partKeyInfoLastEntry.getKey() != partKeyInfoMap.size()) {
-        throw new OMException("Complete Multipart Upload Failed: volume: " +
-            volumeName + "bucket: " + bucketName + "key: " + keyName,
-            OMException.ResultCodes.MISSING_UPLOAD_PARTS);
-      }
-      HddsProtos.ReplicationType type = partKeyInfoLastEntry.getValue()
-          .getPartKeyInfo().getType();
-      HddsProtos.ReplicationFactor factor = partKeyInfoLastEntry.getValue()
-          .getPartKeyInfo().getFactor();
-      List< OmKeyLocationInfo > locations = new ArrayList<>();
-      long size = 0;
-      int partsCount =1;
-      int partsMapSize = partKeyInfoMap.size();
-      for(Map.Entry<Integer, PartKeyInfo > partKeyInfoEntry : partKeyInfoMap
-          .entrySet()) {
-        int partNumber = partKeyInfoEntry.getKey();
-        PartKeyInfo partKeyInfo = partKeyInfoEntry.getValue();
-        // Check we have all parts to complete multipart upload and also
-        // check partNames provided match with actual part names
-        String providedPartName = multipartMap.get(partNumber);
-        String actualPartName = partKeyInfo.getPartName();
-        if (partNumber == partsCount) {
-          if (!actualPartName.equals(providedPartName)) {
+
+        List<OmKeyLocationInfo> partLocationInfos = new ArrayList<>();
+        long dataSize = 0;
+        int currentPartCount = 0;
+        // Now do actual logic, and check for any Invalid part during this.
+        for (OzoneManagerProtocolProtos.Part part : partsList) {
+          currentPartCount++;
+          int partNumber = part.getPartNumber();
+          String partName = part.getPartName();
+
+          PartKeyInfo partKeyInfo = partKeyInfoMap.get(partNumber);
+
+          if (partKeyInfo == null ||
+              !partName.equals(partKeyInfo.getPartName())) {
             throw new OMException("Complete Multipart Upload Failed: volume: " +
                 volumeName + "bucket: " + bucketName + "key: " + keyName,
-                OMException.ResultCodes.MISMATCH_MULTIPART_LIST);
+                OMException.ResultCodes.INVALID_PART);
           }
+
           OmKeyInfo currentPartKeyInfo = OmKeyInfo
               .getFromProtobuf(partKeyInfo.getPartKeyInfo());
-          // Check if any part size is less than 5mb, last part can be less
-          // than 5 mb.
-          if (partsCount != partsMapSize &&
-              currentPartKeyInfo.getDataSize() < OM_MULTIPART_MIN_SIZE) {
-            LOG.error("MultipartUpload: " + ozoneKey + "Part number: " +
-                partKeyInfo.getPartNumber() + "size " + currentPartKeyInfo
-                .getDataSize() + " is less than minimum part size " +
-                OzoneConsts.OM_MULTIPART_MIN_SIZE);
-            throw new OMException("Complete Multipart Upload Failed: Entity " +
-                "too small: volume: " + volumeName + "bucket: " + bucketName
-                + "key: " + keyName, OMException.ResultCodes.ENTITY_TOO_SMALL);
+
+
+          // Except for last part all parts should have minimum size.
+          if (currentPartCount != partsListSize) {
+            if (currentPartKeyInfo.getDataSize() < OM_MULTIPART_MIN_SIZE) {
+              LOG.error("MultipartUpload: " + ozoneKey + "Part number: " +
+                  partKeyInfo.getPartNumber() + "size " + currentPartKeyInfo
+                  .getDataSize() + " is less than minimum part size " +
+                  OzoneConsts.OM_MULTIPART_MIN_SIZE);
+              throw new OMException("Complete Multipart Upload Failed: Entity " +
+                  "too small: volume: " + volumeName + "bucket: " + bucketName
+                  + "key: " + keyName, OMException.ResultCodes.ENTITY_TOO_SMALL);
+            }
           }
+
           // As all part keys will have only one version.
           OmKeyLocationInfoGroup currentKeyInfoGroup = currentPartKeyInfo
               .getKeyLocationVersions().get(0);
-          locations.addAll(currentKeyInfoGroup.getLocationList());
-          size += currentPartKeyInfo.getDataSize();
-        } else {
-          throw new OMException("Complete Multipart Upload Failed: volume: " +
-              volumeName + "bucket: " + bucketName + "key: " + keyName,
-              OMException.ResultCodes.MISSING_UPLOAD_PARTS);
+          partLocationInfos.addAll(currentKeyInfoGroup.getLocationList());
+          dataSize += currentPartKeyInfo.getDataSize();
         }
-        partsCount++;
-      }
-      if (omKeyInfo == null) {
-        // This is a newly added key, it does not have any versions.
-        OmKeyLocationInfoGroup keyLocationInfoGroup = new
-            OmKeyLocationInfoGroup(0, locations);
-        // A newly created key, this is the first version.
-        omKeyInfo = new OmKeyInfo.Builder().setVolumeName(volumeName)
-            .setBucketName(bucketName).setKeyName(keyName)
-            .setReplicationFactor(factor).setReplicationType(type)
-            .setCreationTime(keyArgs.getModificationTime())
-            .setModificationTime(keyArgs.getModificationTime())
-            .setDataSize(size)
-            .setOmKeyLocationInfos(
-                Collections.singletonList(keyLocationInfoGroup))
-            .setAcls(OzoneAclUtil.fromProtobuf(keyArgs.getAclsList()))
-            .build();
+
+        // All parts have same replication information. Here getting from last
+        // part.
+        HddsProtos.ReplicationType type = partKeyInfoMap.lastEntry().getValue()
+            .getPartKeyInfo().getType();
+        HddsProtos.ReplicationFactor factor =
+            partKeyInfoMap.lastEntry().getValue().getPartKeyInfo().getFactor();
+
+        if (omKeyInfo == null) {
+          // This is a newly added key, it does not have any versions.
+          OmKeyLocationInfoGroup keyLocationInfoGroup = new
+              OmKeyLocationInfoGroup(0, partLocationInfos);
+          // A newly created key, this is the first version.
+          omKeyInfo = new OmKeyInfo.Builder().setVolumeName(volumeName)
+              .setBucketName(bucketName).setKeyName(keyName)
+              .setReplicationFactor(factor).setReplicationType(type)
+              .setCreationTime(keyArgs.getModificationTime())
+              .setModificationTime(keyArgs.getModificationTime())
+              .setDataSize(dataSize)
+              .setOmKeyLocationInfos(
+                  Collections.singletonList(keyLocationInfoGroup))
+              .setAcls(OzoneAclUtil.fromProtobuf(keyArgs.getAclsList()))
+              .build();
+        } else {
+          // Already a version exists, so we should add it as a new version.
+          // But now as versioning is not supported, just following the commit
+          // key approach. When versioning support comes, then we can uncomment
+          // below code keyInfo.addNewVersion(locations);
+          omKeyInfo.updateLocationInfoList(partLocationInfos);
+          omKeyInfo.setModificationTime(keyArgs.getModificationTime());
+          omKeyInfo.setDataSize(dataSize);
+        }
+
+        //Find all unused parts.
+
+        List< OmKeyInfo > unUsedParts = new ArrayList<>();
+        for (Map.Entry< Integer, PartKeyInfo > partKeyInfo :
+            partKeyInfoMap.entrySet()) {
+          if (!partNumbers.contains(partKeyInfo.getKey())) {
+            unUsedParts.add(OmKeyInfo
+                .getFromProtobuf(partKeyInfo.getValue().getPartKeyInfo()));
+          }
+        }
+
+        updateCache(omMetadataManager, ozoneKey, multipartKey, omKeyInfo,
+            transactionLogIndex);
+
+        omResponse.setCompleteMultiPartUploadResponse(
+            MultipartUploadCompleteResponse.newBuilder()
+                .setVolume(volumeName)
+                .setBucket(bucketName)
+                .setKey(keyName)
+                .setHash(DigestUtils.sha256Hex(keyName)));
+
+        omClientResponse = new S3MultipartUploadCompleteResponse(multipartKey,
+            omKeyInfo, unUsedParts, omResponse.build());
       } else {
-        // Already a version exists, so we should add it as a new version.
-        // But now as versioning is not supported, just following the commit
-        // key approach. When versioning support comes, then we can uncomment
-        // below code keyInfo.addNewVersion(locations);
-        omKeyInfo.updateLocationInfoList(locations);
-        omKeyInfo.setModificationTime(keyArgs.getModificationTime());
+        throw new OMException("Complete Multipart Upload Failed: volume: " +
+            volumeName + "bucket: " + bucketName + "key: " + keyName +
+            "because of empty part list",
+            OMException.ResultCodes.INVALID_REQUEST);
       }
-
-      updateCache(omMetadataManager, ozoneKey, multipartKey, omKeyInfo,
-          transactionLogIndex);
-
-      omResponse.setCompleteMultiPartUploadResponse(
-          MultipartUploadCompleteResponse.newBuilder()
-              .setVolume(volumeName)
-              .setBucket(bucketName)
-              .setKey(keyName)
-              .setHash(DigestUtils.sha256Hex(keyName)));
-
-      omClientResponse = new S3MultipartUploadCompleteResponse(multipartKey,
-          omKeyInfo, omResponse.build());
 
     } catch (IOException ex) {
       exception = ex;
-      omClientResponse = new S3MultipartUploadCompleteResponse(null, null,
+      omClientResponse = new S3MultipartUploadCompleteResponse(null, null, null,
           createErrorOMResponse(omResponse, exception));
     } finally {
       if (omClientResponse != null) {
@@ -276,10 +292,8 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
     }
 
     Map<String, String> auditMap = buildKeyArgsAuditMap(keyArgs);
-    if (multipartUploadList != null) {
-      auditMap.put(OzoneConsts.MULTIPART_LIST, multipartUploadList
-          .getMultipartMap().toString());
-    }
+    auditMap.put(OzoneConsts.MULTIPART_LIST, partsList.toString());
+
 
     // audit log
     auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -200,9 +200,10 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
                   partKeyInfo.getPartNumber() + "size " + currentPartKeyInfo
                   .getDataSize() + " is less than minimum part size " +
                   OzoneConsts.OM_MULTIPART_MIN_SIZE);
-              throw new OMException("Complete Multipart Upload Failed: Entity " +
-                  "too small: volume: " + volumeName + "bucket: " + bucketName
-                  + "key: " + keyName, OMException.ResultCodes.ENTITY_TOO_SMALL);
+              throw new OMException("Complete Multipart Upload Failed: " +
+                  "Entity too small: volume: " + volumeName + "bucket: " +
+                  bucketName + "key: " + keyName,
+                  OMException.ResultCodes.ENTITY_TOO_SMALL);
             }
           }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
@@ -19,9 +19,12 @@
 package org.apache.hadoop.ozone.om.response.s3.multipart;
 
 import java.io.IOException;
+import java.util.List;
 
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -37,11 +40,14 @@ import javax.annotation.Nonnull;
 public class S3MultipartUploadCompleteResponse extends OMClientResponse {
   private String multipartKey;
   private OmKeyInfo omKeyInfo;
+  private List<OmKeyInfo> partsUnusedList;
 
 
   public S3MultipartUploadCompleteResponse(@Nullable String multipartKey,
-      @Nullable OmKeyInfo omKeyInfo, @Nonnull OMResponse omResponse) {
+      @Nullable OmKeyInfo omKeyInfo,
+      @Nullable List<OmKeyInfo> unUsedParts, @Nonnull OMResponse omResponse) {
     super(omResponse);
+    this.partsUnusedList = unUsedParts;
     this.multipartKey = multipartKey;
     this.omKeyInfo = omKeyInfo;
   }
@@ -58,6 +64,24 @@ public class S3MultipartUploadCompleteResponse extends OMClientResponse {
           multipartKey);
       omMetadataManager.getMultipartInfoTable().deleteWithBatch(batchOperation,
           multipartKey);
+
+      // Add unused parts to deleted key table.
+      String keyName =
+          omMetadataManager.getOzoneKey(omKeyInfo.getVolumeName(),
+              omKeyInfo.getBucketName(), omKeyInfo.getKeyName());
+
+      RepeatedOmKeyInfo repeatedOmKeyInfo =
+          omMetadataManager.getDeletedTable().get(keyName);
+
+      if (repeatedOmKeyInfo == null) {
+        repeatedOmKeyInfo =
+            new RepeatedOmKeyInfo(partsUnusedList);
+      } else {
+        repeatedOmKeyInfo.addOmKeyInfo(omKeyInfo);
+      }
+
+      omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
+          keyName, repeatedOmKeyInfo);
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om.response.s3.multipart;
 import java.io.IOException;
 import java.util.List;
 
-import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
@@ -85,5 +84,3 @@ public class S3MultipartUploadCompleteResponse extends OMClientResponse {
     }
   }
 }
-
-

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadComplete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadComplete.java
@@ -110,7 +110,7 @@ public class TestMultipartUploadComplete {
 
     assertEquals(completeMultipartUploadResponse.getBucket(),
         OzoneConsts.S3_BUCKET);
-    assertEquals(completeMultipartUploadResponse.getKey(), OzoneConsts.KEY);
+    assertEquals(completeMultipartUploadResponse.getKey(), key);
     assertEquals(completeMultipartUploadResponse.getLocation(),
         OzoneConsts.S3_BUCKET);
     assertNotNull(completeMultipartUploadResponse.getETag());
@@ -181,7 +181,7 @@ public class TestMultipartUploadComplete {
       completeMultipartUpload(key, completeMultipartUploadRequest, uploadID);
       fail("testMultipartInvalidPartOrderError");
     } catch (OS3Exception ex) {
-      assertEquals(ex.getCode(), S3ErrorTable.INVALID_PART_ORDER.getCode());
+      assertEquals(S3ErrorTable.INVALID_PART_ORDER.getCode(), ex.getCode());
     }
 
   }
@@ -200,7 +200,7 @@ public class TestMultipartUploadComplete {
     int partNumber = 1;
 
     Part part1 = uploadPart(key, uploadID, partNumber, content);
-    // Change part number
+    // Change part name.
     part1.seteTag("random");
     partsList.add(part1);
 
@@ -216,7 +216,7 @@ public class TestMultipartUploadComplete {
     completeMultipartUploadRequest.setPartList(partsList);
     try {
       completeMultipartUpload(key, completeMultipartUploadRequest, uploadID);
-      fail("testMultipartInvalidPartOrderError");
+      fail("testMultipartInvalidPartError");
     } catch (OS3Exception ex) {
       assertEquals(ex.getCode(), S3ErrorTable.INVALID_PART.getCode());
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix a few cases which were missed during complete Multipart upload.

When uploaded 2 parts, and when complete upload 1 part no error
During complete multipart upload name/part number not matching with uploaded part and part number then InvalidPart error
When parts are not specified in sorted order InvalidPartOrder
During complete multipart upload when no uploaded parts, and we specify some parts then also InvalidPart
Uploaded parts 1,2,3 and during complete we can do upload 1,3 (No error)
When part 3 uploaded, complete with part 3 can be done.

And removed old code logic partially will do complete clean up of old code will be done as part of HDDS-2351.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2395

## How was this patch tested?
Ran S3 smoke tests and also added smoke tests.
