### PR TITLE
HDDS-1515. Add hadolint checks

### DIFF
--- a/hadoop-ozone/dev-support/checks/hadolint.sh
+++ b/hadoop-ozone/dev-support/checks/hadolint.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$DIR/../../.." || exit 1
+REPO_DIR="$DIR/../../.."
+
+ERROR=0
+
+
+for Dockerfile in $(find "$REPO_DIR/hadoop-ozone" "$REPO_DIR/hadoop-hdds" -name Dockerfile | sort); do
+  echo "Checking $Dockerfile"
+
+  result=$( hadolint $Dockerfile )
+  if [ ! -z "$result" ]
+  then
+    echo "$result"
+    echo ""
+    ERROR=1
+  fi
+done
+
+if [ "$ERROR" = 1 ]
+then
+  echo ""
+  echo ""
+  echo "Hadolint errors were found. Exit code: 1."
+  exit 1
+fi


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Hadolint checks

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-1515

## How was this patch tested?

Manually tested. Gives the following output currently
```
Checking /opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dev-support/docker/Dockerfile
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dev-support/docker/Dockerfile:15 DL3006 Always tag the version of an image explicitly
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dev-support/docker/Dockerfile:16 DL3018 Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dev-support/docker/Dockerfile:19 DL3018 Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dev-support/docker/Dockerfile:19 DL3019 Use the `--no-cache` switch to avoid the need to use `--update` and remove `/var/cache/apk/*` when done installing packages
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dev-support/docker/Dockerfile:25 DL3003 Use WORKDIR to switch to a directory
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dev-support/docker/Dockerfile:37 DL4001 Either use Wget or Curl but not both
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dev-support/docker/Dockerfile:37 DL4006 Set the SHELL option -o pipefail before RUN with a pipe in it
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dev-support/docker/Dockerfile:42 DL4001 Either use Wget or Curl but not both
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dev-support/docker/Dockerfile:42 DL4006 Set the SHELL option -o pipefail before RUN with a pipe in it
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dev-support/docker/Dockerfile:47 DL3013 Pin versions in pip. Instead of `pip install <package>` use `pip install <package>==<version>`
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dev-support/docker/Dockerfile:47 DL4001 Either use Wget or Curl but not both
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dev-support/docker/Dockerfile:50 DL4001 Either use Wget or Curl but not both
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dev-support/docker/Dockerfile:54 SC2086 Double quote to prevent globbing and word splitting.
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dev-support/docker/Dockerfile:54 DL4001 Either use Wget or Curl but not both
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dev-support/docker/Dockerfile:63 DL3003 Use WORKDIR to switch to a directory
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dev-support/docker/Dockerfile:63 DL4001 Either use Wget or Curl but not both
Checking /opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile:16 DL3006 Always tag the version of an image explicitly
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile:17 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile:19 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile:20 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile:21 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile:22 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile:23 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile:26 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile:27 DL3020 Use COPY instead of ADD for files and folders
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile:28 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile:29 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile:30 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile:31 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile:33 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
Checking /opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/src/main/docker/Dockerfile
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/src/main/docker/Dockerfile:17:26 unexpected '@' expecting the image tag
Checking /opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/Dockerfile
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/Dockerfile:19 DL3020 Use COPY instead of ADD for files and folders
Checking /opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/compose/ozonescripts/Dockerfile
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/compose/ozonescripts/Dockerfile:16 DL3006 Always tag the version of an image explicitly
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/compose/ozonescripts/Dockerfile:17 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/compose/ozonescripts/Dockerfile:19 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/compose/ozonescripts/Dockerfile:20 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/compose/ozonescripts/Dockerfile:21 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/compose/ozonescripts/Dockerfile:22 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/compose/ozonescripts/Dockerfile:23 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/compose/ozonescripts/Dockerfile:26 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/compose/ozonescripts/Dockerfile:27 DL3020 Use COPY instead of ADD for files and folders
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/compose/ozonescripts/Dockerfile:28 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/compose/ozonescripts/Dockerfile:29 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/compose/ozonescripts/Dockerfile:30 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/compose/ozonescripts/Dockerfile:31 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/compose/ozonescripts/Dockerfile:33 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
Checking /opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/Dockerfile
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/Dockerfile:19 DL3020 Use COPY instead of ADD for files and folders
Checking /opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonescripts/Dockerfile
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonescripts/Dockerfile:16 DL3006 Always tag the version of an image explicitly
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonescripts/Dockerfile:17 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonescripts/Dockerfile:19 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonescripts/Dockerfile:20 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonescripts/Dockerfile:21 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonescripts/Dockerfile:22 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonescripts/Dockerfile:23 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonescripts/Dockerfile:26 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonescripts/Dockerfile:27 DL3020 Use COPY instead of ADD for files and folders
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonescripts/Dockerfile:28 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonescripts/Dockerfile:29 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonescripts/Dockerfile:30 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonescripts/Dockerfile:31 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root
/opt/hadoop-ozone/hadoop-ozone/dev-support/checks/../../../hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonescripts/Dockerfile:33 DL3004 Do not use sudo as it leads to unpredictable behavior. Use a tool like gosu to enforce root


Hadolint errors were found. Exit code: 1.
```