### PR TITLE
HDDS-2397. Fix calling cleanup for few missing tables in OM.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -228,6 +228,10 @@ public class OzoneManagerDoubleBuffer {
     omMetadataManager.getS3Table().cleanupCache(lastRatisTransactionIndex);
     omMetadataManager.getMultipartInfoTable().cleanupCache(
         lastRatisTransactionIndex);
+    omMetadataManager.getS3SecretTable().cleanupCache(lastRatisTransactionIndex);
+    omMetadataManager.getPrefixTable().cleanupCache(lastRatisTransactionIndex);
+    omMetadataManager.getDelegationTokenTable().cleanupCache(
+        lastRatisTransactionIndex);
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -228,10 +228,11 @@ public class OzoneManagerDoubleBuffer {
     omMetadataManager.getS3Table().cleanupCache(lastRatisTransactionIndex);
     omMetadataManager.getMultipartInfoTable().cleanupCache(
         lastRatisTransactionIndex);
-    omMetadataManager.getS3SecretTable().cleanupCache(lastRatisTransactionIndex);
-    omMetadataManager.getPrefixTable().cleanupCache(lastRatisTransactionIndex);
+    omMetadataManager.getS3SecretTable().cleanupCache(
+      lastRatisTransactionIndex);
     omMetadataManager.getDelegationTokenTable().cleanupCache(
         lastRatisTransactionIndex);
+    omMetadataManager.getPrefixTable().cleanupCache(lastRatisTransactionIndex);
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -229,7 +229,7 @@ public class OzoneManagerDoubleBuffer {
     omMetadataManager.getMultipartInfoTable().cleanupCache(
         lastRatisTransactionIndex);
     omMetadataManager.getS3SecretTable().cleanupCache(
-      lastRatisTransactionIndex);
+        lastRatisTransactionIndex);
     omMetadataManager.getDelegationTokenTable().cleanupCache(
         lastRatisTransactionIndex);
     omMetadataManager.getPrefixTable().cleanupCache(lastRatisTransactionIndex);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix calling clean up of few tables which is missing in OzoneManagerDoubleBuffer cleanupcache.

For few tables cleanup of cache is missed:

PrefixTable
S3SecretTable
DelegationTable

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2397

## How was this patch tested?

Ran a few integration tests.
