### PR TITLE
HDDS-2403: Remove leftover reference to OUTPUT_FILE from shellcheck.sh

### DIFF
--- a/hadoop-ozone/dev-support/checks/shellcheck.sh
+++ b/hadoop-ozone/dev-support/checks/shellcheck.sh
@@ -20,7 +20,6 @@ REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/shellcheck"}
 mkdir -p "$REPORT_DIR"
 REPORT_FILE="$REPORT_DIR/summary.txt"
 
-echo "" > "$OUTPUT_FILE"
 if [[ "$(uname -s)" = "Darwin" ]]; then
   find hadoop-hdds hadoop-ozone -type f -perm '-500'
 else


### PR DESCRIPTION
## What changes were proposed in this pull request?
Removed the leftover `OUTPUT_FILE` from shellcheck.sh

## What is the link to the Apache JIRA
HDDS-2403