### PR TITLE
HDDS-2427. Exclude webapps from hadoop-ozone-filesystem-lib-current uber jar

### DIFF
--- a/hadoop-ozone/ozonefs-lib-current/pom.xml
+++ b/hadoop-ozone/ozonefs-lib-current/pom.xml
@@ -74,6 +74,21 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <filters>
+                <filter>
+                <artifact>org.apache.hadoop:hadoop-hdds-server-framework</artifact>
+                <excludes>
+                  <exclude>webapps/datanode/**</exclude>
+                  <exclude>webapps/static/**</exclude>
+                </excludes>
+                </filter>
+                <filter>
+                  <artifact>org.apache.hadoop:hadoop-hdds-container-service</artifact>
+                  <excludes>
+                    <exclude>webapps/hddsDatanode/**</exclude>
+                  </excludes>
+              </filter>
+              </filters>
               <transformers>
                 <transformer
                         implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">


### PR DESCRIPTION
## What changes were proposed in this pull request?

Exclude web apps from filesystem uber jar.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2427


## How was this patch tested?

This has caused Hadoop HDFS DN UI loading, now with placing the fixed jar UI is able to load up.
