### PR TITLE
HDDS-2477. TableCache cleanup issue for OM non-HA.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdds.utils.db;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.NotImplementedException;
@@ -140,11 +141,19 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
 
   /**
    * Removes all the entries from the table cache which are having epoch value
-   * less
-   * than or equal to specified epoch value.
+   * less than or equal to specified epoch value.
    * @param epoch
    */
   default void cleanupCache(long epoch) {
+    throw new NotImplementedException("cleanupCache is not implemented");
+  }
+
+  /**
+   * Removes all the entries from the table cache which are matching with
+   * epoch provided in the epoch list.
+   * @param epochs
+   */
+  default void cleanupCache(List<Long> epochs) {
     throw new NotImplementedException("cleanupCache is not implemented");
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -140,15 +140,6 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
   }
 
   /**
-   * Removes all the entries from the table cache which are having epoch value
-   * less than or equal to specified epoch value.
-   * @param epoch
-   */
-  default void cleanupCache(long epoch) {
-    throw new NotImplementedException("cleanupCache is not implemented");
-  }
-
-  /**
    * Removes all the entries from the table cache which are matching with
    * epoch provided in the epoch list.
    * @param epochs

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -235,11 +235,6 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @Override
-  public void cleanupCache(long epoch) {
-    cache.cleanup(epoch);
-  }
-
-  @Override
   public void cleanupCache(List<Long> epochs) {
     cache.cleanup(epochs);
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.utils.db;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -236,6 +237,11 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   @Override
   public void cleanupCache(long epoch) {
     cache.cleanup(epoch);
+  }
+
+  @Override
+  public void cleanupCache(List<Long> epochs) {
+    cache.cleanup(epochs);
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/cache/EpochEntry.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/cache/EpochEntry.java
@@ -53,7 +53,7 @@ public class EpochEntry<CACHEKEY> implements Comparable<CACHEKEY> {
       return false;
     }
     EpochEntry<?> that = (EpochEntry<?>) o;
-    return epoch == that.epoch && cachekey == that.cachekey;
+    return epoch == that.epoch && Objects.equals(cachekey, that.cachekey);
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
@@ -19,12 +19,14 @@
 
 package org.apache.hadoop.hdds.utils.db.cache;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.classification.InterfaceStability.Evolving;
 
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Cache used for RocksDB tables.
@@ -59,17 +61,6 @@ public interface TableCache<CACHEKEY extends CacheKey,
    * @param value
    */
   void put(CACHEKEY cacheKey, CACHEVALUE value);
-
-  /**
-   * Removes all the entries from the cache which are having epoch value less
-   * than or equal to specified epoch value.
-   *
-   * If clean up policy is NEVER, this is a do nothing operation.
-   * If clean up policy is MANUAL, it is caller responsibility to cleanup the
-   * cache before calling cleanup.
-   * @param epoch
-   */
-  void cleanup(long epoch);
 
   /**
    * Removes all the entries from the cache which are matching with epoch
@@ -115,4 +106,7 @@ public interface TableCache<CACHEKEY extends CacheKey,
    */
   CacheResult<CACHEVALUE> lookup(CACHEKEY cachekey);
 
+
+  @VisibleForTesting
+  Set<EpochEntry<CACHEKEY>> getEpochEntrySet();
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.classification.InterfaceStability.Evolving;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -69,6 +70,17 @@ public interface TableCache<CACHEKEY extends CacheKey,
    * @param epoch
    */
   void cleanup(long epoch);
