### PR TITLE
HDDS-2474. Remove OzoneClient exception Precondition check.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -342,8 +342,12 @@ public final class XceiverClientRatis extends XceiverClientSpi {
               // able to connect to leader in the pipeline, though the
               // pipeline can still be functional.
               RaftException exception = reply.getException();
-              Preconditions.checkNotNull(exception, "Raft reply failure but " +
-                  "no exception propagated.");
+              // TODO: Once RATIS-729 is fixed, we can have a Precondition check
+              //  here to verify exception is not null.
+              if (exception == null) {
+                exception = new RaftException("Raft reply failure but no " +
+                    "exception propagated.");
+              }
               throw new CompletionException(exception);
             }
             ContainerCommandResponseProto response =


### PR DESCRIPTION
## What changes were proposed in this pull request?

If RaftCleintReply encounters an exception other than NotLeaderException, NotReplicatedException, StateMachineException or LeaderNotReady, then it sets success to false but there is no exception set. This causes a Precondition check failure in XceiverClientRatis which expects that there should be an exception if success=false.
This Jira proposes to remove the Precondition check.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2474

## How was this patch tested?

This patch does not require a unit test. We are just removing a Precondition check.