### PR TITLE
HDDS-2458. Avoid list copy in ChecksumData

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
@@ -162,11 +162,9 @@ public class Checksum {
       data = data.asReadOnlyBuffer();
     }
 
-    final ChecksumData checksumData = new ChecksumData(
-        checksumType, bytesPerChecksum);
     if (checksumType == ChecksumType.NONE) {
       // Since type is set to NONE, we do not need to compute the checksums
-      return checksumData;
+      return new ChecksumData(checksumType, bytesPerChecksum);
     }
 
     final Function<ByteBuffer, ByteString> function;
@@ -188,9 +186,7 @@ public class Checksum {
     for (int index = 0; index < numChecksums; index++) {
       checksumList.add(computeChecksum(data, function, bytesPerChecksum));
     }
-    checksumData.setChecksums(checksumList);
-
-    return checksumData;
+    return new ChecksumData(checksumType, bytesPerChecksum, checksumList);
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumData.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChecksumData.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.ozone.common;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
+
+import java.util.Collections;
 import java.util.List;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
@@ -40,7 +40,7 @@ public class ChecksumData {
   private final List<ByteString> checksums;
 
   public ChecksumData(ChecksumType checksumType, int bytesPerChecksum) {
-    this(checksumType, bytesPerChecksum, Lists.newArrayList());
+    this(checksumType, bytesPerChecksum, Collections.emptyList());
   }
 
   public ChecksumData(ChecksumType checksumType, int bytesPerChecksum,
@@ -67,18 +67,8 @@ public class ChecksumData {
   /**
    * Getter method for checksums.
    */
-  @VisibleForTesting
   public List<ByteString> getChecksums() {
     return this.checksums;
-  }
-
-  /**
-   * Setter method for checksums.
-   * @param checksumList list of checksums
-   */
-  public void setChecksums(List<ByteString> checksumList) {
-    this.checksums.clear();
-    this.checksums.addAll(checksumList);
   }
 
   /**
@@ -105,14 +95,10 @@ public class ChecksumData {
       ContainerProtos.ChecksumData checksumDataProto) {
     Preconditions.checkNotNull(checksumDataProto);
 
-    ChecksumData checksumData = new ChecksumData(
-        checksumDataProto.getType(), checksumDataProto.getBytesPerChecksum());
-
-    if (checksumDataProto.getChecksumsCount() != 0) {
-      checksumData.setChecksums(checksumDataProto.getChecksumsList());
-    }
-
-    return checksumData;
+    return new ChecksumData(
+        checksumDataProto.getType(),
+        checksumDataProto.getBytesPerChecksum(),
+        checksumDataProto.getChecksumsList());
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Create `ChecksumData` with checksum list, instead of updating it right after creation, to avoid unnecessarily copying the list.

https://issues.apache.org/jira/browse/HDDS-2458

## How was this patch tested?

Tested on 3-node cluster with a 120MB key.  `ozone sh key get` verifies the checksum.

```
ozone freon ockg -p test -t 1 -n 1 # easy volume and bucket creation ;)
cat share/ozone/lib/*jar > tmp.jar
ozone sh key put vol1/bucket1/test/large tmp.jar
ozone sh key get vol1/bucket1/test/large tmp.jar.out
diff -q tmp.jar tmp.jar.out
```