### PR TITLE
HDDS-2398. Remove usage of LogUtils class from ratis-common.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
@@ -28,9 +28,8 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.apache.log4j.Level;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.ratis.grpc.client.GrpcClientProtocolClient;
-import org.apache.ratis.util.LogUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,7 +68,8 @@ public class MiniOzoneChaosCluster extends MiniOzoneClusterImpl {
     this.executorService =  Executors.newSingleThreadScheduledExecutor();
     this.numDatanodes = getHddsDatanodes().size();
     LOG.info("Starting MiniOzoneChaosCluster with {} datanodes", numDatanodes);
-    LogUtils.setLogLevel(GrpcClientProtocolClient.LOG, Level.WARN);
+    GenericTestUtils.setLogLevel(GrpcClientProtocolClient.LOG,
+        org.slf4j.event.Level.WARN);
   }
 
   // Get the number of datanodes to fail in the cluster.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove usage of LogUtils from ratis-common

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2398

## How was this patch tested?

--
