### PR TITLE
HDDS-2473. Fix code reliability issues found by Sonar in Ozone Recon module.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerKeyService.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerKeyService.java
@@ -20,11 +20,9 @@ package org.apache.hadoop.ozone.recon.api;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.DefaultValue;
@@ -50,8 +48,6 @@ import org.apache.hadoop.ozone.recon.api.types.KeyMetadata.ContainerBlockMetadat
 import org.apache.hadoop.ozone.recon.api.types.KeysResponse;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.spi.ContainerDBServiceProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.ozone.recon.ReconConstants.FETCH_ALL;
 import static org.apache.hadoop.ozone.recon.ReconConstants.PREV_CONTAINER_ID_DEFAULT_VALUE;
@@ -65,9 +61,6 @@ import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_QUERY_PREVKEY;
 @Path("/containers")
 @Produces(MediaType.APPLICATION_JSON)
 public class ContainerKeyService {
-
-  private static final Logger LOG =
-      LoggerFactory.getLogger(ContainerKeyService.class);
 
   @Inject
   private ContainerDBServiceProvider containerDBServiceProvider;
@@ -169,9 +162,8 @@ public class ContainerKeyService {
           keyMetadataMap.get(ozoneKey).getVersions()
               .add(containerKeyPrefix.getKeyVersion());
 
-          keyMetadataMap.get(ozoneKey).getBlockIds().putAll(
-              Collections.singletonMap(containerKeyPrefix.getKeyVersion(),
-                  blockIds));
+          keyMetadataMap.get(ozoneKey).getBlockIds()
+              .put(containerKeyPrefix.getKeyVersion(), blockIds);
         } else {
           // break the for loop if limit has been reached
           if (keyMetadataMap.size() == limit) {
@@ -186,14 +178,10 @@ public class ContainerKeyService {
           keyMetadata.setModificationTime(
               Instant.ofEpochMilli(omKeyInfo.getModificationTime()));
           keyMetadata.setDataSize(omKeyInfo.getDataSize());
-          keyMetadata.setVersions(new ArrayList<Long>() {{
-              add(containerKeyPrefix.getKeyVersion());
-            }});
+          keyMetadata.getVersions().add(containerKeyPrefix.getKeyVersion());
           keyMetadataMap.put(ozoneKey, keyMetadata);
-          keyMetadata.setBlockIds(new TreeMap<Long,
-              List<ContainerBlockMetadata>>() {{
-              put(containerKeyPrefix.getKeyVersion(), blockIds);
-            }});
+          keyMetadata.getBlockIds().put(containerKeyPrefix.getKeyVersion(),
+              blockIds);
         }
       }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyMetadata.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeyMetadata.java
@@ -18,8 +18,10 @@
 package org.apache.hadoop.ozone.recon.api.types;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -47,10 +49,10 @@ public class KeyMetadata {
   private long dataSize;
 
   @XmlElement(name = "Versions")
-  private List<Long> versions;
+  private List<Long> versions = new ArrayList<>();
 
   @XmlElement(name = "Blocks")
-  private Map<Long, List<ContainerBlockMetadata>> blockIds;
+  private Map<Long, List<ContainerBlockMetadata>> blockIds = new TreeMap<>();
 
   @XmlJavaTypeAdapter(IsoDateAdapter.class)
   @XmlElement(name = "CreationTime")

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -68,7 +68,6 @@ import org.apache.hadoop.hdds.utils.db.RocksDBCheckpoint;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.ratis.protocol.ClientId;
 import org.hadoop.ozone.recon.schema.tables.daos.ReconTaskStatusDao;
 import org.hadoop.ozone.recon.schema.tables.pojos.ReconTaskStatus;
 import org.rocksdb.RocksDB;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Sonarcloud.io has flagged a number of code reliability issues in Ozone recon (https://sonarcloud.io/code?id=hadoop-ozone&selected=hadoop-ozone%3Ahadoop-ozone%2Frecon%2Fsrc%2Fmain%2Fjava%2Forg%2Fapache%2Fhadoop%2Fozone%2Frecon).

Following issues have been fixed.
- Double Brace Initialization should not be used
- Resources should be closed
- InterruptedException should not be ignored

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2473

## How was this patch tested?
Ran unit tests in 'recon' module.