### PR TITLE
HDDS-2448 Delete container command should used a thread pool

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -35,12 +35,14 @@ public class DatanodeConfiguration {
    * The maximum number of replication commands a single datanode can execute
    * simultaneously.
    */
-  private int replicationMaxStreams = 10;
+  private final int replicationMaxStreamsDefault = 10;
+  private int replicationMaxStreams = replicationMaxStreamsDefault;
   /**
    * The maximum number of threads used to delete containers on a datanode
    * simultaneously.
    */
-  private int deleteContainerThreads = 2;
+  private final int containerDeleteThreadsDefault = 2;
+  private int containerDeleteThreads = containerDeleteThreadsDefault;
 
   @Config(key = "replication.streams.limit",
       type = ConfigType.INT,
@@ -53,7 +55,8 @@ public class DatanodeConfiguration {
     if (val < 1) {
       LOG.warn("hdds.datanode.replication.streams.limit must be greater than" +
           "zero and was set to {}. Defaulting to {}",
-          val, replicationMaxStreams);
+          val, replicationMaxStreamsDefault);
+      replicationMaxStreams = replicationMaxStreamsDefault;
     } else {
       this.replicationMaxStreams = val;
     }
@@ -63,25 +66,26 @@ public class DatanodeConfiguration {
     return replicationMaxStreams;
   }
 
-  @Config(key = "delete.container.threads",
+  @Config(key = "container.delete.threads.max",
       type = ConfigType.INT,
       defaultValue = "2",
       tags = {DATANODE},
       description = "The maximum number of threads used to delete containers " +
           "on a datanode"
   )
-  public void setDeleteContainerThreads(int val) {
+  public void setContainerDeleteThreads(int val) {
     if (val < 1) {
-      LOG.warn("hdds.datanode.delete.container.threads must be greater than" +
-              "zero and was set to {}. Defaulting to {}",
-          val, deleteContainerThreads);
+      LOG.warn("hdds.datanode.container.delete.threads.max must be greater " +
+          "than zero and was set to {}. Defaulting to {}",
+          val, containerDeleteThreadsDefault);
+      containerDeleteThreads = containerDeleteThreadsDefault;
     } else {
-      this.deleteContainerThreads = val;
+      this.containerDeleteThreads = val;
     }
   }
 
-  public int getDeleteContainerThreads() {
-    return deleteContainerThreads;
+  public int getContainerDeleteThreads() {
+    return containerDeleteThreads;
   }
 
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -36,6 +36,11 @@ public class DatanodeConfiguration {
    * simultaneously.
    */
   private int replicationMaxStreams = 10;
+  /**
+   * The maximum number of threads used to delete containers on a datanode
+   * simultaneously.
+   */
+  private int deleteContainerThreads = 2;
 
   @Config(key = "replication.streams.limit",
       type = ConfigType.INT,
@@ -56,6 +61,27 @@ public class DatanodeConfiguration {
 
   public int getReplicationMaxStreams() {
     return replicationMaxStreams;
+  }
+
+  @Config(key = "delete.container.threads",
+      type = ConfigType.INT,
+      defaultValue = "2",
+      tags = {DATANODE},
+      description = "The maximum number of threads used to delete containers " +
+          "on a datanode"
+  )
+  public void setDeleteContainerThreads(int val) {
+    if (val < 1) {
+      LOG.warn("hdds.datanode.delete.container.threads must be greater than" +
+              "zero and was set to {}. Defaulting to {}",
+          val, deleteContainerThreads);
+    } else {
+      this.deleteContainerThreads = val;
+    }
+  }
+
+  public int getDeleteContainerThreads() {
+    return deleteContainerThreads;
   }
 
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -130,9 +130,10 @@ public class DatanodeStateMachine implements Closeable {
         .addHandler(new DeleteBlocksCommandHandler(container.getContainerSet(),
             conf))
         .addHandler(new ReplicateContainerCommandHandler(conf, supervisor))
-        .addHandler(new DeleteContainerCommandHandler(2))
         .addHandler(new ClosePipelineCommandHandler())
         .addHandler(new CreatePipelineCommandHandler())
+        .addHandler(new DeleteContainerCommandHandler(
+            dnConf.getDeleteContainerThreads()))
         .setConnectionManager(connectionManager)
         .setContainer(container)
         .setContext(context)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -131,7 +131,7 @@ public class DatanodeStateMachine implements Closeable {
             conf))
         .addHandler(new ReplicateContainerCommandHandler(conf, supervisor))
         .addHandler(new DeleteContainerCommandHandler(
-            dnConf.getDeleteContainerThreads()))
+            dnConf.getContainerDeleteThreads()))
         .setConnectionManager(connectionManager)
         .setContainer(container)
         .setContext(context)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -130,8 +130,6 @@ public class DatanodeStateMachine implements Closeable {
         .addHandler(new DeleteBlocksCommandHandler(container.getContainerSet(),
             conf))
         .addHandler(new ReplicateContainerCommandHandler(conf, supervisor))
-        .addHandler(new ClosePipelineCommandHandler())
-        .addHandler(new CreatePipelineCommandHandler())
         .addHandler(new DeleteContainerCommandHandler(
             dnConf.getDeleteContainerThreads()))
         .setConnectionManager(connectionManager)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -130,7 +130,9 @@ public class DatanodeStateMachine implements Closeable {
         .addHandler(new DeleteBlocksCommandHandler(container.getContainerSet(),
             conf))
         .addHandler(new ReplicateContainerCommandHandler(conf, supervisor))
-        .addHandler(new DeleteContainerCommandHandler())
+        .addHandler(new DeleteContainerCommandHandler(2))
+        .addHandler(new ClosePipelineCommandHandler())
+        .addHandler(new CreatePipelineCommandHandler())
         .setConnectionManager(connectionManager)
         .setContainer(container)
         .setContext(context)
@@ -277,6 +279,10 @@ public class DatanodeStateMachine implements Closeable {
 
     if (jvmPauseMonitor != null) {
       jvmPauseMonitor.stop();
+    }
+
+    if (commandDispatcher != null) {
+      commandDispatcher.stop();
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandDispatcher.java
@@ -104,6 +104,12 @@ public final class CommandDispatcher {
     }
   }
 
+  public void stop() {
+    for (CommandHandler c : handlerMap.values()) {
+      c.stop();
+    }
+  }
+
   public static Builder newBuilder() {
     return new Builder();
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandHandler.java
@@ -72,4 +72,12 @@ public interface CommandHandler {
           command.getId());
     }
   }
+
+  /**
+   * Override for any command with an internal threadpool, and stop the
+   * executor when this method is invoked.
+   */
+  default void stop() {
+    // Default implementation does nothing
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -48,7 +49,7 @@ public class DeleteContainerCommandHandler implements CommandHandler {
 
   private final AtomicInteger invocationCount = new AtomicInteger(0);
   private final AtomicLong totalTime = new AtomicLong(0);
-  private final ThreadPoolExecutor executor;
+  private final ExecutorService executor;
 
   public DeleteContainerCommandHandler(int threadPoolSize) {
     this.executor = new ThreadPoolExecutor(
@@ -93,8 +94,9 @@ public class DeleteContainerCommandHandler implements CommandHandler {
 
   @Override
   public long getAverageRunTime() {
-    return invocationCount.get() == 0 ?
-        0 : totalTime.get() / invocationCount.get();
+    final int invocations = invocationCount.get();
+    return invocations == 0 ?
+        0 : totalTime.get() / invocations;
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.container.common.statemachine.commandhandler;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.ozone.container.common.statemachine
@@ -31,6 +32,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Handler to process the DeleteContainerCommand from SCM.
@@ -40,28 +46,39 @@ public class DeleteContainerCommandHandler implements CommandHandler {
   private static final Logger LOG =
       LoggerFactory.getLogger(DeleteContainerCommandHandler.class);
 
-  private int invocationCount;
-  private long totalTime;
+  private final AtomicInteger invocationCount = new AtomicInteger(0);
+  private final AtomicLong totalTime = new AtomicLong(0);
+  private final ThreadPoolExecutor executor;
+
+  public DeleteContainerCommandHandler(int threadPoolSize) {
+    this.executor = new ThreadPoolExecutor(
+        0, threadPoolSize, 60, TimeUnit.SECONDS,
+        new LinkedBlockingQueue<>(),
+        new ThreadFactoryBuilder().setDaemon(true)
+            .setNameFormat("DeleteContainerThread-%d")
+            .build());
+  }
 
   @Override
   public void handle(final SCMCommand command,
                      final OzoneContainer ozoneContainer,
                      final StateContext context,
                      final SCMConnectionManager connectionManager) {
-    final long startTime = Time.monotonicNow();
-    invocationCount++;
-    try {
-      final DeleteContainerCommand deleteContainerCommand =
-          (DeleteContainerCommand) command;
-      final ContainerController controller = ozoneContainer.getController();
-      controller.deleteContainer(deleteContainerCommand.getContainerID(),
-          deleteContainerCommand.isForce());
-    } catch (IOException e) {
-      LOG.error("Exception occurred while deleting the container.", e);
-    } finally {
-      totalTime += Time.monotonicNow() - startTime;
-    }
-
+    final DeleteContainerCommand deleteContainerCommand =
+        (DeleteContainerCommand) command;
+    final ContainerController controller = ozoneContainer.getController();
+    executor.execute(() -> {
+      final long startTime = Time.monotonicNow();
+      invocationCount.incrementAndGet();
+      try {
+        controller.deleteContainer(deleteContainerCommand.getContainerID(),
+            deleteContainerCommand.isForce());
+      } catch (IOException e) {
+        LOG.error("Exception occurred while deleting the container.", e);
+      } finally {
+        totalTime.getAndAdd(Time.monotonicNow() - startTime);
+      }
+    });
   }
 
   @Override
@@ -71,11 +88,26 @@ public class DeleteContainerCommandHandler implements CommandHandler {
 
   @Override
   public int getInvocationCount() {
-    return this.invocationCount;
+    return this.invocationCount.get();
   }
 
   @Override
   public long getAverageRunTime() {
-    return invocationCount == 0 ? 0 : totalTime / invocationCount;
+    return invocationCount.get() == 0 ?
+        0 : totalTime.get() / invocationCount.get();
   }
+
+  @Override
+  public void stop() {
+    try {
+      executor.shutdown();
+      if (!executor.awaitTermination(3, TimeUnit.SECONDS)) {
+        executor.shutdownNow();
+      }
+    } catch (InterruptedException ie) {
+      // Ignore, we don't really care about the failure.
+      Thread.currentThread().interrupt();
+    }
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The datanode receives commands over the heartbeat and queues all commands on a single queue in StateContext.commandQueue. Inside DatanodeStateMachine a single thread is used to process this queue (started by initCommandHander thread) and it passes each command to a ‘handler’. Each command type has its own handler.

The delete container command immediately executes the command on the thread used to process the command queue. Therefore if the delete is slow for some reason (it must access disk, so this is possible) it could cause other commands to backup.

This should be changed to use a threadpool to queue the deleteContainer command, in a similar way to ReplicateContainerCommand.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2448
