### PR TITLE
HDDS-2456. Add explicit base image version for images derived from ozone-runner

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha/Dockerfile
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha/Dockerfile
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM apache/ozone-runner
+ARG OZONE_RUNNER_VERSION
+
+FROM apache/ozone-runner:${OZONE_RUNNER_VERSION}
 
 # Install ssh
 RUN sudo yum install -y openssh-clients openssh-server

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-compose.yaml
@@ -17,7 +17,10 @@
 version: "3"
 services:
    datanode:
-      build: .
+      build:
+         context: .
+         args:
+            - OZONE_RUNNER_VERSION
       privileged: true #required by the profiler
       volumes:
         - ../..:/opt/hadoop
@@ -27,7 +30,10 @@ services:
       env_file:
         - ./docker-config
    om1:
-      build: .
+      build:
+         context: .
+         args:
+            - OZONE_RUNNER_VERSION
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop
@@ -40,7 +46,10 @@ services:
           - ./docker-config
       command: sleep 1d
    om2:
-      build: .
+      build:
+         context: .
+         args:
+            - OZONE_RUNNER_VERSION
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop
@@ -53,7 +62,10 @@ services:
          - ./docker-config
       command: sleep 1d
    om3:
-      build: .
+      build:
+         context: .
+         args:
+            - OZONE_RUNNER_VERSION
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop
@@ -66,7 +78,10 @@ services:
          - ./docker-config
       command: sleep 1d
    scm:
-      build: .
+      build:
+         context: .
+         args:
+            - OZONE_RUNNER_VERSION
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-compose.yaml
@@ -21,6 +21,7 @@ services:
          context: .
          args:
             - OZONE_RUNNER_VERSION
+      image: ozone-runner-om-ha:${OZONE_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
         - ../..:/opt/hadoop
@@ -34,6 +35,7 @@ services:
          context: .
          args:
             - OZONE_RUNNER_VERSION
+      image: ozone-runner-om-ha:${OZONE_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop
@@ -50,6 +52,7 @@ services:
          context: .
          args:
             - OZONE_RUNNER_VERSION
+      image: ozone-runner-om-ha:${OZONE_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop
@@ -66,6 +69,7 @@ services:
          context: .
          args:
             - OZONE_RUNNER_VERSION
+      image: ozone-runner-om-ha:${OZONE_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop
@@ -82,6 +86,7 @@ services:
          context: .
          args:
             - OZONE_RUNNER_VERSION
+      image: ozone-runner-om-ha:${OZONE_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile
@@ -13,7 +13,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM apache/ozone-runner
+
+ARG OZONE_RUNNER_VERSION
+
+FROM apache/ozone-runner:${OZONE_RUNNER_VERSION}
+
 RUN sudo yum install -y openssh-clients openssh-server
 
 RUN sudo ssh-keygen -A

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/README.md
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/README.md
@@ -22,10 +22,10 @@ similar to a real cluster.
 To use it, first start the cluster:
 
 ```
-docker-copmose up -d
+docker-compose up -d
 ```
 
-After a successfull startup (which starts only the ssh daemons) you can start ozone:
+After a successful startup (which starts only the ssh daemons) you can start ozone:
 
 ```
 ./start.sh

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-compose.yaml
@@ -17,7 +17,10 @@
 version: "3"
 services:
    datanode:
-      build: .
+      build:
+         context: .
+         args:
+            - OZONE_RUNNER_VERSION
       volumes:
         - ../..:/opt/hadoop
       ports:
@@ -25,7 +28,10 @@ services:
       env_file:
         - ./docker-config
    om:
-      build: .
+      build:
+         context: .
+         args:
+            - OZONE_RUNNER_VERSION
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -33,7 +39,10 @@ services:
       env_file:
           - ./docker-config
    scm:
-      build: .
+      build:
+         context: .
+         args:
+            - OZONE_RUNNER_VERSION
       volumes:
          - ../..:/opt/hadoop
       ports:

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-compose.yaml
@@ -21,6 +21,7 @@ services:
          context: .
          args:
             - OZONE_RUNNER_VERSION
+      image: ozone-runner-scripts:${OZONE_RUNNER_VERSION}
       volumes:
         - ../..:/opt/hadoop
       ports:
@@ -32,6 +33,7 @@ services:
          context: .
          args:
             - OZONE_RUNNER_VERSION
+      image: ozone-runner-scripts:${OZONE_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -43,6 +45,7 @@ services:
          context: .
          args:
             - OZONE_RUNNER_VERSION
+      image: ozone-runner-scripts:${OZONE_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use explicit base image version (`$OZONE_RUNNER_VERSION`) instead of implicit `latest` for images derived from `ozone-runner` (in `ozone-om-ha` and `ozonescripts` compose environments).  Also tag the resulting image with the same version instead of implicit `latest`.  The goal is to force rebuild of these images if a new `ozone-runner` image is released (and `docker.ozone-runner.version` updated in `hadoop-ozone/dist/pom.xml`).

https://issues.apache.org/jira/browse/HDDS-2456

## How was this patch tested?

```
$ cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonescripts
$ docker-compose up -d
Creating network "ozonescripts_default" with the default driver
Building datanode
Step 1/16 : ARG OZONE_RUNNER_VERSION
Step 2/16 : FROM apache/ozone-runner:${OZONE_RUNNER_VERSION}
20191107-1: Pulling from apache/ozone-runner
Digest: sha256:185e18663394e1976d73a6f7de2aa8ade4d20a0e7314b415cad6f26f446323fe
Status: Downloaded newer image for apache/ozone-runner:20191107-1
...
```