### PR TITLE
HDDS-2404. Added support for Registered id as service identifier for …

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/PKIProfiles/DefaultProfile.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/PKIProfiles/DefaultProfile.java
@@ -74,6 +74,7 @@ public class DefaultProfile implements PKIProfile {
   private static final int[] GENERAL_NAMES = {
       GeneralName.dNSName,
       GeneralName.iPAddress,
+      GeneralName.otherName,
   };
   // Map that handles all the Extensions lookup and validations.
   private static final Map<ASN1ObjectIdentifier, BiFunction<Extension,
@@ -245,6 +246,9 @@ public class DefaultProfile implements PKIProfile {
       }
     case GeneralName.dNSName:
       return DomainValidator.getInstance().isValid(value);
+    case GeneralName.otherName:
+      // for other name its a general string, nothing to validate
+      return true;
     default:
       // This should not happen, since it guarded via isSupportedGeneralName.
       LOG.error("Unexpected type in General Name (int value) : " + type);

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -147,6 +147,7 @@ public class TestDefaultCAServer {
     PKCS10CertificationRequest csr = new CertificateSignRequest.Builder()
         .addDnsName("hadoop.apache.org")
         .addIpAddress("8.8.8.8")
+        .addServiceName("OzoneMarketingCluster002")
         .setCA(false)
         .setClusterID(clusterId)
         .setScmID(scmId)

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultProfile.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultProfile.java
@@ -91,11 +91,11 @@ public class TestDefaultProfile {
 // Positive tests
     assertTrue(defaultProfile.isSupportedGeneralName(GeneralName.iPAddress));
     assertTrue(defaultProfile.isSupportedGeneralName(GeneralName.dNSName));
+    assertTrue(defaultProfile.isSupportedGeneralName(GeneralName.otherName));
 // Negative Tests
     assertFalse(defaultProfile.isSupportedGeneralName(
         GeneralName.directoryName));
     assertFalse(defaultProfile.isSupportedGeneralName(GeneralName.rfc822Name));
-    assertFalse(defaultProfile.isSupportedGeneralName(GeneralName.otherName));
   }
 
   /**
@@ -111,6 +111,7 @@ public class TestDefaultProfile {
     PKCS10CertificationRequest csr = new CertificateSignRequest.Builder()
         .addDnsName("hadoop.apache.org")
         .addIpAddress("8.8.8.8")
+        .addServiceName("OzoneMarketingCluster001")
         .setCA(false)
         .setClusterID("ClusterID")
         .setScmID("SCMID")


### PR DESCRIPTION
## What changes were proposed in this pull request?

The SCM HA needs the ability to represent a group as a single entity. So that Tokens for each of the OM which is part of an HA group can be honored by the data nodes.

This patch adds the notion of a service group ID to the Certificate Infrastructure. In the next JIRAs, we will use this capability when issuing certificates to OM – especially when they are in HA mode.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2404

## How was this patch tested?
Added unit test which handles the newly added field. 

