### PR TITLE
HDDS-2445. Replace ToStringBuilder in BlockData

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/BlockID.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/BlockID.java
@@ -74,10 +74,14 @@ public class BlockID {
 
   @Override
   public String toString() {
-    return new StringBuilder().append(getContainerBlockID().toString())
-        .append(" bcsId: ")
-        .append(blockCommitSequenceId)
-        .toString();
+    StringBuilder sb = new StringBuilder(64);
+    appendTo(sb);
+    return sb.toString();
+  }
+
+  public void appendTo(StringBuilder sb) {
+    containerBlockID.appendTo(sb);
+    sb.append(" bcsId: ").append(blockCommitSequenceId);
   }
 
   public ContainerProtos.DatanodeBlockID getDatanodeBlockIDProtobuf() {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ContainerBlockID.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ContainerBlockID.java
@@ -42,11 +42,14 @@ public class ContainerBlockID {
 
   @Override
   public String toString() {
-    return new StringBuffer()
-        .append("conID: ")
-        .append(containerID)
-        .append(" locID: ")
-        .append(localID).toString();
+    StringBuilder sb = new StringBuilder(48);
+    appendTo(sb);
+    return sb.toString();
+  }
+
+  public void appendTo(StringBuilder sb) {
+    sb.append("conID: ").append(containerID)
+        .append(" locID: ").append(localID);
   }
 
   public HddsProtos.ContainerBlockID getProtobuf() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestBlockData.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestBlockData.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.container.common.helpers;
 
+import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.ozone.common.Checksum;
 import org.junit.Assert;
@@ -30,6 +31,8 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests to test block deleting service.
@@ -128,5 +131,14 @@ public class TestBlockData {
       computed.setChunks(expected);
       assertChunks(expected, computed);
     }
+  }
+
+  @Test
+  public void testToString() {
+    final BlockID blockID = new BlockID(5, 123);
+    blockID.setBlockCommitSequenceId(42);
+    final BlockData subject = new BlockData(blockID);
+    assertEquals("[blockId=conID: 5 locID: 123 bcsId: 42,size=0]",
+        subject.toString());
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchmarkBlockDataToString.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchmarkBlockDataToString.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.genesis;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.client.ContainerBlockID;
+import org.apache.hadoop.ozone.container.common.helpers.BlockData;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Benchmarks various implementations of {@link BlockData#toString}.
+ */
+@State(Scope.Benchmark)
+public class BenchmarkBlockDataToString {
+
+  @Param("1000")
+  private int count;
+
+  @Param({"112"})
+  private int capacity;
+
+  private List<BlockData> data;
+  private List<String> values;
+
+  @Setup
+  public void createData() {
+    ThreadLocalRandom rnd = ThreadLocalRandom.current();
+    data = new ArrayList<>(count);
+    values = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      BlockID blockID = new BlockID(rnd.nextLong(), rnd.nextLong());
+      BlockData item = new BlockData(blockID);
+      item.setBlockCommitSequenceId(rnd.nextLong());
+      data.add(item);
+      values.add(item.toString());
+    }
+  }
+
+  @Benchmark
+  public void usingToStringBuilderDefaultCapacity(
+      BenchmarkBlockDataToString state, Blackhole sink) {
+    for (int i = 0; i < state.count; i++) {
+      BlockData item = state.data.get(i);
+      String str = new ToStringBuilder(item, ToStringStyle.NO_CLASS_NAME_STYLE)
+          .append("blockId", item.getBlockID().toString())
+          .append("size", item.getSize())
+          .toString();
+      sink.consume(str);
+      Preconditions.checkArgument(str.equals(state.values.get(i)));
+    }
+  }
+
+  @Benchmark
+  public void usingToStringBuilder(
+      BenchmarkBlockDataToString state, Blackhole sink) {
+    for (int i = 0; i < state.count; i++) {
+      BlockData item = state.data.get(i);
+      String str = new ToStringBuilder(item, ToStringStyle.NO_CLASS_NAME_STYLE,
+          new StringBuffer(capacity))
+          .append("blockId", item.getBlockID().toString())
+          .append("size", item.getSize())
+          .toString();
+      sink.consume(str);
+      Preconditions.checkArgument(str.equals(state.values.get(i)));
+    }
+  }
+
+  @Benchmark
+  public void usingSimpleStringBuilder(
+      BenchmarkBlockDataToString state, Blackhole sink) {
+    for (int i = 0; i < state.count; i++) {
+      BlockData item = state.data.get(i);
+      String str = new StringBuilder(capacity)
+          .append("[")
+          .append("blockId=")
+          .append(item.getBlockID())
+          .append(",size=")
+          .append(item.getSize())
+          .append("]")
+          .toString();
+      sink.consume(str);
+      Preconditions.checkArgument(str.equals(state.values.get(i)));
+    }
+  }
+
+  @Benchmark
+  public void usingPushDownStringBuilder(
+      BenchmarkBlockDataToString state, Blackhole sink) {
+    for (int i = 0; i < state.count; i++) {
+      BlockData item = state.data.get(i);
+      StringBuilder sb = new StringBuilder(capacity);
+      item.appendTo(sb);
+      String str = sb.toString();
+      sink.consume(str);
+      Preconditions.checkArgument(str.equals(state.values.get(i)));
+    }
+  }
+
+  @Benchmark
+  public void usingConcatenation(
+      BenchmarkBlockDataToString state, Blackhole sink) {
+    for (int i = 0; i < state.count; i++) {
+      BlockData item = state.data.get(i);
+      String str = "[blockId=" +
+          item.getBlockID() +
+          ",size=" +
+          item.getSize() +
+          "]";
+      sink.consume(str);
+      Preconditions.checkArgument(str.equals(state.values.get(i)));
+    }
+  }
+
+  @Benchmark
+  public void usingInlineStringBuilder(
+      BenchmarkBlockDataToString state, Blackhole sink) {
+    for (int i = 0; i < state.count; i++) {
+      BlockData item = state.data.get(i);
+      BlockID blockID = item.getBlockID();
+      ContainerBlockID containerBlockID = blockID.getContainerBlockID();
+      String str = new StringBuilder(capacity)
+          .append("[")
+          .append("blockId=")
+          .append("conID: ")
+          .append(containerBlockID.getContainerID())
+          .append(" locID: ")
+          .append(containerBlockID.getLocalID())
+          .append(" bcsId: ")
+          .append(blockID.getBlockCommitSequenceId())
+          .append(",size=")
+          .append(item.getSize())
+          .append("]")
+          .toString();
+      sink.consume(str);
+      Preconditions.checkArgument(str.equals(state.values.get(i)));
+    }
+  }
+
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/Genesis.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/Genesis.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.genesis;
 
+import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.profile.StackProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
@@ -83,6 +84,7 @@ public final class Genesis {
     optionsBuilder.warmupIterations(2)
         .measurementIterations(20)
         .addProfiler(StackProfiler.class)
+        .addProfiler(GCProfiler.class)
         .shouldDoGC(true)
         .forks(1)
         .threads(numThreads);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Eliminate `ToStringBuilder` from `BlockData`.  Use a single `StringBuilder` to collect parts of the final result.

Also avoid stream-processing in `setChunks` for the special cases of 0 or 1 elements.

https://issues.apache.org/jira/browse/HDDS-2445

## How was this patch tested?

Added benchmark with various implementations.

```
bin/ozone genesis -benchmark BenchmarkBlockDataToString
```

Normalized GC allocation rates are below (absolute values are not important, only relative to one another).  Using a single string builder saves ~78% of allocations compared to the current implementation (`ToStringBuilderDefaultCapacity`).

```
Benchmark                  (capacity)  (count)   Mode  Cnt        Score       Error   Units
PushDownStringBuilder             112     1000  thrpt   20   503403.364 ±     6.593    B/op
InlineStringBuilder               112     1000  thrpt   20   503625.761 ±     2.665    B/op
SimpleStringBuilder               112     1000  thrpt   20  1133643.831 ±     4.051    B/op
ToStringBuilder                   112     1000  thrpt   20  1429626.864 ±     7.415    B/op
Concatenation                     112     1000  thrpt   20  1523808.749 ±    13.819    B/op
ToStringBuilderDefaultCapacity    N/A     1000  thrpt   20  2229699.096 ±     6.739    B/op
```

(Tested various capacities with the same benchmark to come up with final value of 112.)

Added a simple unit test to verify the output is unchanged.

Stream-processing change is verified by existing `TestBlockData#testSetChunks`.