### PR TITLE
HDDS-2461. Logging by ChunkUtils is misleading

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
@@ -63,6 +63,9 @@ public final class ChunkUtils {
 
   private static final Set<Path> LOCKS = ConcurrentHashMap.newKeySet();
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ChunkManagerImpl.class);
+
   // skip SYNC and DSYNC to reduce contention on file.lock
   private static final Set<? extends OpenOption> WRITE_OPTIONS =
       unmodifiableSet(EnumSet.of(
@@ -94,8 +97,8 @@ public final class ChunkUtils {
       ByteBuffer data, VolumeIOStats volumeIOStats, boolean sync)
       throws StorageContainerException, ExecutionException,
       InterruptedException, NoSuchAlgorithmException {
-    Logger log = LoggerFactory.getLogger(ChunkManagerImpl.class);
-    final int bufferSize = validateBufferSize(chunkInfo, data, log);
+
+    final int bufferSize = validateBufferSize(chunkInfo, data);
 
     Path path = chunkFile.toPath();
     long startTime = Time.monotonicNow();
@@ -114,7 +117,7 @@ public final class ChunkUtils {
         volumeIOStats.incWriteOpCount();
         volumeIOStats.incWriteBytes(size);
         if (size != bufferSize) {
-          log.error("Invalid write size found. Size:{}  Expected: {} ", size,
+          LOG.error("Invalid write size found. Size:{}  Expected: {} ", size,
               bufferSize);
           throw new StorageContainerException("Invalid write size found. " +
               "Size: " + size + " Expected: " + bufferSize, INVALID_WRITE_SIZE);
@@ -130,21 +133,21 @@ public final class ChunkUtils {
       return null;
     });
 
-    if (log.isDebugEnabled()) {
-      log.debug("Write Chunk completed for chunkFile: {}, size {}", chunkFile,
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Write Chunk completed for chunkFile: {}, size {}", chunkFile,
           bufferSize);
     }
   }
 
   public static int validateBufferSize(
-      ChunkInfo chunkInfo, ByteBuffer data, Logger log)
+      ChunkInfo chunkInfo, ByteBuffer data)
       throws StorageContainerException {
     final int bufferSize = data.remaining();
     if (bufferSize != chunkInfo.getLen()) {
       String err = String.format("data array does not match the length " +
               "specified. DataLen: %d Byte Array: %d",
           chunkInfo.getLen(), bufferSize);
-      log.error(err);
+      LOG.error(err);
       throw new StorageContainerException(err, INVALID_WRITE_SIZE);
     }
     return bufferSize;
@@ -160,10 +163,9 @@ public final class ChunkUtils {
    */
   public static ByteBuffer readData(File chunkFile, ChunkInfo data,
       VolumeIOStats volumeIOStats) throws StorageContainerException {
-    Logger log = LoggerFactory.getLogger(ChunkManagerImpl.class);
 
     if (!chunkFile.exists()) {
-      log.error("Unable to find the chunk file. chunk info : {}",
+      LOG.error("Unable to find the chunk file. chunk info : {}",
           data.toString());
       throw new StorageContainerException("Unable to find the chunk file. " +
           "chunk info " +
@@ -215,11 +217,9 @@ public final class ChunkUtils {
   public static boolean validateChunkForOverwrite(File chunkFile,
       ChunkInfo info) {
 
-    Logger log = LoggerFactory.getLogger(ChunkManagerImpl.class);
-
     if (isOverWriteRequested(chunkFile, info)) {
       if (!isOverWritePermitted(info)) {
-        log.warn("Duplicate write chunk request. Chunk overwrite " +
+        LOG.warn("Duplicate write chunk request. Chunk overwrite " +
             "without explicit request. {}", info.toString());
       }
       return true;
@@ -240,17 +240,16 @@ public final class ChunkUtils {
       StorageContainerException {
 
     Preconditions.checkNotNull(containerData, "Container data can't be null");
-    Logger log = LoggerFactory.getLogger(ChunkManagerImpl.class);
 
     String chunksPath = containerData.getChunksPath();
     if (chunksPath == null) {
-      log.error("Chunks path is null in the container data");
+      LOG.error("Chunks path is null in the container data");
       throw new StorageContainerException("Unable to get Chunks directory.",
           UNABLE_TO_FIND_DATA_DIR);
     }
     File chunksLoc = new File(chunksPath);
     if (!chunksLoc.exists()) {
-      log.error("Chunks path does not exist");
+      LOG.error("Chunks path does not exist");
       throw new StorageContainerException("Unable to get Chunks directory.",
           UNABLE_TO_FIND_DATA_DIR);
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
-import org.apache.hadoop.ozone.container.keyvalue.impl.ChunkManagerImpl;
 import org.apache.hadoop.ozone.container.common.volume.VolumeIOStats;
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.util.function.CheckedSupplier;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
@@ -64,7 +64,7 @@ public final class ChunkUtils {
   private static final Set<Path> LOCKS = ConcurrentHashMap.newKeySet();
 
   private static final Logger LOG =
-      LoggerFactory.getLogger(ChunkManagerImpl.class);
+      LoggerFactory.getLogger(ChunkUtils.class);
 
   // skip SYNC and DSYNC to reduce contention on file.lock
   private static final Set<? extends OpenOption> WRITE_OPTIONS =

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDummyImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDummyImpl.java
@@ -29,8 +29,6 @@ import org.apache.hadoop.ozone.container.common.volume.VolumeIOStats;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.ChunkUtils;
 import org.apache.hadoop.util.Time;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -42,8 +40,6 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
  * Chunks are not written to disk, Reads are returned with zero-filled buffers
  */
 public class ChunkManagerDummyImpl extends ChunkManagerImpl {
-  private static final Logger LOG = LoggerFactory.getLogger(
-      ChunkManagerDummyImpl.class);
 
   public ChunkManagerDummyImpl(boolean sync) {
     super(sync);
@@ -76,7 +72,7 @@ public class ChunkManagerDummyImpl extends ChunkManagerImpl {
 
       switch (stage) {
       case WRITE_DATA:
-        ChunkUtils.validateBufferSize(info, data, LOG);
+        ChunkUtils.validateBufferSize(info, data);
 
         // Increment volumeIO stats here.
         volumeIOStats.incWriteTime(Time.monotonicNow() - writeTimeStart);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDummyImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDummyImpl.java
@@ -34,12 +34,17 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of ChunkManager built for running performance tests.
  * Chunks are not written to disk, Reads are returned with zero-filled buffers
  */
 public class ChunkManagerDummyImpl extends ChunkManagerImpl {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ChunkManagerDummyImpl.class);
 
   public ChunkManagerDummyImpl(boolean sync) {
     super(sync);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerImpl.java
@@ -53,7 +53,10 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
  * This class is for performing chunk related operations.
  */
 public class ChunkManagerImpl implements ChunkManager {
-  static final Logger LOG = LoggerFactory.getLogger(ChunkManagerImpl.class);
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ChunkManagerImpl.class);
+
   private final boolean doSyncWrite;
 
   public ChunkManagerImpl(boolean sync) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
@@ -21,12 +21,16 @@ import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.volume.VolumeIOStats;
 import org.apache.hadoop.test.GenericTestUtils;
+
+import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -159,6 +163,21 @@ public class TestChunkUtils {
     } finally {
       Files.deleteIfExists(tempFile);
     }
+  }
+
+  @Test
+  public void validateChunkForOverwrite() throws IOException {
+
+    Path tempFile = Files.createTempFile(PREFIX, "overwrite");
+    FileUtils.write(tempFile.toFile(), "test", StandardCharsets.UTF_8);
+
+    Assert.assertTrue(
+        ChunkUtils.validateChunkForOverwrite(tempFile.toFile(),
+            new ChunkInfo("chunk", 3, 5)));
+
+    Assert.assertFalse(
+        ChunkUtils.validateChunkForOverwrite(tempFile.toFile(),
+            new ChunkInfo("chunk", 5, 5)));
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

During a k8s based test I found a lot of log message like:
```
2019-11-12 14:27:13 WARN  ChunkManagerImpl:209 - Duplicate write chunk request. Chunk overwrite without explicit request. ChunkInfo{chunkName='A9UrLxiEUN_testdata_chunk_4465025, offset=0, len=1024} 
```

I was very surprised as at `ChunkManagerImpl:209` there was no related lines.

It turned out that it's logged by `ChunkUtils` but it's used the logger of `ChunkManagerImpl`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2461

## How was this patch tested?

I deployed a new version  from Ozone to the kubernetes cluster. But I also added a new test method TestChunkUtil to have at least one unit test method which uses the logger. 
