### PR TITLE
HDDS-2064. Add tests for incorrect OM HA config when node ID or RPC address is not configured

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
@@ -281,6 +281,59 @@ public class TestOzoneManagerConfiguration {
   }
 
   /**
+   * A configuration with an empty node list while service ID is configured.
+   * Cluster should fail to start during config check.
+   * @throws Exception
+   */
+  @Test
+  public void testNoOMNodes() throws Exception {
+    String omServiceId = "service1";
+    conf.set(OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY, omServiceId);
+    // Deliberately skip OZONE_OM_NODES_KEY and OZONE_OM_ADDRESS_KEY config
+
+    try {
+      startCluster();
+      Assert.fail("Should have failed to start the cluster!");
+    }
+    catch (OzoneIllegalArgumentException e) {
+      // Expect error message
+      Assert.assertTrue(e.getMessage().contains(
+          "List of OM Node ID's should be specified"));
+    }
+  }
+
+  /**
+   * A configuration with no OM addresses while service ID is configured.
+   * Cluster should fail to start during config check.
+   * @throws Exception
+   */
+  @Test
+  public void testNoOMAddrs() throws Exception {
+    String omServiceId = "service1";
+
+    String omNode1Id = "omNode1";
+    String omNode2Id = "omNode2";
+    String omNode3Id = "omNode3";
+    String omNodesKeyValue = omNode1Id + "," + omNode2Id + "," + omNode3Id;
+    String omNodesKey = OmUtils.addKeySuffixes(
+        OMConfigKeys.OZONE_OM_NODES_KEY, omServiceId);
+
+    conf.set(OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY, omServiceId);
+    conf.set(omNodesKey, omNodesKeyValue);
+    // Deliberately skip OZONE_OM_ADDRESS_KEY config
+
+    try {
+      startCluster();
+      Assert.fail("Should have failed to start the cluster!");
+    }
+    catch (OzoneIllegalArgumentException e) {
+      // Expect error message
+      Assert.assertTrue(e.getMessage().contains(
+          "OM Rpc Address should be set for all node"));
+    }
+  }
+
+  /**
    * Test multiple OM service configuration.
    */
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
@@ -294,8 +294,7 @@ public class TestOzoneManagerConfiguration {
     try {
       startCluster();
       Assert.fail("Should have failed to start the cluster!");
-    }
-    catch (OzoneIllegalArgumentException e) {
+    } catch (OzoneIllegalArgumentException e) {
       // Expect error message
       Assert.assertTrue(e.getMessage().contains(
           "List of OM Node ID's should be specified"));
@@ -325,8 +324,7 @@ public class TestOzoneManagerConfiguration {
     try {
       startCluster();
       Assert.fail("Should have failed to start the cluster!");
-    }
-    catch (OzoneIllegalArgumentException e) {
+    } catch (OzoneIllegalArgumentException e) {
       // Expect error message
       Assert.assertTrue(e.getMessage().contains(
           "OM Rpc Address should be set for all node"));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add two unit tests for HDDS-2162, when OM service ID is specified:
(1) Cluster should fail to start if a list of OM Node IDs is **not** specified;
(2) Cluster should fail to start if a list of OM Node IDs is specified, but OM RPC address is **not** specified.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2064

## How was this patch tested?

Run the two newly added unit tests in this patch.