### PR TITLE
HDDS-2410. Ozoneperf docker cluster should use privileged containers

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozoneperf/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozoneperf/docker-compose.yaml
@@ -18,6 +18,7 @@ version: "3"
 services:
    datanode:
       image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      privileged: true
       volumes:
         - ../..:/opt/hadoop
       ports:
@@ -27,6 +28,7 @@ services:
         - ./docker-config
    om:
       image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      privileged: true
       volumes:
         - ../..:/opt/hadoop
       ports:
@@ -38,6 +40,7 @@ services:
       command: ["ozone","om"]
    scm:
       image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      privileged: true
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -71,6 +74,7 @@ services:
          - 3000:3000
    s3g:
      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+     privileged: true
      volumes:
        - ../..:/opt/hadoop
      ports:


### PR DESCRIPTION
## What changes were proposed in this pull request?

The [profiler servlet](https://github.com/elek/hadoop-ozone/blob/master/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/ProfileServlet.java) (which helps to run java profiler in the background and publishes the result on the web interface) requires privileged docker containers.

 

This flag is missing from the ozoneperf docker-compose cluster (which is designed to run performance tests).

## What is the link to the Apache JIRA

https://github.com/elek/hadoop-ozone/pull/new/HDDS-2410

## How was this patch tested?

```
cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozoneperf/
docker-compose up -d
```

firefox http://localhost:9876/prof

Execute the proposed kernel parameter adjustments:

```
echo 1 > /proc/sys/kernel/perf_event_paranoid
echo 0 > /proc/sys/kernel/kptr_restrict
```

Reponed http://localhost:9876/prof

After 10 seconds you should see the profiler flame graph