### PR TITLE
HDDS-2407. Reduce log level of per-node failure in XceiverClientGrpc

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -329,8 +329,8 @@ public class XceiverClientGrpc extends XceiverClientSpi {
         }
         break;
       } catch (ExecutionException | InterruptedException | IOException e) {
-        LOG.error("Failed to execute command " + request + " on datanode " + dn
-            .getUuidString(), e);
+        LOG.debug("Failed to execute command {} on datanode {}",
+            request, dn.getUuid(), e);
         if (!(e instanceof IOException)) {
           if (Status.fromThrowable(e.getCause()).getCode()
               == Status.UNAUTHENTICATED.getCode()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When reading from a pipeline, client should not care if some datanode could not service the request, as long as the pipeline as a whole is OK.  The [log message](https://github.com/apache/hadoop-ozone/blob/2529cee1a7dd27c51cb9aed0dc57af283ff24e26/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java#L303-L304) indicating node failure was [increased to error level](https://github.com/apache/hadoop-ozone/commit/a79dc4609a975d46a3e051ad6904fb1eb40705ee#diff-b9b6f3ccb12829d90886e041d11395b1R288) in [HDDS-1780](https://issues.apache.org/jira/browse/HDDS-1780).  This PR proposes to change it back to debug.  Pipeline-level failure is still logged as error.

https://issues.apache.org/jira/browse/HDDS-2407

## How was this patch tested?

Tested locally on docker-compose cluster with 0/1/2/3 datanodes down.