### PR TITLE
HDDS-2451. Use lazy string evaluation in preconditions

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -589,6 +589,6 @@ public final class HddsUtils {
         "Ancestor should not be null");
     Preconditions.checkArgument(
         path.normalize().startsWith(ancestor.normalize()),
-        "Path should be a descendant of " + ancestor);
+        "Path should be a descendant of %s", ancestor);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
@@ -68,8 +68,8 @@ public class ReplicateContainerCommandHandler implements CommandHandler {
     final long containerID = replicateCommand.getContainerID();
 
     Preconditions.checkArgument(sourceDatanodes.size() > 0,
-        String.format("Replication command is received for container %d "
-            + "but the size of source datanodes was 0.", containerID));
+        "Replication command is received for container %s "
+            + "without source datanodes.", containerID);
 
     supervisor.addTask(new ReplicationTask(containerID, sourceDatanodes));
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -576,10 +576,10 @@ public class ContainerStateMachine extends BaseStateMachine {
     ByteString data = responseProto.getData();
     // assert that the response has data in it.
     Preconditions
-        .checkNotNull(data, "read chunk data is null for chunk:" + chunkInfo);
-    Preconditions.checkState(data.size() == chunkInfo.getLen(), String.format(
-        "read chunk len=%d does not match chunk expected len=%d for chunk:%s",
-        data.size(), chunkInfo.getLen(), chunkInfo));
+        .checkNotNull(data, "read chunk data is null for chunk: %s", chunkInfo);
+    Preconditions.checkState(data.size() == chunkInfo.getLen(),
+        "read chunk len=%s does not match chunk expected len=%s for chunk:%s",
+        data.size(), chunkInfo.getLen(), chunkInfo);
     return data;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -210,7 +210,7 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
         OMClientRequest omClientRequest =
             OzoneManagerRatisUtils.createClientRequest(request);
         Preconditions.checkState(omClientRequest != null,
-            "Unrecognized write command type request" + request.toString());
+            "Unrecognized write command type request: %s", request);
         request = omClientRequest.preExecute(ozoneManager);
         index = transactionIndex.incrementAndGet();
         omClientRequest = OzoneManagerRatisUtils.createClientRequest(request);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use the version of `Preconditions.check...` that accepts `errorMessageTemplate` and `errorMessageArgs`.

There are occurrences of the `errorMessage` version left, but they do not seem to be important:

1. use constant message, or
2. are infrequently used (eg. one-time init in `MetadataKeyFilters`), or
3. only append a plain `long` (container ID) to the message.

https://issues.apache.org/jira/browse/HDDS-2451

## How was this patch tested?

Ran related unit tests and checkstyle.