### PR TITLE
HDDS-2446. ContainerReplica should contain DatanodeInfo rather than DatanodeDetails

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.slf4j.Logger;
 
 import java.io.IOException;
@@ -57,13 +58,13 @@ public class AbstractContainerReportHandler {
   /**
    * Process the given ContainerReplica received from specified datanode.
    *
-   * @param datanodeDetails DatanodeDetails of the node which reported
+   * @param datanodeInfo DatanodeInfo of the node which reported
    *                        this replica
    * @param replicaProto ContainerReplica
    *
    * @throws IOException In case of any Exception while processing the report
    */
-  void processContainerReplica(final DatanodeDetails datanodeDetails,
+  void processContainerReplica(final DatanodeInfo datanodeInfo,
                                final ContainerReplicaProto replicaProto)
       throws IOException {
     final ContainerID containerId = ContainerID
@@ -71,20 +72,20 @@ public class AbstractContainerReportHandler {
     final ContainerReplica replica = ContainerReplica.newBuilder()
         .setContainerID(containerId)
         .setContainerState(replicaProto.getState())
-        .setDatanodeDetails(datanodeDetails)
+        .setDatanodeInfo(datanodeInfo)
         .setOriginNodeId(UUID.fromString(replicaProto.getOriginNodeId()))
         .setSequenceId(replicaProto.getBlockCommitSequenceId())
         .build();
 
     if (logger.isDebugEnabled()) {
       logger.debug("Processing replica of container {} from datanode {}",
-          containerId, datanodeDetails);
+          containerId, datanodeInfo);
     }
     // Synchronized block should be replaced by container lock,
     // once we have introduced lock inside ContainerInfo.
     synchronized (containerManager.getContainer(containerId)) {
       updateContainerStats(containerId, replicaProto);
-      updateContainerState(datanodeDetails, containerId, replica);
+      updateContainerState(datanodeInfo, containerId, replica);
       containerManager.updateContainerReplica(containerId, replica);
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplica.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplica.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -35,18 +36,18 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
 
   final private ContainerID containerID;
   final private ContainerReplicaProto.State state;
-  final private DatanodeDetails datanodeDetails;
+  final private DatanodeInfo datanodeInfo;
   final private UUID placeOfBirth;
 
   private Long sequenceId;
 
 
   private ContainerReplica(final ContainerID containerID,
-      final ContainerReplicaProto.State state, final DatanodeDetails datanode,
+      final ContainerReplicaProto.State state, final DatanodeInfo datanode,
       final UUID originNodeId) {
     this.containerID = containerID;
     this.state = state;
-    this.datanodeDetails = datanode;
+    this.datanodeInfo = datanode;
     this.placeOfBirth = originNodeId;
   }
 
@@ -60,7 +61,15 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
    * @return DatanodeDetails
    */
   public DatanodeDetails getDatanodeDetails() {
-    return datanodeDetails;
+    return datanodeInfo;
+  }
+
+  /**
+   * Returns the DatanodeInfo to which this replica belongs.
+   * @return
+   */
+  public DatanodeInfo getDatanodeInfo() {
+    return datanodeInfo;
   }
 
   /**
@@ -94,7 +103,7 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
   public int hashCode() {
     return new HashCodeBuilder(61, 71)
         .append(containerID)
-        .append(datanodeDetails)
+        .append(datanodeInfo)
         .toHashCode();
   }
 
@@ -112,7 +121,7 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
 
     return new EqualsBuilder()
         .append(containerID, that.containerID)
-        .append(datanodeDetails, that.datanodeDetails)
+        .append(datanodeInfo, that.datanodeInfo)
         .isEquals();
   }
 
@@ -121,7 +130,7 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
     Preconditions.checkNotNull(that);
     return new CompareToBuilder()
         .append(this.containerID, that.containerID)
-        .append(this.datanodeDetails, that.datanodeDetails)
+        .append(this.datanodeInfo, that.datanodeInfo)
         .build();
   }
 
@@ -138,7 +147,7 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
   public String toString() {
     return "ContainerReplica{" +
         "containerID=" + containerID +
-        ", datanodeDetails=" + datanodeDetails +
+        ", datanodeDetails=" + datanodeInfo +
         ", placeOfBirth=" + placeOfBirth +
         ", sequenceId=" + sequenceId +
         '}';
@@ -151,7 +160,7 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
 
     private ContainerID containerID;
     private ContainerReplicaProto.State state;
-    private DatanodeDetails datanode;
+    private DatanodeInfo datanode;
     private UUID placeOfBirth;
     private Long sequenceId;
 
@@ -176,12 +185,12 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
     /**
      * Set DatanodeDetails.
      *
-     * @param datanodeDetails DatanodeDetails
+     * @param datanodeInfo DatanodeDetails
      * @return ContainerReplicaBuilder
      */
-    public ContainerReplicaBuilder setDatanodeDetails(
-        DatanodeDetails datanodeDetails) {
-      datanode = datanodeDetails;
+    public ContainerReplicaBuilder setDatanodeInfo(
+        DatanodeInfo datanodeInfo) {
+      datanode = datanodeInfo;
       return this;
     }
 
@@ -218,7 +227,7 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
       Preconditions.checkNotNull(state,
           "Container state can't be null");
       Preconditions.checkNotNull(datanode,
-          "DatanodeDetails can't be null");
+          "DatanodeInfo can't be null");
       ContainerReplica replica = new ContainerReplica(
           containerID, state, datanode,
           Optional.ofNullable(placeOfBirth).orElse(datanode.getUuid()));

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos
     .ContainerReplicaProto;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher
@@ -64,10 +65,11 @@ public class IncrementalContainerReportHandler extends
         report.getReport().getReportList()) {
       try {
         final DatanodeDetails dd = report.getDatanodeDetails();
+        final DatanodeInfo dnInfo = nodeManager.getDatanodeInfo(dd);
         final ContainerID id = ContainerID.valueof(
             replicaProto.getContainerID());
         nodeManager.addContainer(dd, id);
-        processContainerReplica(dd, replicaProto);
+        processContainerReplica(dnInfo, replicaProto);
       } catch (ContainerNotFoundException e) {
         success = false;
         LOG.warn("Container {} not found!", replicaProto.getContainerID());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -228,4 +228,14 @@ public interface NodeManager extends StorageContainerNodeProtocol,
    * @return the given datanode, or empty list if none found
    */
   List<DatanodeDetails> getNodesByAddress(String address);
+
+  /**
+   * Get the DatanodeInfo object which is associated with the given
+   * DatanodeDetails object.
+   *
+   * @param datanodeDetails The datanode to lookup
+   * @return The DatanodeInfo associated with the given DatanodeDetails
+   */
+  DatanodeInfo getDatanodeInfo(DatanodeDetails datanodeDetails)
+      throws NodeNotFoundException;
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -689,6 +689,19 @@ public class SCMNodeManager implements NodeManager {
     return results;
   }
 
+  /**
+   * Get the DatanodeInfo object which is associated with the given
+   * DatanodeDetails object.
+   *
+   * @param datanodeDetails The datanode to lookup
+   * @return The DatanodeInfo associated with the given DatanodeDetails
+   */
+  @Override
+  public DatanodeInfo getDatanodeInfo(DatanodeDetails datanodeDetails)
+      throws NodeNotFoundException {
+    return nodeStateManager.getNode(datanodeDetails);
+  }
+
   private String nodeResolve(String hostname) {
     List<String> hosts = new ArrayList<>(1);
     hosts.add(hostname);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
@@ -33,6 +33,8 @@ import org.apache.hadoop.hdds.protocol.proto
         .StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.server.SCMConfigurator;
 import org.apache.hadoop.hdds.scm.server
@@ -92,6 +94,16 @@ public final class TestUtils {
    */
   public static DatanodeDetails randomDatanodeDetails() {
     return createDatanodeDetails(UUID.randomUUID());
+  }
+
+  /**
+   * Creates DatanodeInfo with random UUID.
+   *
+   * @return DatanodeInfo
+   */
+  public static DatanodeInfo randomDatanodeInfo() {
+    return new DatanodeInfo(createDatanodeDetails(UUID.randomUUID()),
+        NodeStatus.inServiceHealthy());
   }
 
   /**
@@ -559,17 +571,17 @@ public final class TestUtils {
   public static Set<ContainerReplica> getReplicas(
       final ContainerID containerId,
       final ContainerReplicaProto.State state,
-      final DatanodeDetails... datanodeDetails) {
-    return getReplicas(containerId, state, 10000L, datanodeDetails);
+      final DatanodeInfo... datanodeInfo) {
+    return getReplicas(containerId, state, 10000L, datanodeInfo);
   }
 
   public static Set<ContainerReplica> getReplicas(
       final ContainerID containerId,
       final ContainerReplicaProto.State state,
       final long sequenceId,
-      final DatanodeDetails... datanodeDetails) {
+      final DatanodeInfo... datanodeInfo) {
     Set<ContainerReplica> replicas = new HashSet<>();
-    for (DatanodeDetails datanode : datanodeDetails) {
+    for (DatanodeInfo datanode : datanodeInfo) {
       replicas.add(getReplicas(containerId, state,
           sequenceId, datanode.getUuid(), datanode));
     }
@@ -581,11 +593,11 @@ public final class TestUtils {
       final ContainerReplicaProto.State state,
       final long sequenceId,
       final UUID originNodeId,
-      final DatanodeDetails datanodeDetails) {
+      final DatanodeInfo datanodeInfo) {
     return ContainerReplica.newBuilder()
         .setContainerID(containerId)
         .setContainerState(state)
-        .setDatanodeDetails(datanodeDetails)
+        .setDatanodeInfo(datanodeInfo)
         .setOriginNodeId(originNodeId)
         .setSequenceId(sequenceId)
         .build();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.scm.TestUtils;
 import org.apache.hadoop.hdds.scm.net.NetConstants;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.net.Node;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
@@ -551,6 +552,18 @@ public class MockNodeManager implements NodeManager {
       }
     }
     return results;
+  }
+
+  /**
+   * Get the DatanodeInfo object which is associated with the given
+   * DatanodeDetails object.
+   *
+   * @param datanodeDetails The datanode to lookup
+   * @return The DatanodeInfo associated with the given DatanodeDetails
+   */
+  public DatanodeInfo getDatanodeInfo(DatanodeDetails datanodeDetails)
+      throws NodeNotFoundException {
+    return new DatanodeInfo(datanodeDetails, NodeStatus.inServiceHealthy());
   }
 
   public void setNetworkTopology(NetworkTopology topology) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.protocol.proto
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
@@ -115,9 +116,12 @@ public class TestContainerReportHandler {
         nodeManager, containerManager);
     final Iterator<DatanodeDetails> nodeIterator = nodeManager.getNodes(
         NodeStatus.inServiceHealthy()).iterator();
-    final DatanodeDetails datanodeOne = nodeIterator.next();
-    final DatanodeDetails datanodeTwo = nodeIterator.next();
-    final DatanodeDetails datanodeThree = nodeIterator.next();
+    final DatanodeInfo datanodeOne =
+        nodeManager.getDatanodeInfo(nodeIterator.next());
+    final DatanodeInfo datanodeTwo =
+        nodeManager.getDatanodeInfo(nodeIterator.next());
+    final DatanodeInfo datanodeThree =
+        nodeManager.getDatanodeInfo(nodeIterator.next());
 
     final ContainerInfo containerOne = getContainer(LifeCycleState.CLOSED);
     final ContainerInfo containerTwo = getContainer(LifeCycleState.CLOSED);
@@ -184,10 +188,14 @@ public class TestContainerReportHandler {
 
     final Iterator<DatanodeDetails> nodeIterator = nodeManager.getNodes(
         NodeStatus.inServiceHealthy()).iterator();
-    final DatanodeDetails datanodeOne = nodeIterator.next();
-    final DatanodeDetails datanodeTwo = nodeIterator.next();
-    final DatanodeDetails datanodeThree = nodeIterator.next();
-    final DatanodeDetails datanodeFour = nodeIterator.next();
+    final DatanodeInfo datanodeOne =
+        nodeManager.getDatanodeInfo(nodeIterator.next());
+    final DatanodeInfo datanodeTwo =
+        nodeManager.getDatanodeInfo(nodeIterator.next());
+    final DatanodeInfo datanodeThree =
+        nodeManager.getDatanodeInfo(nodeIterator.next());
+    final DatanodeDetails datanodeFour =
+        nodeManager.getDatanodeInfo(nodeIterator.next());
 
     final ContainerInfo containerOne = getContainer(LifeCycleState.CLOSED);
     final ContainerInfo containerTwo = getContainer(LifeCycleState.CLOSED);
@@ -263,9 +271,12 @@ public class TestContainerReportHandler {
 
     final Iterator<DatanodeDetails> nodeIterator = nodeManager.getNodes(
         NodeStatus.inServiceHealthy()).iterator();
-    final DatanodeDetails datanodeOne = nodeIterator.next();
-    final DatanodeDetails datanodeTwo = nodeIterator.next();
-    final DatanodeDetails datanodeThree = nodeIterator.next();
+    final DatanodeInfo datanodeOne =
+        nodeManager.getDatanodeInfo(nodeIterator.next());
+    final DatanodeInfo datanodeTwo =
+        nodeManager.getDatanodeInfo(nodeIterator.next());
+    final DatanodeInfo datanodeThree =
+        nodeManager.getDatanodeInfo(nodeIterator.next());
 
     final ContainerInfo containerOne = getContainer(LifeCycleState.CLOSING);
     final ContainerInfo containerTwo = getContainer(LifeCycleState.CLOSED);
@@ -342,9 +353,12 @@ public class TestContainerReportHandler {
 
     final Iterator<DatanodeDetails> nodeIterator = nodeManager.getNodes(
         NodeStatus.inServiceHealthy()).iterator();
-    final DatanodeDetails datanodeOne = nodeIterator.next();
-    final DatanodeDetails datanodeTwo = nodeIterator.next();
-    final DatanodeDetails datanodeThree = nodeIterator.next();
+    final DatanodeInfo datanodeOne =
+        nodeManager.getDatanodeInfo(nodeIterator.next());
+    final DatanodeInfo datanodeTwo =
+        nodeManager.getDatanodeInfo(nodeIterator.next());
+    final DatanodeInfo datanodeThree =
+        nodeManager.getDatanodeInfo(nodeIterator.next());
 
     final ContainerInfo containerOne = getContainer(LifeCycleState.CLOSING);
     final ContainerInfo containerTwo = getContainer(LifeCycleState.CLOSED);
@@ -420,9 +434,12 @@ public class TestContainerReportHandler {
     final Iterator<DatanodeDetails> nodeIterator = nodeManager.getNodes(
         NodeStatus.inServiceHealthy()).iterator();
 
-    final DatanodeDetails datanodeOne = nodeIterator.next();
-    final DatanodeDetails datanodeTwo = nodeIterator.next();
-    final DatanodeDetails datanodeThree = nodeIterator.next();
+    final DatanodeInfo datanodeOne =
+        nodeManager.getDatanodeInfo(nodeIterator.next());
+    final DatanodeInfo datanodeTwo =
+        nodeManager.getDatanodeInfo(nodeIterator.next());
+    final DatanodeInfo datanodeThree =
+        nodeManager.getDatanodeInfo(nodeIterator.next());
 
     final ContainerInfo containerOne =
         getContainer(LifeCycleState.QUASI_CLOSED);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
@@ -22,12 +22,12 @@ import java.util.ArrayList;
 import java.util.Set;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.TestUtils;
 
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
@@ -58,9 +58,9 @@ public class TestContainerStateManager {
     //GIVEN
     ContainerInfo c1 = allocateContainer();
 
-    DatanodeDetails d1 = TestUtils.randomDatanodeDetails();
-    DatanodeDetails d2 = TestUtils.randomDatanodeDetails();
-    DatanodeDetails d3 = TestUtils.randomDatanodeDetails();
+    DatanodeInfo d1 = TestUtils.randomDatanodeInfo();
+    DatanodeInfo d2 = TestUtils.randomDatanodeInfo();
+    DatanodeInfo d3 = TestUtils.randomDatanodeInfo();
 
     addReplica(c1, d1);
     addReplica(c1, d2);
@@ -80,8 +80,8 @@ public class TestContainerStateManager {
 
     ContainerInfo c1 = allocateContainer();
 
-    DatanodeDetails d1 = TestUtils.randomDatanodeDetails();
-    DatanodeDetails d2 = TestUtils.randomDatanodeDetails();
+    DatanodeInfo d1 = TestUtils.randomDatanodeInfo();
+    DatanodeInfo d2 = TestUtils.randomDatanodeInfo();
 
     addReplica(c1, d1);
     addReplica(c1, d2);
@@ -94,12 +94,12 @@ public class TestContainerStateManager {
     Assert.assertEquals(3, c1.getReplicationFactor().getNumber());
   }
 
-  private void addReplica(ContainerInfo cont, DatanodeDetails node)
+  private void addReplica(ContainerInfo cont, DatanodeInfo node)
       throws ContainerNotFoundException {
     ContainerReplica replica = ContainerReplica.newBuilder()
         .setContainerID(cont.containerID())
         .setContainerState(ContainerReplicaProto.State.CLOSED)
-        .setDatanodeDetails(node)
+        .setDatanodeInfo(node)
         .build();
     containerStateManager
         .updateContainerReplica(cont.containerID(), replica);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
@@ -27,7 +27,10 @@ import org.apache.hadoop.hdds.protocol.proto
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.IncrementalContainerReportProto;
 import org.apache.hadoop.hdds.scm.TestUtils;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher
     .IncrementalContainerReportFromDatanode;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
@@ -54,7 +57,7 @@ public class TestIncrementalContainerReportHandler {
   private EventPublisher publisher;
 
   @Before
-  public void setup() throws IOException {
+  public void setup() throws IOException, NodeNotFoundException {
     final Configuration conf = new OzoneConfiguration();
     this.containerManager = Mockito.mock(ContainerManager.class);
     this.nodeManager = Mockito.mock(NodeManager.class);
@@ -80,6 +83,11 @@ public class TestIncrementalContainerReportHandler {
         Mockito.any(ContainerID.class),
         Mockito.any(HddsProtos.LifeCycleEvent.class));
 
+    Mockito.when(
+        nodeManager.getDatanodeInfo(Mockito.any(DatanodeDetails.class)))
+        .thenAnswer(invocation ->
+            new DatanodeInfo((DatanodeDetails)invocation.getArguments()[0],
+                NodeStatus.inServiceHealthy()));
   }
 
   @After
@@ -93,9 +101,9 @@ public class TestIncrementalContainerReportHandler {
     final IncrementalContainerReportHandler reportHandler =
         new IncrementalContainerReportHandler(nodeManager, containerManager);
     final ContainerInfo container = getContainer(LifeCycleState.CLOSING);
-    final DatanodeDetails datanodeOne = TestUtils.randomDatanodeDetails();
-    final DatanodeDetails datanodeTwo = TestUtils.randomDatanodeDetails();
-    final DatanodeDetails datanodeThree = TestUtils.randomDatanodeDetails();
+    final DatanodeInfo datanodeOne = TestUtils.randomDatanodeInfo();
+    final DatanodeInfo datanodeTwo = TestUtils.randomDatanodeInfo();
+    final DatanodeInfo datanodeThree = TestUtils.randomDatanodeInfo();
     final Set<ContainerReplica> containerReplicas = getReplicas(
         container.containerID(),
         ContainerReplicaProto.State.CLOSING,
@@ -127,9 +135,9 @@ public class TestIncrementalContainerReportHandler {
     final IncrementalContainerReportHandler reportHandler =
         new IncrementalContainerReportHandler(nodeManager, containerManager);
     final ContainerInfo container = getContainer(LifeCycleState.CLOSING);
-    final DatanodeDetails datanodeOne = TestUtils.randomDatanodeDetails();
-    final DatanodeDetails datanodeTwo = TestUtils.randomDatanodeDetails();
-    final DatanodeDetails datanodeThree = TestUtils.randomDatanodeDetails();
+    final DatanodeInfo datanodeOne = TestUtils.randomDatanodeInfo();
+    final DatanodeInfo datanodeTwo = TestUtils.randomDatanodeInfo();
+    final DatanodeInfo datanodeThree = TestUtils.randomDatanodeInfo();
     final Set<ContainerReplica> containerReplicas = getReplicas(
         container.containerID(),
         ContainerReplicaProto.State.CLOSING,
@@ -162,9 +170,9 @@ public class TestIncrementalContainerReportHandler {
     final IncrementalContainerReportHandler reportHandler =
         new IncrementalContainerReportHandler(nodeManager, containerManager);
     final ContainerInfo container = getContainer(LifeCycleState.QUASI_CLOSED);
-    final DatanodeDetails datanodeOne = TestUtils.randomDatanodeDetails();
-    final DatanodeDetails datanodeTwo = TestUtils.randomDatanodeDetails();
-    final DatanodeDetails datanodeThree = TestUtils.randomDatanodeDetails();
+    final DatanodeInfo datanodeOne = TestUtils.randomDatanodeInfo();
+    final DatanodeInfo datanodeTwo = TestUtils.randomDatanodeInfo();
+    final DatanodeInfo datanodeThree = TestUtils.randomDatanodeInfo();
     final Set<ContainerReplica> containerReplicas = getReplicas(
         container.containerID(),
         ContainerReplicaProto.State.CLOSING,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.hdds.scm.container.placement.algorithms
     .ContainerPlacementPolicy;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
@@ -54,10 +56,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.apache.hadoop.hdds.scm.TestUtils.createDatanodeDetails;
-import static org.apache.hadoop.hdds.scm.TestUtils.getContainer;
-import static org.apache.hadoop.hdds.scm.TestUtils.getReplicas;
-import static org.apache.hadoop.hdds.scm.TestUtils.randomDatanodeDetails;
+import static org.apache.hadoop.hdds.scm.TestUtils.*;
 
 /**
  * Test cases to verify the functionality of ReplicationManager.
@@ -162,11 +161,11 @@ public class TestReplicationManager {
 
     // Two replicas in CLOSING state
     final Set<ContainerReplica> replicas = getReplicas(id, State.CLOSING,
-        randomDatanodeDetails(),
-        randomDatanodeDetails());
+        randomDatanodeInfo(),
+        randomDatanodeInfo());
 
     // One replica in OPEN state
-    final DatanodeDetails datanode = randomDatanodeDetails();
+    final DatanodeInfo datanode = randomDatanodeInfo();
     replicas.addAll(getReplicas(id, State.OPEN, datanode));
 
     for (ContainerReplica replica : replicas) {
@@ -207,12 +206,12 @@ public class TestReplicationManager {
     final ContainerID id = container.containerID();
     final UUID originNodeId = UUID.randomUUID();
     final ContainerReplica replicaOne = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeInfo());
     final ContainerReplica replicaTwo = getReplicas(
-        id, State.OPEN, 1000L, originNodeId, randomDatanodeDetails());
-    final DatanodeDetails datanodeDetails = randomDatanodeDetails();
+        id, State.OPEN, 1000L, originNodeId, randomDatanodeInfo());
+    final DatanodeInfo datanodeInfo = randomDatanodeInfo();
     final ContainerReplica replicaThree = getReplicas(
-        id, State.OPEN, 1000L, datanodeDetails.getUuid(), datanodeDetails);
+        id, State.OPEN, 1000L, datanodeInfo.getUuid(), datanodeInfo);
 
     containerStateManager.loadContainer(container);
     containerStateManager.updateContainerReplica(id, replicaOne);
@@ -247,11 +246,11 @@ public class TestReplicationManager {
     final ContainerID id = container.containerID();
     final UUID originNodeId = UUID.randomUUID();
     final ContainerReplica replicaOne = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeInfo());
     final ContainerReplica replicaTwo = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeInfo());
     final ContainerReplica replicaThree = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeInfo());
 
     containerStateManager.loadContainer(container);
     containerStateManager.updateContainerReplica(id, replicaOne);
@@ -283,11 +282,11 @@ public class TestReplicationManager {
     final ContainerID id = container.containerID();
     final UUID originNodeId = UUID.randomUUID();
     final ContainerReplica replicaOne = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeInfo());
     final ContainerReplica replicaTwo = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeInfo());
     final ContainerReplica replicaThree = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeInfo());
 
     containerStateManager.loadContainer(container);
     containerStateManager.updateContainerReplica(id, replicaOne);
@@ -309,7 +308,7 @@ public class TestReplicationManager {
     // Make the first replica unhealthy
     final ContainerReplica unhealthyReplica = getReplicas(
         id, State.UNHEALTHY, 1000L, originNodeId,
-        replicaOne.getDatanodeDetails());
+        replicaOne.getDatanodeInfo());
     containerStateManager.updateContainerReplica(id, unhealthyReplica);
 
     replicationManager.processContainersNow();
@@ -346,13 +345,13 @@ public class TestReplicationManager {
     final ContainerID id = container.containerID();
     final UUID originNodeId = UUID.randomUUID();
     final ContainerReplica replicaOne = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeInfo());
     final ContainerReplica replicaTwo = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeInfo());
     final ContainerReplica replicaThree = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeInfo());
     final ContainerReplica replicaFour = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeInfo());
 
     containerStateManager.loadContainer(container);
     containerStateManager.updateContainerReplica(id, replicaOne);
@@ -383,13 +382,13 @@ public class TestReplicationManager {
     final ContainerID id = container.containerID();
     final UUID originNodeId = UUID.randomUUID();
     final ContainerReplica replicaOne = getReplicas(
-        id, State.UNHEALTHY, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.UNHEALTHY, 1000L, originNodeId, randomDatanodeInfo());
     final ContainerReplica replicaTwo = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeInfo());
     final ContainerReplica replicaThree = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeInfo());
     final ContainerReplica replicaFour = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeInfo());
 
     containerStateManager.loadContainer(container);
     containerStateManager.updateContainerReplica(id, replicaOne);
@@ -421,9 +420,9 @@ public class TestReplicationManager {
     final ContainerID id = container.containerID();
     final UUID originNodeId = UUID.randomUUID();
     final ContainerReplica replicaOne = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeInfo());
     final ContainerReplica replicaTwo = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeInfo());
 
     containerStateManager.loadContainer(container);
     containerStateManager.updateContainerReplica(id, replicaOne);
@@ -467,9 +466,9 @@ public class TestReplicationManager {
     final ContainerID id = container.containerID();
     final UUID originNodeId = UUID.randomUUID();
     final ContainerReplica replicaOne = getReplicas(
-        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeInfo());
     final ContainerReplica replicaTwo = getReplicas(
-        id, State.UNHEALTHY, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.UNHEALTHY, 1000L, originNodeId, randomDatanodeInfo());
 
     containerStateManager.loadContainer(container);
     containerStateManager.updateContainerReplica(id, replicaOne);
@@ -495,8 +494,8 @@ public class TestReplicationManager {
 
     Assert.assertTrue(replicateCommand.isPresent());
 
-    DatanodeDetails newNode = createDatanodeDetails(
-        replicateCommand.get().getDatanodeId());
+    DatanodeInfo newNode = new DatanodeInfo(createDatanodeDetails(
+        replicateCommand.get().getDatanodeId()), NodeStatus.inServiceHealthy());
     ContainerReplica newReplica = getReplicas(
         id, State.QUASI_CLOSED, 1000L, originNodeId, newNode);
     containerStateManager.updateContainerReplica(id, newReplica);
@@ -545,9 +544,9 @@ public class TestReplicationManager {
     final ContainerInfo container = getContainer(LifeCycleState.QUASI_CLOSED);
     final ContainerID id = container.containerID();
     final Set<ContainerReplica> replicas = getReplicas(id, State.QUASI_CLOSED,
-        randomDatanodeDetails(),
-        randomDatanodeDetails(),
-        randomDatanodeDetails());
+        randomDatanodeInfo(),
+        randomDatanodeInfo(),
+        randomDatanodeInfo());
     containerStateManager.loadContainer(container);
     for (ContainerReplica replica : replicas) {
       containerStateManager.updateContainerReplica(id, replica);
@@ -577,9 +576,9 @@ public class TestReplicationManager {
     final ContainerInfo container = getContainer(LifeCycleState.CLOSED);
     final ContainerID id = container.containerID();
     final Set<ContainerReplica> replicas = getReplicas(id, State.CLOSED,
-        randomDatanodeDetails(),
-        randomDatanodeDetails(),
-        randomDatanodeDetails());
+        randomDatanodeInfo(),
+        randomDatanodeInfo(),
+        randomDatanodeInfo());
 
     containerStateManager.loadContainer(container);
     for (ContainerReplica replica : replicas) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestSCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestSCMContainerManager.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleEvent;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -207,7 +208,7 @@ public class TestSCMContainerManager {
     // Add dummy replicas for container.
     Iterator<DatanodeDetails> nodes = pipelineManager
         .getPipeline(contInfo.getPipelineID()).getNodes().iterator();
-    DatanodeDetails dn1 = nodes.next();
+    DatanodeInfo dn1 = nodeManager.getDatanodeInfo(nodes.next());
     containerManager.updateContainerState(contInfo.containerID(),
         LifeCycleEvent.FINALIZE);
     containerManager
@@ -220,7 +221,7 @@ public class TestSCMContainerManager {
     containerManager.updateContainerReplica(contInfo.containerID(),
         ContainerReplica.newBuilder().setContainerID(contInfo.containerID())
             .setContainerState(ContainerReplicaProto.State.CLOSED)
-            .setDatanodeDetails(dn1).build());
+            .setDatanodeInfo(dn1).build());
 
     Assert.assertEquals(1,
         containerManager.getContainerReplicas(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -47,17 +47,11 @@ import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
 import org.hamcrest.MatcherAssert;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import static org.mockito.Matchers.anyObject;
-import org.mockito.Mockito;
 import static org.mockito.Mockito.when;
 
 /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -112,9 +112,9 @@ public class TestDeadNodeHandler {
   @Test
   public void testOnMessage() throws IOException, NodeNotFoundException {
     //GIVEN
-    DatanodeDetails datanode1 = TestUtils.randomDatanodeDetails();
-    DatanodeDetails datanode2 = TestUtils.randomDatanodeDetails();
-    DatanodeDetails datanode3 = TestUtils.randomDatanodeDetails();
+    DatanodeInfo datanode1 = TestUtils.randomDatanodeInfo();
+    DatanodeInfo datanode2 = TestUtils.randomDatanodeInfo();
+    DatanodeInfo datanode3 = TestUtils.randomDatanodeInfo();
 
     String storagePath = GenericTestUtils.getRandomizedTempPath()
         .concat("/" + datanode1.getUuidString());
@@ -191,15 +191,15 @@ public class TestDeadNodeHandler {
   }
 
   private void registerReplicas(ContainerManager contManager,
-      ContainerInfo container, DatanodeDetails... datanodes)
+      ContainerInfo container, DatanodeInfo... datanodes)
       throws ContainerNotFoundException {
-    for (DatanodeDetails datanode : datanodes) {
+    for (DatanodeInfo datanode : datanodes) {
       contManager.updateContainerReplica(
           new ContainerID(container.getContainerID()),
           ContainerReplica.newBuilder()
               .setContainerState(ContainerReplicaProto.State.OPEN)
               .setContainerID(container.containerID())
-              .setDatanodeDetails(datanode).build());
+              .setDatanodeInfo(datanode).build());
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto
         .StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
@@ -316,6 +317,19 @@ public class ReplicationNodeManagerMock implements NodeManager {
   public Boolean isNodeRegistered(
       DatanodeDetails datanodeDetails) {
     return null;
+  }
+
+  /**
+   * Get the DatanodeInfo object which is associated with the given
+   * DatanodeDetails object.
+   *
+   * @param datanodeDetails The datanode to lookup
+   * @return The DatanodeInfo associated with the given DatanodeDetails
+   */
+  @Override
+  public DatanodeInfo getDatanodeInfo(DatanodeDetails datanodeDetails)
+      throws NodeNotFoundException {
+    return new DatanodeInfo(datanodeDetails, NodeStatus.inServiceHealthy());
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -30,6 +30,8 @@ import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -405,12 +407,16 @@ public class TestContainerStateManagerIntegration {
 
   @Test
   public void testReplicaMap() throws Exception {
-    DatanodeDetails dn1 = DatanodeDetails.newBuilder().setHostName("host1")
+    DatanodeInfo dn1 = new DatanodeInfo(
+        DatanodeDetails.newBuilder().setHostName("host1")
         .setIpAddress("1.1.1.1")
-        .setUuid(UUID.randomUUID().toString()).build();
-    DatanodeDetails dn2 = DatanodeDetails.newBuilder().setHostName("host2")
+        .setUuid(UUID.randomUUID().toString()).build(),
+        NodeStatus.inServiceHealthy());
+    DatanodeInfo dn2 = new DatanodeInfo(
+        DatanodeDetails.newBuilder().setHostName("host2")
         .setIpAddress("2.2.2.2")
-        .setUuid(UUID.randomUUID().toString()).build();
+        .setUuid(UUID.randomUUID().toString()).build(),
+        NodeStatus.inServiceHealthy());
 
     // Test 1: no replica's exist
     ContainerID containerID = ContainerID.valueof(RandomUtils.nextLong());
@@ -433,12 +439,12 @@ public class TestContainerStateManagerIntegration {
     ContainerReplica replicaOne = ContainerReplica.newBuilder()
         .setContainerID(id)
         .setContainerState(ContainerReplicaProto.State.OPEN)
-        .setDatanodeDetails(dn1)
+        .setDatanodeInfo(dn1)
         .build();
     ContainerReplica replicaTwo = ContainerReplica.newBuilder()
         .setContainerID(id)
         .setContainerState(ContainerReplicaProto.State.OPEN)
-        .setDatanodeDetails(dn2)
+        .setDatanodeInfo(dn2)
         .build();
     containerStateManager.updateContainerReplica(id, replicaOne);
     containerStateManager.updateContainerReplica(id, replicaTwo);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.scm.node;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.client.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;


### PR DESCRIPTION
The ContainerReplica object is used by the SCM to track containers reported by the datanodes. The current fields stored in ContainerReplica are:
```
final private ContainerID containerID;
final private ContainerReplicaProto.State state;
final private DatanodeDetails datanodeDetails;
final private UUID placeOfBirth;
```
Now we have introduced decommission and maintenance mode, the replication manager (and potentially other parts of the code) need to know the status of the replica in terms of IN_SERVICE, DECOMMISSIONING, DECOMMISSIONED etc to make replication decisions.

The DatanodeDetails object does not carry this information, however the DatanodeInfo object extends DatanodeDetails and does carry the required information.

As DatanodeInfo extends DatanodeDetails, any place which needs a DatanodeDetails can accept a DatanodeInfo instead.

In this PR I propose we change the DatanodeDetails stored in ContainerReplica to DatanodeInfo.
