### PR TITLE
HDDS-2105. Merge OzoneClientFactory#getRpcClient functions

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
@@ -81,41 +81,6 @@ public final class OzoneClientFactory {
    * @param omHost
    *        hostname of OzoneManager to connect.
    *
-   * @return OzoneClient
-   *
-   * @throws IOException
-   */
-  public static OzoneClient getRpcClient(String omHost)
-      throws IOException {
-    Configuration config = new OzoneConfiguration();
-    int port = OmUtils.getOmRpcPort(config);
-    return getRpcClient(omHost, port, config);
-  }
-
-  /**
-   * Returns an OzoneClient which will use RPC protocol.
-   *
-   * @param omHost
-   *        hostname of OzoneManager to connect.
-   *
-   * @param omRpcPort
-   *        RPC port of OzoneManager.
-   *
-   * @return OzoneClient
-   *
-   * @throws IOException
-   */
-  public static OzoneClient getRpcClient(String omHost, Integer omRpcPort)
-      throws IOException {
-    return getRpcClient(omHost, omRpcPort, new OzoneConfiguration());
-  }
-
-  /**
-   * Returns an OzoneClient which will use RPC protocol.
-   *
-   * @param omHost
-   *        hostname of OzoneManager to connect.
-   *
    * @param omRpcPort
    *        RPC port of OzoneManager.
    *
@@ -200,8 +165,7 @@ public final class OzoneClientFactory {
   public static OzoneClient getRpcClient(Configuration config)
       throws IOException {
     Preconditions.checkNotNull(config);
-    return getClient(getClientProtocol(config),
-        config);
+    return getClient(getClientProtocol(config), config);
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
@@ -84,35 +84,6 @@ public final class OzoneClientFactory {
    * @param omRpcPort
    *        RPC port of OzoneManager.
    *
-   * @param omServiceId
-   *        Service ID of OzoneManager HA cluster.
-   *
-   * @param config
-   *        Configuration to be used for OzoneClient creation
-   *
-   * @return OzoneClient
-   *
-   * @throws IOException
-   */
-  public static OzoneClient getRpcClient(String omHost, Integer omRpcPort,
-      String omServiceId, Configuration config) throws IOException {
-    Preconditions.checkNotNull(omHost);
-    Preconditions.checkNotNull(omRpcPort);
-    Preconditions.checkNotNull(omServiceId);
-    Preconditions.checkNotNull(config);
-    config.set(OZONE_OM_ADDRESS_KEY, omHost + ":" + omRpcPort);
-    return getRpcClient(omServiceId, config);
-  }
-
-  /**
-   * Returns an OzoneClient which will use RPC protocol.
-   *
-   * @param omHost
-   *        hostname of OzoneManager to connect.
-   *
-   * @param omRpcPort
-   *        RPC port of OzoneManager.
-   *
    * @param config
    *        Configuration to be used for OzoneClient creation
    *

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Proxy;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.client.rpc.RpcClient;
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -778,10 +778,6 @@ public class TestOzoneManagerHA {
     for (int i = 0; i < numOfOMs; i++) {
       // Failover OMFailoverProxyProvider to OM at index i
       OzoneManager ozoneManager = cluster.getOzoneManager(i);
-      String omHostName = ozoneManager.getOmRpcServerAddr().getHostName();
-      int rpcPort = ozoneManager.getOmRpcServerAddr().getPort();
-      // Test can pass without this line below
-      conf.set(OZONE_OM_ADDRESS_KEY, omHostName + ":" + rpcPort);
 
       // Get the ObjectStore and FailoverProxyProvider for OM at index i
       final ObjectStore store = OzoneClientFactory.getRpcClient(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -90,7 +90,6 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys
     .OZONE_CLIENT_FAILOVER_SLEEP_BASE_MILLIS_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys
     .OZONE_OPEN_KEY_EXPIRE_THRESHOLD_SECONDS;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.USER;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -90,6 +90,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys
     .OZONE_CLIENT_FAILOVER_SLEEP_BASE_MILLIS_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys
     .OZONE_OPEN_KEY_EXPIRE_THRESHOLD_SECONDS;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.USER;
@@ -779,10 +780,12 @@ public class TestOzoneManagerHA {
       OzoneManager ozoneManager = cluster.getOzoneManager(i);
       String omHostName = ozoneManager.getOmRpcServerAddr().getHostName();
       int rpcPort = ozoneManager.getOmRpcServerAddr().getPort();
+      // Test can pass without this line below
+      conf.set(OZONE_OM_ADDRESS_KEY, omHostName + ":" + rpcPort);
 
       // Get the ObjectStore and FailoverProxyProvider for OM at index i
       final ObjectStore store = OzoneClientFactory.getRpcClient(
-          omHostName, rpcPort, omServiceId, conf).getObjectStore();
+          omServiceId, conf).getObjectStore();
       final OMFailoverProxyProvider proxyProvider =
           store.getClientProxy().getOMProxyProvider();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/OzoneAddress.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/OzoneAddress.java
@@ -103,7 +103,7 @@ public class OzoneAddress {
           }
           client = OzoneClientFactory.getRpcClient(ozoneURI.getHost(), conf);
         } else if (ozoneURI.getPort() == -1) {
-          client = OzoneClientFactory.getRpcClient(ozoneURI.getHost());
+          client = OzoneClientFactory.getRpcClient(ozoneURI.getHost(), conf);
         } else {
           client = OzoneClientFactory
               .getRpcClient(ozoneURI.getHost(), ozoneURI.getPort(), conf);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/OzoneAddress.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/OzoneAddress.java
@@ -103,7 +103,8 @@ public class OzoneAddress {
           }
           client = OzoneClientFactory.getRpcClient(ozoneURI.getHost(), conf);
         } else if (ozoneURI.getPort() == -1) {
-          client = OzoneClientFactory.getRpcClient(ozoneURI.getHost(), conf);
+          client = OzoneClientFactory.getRpcClient(ozoneURI.getHost(),
+              OmUtils.getOmRpcPort(conf), conf);
         } else {
           client = OzoneClientFactory
               .getRpcClient(ozoneURI.getHost(), ozoneURI.getPort(), conf);


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are in total 6 overloaded `OzoneClientFactory#getRpcClient` functions now. Some of them are not used or just used once. Remove/merge some of them. (Should be fine to simply remove public function without deprecating at this moment since ozone is still in alpha?)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2105

## How was this patch tested?

Rerun all existing tests, since this is just a straightforward refactoring.