### PR TITLE
HDDS-2472. Use try-with-resources while creating FlushOptions in RDBStore

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -297,7 +297,9 @@ public class RDBStore implements DBStore {
 
   @Override
   public DBCheckpoint getCheckpoint(boolean flush) throws IOException {
-    this.flush();
+    if (flush) {
+      this.flush();
+    }
     return checkPointManager.createCheckpoint(checkpointsParentDir);
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -286,8 +286,8 @@ public class RDBStore implements DBStore {
 
   @Override
   public void flush() throws IOException {
-    final FlushOptions flushOptions = new FlushOptions().setWaitForFlush(true);
-    try {
+    try (FlushOptions flushOptions = new FlushOptions()) {
+      flushOptions.setWaitForFlush(true);
       db.flush(flushOptions);
     } catch (RocksDBException e) {
       LOG.error("Unable to Flush RocksDB data", e);
@@ -296,13 +296,8 @@ public class RDBStore implements DBStore {
   }
 
   @Override
-  public DBCheckpoint getCheckpoint(boolean flush) {
-    final FlushOptions flushOptions = new FlushOptions().setWaitForFlush(flush);
-    try {
-      db.flush(flushOptions);
-    } catch (RocksDBException e) {
-      LOG.error("Unable to Flush RocksDB data before creating snapshot", e);
-    }
+  public DBCheckpoint getCheckpoint(boolean flush) throws IOException {
+    this.flush();
     return checkPointManager.createCheckpoint(checkpointsParentDir);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use try-with-resources while creating FlushOptions in RDBStore class. Remove code duplication in getCheckpoint method.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2472

## How was this patch tested?
Unit tested.
