### PR TITLE
HDDS-2415. Completely disable tracer if hdds.tracing.enabled=false

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/StringCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/StringCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -42,7 +42,7 @@ public class StringCodec implements Codec<StringBuilder> {
       throw new EmptyTracerStateStringException();
     }
     String value = s.toString();
-    if (value != null && !value.equals("")) {
+    if (!"".equals(value)) {
       String[] parts = value.split(":");
       if (parts.length != 4) {
         if (LOG.isDebugEnabled()) {
@@ -59,7 +59,7 @@ public class StringCodec implements Codec<StringBuilder> {
               (new BigInteger(parts[3], 16)).byteValue());
         } else {
           throw new TraceIdOutOfBoundException(
-              "Trace id [" + traceId + "] length is not withing 1 and 32");
+              "Trace id [" + traceId + "] length is not within 1 and 32");
         }
       }
     } else {
@@ -68,13 +68,12 @@ public class StringCodec implements Codec<StringBuilder> {
   }
 
   @Override
-  public void inject(JaegerSpanContext context,
-      StringBuilder string) {
+  public void inject(JaegerSpanContext context, StringBuilder string) {
     int intFlag = context.getFlags() & 255;
-    string.append(
-        context.getTraceId() + ":" + Long.toHexString(context.getSpanId())
-            + ":" + Long.toHexString(context.getParentId()) + ":" + Integer
-            .toHexString(intFlag));
+    string.append(context.getTraceId())
+        .append(":").append(Long.toHexString(context.getSpanId()))
+        .append(":").append(Long.toHexString(context.getParentId()))
+        .append(":").append(Integer.toHexString(intFlag));
   }
 
   private static long high(String hexString) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -182,7 +182,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
       datanodeDetails.setIpAddress(ip);
       TracingUtil.initTracing(
           "HddsDatanodeService." + datanodeDetails.getUuidString()
-              .substring(0, 8));
+              .substring(0, 8), conf);
       LOG.info("HddsDatanodeService host:{} ip:{}", hostname, ip);
       // Authenticate Hdds Datanode service if security is enabled
       if (OzoneSecurityUtil.isSecurityEnabled(conf)) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
@@ -50,14 +50,12 @@ public class StorageContainerManagerStarter extends GenericCli {
   private static final Logger LOG =
       LoggerFactory.getLogger(StorageContainerManagerStarter.class);
 
-  public static void main(String[] args) throws Exception {
-    TracingUtil.initTracing("StorageContainerManager");
+  public static void main(String[] args) {
     new StorageContainerManagerStarter(
         new StorageContainerManagerStarter.SCMStarterHelper()).run(args);
   }
 
   public StorageContainerManagerStarter(SCMStarterInterface receiverObj) {
-    super();
     receiver = receiverObj;
   }
 
@@ -121,6 +119,7 @@ public class StorageContainerManagerStarter extends GenericCli {
    */
   private void commonInit() {
     conf = createOzoneConfiguration();
+    TracingUtil.initTracing("StorageContainerManager", conf);
 
     String[] originalArgs = getCmd().getParseResult().originalArgs()
         .toArray(new String[0]);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
@@ -46,13 +46,11 @@ public class OzoneManagerStarter extends GenericCli {
       LoggerFactory.getLogger(OzoneManagerStarter.class);
 
   public static void main(String[] args) throws Exception {
-    TracingUtil.initTracing("OzoneManager");
     new OzoneManagerStarter(
         new OzoneManagerStarter.OMStarterHelper()).run(args);
   }
 
   public OzoneManagerStarter(OMStarterInterface receiverObj) {
-    super();
     receiver = receiverObj;
   }
 
@@ -100,6 +98,7 @@ public class OzoneManagerStarter extends GenericCli {
    */
   private void commonInit() {
     conf = createOzoneConfiguration();
+    TracingUtil.initTracing("OzoneManager", conf);
 
     String[] originalArgs = getCmd().getParseResult().originalArgs()
         .toArray(new String[0]);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/OzoneShell.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/OzoneShell.java
@@ -55,7 +55,7 @@ public class OzoneShell extends Shell {
 
   @Override
   public void execute(String[] argv) {
-    TracingUtil.initTracing("shell");
+    TracingUtil.initTracing("shell", createOzoneConfiguration());
     try (Scope scope = GlobalTracer.get().buildSpan("main").startActive(true)) {
       super.execute(argv);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/S3Shell.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/S3Shell.java
@@ -38,7 +38,7 @@ public class S3Shell extends Shell {
 
   @Override
   public void execute(String[] argv) {
-    TracingUtil.initTracing("s3shell");
+    TracingUtil.initTracing("s3shell", createOzoneConfiguration());
     try (Scope scope = GlobalTracer.get().buildSpan("main").startActive(true)) {
       super.execute(argv);
     }
@@ -48,9 +48,8 @@ public class S3Shell extends Shell {
    * Main for the S3Shell Command handling.
    *
    * @param argv - System Args Strings[]
-   * @throws Exception
    */
-  public static void main(String[] argv) throws Exception {
+  public static void main(String[] argv) {
     new S3Shell().run(argv);
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 
 import org.slf4j.Logger;
@@ -57,11 +58,13 @@ public class Freon extends GenericCli {
   private boolean httpServer = false;
 
   private FreonHttpServer freonHttpServer;
+  private OzoneConfiguration conf;
 
   @Override
   public void execute(String[] argv) {
-    HddsUtils.initializeMetrics(createOzoneConfiguration(), "ozone-freon");
-    TracingUtil.initTracing("freon");
+    conf = createOzoneConfiguration();
+    HddsUtils.initializeMetrics(conf, "ozone-freon");
+    TracingUtil.initTracing("freon", conf);
     super.execute(argv);
   }
 
@@ -78,7 +81,7 @@ public class Freon extends GenericCli {
   public void startHttpServer() {
     if (httpServer) {
       try {
-        freonHttpServer = new FreonHttpServer(createOzoneConfiguration());
+        freonHttpServer = new FreonHttpServer(conf);
         freonHttpServer.start();
       } catch (IOException e) {
         LOG.error("Freon http server can't be started", e);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Skip registering a real tracer with `GlobalTracer` if `hdds.tracing.enabled` is set to `false`.  This lets us avoid tracer-related busywork.

https://issues.apache.org/jira/browse/HDDS-2415

## How was this patch tested?

1. Checked Jaeger in `ozoneperf` cluster with default config, verified that it shows traces (OM, SCM, DN, Freon, S3 shell, Ozone shell)
2. With `OZONE-SITE.XML_hdds.tracing.enabled=false` added to `docker-config`, verified that Jaeger shows no traces
3. Also with tracing disabled in `ozone` cluster, verified that `GlobalTracer` no longer shows up in breakdown of allocations from `HddsDispatcher.dispatch` in the profiler