+
+  /**
+   * Removes all the entries from the cache which are matching with epoch
+   * provided in the epoch list.
+   *
+   * If clean up policy is NEVER, this is a do nothing operation.
+   * If clean up policy is MANUAL, it is caller responsibility to cleanup the
+   * cache before calling cleanup.
+   * @param epochs
+   */
+  void cleanup(List<Long> epochs);
 
   /**
    * Return the size of the cache.

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.hdds.utils.db;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -293,7 +294,11 @@ public class TestTypedRDBTableStore {
         }
       }
 
-      testTable.cleanupCache(5);
+      ArrayList<Long> epochs = new ArrayList<>();
+      for (long i=0; i<=5L; i++) {
+        epochs.add(i);
+      }
+      testTable.cleanupCache(epochs);
 
       GenericTestUtils.waitFor(() ->
           ((TypedTable<String, String>) testTable).getCache().size() == 4,

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCacheImpl.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCacheImpl.java
@@ -94,7 +94,7 @@ public class TestTableCacheImpl {
     int totalCount = 0;
     int insertedCount = 3000;
 
-    int cleanupCount = 1000;
+    int cleanupCount = 0;
 
     ArrayList<Long> epochs = new ArrayList();
     for (long i=0; i<insertedCount; i+=2) {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCacheImpl.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCacheImpl.java
@@ -22,6 +22,7 @@ package org.apache.hadoop.hdds.utils.db.cache;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import com.google.common.base.Optional;
@@ -79,8 +80,14 @@ public class TestTableCacheImpl {
           tableCache.get(new CacheKey<>(Integer.toString(i))).getCacheValue());
     }
 
+    ArrayList<Long> epochs = new ArrayList();
+    epochs.add(0L);
+    epochs.add(1L);
+    epochs.add(2L);
+    epochs.add(3L);
+    epochs.add(4L);
     // On a full table cache if some one calls cleanup it is a no-op.
-    tableCache.cleanup(4);
+    tableCache.cleanup(epochs);
 
     for (int i=5; i < 10; i++) {
       Assert.assertEquals(Integer.toString(i),
@@ -139,6 +146,172 @@ public class TestTableCacheImpl {
   }
 
   @Test
+  public void testPartialTableCacheWithOverrideEntries() throws Exception {
+
+    tableCache.put(new CacheKey<>(Long.toString(0)),
+          new CacheValue<>(Optional.of(Long.toString(0)), 0));
+    tableCache.put(new CacheKey<>(Long.toString(1)),
+        new CacheValue<>(Optional.of(Long.toString(1)), 1));
+    tableCache.put(new CacheKey<>(Long.toString(2)),
+        new CacheValue<>(Optional.of(Long.toString(2)), 2));
+
+
+    //Override first 2 entries
+    // This is to simulate a case like create mpu key, commit part1, commit
+    // part2. They override the same key.
+    tableCache.put(new CacheKey<>(Long.toString(0)),
+        new CacheValue<>(Optional.of(Long.toString(0)), 3));
+    tableCache.put(new CacheKey<>(Long.toString(1)),
+        new CacheValue<>(Optional.of(Long.toString(1)), 4));
+
+
+
+
+    Assert.assertEquals(3, tableCache.size());
+    // It will have 2 additional entries because we have 2 override entries.
+    Assert.assertEquals(3 + 2,
+        tableCache.getEpochEntrySet().size());
+
+    // Now remove
+
+    List<Long> epochs = new ArrayList<>();
+    epochs.add(0L);
+    epochs.add(1L);
+    epochs.add(2L);
+    epochs.add(3L);
+    epochs.add(4L);
+
+    if (cacheCleanupPolicy == cacheCleanupPolicy.MANUAL) {
+      tableCache.cleanup(epochs);
+
+      GenericTestUtils.waitFor(() -> {
+        return 0 == tableCache.size();
+      }, 100, 10000);
+
+      // Epoch entries which are overrided still exist.
+      Assert.assertEquals(2, tableCache.getEpochEntrySet().size());
+    }
+
+    // Add a new entry.
+    tableCache.put(new CacheKey<>(Long.toString(5)),
+        new CacheValue<>(Optional.of(Long.toString(5)), 5));
+
+    epochs = new ArrayList<>();
+    epochs.add(5L);
+    if (cacheCleanupPolicy == cacheCleanupPolicy.MANUAL) {
+      tableCache.cleanup(epochs);
+
+      GenericTestUtils.waitFor(() -> {
+        return 0 == tableCache.size();
+      }, 100, 10000);
+
+      // Overrided entries would have been deleted.
+      Assert.assertEquals(0, tableCache.getEpochEntrySet().size());
+    }
+
+
+  }
+
+  @Test
+  public void testPartialTableCacheWithOverrideAndDelete() throws Exception {
+
+    tableCache.put(new CacheKey<>(Long.toString(0)),
+        new CacheValue<>(Optional.of(Long.toString(0)), 0));
+    tableCache.put(new CacheKey<>(Long.toString(1)),
+        new CacheValue<>(Optional.of(Long.toString(1)), 1));
+    tableCache.put(new CacheKey<>(Long.toString(2)),
+        new CacheValue<>(Optional.of(Long.toString(2)), 2));
+
+
+    //Override entries
+    tableCache.put(new CacheKey<>(Long.toString(0)),
+        new CacheValue<>(Optional.of(Long.toString(0)), 3));
+    tableCache.put(new CacheKey<>(Long.toString(1)),
+        new CacheValue<>(Optional.of(Long.toString(1)), 4));
+
+    // Finally mark them for deleted
+    tableCache.put(new CacheKey<>(Long.toString(0)),
+        new CacheValue<>(Optional.absent(), 5));
+    tableCache.put(new CacheKey<>(Long.toString(1)),
+        new CacheValue<>(Optional.absent(), 6));
+
+    // So now our cache epoch entries looks like
+    // 0-0, 1-1, 2-2, 0-3, 1-4, 0-5, 1-6
+    // Cache looks like
+    // 0-5, 1-6, 2-2
+
+
+    Assert.assertEquals(3, tableCache.size());
+    // It will have 4 additional entries because we have 4 override entries.
+    Assert.assertEquals(3 + 4,
+        tableCache.getEpochEntrySet().size());
+
+    // Now remove
+
+    List<Long> epochs = new ArrayList<>();
+    epochs.add(0L);
+    epochs.add(1L);
+    epochs.add(2L);
+    epochs.add(3L);
+    epochs.add(4L);
+    epochs.add(5L);
+    epochs.add(6L);
+
+
+    if (cacheCleanupPolicy == cacheCleanupPolicy.MANUAL) {
+      tableCache.cleanup(epochs);
+
+      GenericTestUtils.waitFor(() -> {
+        return 0 == tableCache.size();
+      }, 100, 10000);
+
+      // Epoch entries which are overrided still exist.
+      Assert.assertEquals(4, tableCache.getEpochEntrySet().size());
+    } else {
+      tableCache.cleanup(epochs);
+
+      GenericTestUtils.waitFor(() -> {
+        return 1 == tableCache.size();
+      }, 100, 10000);
+
+      // Epoch entries which are overrided still exist and one not deleted As
+      // this cache clean up policy is NEVER.
+      Assert.assertEquals(5, tableCache.getEpochEntrySet().size());
+    }
+
+    // Add a new entry, now old override entries will be cleaned up.
+    tableCache.put(new CacheKey<>(Long.toString(3)),
+        new CacheValue<>(Optional.of(Long.toString(3)), 7));
+
+    epochs = new ArrayList<>();
+    epochs.add(7L);
+
+    if (cacheCleanupPolicy == cacheCleanupPolicy.MANUAL) {
+      tableCache.cleanup(epochs);
+
+      GenericTestUtils.waitFor(() -> {
+        return 0 == tableCache.size();
+      }, 100, 10000);
+
+      // Epoch entries which are overrided now would have been deleted.
+      Assert.assertEquals(0, tableCache.getEpochEntrySet().size());
+    } else {
+      tableCache.cleanup(epochs);
+
+      // 2 entries will be in cache, as 2 are not deleted.
+      GenericTestUtils.waitFor(() -> {
+        return 2 == tableCache.size();
+      }, 100, 10000);
+
+      // Epoch entries which are not marked for delete will exist override
+      // entries will be cleaned up.
+      Assert.assertEquals(2, tableCache.getEpochEntrySet().size());
+    }
+
+
+  }
+
+  @Test
   public void testPartialTableCacheParallel() throws Exception {
 
     int totalCount = 0;
@@ -182,7 +355,14 @@ public class TestTableCacheImpl {
       int deleted = 5;
 
       // cleanup first 5 entires
-      tableCache.cleanup(deleted);
+
+      ArrayList<Long> epochs = new ArrayList<>();
+      epochs.add(1L);
+      epochs.add(2L);
+      epochs.add(3L);
+      epochs.add(4L);
+      epochs.add(5L);
+      tableCache.cleanup(epochs);
 
       // We should totalCount - deleted entries in cache.
       final int tc = totalCount;
@@ -193,15 +373,23 @@ public class TestTableCacheImpl {
         Assert.assertEquals(Integer.toString(i), tableCache.get(
             new CacheKey<>(Integer.toString(i))).getCacheValue());
       }
-      tableCache.cleanup(10);
 
-      tableCache.cleanup(totalCount);
+      epochs = new ArrayList<>();
+      for (long i=6; i<= totalCount; i++) {
+        epochs.add(i);
+      }
+
+      tableCache.cleanup(epochs);
 
       // Cleaned up all entries, so cache size should be zero.
       GenericTestUtils.waitFor(() -> (0 == tableCache.size()), 100,
           5000);
     } else {
-      tableCache.cleanup(totalCount);
+      ArrayList<Long> epochs = new ArrayList<>();
+      for (long i=0; i<= totalCount; i++) {
+        epochs.add(i);
+      }
+      tableCache.cleanup(epochs);
       Assert.assertEquals(totalCount, tableCache.size());
     }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCacheImpl.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCacheImpl.java
@@ -93,20 +93,20 @@ public class TestTableCacheImpl {
   public void testPartialTableCacheWithNotContinousEntries() throws Exception {
     int totalCount = 0;
     int insertedCount = 3000;
+
+    int cleanupCount = 1000;
+
+    ArrayList<Long> epochs = new ArrayList();
     for (long i=0; i<insertedCount; i+=2) {
+      if (cleanupCount++ < 1000) {
+        epochs.add(i);
+      }
       tableCache.put(new CacheKey<>(Long.toString(i)),
           new CacheValue<>(Optional.of(Long.toString(i)), i));
       totalCount++;
     }
 
     Assert.assertEquals(totalCount, tableCache.size());
-
-    ArrayList<Long> epochs = new ArrayList();
-    epochs.add(0L);
-    epochs.add(10L);
-    epochs.add(300L);
-    epochs.add(500L);
-    epochs.add(1000L);
 
     tableCache.cleanup(epochs);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -169,8 +169,6 @@ public class OzoneManagerDoubleBuffer {
                 flushedTransactionsSize);
           }
 
-          readyBuffer.clear();
-
           long lastRatisTransactionIndex =
               readyBuffer.stream().map(DoubleBufferEntry::getTrxLogIndex)
                   .max(Long::compareTo).get();
@@ -185,6 +183,8 @@ public class OzoneManagerDoubleBuffer {
             // cleanup cache.
             cleanupCache(lastRatisTransactionIndex);
           }
+
+          readyBuffer.clear();
 
           // TODO: Need to revisit this logic, once we have multiple
           //  executors for volume/bucket request handling. As for now

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -173,16 +173,12 @@ public class OzoneManagerDoubleBuffer {
               readyBuffer.stream().map(DoubleBufferEntry::getTrxLogIndex)
                   .max(Long::compareTo).get();
 
-          if (!isRatisEnabled) {
-            List<Long> flushedEpochs =
-                readyBuffer.stream().map(DoubleBufferEntry::getTrxLogIndex)
-                    .sorted().collect(Collectors.toList());
+          List<Long> flushedEpochs =
+              readyBuffer.stream().map(DoubleBufferEntry::getTrxLogIndex)
+                  .sorted().collect(Collectors.toList());
 
-            cleanupCache(flushedEpochs);
-          } else {
-            // cleanup cache.
-            cleanupCache(lastRatisTransactionIndex);
-          }
+          cleanupCache(flushedEpochs);
+
 
           readyBuffer.clear();
 
@@ -218,32 +214,6 @@ public class OzoneManagerDoubleBuffer {
         ExitUtils.terminate(2, s, t, LOG);
       }
     }
-  }
-
-  private void cleanupCache(long lastRatisTransactionIndex) {
-    // As now only volume and bucket transactions are handled only called
-    // cleanupCache on bucketTable.
-    // TODO: After supporting all write operations we need to call
-    //  cleanupCache on the tables only when buffer has entries for that table.
-    omMetadataManager.getBucketTable().cleanupCache(lastRatisTransactionIndex);
-    omMetadataManager.getVolumeTable().cleanupCache(lastRatisTransactionIndex);
-    omMetadataManager.getUserTable().cleanupCache(lastRatisTransactionIndex);
-
-    //TODO: Optimization we can do here is for key transactions we can only
-    // cleanup cache when it is key commit transaction. In this way all
-    // intermediate transactions for a key will be read from in-memory cache.
-    omMetadataManager.getOpenKeyTable().cleanupCache(lastRatisTransactionIndex);
-    omMetadataManager.getKeyTable().cleanupCache(lastRatisTransactionIndex);
-    omMetadataManager.getDeletedTable().cleanupCache(lastRatisTransactionIndex);
-    omMetadataManager.getS3Table().cleanupCache(lastRatisTransactionIndex);
-    omMetadataManager.getMultipartInfoTable().cleanupCache(
-        lastRatisTransactionIndex);
-    omMetadataManager.getS3SecretTable().cleanupCache(
-        lastRatisTransactionIndex);
-    omMetadataManager.getDelegationTokenTable().cleanupCache(
-        lastRatisTransactionIndex);
-    omMetadataManager.getPrefixTable().cleanupCache(lastRatisTransactionIndex);
-
   }
 
   private void cleanupCache(List<Long> lastRatisTransactionIndex) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In OM in non-HA case, the ratisTransactionLogIndex is generated by OmProtocolServersideTranslatorPB.java. And in OM non-HA validateAndUpdateCache is called from multipleHandler threads. So think of a case where one thread which has an index - 10 has added to doubleBuffer. (0-9 still have not added). DoubleBuffer flush thread flushes and call cleanup. (So, now cleanup will go and cleanup all cache entries with less than 10 epoch) This should not have cleanup those which might have put in to cache later and which are in process of flush to DB. This will cause inconsitency for few OM requests.

Example:

4 threads Committing 4 parts.

1st thread - part 1 - ratis Index - 3

2nd thread - part 2 - ratis index - 2

3rd thread - part3 - ratis index - 1

 

First thread got lock, and put in to doubleBuffer and cache with OmMultipartInfo (with part1). And cleanup is called to cleanup all entries in cache with less than 3. In the mean time 2nd thread and 1st thread put 2,3 parts in to OmMultipartInfo in to Cache and doubleBuffer. But first thread might cleanup those entries, as it is called with index 3 for cleanup.

 

Now when the 4th part upload came -> when it is commit Multipart upload when it gets multipartinfo it get Only part1 in OmMultipartInfo, as the OmMultipartInfo (with 1,2,3 is still in process of committing to DB). So now after 4th part upload is complete in DB and Cache we will have 1,4 parts only. We will miss part2,3 information.

 

So for non-HA case cleanup will be called with list of epochs that need to be cleanedup.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2477

## How was this patch tested?

Added UT.
