### PR TITLE
HDDS-2460: Default checksum type is wrong in description

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1492,7 +1492,7 @@
     <tag>OZONE, CLIENT, MANAGEMENT</tag>
     <description>The checksum type [NONE/ CRC32/ CRC32C/ SHA256/ MD5] determines
       which algorithm would be used to compute checksum for chunk data.
-      Default checksum type is SHA256.
+      Default checksum type is CRC32.
     </description>
   </property>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Updated Default checksum type to CRC32 in the description.

## What is the link to the Apache JIRA

HDDS-2460