### PR TITLE
HDDS-2462. Add jq dependency in Contribution guideline

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -57,6 +57,7 @@ Additional requirements to execute different type of tests:
 * [Robot framework](https://robotframework.org/) (for executing acceptance tests)
 * docker-compose (to start pseudo cluster, also used for blockade and acceptance tests)
 * [blockade](https://pypi.org/project/blockade/) To execute network fault-injection testing.
+* [jq](https://stedolan.github.io/jq/) To parse JMX results from different processes running in containers in docker based tests.
 
 Optional dependencies:
 

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -57,7 +57,7 @@ Additional requirements to execute different type of tests:
 * [Robot framework](https://robotframework.org/) (for executing acceptance tests)
 * docker-compose (to start pseudo cluster, also used for blockade and acceptance tests)
 * [blockade](https://pypi.org/project/blockade/) To execute network fault-injection testing.
-* [jq](https://stedolan.github.io/jq/) To parse JMX results from different processes running in containers in docker based tests.
+* [jq](https://stedolan.github.io/jq/) (for executing acceptance tests)
 
 Optional dependencies:
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Documentation update, add jq dependency into the Contribution Guideline in the "Additional requirements to execute different type of tests" section

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2462

## How was this patch tested?
Doc change, no tests needed as far as I can tell.
