### PR TITLE
HDDS-2417 Add the list trash command to the client side

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
+import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
@@ -314,6 +315,25 @@ public interface ClientProtocol {
                           String keyPrefix, String prevKey, int maxListResult)
       throws IOException;
 
+  /**
+   * List trash allows the user to list the keys that were marked as deleted,
+   * but not actually deleted by Ozone Manager. This allows a user to recover
+   * keys within a configurable window.
+   * @param volumeName - The volume name, which can also be a wild card
+   *                   using '*'.
+   * @param bucketName - The bucket name, which can also be a wild card
+   *                   using '*'.
+   * @param startKeyName - List keys from a specific key name.
+   * @param keyPrefix - List keys using a specific prefix.
+   * @param maxKeys - The number of keys to be returned. This must be below
+   *                the cluster level set by admins.
+   * @return The list of keys that are deleted from the deleted table.
+   * @throws IOException
+   */
+  List<RepeatedOmKeyInfo> listTrash(String volumeName, String bucketName,
+                                    String startKeyName, String keyPrefix,
+                                    int maxKeys)
+      throws IOException;
 
   /**
    * Get OzoneKey.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -63,6 +63,7 @@ import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
+import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
@@ -706,6 +707,17 @@ public class RpcClient implements ClientProtocol {
         ReplicationType.valueOf(key.getType().toString()),
         key.getFactor().getNumber()))
         .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<RepeatedOmKeyInfo> listTrash(String volumeName, String bucketName,
+      String startKeyName, String keyPrefix, int maxKeys) throws IOException {
+
+    Preconditions.checkNotNull(volumeName);
+    Preconditions.checkNotNull(bucketName);
+
+    return ozoneManagerClient.listTrash(volumeName, bucketName, startKeyName,
+        keyPrefix, maxKeys);
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -224,6 +224,7 @@ public final class OmUtils {
     case ListBuckets:
     case LookupKey:
     case ListKeys:
+    case ListTrash:
     case InfoS3Bucket:
     case ListS3Buckets:
     case ServiceList:

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadListParts;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
+import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
@@ -526,5 +527,23 @@ public interface OzoneManagerProtocol
   DBUpdatesWrapper getDBUpdates(
       OzoneManagerProtocolProtos.DBUpdatesRequest dbUpdatesRequest)
       throws IOException;
+
+  /**
+   * List trash allows the user to list the keys that were marked as deleted,
+   * but not actually deleted by Ozone Manager. This allows a user to recover
+   * keys within a configurable window.
+   * @param volumeName - The volume name, which can also be a wild card
+   *                   using '*'.
+   * @param bucketName - The bucket name, which can also be a wild card
+   *                   using '*'.
+   * @param startKeyName - List keys from a specific key name.
+   * @param keyPrefix - List keys using a specific prefix.
+   * @param maxKeys - The number of keys to be returned. This must be below
+   *                the cluster level set by admins.
+   * @return The list of keys that are deleted from the deleted table.
+   * @throws IOException
+   */
+  List<RepeatedOmKeyInfo> listTrash(String volumeName, String bucketName,
+      String startKeyName, String keyPrefix, int maxKeys) throws IOException;
 
 }

--- a/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
+++ b/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
@@ -92,6 +92,8 @@ enum Type {
   PurgeKeys = 81;
 
   ListMultipartUploads = 82;
+
+  ListTrash = 91;
 }
 
 message OMRequest {
@@ -161,6 +163,8 @@ message OMRequest {
 
   optional UpdateGetS3SecretRequest         updateGetS3SecretRequest       = 82;
   optional ListMultipartUploadsRequest      listMultipartUploadsRequest    = 83;
+
+  optional ListTrashRequest                 listTrashRequest               = 91;
 }
 
 message OMResponse {
@@ -230,6 +234,8 @@ message OMResponse {
   optional PurgeKeysResponse                  purgeKeysResponse            = 81;
 
   optional ListMultipartUploadsResponse listMultipartUploadsResponse = 82;
+
+  optional ListTrashResponse                  listTrashResponse            = 91;
 }
 
 enum Status {
@@ -302,6 +308,21 @@ enum Status {
     INVALID_PART_ORDER = 56;
 }
 
+/**
+    This command acts as a list command for deleted keys that are still present
+    in the deleted table on Ozone Manager.
+*/
+message ListTrashRequest {
+  required string volumeName = 1;
+  required string bucketName = 2;
+  optional string startKeyName = 3;
+  optional string keyPrefix = 4;
+  optional int32 maxKeys = 5;
+}
+
+message ListTrashResponse {
+  repeated RepeatedKeyInfo deletedKeys = 1;
+}
 
 message VolumeInfo {
     required string adminName = 1;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -78,6 +78,7 @@ import org.apache.hadoop.ozone.om.ha.OMFailoverProxyProvider;
 import org.apache.hadoop.ozone.om.ha.OMHANodeDetails;
 import org.apache.hadoop.ozone.om.ha.OMNodeDetails;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadList;
+import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerServerProtocol;
 import org.apache.hadoop.ozone.om.ratis.OMRatisSnapshotInfo;
@@ -2237,6 +2238,16 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
             auditMap));
       }
     }
+  }
+
+  // TODO: HDDS-2418 - Complete stub below for server logic
+  @Override
+  public List<RepeatedOmKeyInfo> listTrash(String volumeName,
+      String bucketName, String startKeyName, String keyPrefix, int maxKeys)
+      throws IOException {
+
+    List<RepeatedOmKeyInfo> deletedKeys = new ArrayList<>();
+    return deletedKeys;
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
This is the first commit for a new trash feature for Ozone.  This PR tackles adding client side changes to support a list trash command which will show deleted keys from the deleted keys tables.  

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2417

## How was this patch tested?

New tests will be added as this is built out further with the core logic.  For the initial changes in this PR, check style and local mvn build passed.
