### PR TITLE
HDDS-2469. Avoid changing client-side key metadata

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -97,7 +97,6 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.Time;
 
-import com.google.common.collect.ImmutableMap;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -694,13 +693,10 @@ public abstract class TestOzoneRpcClientAbstract {
 
     for (int i = 0; i < 10; i++) {
       String keyName = UUID.randomUUID().toString();
-      Map<String, String> metadata = new HashMap<>(1);
-      metadata.put(OzoneConsts.GDPR_FLAG, Boolean.toString(i % 2 == 0));
-      Map<String, String> originalMetadata = ImmutableMap.copyOf(metadata);
 
       OzoneOutputStream out = bucket.createKey(keyName,
           value.getBytes().length, STAND_ALONE,
-          ONE, metadata);
+          ONE, new HashMap<>());
       out.write(value.getBytes());
       out.close();
       OzoneKey key = bucket.getKey(keyName);
@@ -714,7 +710,6 @@ public abstract class TestOzoneRpcClientAbstract {
       Assert.assertEquals(value, new String(fileContent));
       Assert.assertTrue(key.getCreationTime() >= currentTime);
       Assert.assertTrue(key.getModificationTime() >= currentTime);
-      Assert.assertEquals(originalMetadata, metadata);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Let OM `RpcClient` add extra metadata keys only into the request to OM, not to the input from client.

https://issues.apache.org/jira/browse/HDDS-2469

## How was this patch tested?

Tweaked integration tests:

```
Tests run: 69, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 26.154 s - in org.apache.hadoop.ozone.client.rpc.TestOzoneRpcClient
Tests run: 70, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 27.976 s - in org.apache.hadoop.ozone.client.rpc.TestOzoneRpcClientWithRatis
Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.035 s - in org.apache.hadoop.ozone.client.rpc.TestOzoneRpcClientForAclAuditLog
```

Also ran `ozone` smoketest, which includes GDPR test:

```
ozone-gdpr :: Smoketest Ozone GDPR Feature
==============================================================================
Test GDPR disabled                                                    | PASS |
------------------------------------------------------------------------------
Test GDPR --enforcegdpr=true                                          | PASS |
------------------------------------------------------------------------------
Test GDPR -g=true                                                     | PASS |
------------------------------------------------------------------------------
Test GDPR -g=false                                                    | PASS |
------------------------------------------------------------------------------
ozone-gdpr :: Smoketest Ozone GDPR Feature                            | PASS |
4 critical tests, 4 passed, 0 failed
4 tests total, 4 passed, 0 failed
```