### PR TITLE
HDDS-426. Add field modificationTime for Volume and Bucket

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -280,6 +280,7 @@ public final class OzoneConsts {
   public static final String RESOURCE_TYPE = "resourceType";
   public static final String IS_VERSION_ENABLED = "isVersionEnabled";
   public static final String CREATION_TIME = "creationTime";
+  public static final String MODIFICATION_TIME = "modificationTime";
   public static final String DATA_SIZE = "dataSize";
   public static final String REPLICATION_TYPE = "replicationType";
   public static final String REPLICATION_FACTOR = "replicationFactor";

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.WithMetadata;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
+import org.apache.hadoop.util.Time;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -140,16 +141,31 @@ public class OzoneBucket extends WithMetadata {
   @SuppressWarnings("parameternumber")
   public OzoneBucket(ConfigurationSource conf, ClientProtocol proxy,
       String volumeName, String bucketName, StorageType storageType,
-      Boolean versioning, long creationTime, long modificationTime,
-      Map<String, String> metadata, String encryptionKeyName) {
+      Boolean versioning, long creationTime, Map<String, String> metadata,
+      String encryptionKeyName) {
     this(conf, volumeName, bucketName, null, null, proxy);
     this.storageType = storageType;
     this.versioning = versioning;
     this.listCacheSize = HddsClientUtils.getListCacheSize(conf);
     this.creationTime = Instant.ofEpochMilli(creationTime);
-    this.modificationTime = Instant.ofEpochMilli(modificationTime);
     this.metadata = metadata;
     this.encryptionKeyName = encryptionKeyName;
+    long modificationTime = Time.now();
+    if (modificationTime < creationTime) {
+      this.modificationTime = Instant.ofEpochMilli(creationTime);
+    } else {
+      this.modificationTime = Instant.ofEpochMilli(modificationTime);
+    }
+  }
+
+  @SuppressWarnings("parameternumber")
+  public OzoneBucket(Configuration conf, ClientProtocol proxy,
+      String volumeName, String bucketName, StorageType storageType,
+      Boolean versioning, long creationTime, long modificationTime,
+      Map<String, String> metadata, String encryptionKeyName) {
+    this(conf, proxy, volumeName, bucketName, storageType, versioning,
+        creationTime, metadata, encryptionKeyName);
+    this.modificationTime = Instant.ofEpochMilli(modificationTime);
   }
 
   /**
@@ -161,20 +177,36 @@ public class OzoneBucket extends WithMetadata {
    * @param storageType StorageType of the bucket.
    * @param versioning versioning status of the bucket.
    * @param creationTime creation time of the bucket.
-   * @param modificationTime modification time of the bucket.
    */
   @SuppressWarnings("parameternumber")
   public OzoneBucket(ConfigurationSource conf, ClientProtocol proxy,
       String volumeName, String bucketName, StorageType storageType,
-      Boolean versioning, long creationTime, long modificationTime,
-      Map<String, String> metadata) {
+      Boolean versioning, long creationTime, Map<String, String> metadata) {
     this(conf, volumeName, bucketName, null, null, proxy);
     this.storageType = storageType;
     this.versioning = versioning;
     this.listCacheSize = HddsClientUtils.getListCacheSize(conf);
     this.creationTime = Instant.ofEpochMilli(creationTime);
-    this.modificationTime = Instant.ofEpochMilli(modificationTime);
     this.metadata = metadata;
+    long modificationTime = Time.now();
+    if (modificationTime < creationTime) {
+      this.modificationTime = Instant.ofEpochMilli(creationTime);
+    } else {
+      this.modificationTime = Instant.ofEpochMilli(modificationTime);
+    }
+  }
+
+  /**
+   * @param modificationTime modification time of the bucket.
+   */
+  @SuppressWarnings("parameternumber")
+  public OzoneBucket(Configuration conf, ClientProtocol proxy,
+      String volumeName, String bucketName, StorageType storageType,
+      Boolean versioning, long creationTime, long modificationTime,
+      Map<String, String> metadata) {
+    this(conf, proxy, volumeName, bucketName, storageType, versioning,
+        creationTime, metadata);
+    this.modificationTime = Instant.ofEpochMilli(modificationTime);
   }
 
   @VisibleForTesting
@@ -182,7 +214,7 @@ public class OzoneBucket extends WithMetadata {
   OzoneBucket(String volumeName, String name,
       ReplicationFactor defaultReplication,
       ReplicationType defaultReplicationType, StorageType storageType,
-      Boolean versioning, long creationTime, long modificationTime) {
+      Boolean versioning, long creationTime) {
     this.proxy = null;
     this.volumeName = volumeName;
     this.name = name;
@@ -191,14 +223,18 @@ public class OzoneBucket extends WithMetadata {
     this.storageType = storageType;
     this.versioning = versioning;
     this.creationTime = Instant.ofEpochMilli(creationTime);
-    this.modificationTime = Instant.ofEpochMilli(modificationTime);
     this.ozoneObj = OzoneObjInfo.Builder.newBuilder()
         .setBucketName(name)
         .setVolumeName(volumeName)
         .setResType(OzoneObj.ResourceType.BUCKET)
         .setStoreType(OzoneObj.StoreType.OZONE).build();
+    long modificationTime = Time.now();
+    if (modificationTime < creationTime) {
+      this.modificationTime = Instant.ofEpochMilli(creationTime);
+    } else {
+      this.modificationTime = Instant.ofEpochMilli(modificationTime);
+    }
   }
-
 
   /**
    * Returns Volume Name.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -150,11 +150,11 @@ public class OzoneBucket extends WithMetadata {
     this.creationTime = Instant.ofEpochMilli(creationTime);
     this.metadata = metadata;
     this.encryptionKeyName = encryptionKeyName;
-    long modificationTime = Time.now();
-    if (modificationTime < creationTime) {
+    long modifiedTime = Time.now();
+    if (modifiedTime < creationTime) {
       this.modificationTime = Instant.ofEpochMilli(creationTime);
     } else {
-      this.modificationTime = Instant.ofEpochMilli(modificationTime);
+      this.modificationTime = Instant.ofEpochMilli(modifiedTime);
     }
   }
 
@@ -188,11 +188,11 @@ public class OzoneBucket extends WithMetadata {
     this.listCacheSize = HddsClientUtils.getListCacheSize(conf);
     this.creationTime = Instant.ofEpochMilli(creationTime);
     this.metadata = metadata;
-    long modificationTime = Time.now();
-    if (modificationTime < creationTime) {
+    long modifiedTime = Time.now();
+    if (modifiedTime < creationTime) {
       this.modificationTime = Instant.ofEpochMilli(creationTime);
     } else {
-      this.modificationTime = Instant.ofEpochMilli(modificationTime);
+      this.modificationTime = Instant.ofEpochMilli(modifiedTime);
     }
   }
 
@@ -228,11 +228,11 @@ public class OzoneBucket extends WithMetadata {
         .setVolumeName(volumeName)
         .setResType(OzoneObj.ResourceType.BUCKET)
         .setStoreType(OzoneObj.StoreType.OZONE).build();
-    long modificationTime = Time.now();
-    if (modificationTime < creationTime) {
+    long modifiedTime = Time.now();
+    if (modifiedTime < creationTime) {
       this.modificationTime = Instant.ofEpochMilli(creationTime);
     } else {
-      this.modificationTime = Instant.ofEpochMilli(modificationTime);
+      this.modificationTime = Instant.ofEpochMilli(modifiedTime);
     }
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -159,7 +159,7 @@ public class OzoneBucket extends WithMetadata {
   }
 
   @SuppressWarnings("parameternumber")
-  public OzoneBucket(Configuration conf, ClientProtocol proxy,
+  public OzoneBucket(ConfigurationSource conf, ClientProtocol proxy,
       String volumeName, String bucketName, StorageType storageType,
       Boolean versioning, long creationTime, long modificationTime,
       Map<String, String> metadata, String encryptionKeyName) {
@@ -200,7 +200,7 @@ public class OzoneBucket extends WithMetadata {
    * @param modificationTime modification time of the bucket.
    */
   @SuppressWarnings("parameternumber")
-  public OzoneBucket(Configuration conf, ClientProtocol proxy,
+  public OzoneBucket(ConfigurationSource conf, ClientProtocol proxy,
       String volumeName, String bucketName, StorageType storageType,
       Boolean versioning, long creationTime, long modificationTime,
       Map<String, String> metadata) {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -97,6 +97,11 @@ public class OzoneBucket extends WithMetadata {
   private Instant creationTime;
 
   /**
+   * Modification time of the bucket.
+   */
+  private Instant modificationTime;
+
+  /**
    * Bucket Encryption key name if bucket encryption is enabled.
    */
   private String encryptionKeyName;
@@ -135,13 +140,14 @@ public class OzoneBucket extends WithMetadata {
   @SuppressWarnings("parameternumber")
   public OzoneBucket(ConfigurationSource conf, ClientProtocol proxy,
       String volumeName, String bucketName, StorageType storageType,
-      Boolean versioning, long creationTime, Map<String, String> metadata,
-      String encryptionKeyName) {
+      Boolean versioning, long creationTime, long modificationTime,
+      Map<String, String> metadata, String encryptionKeyName) {
     this(conf, volumeName, bucketName, null, null, proxy);
     this.storageType = storageType;
     this.versioning = versioning;
     this.listCacheSize = HddsClientUtils.getListCacheSize(conf);
     this.creationTime = Instant.ofEpochMilli(creationTime);
+    this.modificationTime = Instant.ofEpochMilli(modificationTime);
     this.metadata = metadata;
     this.encryptionKeyName = encryptionKeyName;
   }
@@ -155,16 +161,19 @@ public class OzoneBucket extends WithMetadata {
    * @param storageType StorageType of the bucket.
    * @param versioning versioning status of the bucket.
    * @param creationTime creation time of the bucket.
+   * @param modificationTime modification time of the bucket.
    */
   @SuppressWarnings("parameternumber")
   public OzoneBucket(ConfigurationSource conf, ClientProtocol proxy,
       String volumeName, String bucketName, StorageType storageType,
-      Boolean versioning, long creationTime, Map<String, String> metadata) {
+      Boolean versioning, long creationTime, long modificationTime,
+      Map<String, String> metadata) {
     this(conf, volumeName, bucketName, null, null, proxy);
     this.storageType = storageType;
     this.versioning = versioning;
     this.listCacheSize = HddsClientUtils.getListCacheSize(conf);
     this.creationTime = Instant.ofEpochMilli(creationTime);
+    this.modificationTime = Instant.ofEpochMilli(modificationTime);
     this.metadata = metadata;
   }
 
@@ -173,7 +182,7 @@ public class OzoneBucket extends WithMetadata {
   OzoneBucket(String volumeName, String name,
       ReplicationFactor defaultReplication,
       ReplicationType defaultReplicationType, StorageType storageType,
-      Boolean versioning, long creationTime) {
+      Boolean versioning, long creationTime, long modificationTime) {
     this.proxy = null;
     this.volumeName = volumeName;
     this.name = name;
@@ -182,6 +191,7 @@ public class OzoneBucket extends WithMetadata {
     this.storageType = storageType;
     this.versioning = versioning;
     this.creationTime = Instant.ofEpochMilli(creationTime);
+    this.modificationTime = Instant.ofEpochMilli(modificationTime);
     this.ozoneObj = OzoneObjInfo.Builder.newBuilder()
         .setBucketName(name)
         .setVolumeName(volumeName)
@@ -243,6 +253,15 @@ public class OzoneBucket extends WithMetadata {
    */
   public Instant getCreationTime() {
     return creationTime;
+  }
+
+  /**
+   * Returns modification time of the Bucket.
+   *
+   * @return modification time of the bucket
+   */
+  public Instant getModificationTime() {
+    return modificationTime;
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -150,11 +150,10 @@ public class OzoneBucket extends WithMetadata {
     this.creationTime = Instant.ofEpochMilli(creationTime);
     this.metadata = metadata;
     this.encryptionKeyName = encryptionKeyName;
-    long modifiedTime = Time.now();
-    if (modifiedTime < creationTime) {
-      this.modificationTime = Instant.ofEpochMilli(creationTime);
-    } else {
-      this.modificationTime = Instant.ofEpochMilli(modifiedTime);
+    modificationTime = Instant.now();
+    if (modificationTime.isBefore(this.creationTime)) {
+      modificationTime = Instant.ofEpochSecond(
+          this.creationTime.getEpochSecond(), this.creationTime.getNano());
     }
   }
 
@@ -188,11 +187,10 @@ public class OzoneBucket extends WithMetadata {
     this.listCacheSize = HddsClientUtils.getListCacheSize(conf);
     this.creationTime = Instant.ofEpochMilli(creationTime);
     this.metadata = metadata;
-    long modifiedTime = Time.now();
-    if (modifiedTime < creationTime) {
-      this.modificationTime = Instant.ofEpochMilli(creationTime);
-    } else {
-      this.modificationTime = Instant.ofEpochMilli(modifiedTime);
+    modificationTime = Instant.now();
+    if (modificationTime.isBefore(this.creationTime)) {
+      modificationTime = Instant.ofEpochSecond(
+          this.creationTime.getEpochSecond(), this.creationTime.getNano());
     }
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
@@ -106,11 +106,11 @@ public class OzoneVolume extends WithMetadata {
     this.acls = acls;
     this.listCacheSize = HddsClientUtils.getListCacheSize(conf);
     this.metadata = metadata;
-    long modificationTime = Time.now();
-    if (modificationTime < creationTime) {
+    long modifiedTime = Time.now();
+    if (modifiedTime < creationTime) {
       this.modificationTime = Instant.ofEpochMilli(creationTime);
     } else {
-      this.modificationTime = Instant.ofEpochMilli(modificationTime);
+      this.modificationTime = Instant.ofEpochMilli(modifiedTime);
     }
   }
 
@@ -133,11 +133,11 @@ public class OzoneVolume extends WithMetadata {
       long creationTime, List<OzoneAcl> acls) {
     this(conf, proxy, name, admin, owner, quotaInBytes, creationTime, acls,
         new HashMap<>());
-    long modificationTime = Time.now();
-    if (modificationTime < creationTime) {
+    long modifiedTime = Time.now();
+    if (modifiedTime < creationTime) {
       this.modificationTime = Instant.ofEpochMilli(creationTime);
     } else {
-      this.modificationTime = Instant.ofEpochMilli(modificationTime);
+      this.modificationTime = Instant.ofEpochMilli(modifiedTime);
     }
   }
 
@@ -160,11 +160,11 @@ public class OzoneVolume extends WithMetadata {
     this.creationTime = Instant.ofEpochMilli(creationTime);
     this.acls = acls;
     this.metadata = new HashMap<>();
-    long modificationTime = Time.now();
-    if (modificationTime < creationTime) {
+    long modifiedTime = Time.now();
+    if (modifiedTime < creationTime) {
       this.modificationTime = Instant.ofEpochMilli(creationTime);
     } else {
-      this.modificationTime = Instant.ofEpochMilli(modificationTime);
+      this.modificationTime = Instant.ofEpochMilli(modifiedTime);
     }
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
@@ -128,8 +128,8 @@ public class OzoneVolume extends WithMetadata {
   }
 
   @SuppressWarnings("parameternumber")
-  public OzoneVolume(ConfigurationSource conf, ClientProtocol proxy, String name,
-      String admin, String owner, long quotaInBytes,
+  public OzoneVolume(ConfigurationSource conf, ClientProtocol proxy,
+      String name, String admin, String owner, long quotaInBytes,
       long creationTime, List<OzoneAcl> acls) {
     this(conf, proxy, name, admin, owner, quotaInBytes, creationTime, acls,
         new HashMap<>());
@@ -142,9 +142,9 @@ public class OzoneVolume extends WithMetadata {
   }
 
   @SuppressWarnings("parameternumber")
-  public OzoneVolume(ConfigurationSourceq conf, ClientProtocol proxy, String name,
-      String admin, String owner, long quotaInBytes, long creationTime,
-      long modificationTime, List<OzoneAcl> acls) {
+  public OzoneVolume(ConfigurationSource conf, ClientProtocol proxy,
+      String name, String admin, String owner, long quotaInBytes,
+      long creationTime, long modificationTime, List<OzoneAcl> acls) {
     this(conf, proxy, name, admin, owner, quotaInBytes, creationTime, acls);
     this.modificationTime = Instant.ofEpochMilli(modificationTime);
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.ozone.om.helpers.WithMetadata;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.util.Time;
 
 /**
  * A class that encapsulates OzoneVolume.
@@ -88,15 +89,13 @@ public class OzoneVolume extends WithMetadata {
    * @param owner Volume owner.
    * @param quotaInBytes Volume quota in bytes.
    * @param creationTime creation time of the volume
-   * @param modificationTime modification time of the volume.
    * @param acls ACLs associated with the volume.
    * @param metadata custom key value metadata.
    */
   @SuppressWarnings("parameternumber")
   public OzoneVolume(ConfigurationSource conf, ClientProtocol proxy,
       String name, String admin, String owner, long quotaInBytes,
-      long creationTime, long modificationTime, List<OzoneAcl> acls,
-      Map<String, String> metadata) {
+      long creationTime, List<OzoneAcl> acls, Map<String, String> metadata) {
     Preconditions.checkNotNull(proxy, "Client proxy is not set.");
     this.proxy = proxy;
     this.name = name;
@@ -104,33 +103,77 @@ public class OzoneVolume extends WithMetadata {
     this.owner = owner;
     this.quotaInBytes = quotaInBytes;
     this.creationTime = Instant.ofEpochMilli(creationTime);
-    this.modificationTime = Instant.ofEpochMilli(modificationTime);
     this.acls = acls;
     this.listCacheSize = HddsClientUtils.getListCacheSize(conf);
     this.metadata = metadata;
+    long modificationTime = Time.now();
+    if (modificationTime < creationTime) {
+      this.modificationTime = Instant.ofEpochMilli(creationTime);
+    } else {
+      this.modificationTime = Instant.ofEpochMilli(modificationTime);
+    }
   }
 
+  /**
+   * @param modificationTime modification time of the volume.
+   */
   @SuppressWarnings("parameternumber")
   public OzoneVolume(ConfigurationSource conf, ClientProtocol proxy,
       String name, String admin, String owner, long quotaInBytes,
-      long creationTime, long modificationTime, List<OzoneAcl> acls) {
+      long creationTime, long modificationTime, List<OzoneAcl> acls,
+      Map<String, String> metadata) {
     this(conf, proxy, name, admin, owner, quotaInBytes,
-        creationTime, modificationTime, acls, new HashMap<>());
+        creationTime, acls, metadata);
+    this.modificationTime = Instant.ofEpochMilli(modificationTime);
+  }
+
+  @SuppressWarnings("parameternumber")
+  public OzoneVolume(ConfigurationSource conf, ClientProtocol proxy, String name,
+      String admin, String owner, long quotaInBytes,
+      long creationTime, List<OzoneAcl> acls) {
+    this(conf, proxy, name, admin, owner, quotaInBytes, creationTime, acls,
+        new HashMap<>());
+    long modificationTime = Time.now();
+    if (modificationTime < creationTime) {
+      this.modificationTime = Instant.ofEpochMilli(creationTime);
+    } else {
+      this.modificationTime = Instant.ofEpochMilli(modificationTime);
+    }
+  }
+
+  @SuppressWarnings("parameternumber")
+  public OzoneVolume(ConfigurationSourceq conf, ClientProtocol proxy, String name,
+      String admin, String owner, long quotaInBytes, long creationTime,
+      long modificationTime, List<OzoneAcl> acls) {
+    this(conf, proxy, name, admin, owner, quotaInBytes, creationTime, acls);
+    this.modificationTime = Instant.ofEpochMilli(modificationTime);
   }
 
   @VisibleForTesting
   protected OzoneVolume(String name, String admin, String owner,
-      long quotaInBytes, long creationTime,
-      long modificationTime, List<OzoneAcl> acls) {
+      long quotaInBytes, long creationTime, List<OzoneAcl> acls) {
     this.proxy = null;
     this.name = name;
     this.admin = admin;
     this.owner = owner;
     this.quotaInBytes = quotaInBytes;
     this.creationTime = Instant.ofEpochMilli(creationTime);
-    this.modificationTime = Instant.ofEpochMilli(modificationTime);
     this.acls = acls;
     this.metadata = new HashMap<>();
+    long modificationTime = Time.now();
+    if (modificationTime < creationTime) {
+      this.modificationTime = Instant.ofEpochMilli(creationTime);
+    } else {
+      this.modificationTime = Instant.ofEpochMilli(modificationTime);
+    }
+  }
+
+  @VisibleForTesting
+  protected OzoneVolume(String name, String admin, String owner,
+      long quotaInBytes, long creationTime, long modificationTime,
+      List<OzoneAcl> acls) {
+    this(name, admin, owner, quotaInBytes, creationTime, acls);
+    this.modificationTime = Instant.ofEpochMilli(modificationTime);
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
@@ -69,6 +69,10 @@ public class OzoneVolume extends WithMetadata {
    */
   private Instant creationTime;
   /**
+   * Modification time of the volume.
+   */
+  private Instant modificationTime;
+  /**
    * Volume ACLs.
    */
   private List<OzoneAcl> acls;
@@ -84,14 +88,14 @@ public class OzoneVolume extends WithMetadata {
    * @param owner Volume owner.
    * @param quotaInBytes Volume quota in bytes.
    * @param creationTime creation time of the volume
+   * @param modificationTime modification time of the volume.
    * @param acls ACLs associated with the volume.
    * @param metadata custom key value metadata.
    */
   @SuppressWarnings("parameternumber")
   public OzoneVolume(ConfigurationSource conf, ClientProtocol proxy,
-      String name,
-      String admin, String owner, long quotaInBytes,
-      long creationTime, List<OzoneAcl> acls,
+      String name, String admin, String owner, long quotaInBytes,
+      long creationTime, long modificationTime, List<OzoneAcl> acls,
       Map<String, String> metadata) {
     Preconditions.checkNotNull(proxy, "Client proxy is not set.");
     this.proxy = proxy;
@@ -100,6 +104,7 @@ public class OzoneVolume extends WithMetadata {
     this.owner = owner;
     this.quotaInBytes = quotaInBytes;
     this.creationTime = Instant.ofEpochMilli(creationTime);
+    this.modificationTime = Instant.ofEpochMilli(modificationTime);
     this.acls = acls;
     this.listCacheSize = HddsClientUtils.getListCacheSize(conf);
     this.metadata = metadata;
@@ -107,23 +112,23 @@ public class OzoneVolume extends WithMetadata {
 
   @SuppressWarnings("parameternumber")
   public OzoneVolume(ConfigurationSource conf, ClientProtocol proxy,
-      String name,
-      String admin, String owner, long quotaInBytes,
-      long creationTime, List<OzoneAcl> acls) {
-    this(conf, proxy, name, admin, owner, quotaInBytes, creationTime, acls,
-        new HashMap<>());
+      String name, String admin, String owner, long quotaInBytes,
+      long creationTime, long modificationTime, List<OzoneAcl> acls) {
+    this(conf, proxy, name, admin, owner, quotaInBytes,
+        creationTime, modificationTime, acls, new HashMap<>());
   }
 
   @VisibleForTesting
   protected OzoneVolume(String name, String admin, String owner,
-      long quotaInBytes,
-      long creationTime, List<OzoneAcl> acls) {
+      long quotaInBytes, long creationTime,
+      long modificationTime, List<OzoneAcl> acls) {
     this.proxy = null;
     this.name = name;
     this.admin = admin;
     this.owner = owner;
     this.quotaInBytes = quotaInBytes;
     this.creationTime = Instant.ofEpochMilli(creationTime);
+    this.modificationTime = Instant.ofEpochMilli(modificationTime);
     this.acls = acls;
     this.metadata = new HashMap<>();
   }
@@ -171,6 +176,15 @@ public class OzoneVolume extends WithMetadata {
    */
   public Instant getCreationTime() {
     return creationTime;
+  }
+
+  /**
+   * Returns modification time of the volume.
+   *
+   * @return modification time.
+   */
+  public Instant getModificationTime() {
+    return modificationTime;
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.ozone.om.helpers.WithMetadata;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import org.apache.hadoop.util.Time;
 
 /**
  * A class that encapsulates OzoneVolume.
@@ -106,11 +105,10 @@ public class OzoneVolume extends WithMetadata {
     this.acls = acls;
     this.listCacheSize = HddsClientUtils.getListCacheSize(conf);
     this.metadata = metadata;
-    long modifiedTime = Time.now();
-    if (modifiedTime < creationTime) {
-      this.modificationTime = Instant.ofEpochMilli(creationTime);
-    } else {
-      this.modificationTime = Instant.ofEpochMilli(modifiedTime);
+    modificationTime = Instant.now();
+    if (modificationTime.isBefore(this.creationTime)) {
+      modificationTime = Instant.ofEpochSecond(
+          this.creationTime.getEpochSecond(), this.creationTime.getNano());
     }
   }
 
@@ -133,11 +131,10 @@ public class OzoneVolume extends WithMetadata {
       long creationTime, List<OzoneAcl> acls) {
     this(conf, proxy, name, admin, owner, quotaInBytes, creationTime, acls,
         new HashMap<>());
-    long modifiedTime = Time.now();
-    if (modifiedTime < creationTime) {
-      this.modificationTime = Instant.ofEpochMilli(creationTime);
-    } else {
-      this.modificationTime = Instant.ofEpochMilli(modifiedTime);
+    modificationTime = Instant.now();
+    if (modificationTime.isBefore(this.creationTime)) {
+      modificationTime = Instant.ofEpochSecond(
+          this.creationTime.getEpochSecond(), this.creationTime.getNano());
     }
   }
 
@@ -160,11 +157,10 @@ public class OzoneVolume extends WithMetadata {
     this.creationTime = Instant.ofEpochMilli(creationTime);
     this.acls = acls;
     this.metadata = new HashMap<>();
-    long modifiedTime = Time.now();
-    if (modifiedTime < creationTime) {
-      this.modificationTime = Instant.ofEpochMilli(creationTime);
-    } else {
-      this.modificationTime = Instant.ofEpochMilli(modifiedTime);
+    modificationTime = Instant.now();
+    if (modificationTime.isBefore(this.creationTime)) {
+      modificationTime = Instant.ofEpochSecond(
+          this.creationTime.getEpochSecond(), this.creationTime.getNano());
     }
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -345,6 +345,7 @@ public class RpcClient implements ClientProtocol {
         volume.getOwnerName(),
         volume.getQuotaInBytes(),
         volume.getCreationTime(),
+        volume.getModificationTime(),
         volume.getAclMap().ozoneAclGetProtobuf().stream().
             map(OzoneAcl::fromProtobuf).collect(Collectors.toList()),
         volume.getMetadata());
@@ -377,6 +378,7 @@ public class RpcClient implements ClientProtocol {
         volume.getOwnerName(),
         volume.getQuotaInBytes(),
         volume.getCreationTime(),
+        volume.getModificationTime(),
         volume.getAclMap().ozoneAclGetProtobuf().stream().
             map(OzoneAcl::fromProtobuf).collect(Collectors.toList())))
         .collect(Collectors.toList());
@@ -397,6 +399,7 @@ public class RpcClient implements ClientProtocol {
         volume.getOwnerName(),
         volume.getQuotaInBytes(),
         volume.getCreationTime(),
+        volume.getModificationTime(),
         volume.getAclMap().ozoneAclGetProtobuf().stream().
             map(OzoneAcl::fromProtobuf).collect(Collectors.toList()),
         volume.getMetadata()))
@@ -604,6 +607,7 @@ public class RpcClient implements ClientProtocol {
         bucketInfo.getStorageType(),
         bucketInfo.getIsVersionEnabled(),
         bucketInfo.getCreationTime(),
+        bucketInfo.getModificationTime(),
         bucketInfo.getMetadata(),
         bucketInfo.getEncryptionKeyInfo() != null ? bucketInfo
             .getEncryptionKeyInfo().getKeyName() : null);
@@ -624,6 +628,7 @@ public class RpcClient implements ClientProtocol {
         bucket.getStorageType(),
         bucket.getIsVersionEnabled(),
         bucket.getCreationTime(),
+        bucket.getModificationTime(),
         bucket.getMetadata(),
         bucket.getEncryptionKeyInfo() != null ? bucket
             .getEncryptionKeyInfo().getKeyName() : null))

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -66,6 +66,20 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
    * Creation time of bucket.
    */
   private final long creationTime;
+  /**
+   * modification time of bucket.
+   */
+  private long modificationTime;
+  /**
+   * ObjectIDs are unique and immutable identifier for each object in the
+   * System.
+   */
+  private long objectID;
+  /**
+   * UpdateIDs are monotonically increasing values which are updated
+   * each time there is an update.
+   */
+  private long updateID;
 
   /**
    * Bucket encryption key info if encryption is enabled.
@@ -80,6 +94,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
    * @param isVersionEnabled - Bucket version flag.
    * @param storageType - Storage type to be used.
    * @param creationTime - Bucket creation time.
+   * @param modificationTime - Bucket modification time.
    * @param metadata - metadata.
    * @param bekInfo - bucket encryption key info.
    */
@@ -90,6 +105,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
                        boolean isVersionEnabled,
                        StorageType storageType,
                        long creationTime,
+                       long modificationTime,
                        long objectID,
                        long updateID,
                        Map<String, String> metadata,
@@ -100,6 +116,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
     this.isVersionEnabled = isVersionEnabled;
     this.storageType = storageType;
     this.creationTime = creationTime;
+    this.modificationTime = modificationTime;
     this.objectID = objectID;
     this.updateID = updateID;
     this.metadata = metadata;
@@ -185,6 +202,30 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
   }
 
   /**
+   * Returns modification time.
+   * @return long
+   */
+  public long getModificationTime() {
+    return modificationTime;
+  }
+
+  /**
+   * Returns objectID.
+   * @return long
+   */
+  public long getObjectID() {
+    return objectID;
+  }
+
+  /**
+   * Returns updateID.
+   * @return long
+   */
+  public long getUpdateID() {
+    return updateID;
+  }
+
+  /**
    * Returns bucket encryption key info.
    * @return bucket encryption key info
    */
@@ -217,6 +258,8 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
     auditMap.put(OzoneConsts.CREATION_TIME, String.valueOf(this.creationTime));
     auditMap.put(OzoneConsts.BUCKET_ENCRYPTION_KEY,
         (bekInfo != null) ? bekInfo.getKeyName() : null);
+    auditMap.put(OzoneConsts.MODIFICATION_TIME,
+        String.valueOf(this.modificationTime));
     return auditMap;
   }
 
@@ -230,6 +273,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
         .setStorageType(storageType)
         .setIsVersionEnabled(isVersionEnabled)
         .setCreationTime(creationTime)
+        .setModificationTime(modificationTime)
         .setObjectID(objectID)
         .setUpdateID(updateID)
         .setBucketEncryptionKey(bekInfo != null ?
@@ -257,6 +301,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
     private Boolean isVersionEnabled;
     private StorageType storageType;
     private long creationTime;
+    private long modificationTime;
     private long objectID;
     private long updateID;
     private Map<String, String> metadata;
@@ -309,6 +354,11 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
       return this;
     }
 
+    public Builder setModificationTime(long modifiedOn) {
+      this.modificationTime = modifiedOn;
+      return this;
+    }
+
     public Builder setObjectID(long obId) {
       this.objectID = obId;
       return this;
@@ -349,7 +399,8 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
       Preconditions.checkNotNull(storageType);
 
       return new OmBucketInfo(volumeName, bucketName, acls, isVersionEnabled,
-          storageType, creationTime, objectID, updateID, metadata, bekInfo);
+          storageType, creationTime, modificationTime, objectID, updateID,
+          metadata, bekInfo);
     }
   }
 
@@ -364,6 +415,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
         .setIsVersionEnabled(isVersionEnabled)
         .setStorageType(storageType.toProto())
         .setCreationTime(creationTime)
+        .setModificationTime(modificationTime)
         .setObjectID(objectID)
         .setUpdateID(updateID)
         .addAllMetadata(KeyValueUtil.toProtobuf(metadata));
@@ -386,7 +438,8 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
             OzoneAcl::fromProtobuf).collect(Collectors.toList()))
         .setIsVersionEnabled(bucketInfo.getIsVersionEnabled())
         .setStorageType(StorageType.valueOf(bucketInfo.getStorageType()))
-        .setCreationTime(bucketInfo.getCreationTime());
+        .setCreationTime(bucketInfo.getCreationTime())
+        .setModificationTime(bucketInfo.getModificationTime());
     if (bucketInfo.hasObjectID()) {
       obib.setObjectID(bucketInfo.getObjectID());
     }
@@ -424,6 +477,7 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
     }
     OmBucketInfo that = (OmBucketInfo) o;
     return creationTime == that.creationTime &&
+        modificationTime == that.modificationTime &&
         volumeName.equals(that.volumeName) &&
         bucketName.equals(that.bucketName) &&
         Objects.equals(acls, that.acls) &&

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -70,16 +70,6 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
    * modification time of bucket.
    */
   private long modificationTime;
-  /**
-   * ObjectIDs are unique and immutable identifier for each object in the
-   * System.
-   */
-  private long objectID;
-  /**
-   * UpdateIDs are monotonically increasing values which are updated
-   * each time there is an update.
-   */
-  private long updateID;
 
   /**
    * Bucket encryption key info if encryption is enabled.
@@ -209,21 +199,6 @@ public final class OmBucketInfo extends WithObjectID implements Auditable {
     return modificationTime;
   }
 
-  /**
-   * Returns objectID.
-   * @return long
-   */
-  public long getObjectID() {
-    return objectID;
-  }
-
-  /**
-   * Returns updateID.
-   * @return long
-   */
-  public long getUpdateID() {
-    return updateID;
-  }
 
   /**
    * Returns bucket encryption key info.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmVolumeArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmVolumeArgs.java
@@ -42,6 +42,7 @@ public final class OmVolumeArgs extends WithObjectID implements Auditable {
   private String ownerName;
   private final String volume;
   private long creationTime;
+  private long modificationTime;
   private long quotaInBytes;
   private final OmOzoneAclMap aclMap;
 
@@ -62,8 +63,8 @@ public final class OmVolumeArgs extends WithObjectID implements Auditable {
       "builder."})
   private OmVolumeArgs(String adminName, String ownerName, String volume,
                        long quotaInBytes, Map<String, String> metadata,
-                       OmOzoneAclMap aclMap, long creationTime, long objectID,
-                      long updateID) {
+                       OmOzoneAclMap aclMap, long creationTime,
+                       long modificationTime, long objectID, long updateID) {
     this.adminName = adminName;
     this.ownerName = ownerName;
     this.volume = volume;
@@ -71,6 +72,7 @@ public final class OmVolumeArgs extends WithObjectID implements Auditable {
     this.metadata = metadata;
     this.aclMap = aclMap;
     this.creationTime = creationTime;
+    this.modificationTime = modificationTime;
     this.objectID = objectID;
     this.updateID = updateID;
   }
@@ -86,6 +88,10 @@ public final class OmVolumeArgs extends WithObjectID implements Auditable {
 
   public void setCreationTime(long time) {
     this.creationTime = time;
+  }
+
+  public void setModificationTime(long time) {
+    this.modificationTime = time;
   }
 
   public void addAcl(OzoneAcl acl) throws OMException {
@@ -133,6 +139,14 @@ public final class OmVolumeArgs extends WithObjectID implements Auditable {
   }
 
   /**
+   * Returns modification time.
+   * @return long
+   */
+  public long getModificationTime() {
+    return modificationTime;
+  }
+
+  /**
    * Returns Quota in Bytes.
    * @return long, Quota in bytes.
    */
@@ -159,6 +173,8 @@ public final class OmVolumeArgs extends WithObjectID implements Auditable {
     auditMap.put(OzoneConsts.OWNER, this.ownerName);
     auditMap.put(OzoneConsts.VOLUME, this.volume);
     auditMap.put(OzoneConsts.CREATION_TIME, String.valueOf(this.creationTime));
+    auditMap.put(OzoneConsts.MODIFICATION_TIME,
+        String.valueOf(this.modificationTime));
     auditMap.put(OzoneConsts.QUOTA_IN_BYTES, String.valueOf(this.quotaInBytes));
     auditMap.put(OzoneConsts.OBJECT_ID, String.valueOf(this.getObjectID()));
     auditMap.put(OzoneConsts.UPDATE_ID, String.valueOf(this.getUpdateID()));
@@ -190,6 +206,7 @@ public final class OmVolumeArgs extends WithObjectID implements Auditable {
     private String ownerName;
     private String volume;
     private long creationTime;
+    private long modificationTime;
     private long quotaInBytes;
     private Map<String, String> metadata;
     private OmOzoneAclMap aclMap;
@@ -245,6 +262,11 @@ public final class OmVolumeArgs extends WithObjectID implements Auditable {
       return this;
     }
 
+    public Builder setModificationTime(long modifiedOn) {
+      this.modificationTime = modifiedOn;
+      return this;
+    }
+
     public Builder setQuotaInBytes(long quota) {
       this.quotaInBytes = quota;
       return this;
@@ -276,7 +298,7 @@ public final class OmVolumeArgs extends WithObjectID implements Auditable {
       Preconditions.checkNotNull(ownerName);
       Preconditions.checkNotNull(volume);
       return new OmVolumeArgs(adminName, ownerName, volume, quotaInBytes,
-          metadata, aclMap, creationTime, objectID, updateID);
+          metadata, aclMap, creationTime, modificationTime, objectID, updateID);
     }
 
   }
@@ -292,6 +314,7 @@ public final class OmVolumeArgs extends WithObjectID implements Auditable {
         .addAllVolumeAcls(aclList)
         .setCreationTime(
             creationTime == 0 ? System.currentTimeMillis() : creationTime)
+        .setModificationTime(modificationTime)
         .setObjectID(objectID)
         .setUpdateID(updateID)
         .build();
@@ -309,6 +332,7 @@ public final class OmVolumeArgs extends WithObjectID implements Auditable {
         KeyValueUtil.getFromProtobuf(volInfo.getMetadataList()),
         aclMap,
         volInfo.getCreationTime(),
+        volInfo.getModificationTime(),
         volInfo.getObjectID(),
         volInfo.getUpdateID());
   }
@@ -336,6 +360,7 @@ public final class OmVolumeArgs extends WithObjectID implements Auditable {
     OmOzoneAclMap cloneAclMap = aclMap.copyObject();
 
     return new OmVolumeArgs(adminName, ownerName, volume, quotaInBytes,
-        cloneMetadata, cloneAclMap, creationTime, objectID, updateID);
+        cloneMetadata, cloneAclMap, creationTime, modificationTime,
+        objectID, updateID);
   }
 }

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -346,6 +346,7 @@ message VolumeInfo {
     optional uint64 creationTime = 7;
     optional uint64 objectID = 8;
     optional uint64 updateID = 9;
+    optional uint64 modificationTime = 10;
 }
 
 /**
@@ -403,6 +404,7 @@ message SetVolumePropertyRequest {
     required string volumeName = 1;
     optional string ownerName = 2;
     optional uint64 quotaInBytes = 3;
+    optional uint64 modificationTime = 4;
 }
 
 message SetVolumePropertyResponse {
@@ -478,6 +480,7 @@ message BucketInfo {
     optional BucketEncryptionInfoProto beinfo = 8;
     optional uint64 objectID = 9;
     optional uint64 updateID = 10;
+    optional uint64 modificationTime = 11;
 }
 
 enum StorageTypeProto {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -104,8 +104,10 @@ public class OMBucketCreateRequest extends OMClientRequest {
 
     BucketInfo.Builder newBucketInfo = bucketInfo.toBuilder();
 
-    // Set creation time.
-    newBucketInfo.setCreationTime(Time.now());
+    // Set creation time & modification time.
+    long initialTime = Time.now();
+    newBucketInfo.setCreationTime(initialTime)
+        .setModificationTime(initialTime);
 
     if (bucketInfo.hasBeinfo()) {
       newBucketInfo.setBeinfo(getBeinfo(kmsProvider, bucketInfo));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
@@ -79,7 +79,6 @@ public class OMVolumeCreateRequest extends OMVolumeRequest {
     // Set creation time & set modification time
     long initialTime = Time.now();
     VolumeInfo updatedVolumeInfo =
-        volumeInfo.toBuilder().setCreationTime(Time.now()).build();
         volumeInfo.toBuilder()
             .setCreationTime(initialTime)
             .setModificationTime(initialTime)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
@@ -76,9 +76,14 @@ public class OMVolumeCreateRequest extends OMVolumeRequest {
     // Verify resource name
     OmUtils.validateVolumeName(volumeInfo.getVolume());
 
-    // Set creation time
+    // Set creation time & set modification time
+    long initialTime = Time.now();
     VolumeInfo updatedVolumeInfo =
         volumeInfo.toBuilder().setCreationTime(Time.now()).build();
+        volumeInfo.toBuilder()
+            .setCreationTime(initialTime)
+            .setModificationTime(initialTime)
+            .build();
 
     return getOmRequest().toBuilder().setCreateVolumeRequest(
         CreateVolumeRequest.newBuilder().setVolumeInfo(updatedVolumeInfo))

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetOwnerRequest.java
@@ -84,7 +84,6 @@ public class OMVolumeSetOwnerRequest extends OMVolumeRequest {
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
       long transactionLogIndex,
       OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper) {
-
     SetVolumePropertyRequest setVolumePropertyRequest =
         getOmRequest().getSetVolumePropertyRequest();
     Preconditions.checkNotNull(setVolumePropertyRequest);
@@ -149,7 +148,6 @@ public class OMVolumeSetOwnerRequest extends OMVolumeRequest {
             transactionLogIndex, setVolumePropertyRequest);
         return new OMVolumeSetOwnerResponse(createReplayOMResponse(omResponse));
       }
-
       oldOwner = omVolumeArgs.getOwnerName();
 
       // Return OK immediately if newOwner is the same as oldOwner.
@@ -203,7 +201,6 @@ public class OMVolumeSetOwnerRequest extends OMVolumeRequest {
           SetVolumePropertyResponse.newBuilder().setResponse(true).build());
       omClientResponse = new OMVolumeSetOwnerResponse(omResponse.build(),
           oldOwner, oldOwnerVolumeList, newOwnerVolumeList, omVolumeArgs);
-
     } catch (IOException ex) {
       exception = ex;
       omClientResponse = new OMVolumeSetOwnerResponse(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -350,7 +350,7 @@ public final class TestOMRequestUtils {
       String newOwner) {
     SetVolumePropertyRequest setVolumePropertyRequest =
         SetVolumePropertyRequest.newBuilder().setVolumeName(volumeName)
-            .setOwnerName(newOwner).build();
+            .setOwnerName(newOwner).setModificationTime(Time.now()).build();
 
     return OMRequest.newBuilder().setClientId(UUID.randomUUID().toString())
         .setCmdType(OzoneManagerProtocolProtos.Type.SetVolumeProperty)
@@ -368,7 +368,7 @@ public final class TestOMRequestUtils {
       long quota) {
     SetVolumePropertyRequest setVolumePropertyRequest =
         SetVolumePropertyRequest.newBuilder().setVolumeName(volumeName)
-            .setQuotaInBytes(quota).build();
+            .setQuotaInBytes(quota).setModificationTime(Time.now()).build();
 
     return OMRequest.newBuilder().setClientId(UUID.randomUUID().toString())
         .setCmdType(OzoneManagerProtocolProtos.Type.SetVolumeProperty)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
@@ -168,6 +168,8 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
 
     Assert.assertEquals(bucketInfoFromProto.getCreationTime(),
         dbBucketInfo.getCreationTime());
+    Assert.assertEquals(bucketInfoFromProto.getModificationTime(),
+        dbBucketInfo.getModificationTime());
     Assert.assertEquals(bucketInfoFromProto.getAcls(),
         dbBucketInfo.getAcls());
     Assert.assertEquals(bucketInfoFromProto.getIsVersionEnabled(),

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
@@ -241,6 +241,8 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
         updated.getOwnerName());
     Assert.assertNotEquals(original.getCreationTime(),
         updated.getCreationTime());
+    Assert.assertNotEquals(original.getModificationTime(),
+        updated.getModificationTime());
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
@@ -139,6 +139,11 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
     Assert.assertEquals(expectedObjId, omVolumeArgs.getObjectID());
     Assert.assertEquals(txLogIndex, omVolumeArgs.getUpdateID());
 
+    // Initial modificationTime should be equal to creationTime.
+    long creationTime = omVolumeArgs.getCreationTime();
+    long modificationTime = omVolumeArgs.getModificationTime();
+    Assert.assertEquals(creationTime, modificationTime);
+
     // Check data from table and request.
     Assert.assertEquals(volumeInfo.getVolume(), omVolumeArgs.getVolume());
     Assert.assertEquals(volumeInfo.getOwnerName(), omVolumeArgs.getOwnerName());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetOwnerRequest.java
@@ -92,6 +92,13 @@ public class TestOMVolumeSetOwnerRequest extends TestOMVolumeRequest {
         .getVolumeTable().get(volumeKey).getOwnerName();
     Assert.assertEquals(newOwner, fromDBOwner);
 
+    // modificationTime should be greater than creationTime.
+    long creationTime = omMetadataManager.getVolumeTable()
+        .get(volumeKey).getCreationTime();
+    long modificationTime = omMetadataManager.getVolumeTable()
+        .get(volumeKey).getModificationTime();
+    Assert.assertTrue(modificationTime > creationTime);
+
 
     OzoneManagerProtocolProtos.UserVolumeInfo newOwnerVolumeList =
         omMetadataManager.getUserTable().get(newOwnerKey);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetQuotaRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetQuotaRequest.java
@@ -92,6 +92,13 @@ public class TestOMVolumeSetQuotaRequest extends TestOMVolumeRequest {
         .getVolumeTable().get(volumeKey).getQuotaInBytes();
     Assert.assertEquals(quotaSet, quotaAfterSet);
     Assert.assertNotEquals(quotaBeforeSet, quotaAfterSet);
+
+    // modificationTime should be greater than creationTime.
+    long creationTime = omMetadataManager
+        .getVolumeTable().get(volumeKey).getCreationTime();
+    long modificationTime = omMetadataManager
+        .getVolumeTable().get(volumeKey).getModificationTime();
+    Assert.assertTrue(modificationTime > creationTime);
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ObjectStoreStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ObjectStoreStub.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.util.Time;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_EMPTY;
@@ -61,12 +62,14 @@ public class ObjectStoreStub extends ObjectStore {
   @Override
   public void createVolume(String volumeName, VolumeArgs volumeArgs)
       throws IOException {
+    long initialTime = Time.now();
     OzoneVolumeStub volume =
         new OzoneVolumeStub(volumeName,
             volumeArgs.getAdmin(),
             volumeArgs.getOwner(),
             Long.parseLong(volumeArgs.getQuota()),
-            System.currentTimeMillis(),
+            initialTime,
+            initialTime,
             volumeArgs.getAcls());
     volumes.put(volumeName, volume);
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ObjectStoreStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ObjectStoreStub.java
@@ -60,16 +60,13 @@ public class ObjectStoreStub extends ObjectStore {
   }
 
   @Override
-  public void createVolume(String volumeName, VolumeArgs volumeArgs)
-      throws IOException {
-    long initialTime = Time.now();
+  public void createVolume(String volumeName, VolumeArgs volumeArgs) {
     OzoneVolumeStub volume =
         new OzoneVolumeStub(volumeName,
             volumeArgs.getAdmin(),
             volumeArgs.getOwner(),
             Long.parseLong(volumeArgs.getQuota()),
-            initialTime,
-            initialTime,
+            Time.now(),
             volumeArgs.getAcls());
     volumes.put(volumeName, volume);
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -65,19 +65,21 @@ public class OzoneBucketStub extends OzoneBucket {
    * @param storageType  StorageType of the bucket.
    * @param versioning   versioning status of the bucket.
    * @param creationTime creation time of the bucket.
+   * @param modificationTime modification time of the bucket.
    */
   public OzoneBucketStub(
       String volumeName,
       String bucketName,
       StorageType storageType, Boolean versioning,
-      long creationTime) {
+      long creationTime, long modificationTime) {
     super(volumeName,
         bucketName,
         ReplicationFactor.ONE,
         ReplicationType.STAND_ALONE,
         storageType,
         versioning,
-        creationTime);
+        creationTime,
+        modificationTime);
   }
 
   @Override

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -65,21 +65,19 @@ public class OzoneBucketStub extends OzoneBucket {
    * @param storageType  StorageType of the bucket.
    * @param versioning   versioning status of the bucket.
    * @param creationTime creation time of the bucket.
-   * @param modificationTime modification time of the bucket.
    */
   public OzoneBucketStub(
       String volumeName,
       String bucketName,
       StorageType storageType, Boolean versioning,
-      long creationTime, long modificationTime) {
+      long creationTime) {
     super(volumeName,
         bucketName,
         ReplicationFactor.ONE,
         ReplicationType.STAND_ALONE,
         storageType,
         versioning,
-        creationTime,
-        modificationTime);
+        creationTime);
   }
 
   @Override

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneVolumeStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneVolumeStub.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.util.Time;
 
 /**
  * Ozone volume with in-memory state for testing.
@@ -38,9 +39,10 @@ public class OzoneVolumeStub extends OzoneVolume {
   private Map<String, OzoneBucketStub> buckets = new HashMap<>();
 
   public OzoneVolumeStub(String name, String admin, String owner,
-      long quotaInBytes,
-      long creationTime, List<OzoneAcl> acls) {
-    super(name, admin, owner, quotaInBytes, creationTime, acls);
+      long quotaInBytes, long creationTime,
+      long modificationTime, List<OzoneAcl> acls) {
+    super(name, admin, owner, quotaInBytes,
+        creationTime, modificationTime, acls);
   }
 
   @Override
@@ -53,13 +55,13 @@ public class OzoneVolumeStub extends OzoneVolume {
 
   @Override
   public void createBucket(String bucketName, BucketArgs bucketArgs) {
+    long initialTime = Time.now();
     buckets.put(bucketName, new OzoneBucketStub(
         getName(),
         bucketName,
         bucketArgs.getStorageType(),
         bucketArgs.getVersioning(),
-        System.currentTimeMillis()));
-
+        initialTime, initialTime));
   }
 
   @Override

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneVolumeStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneVolumeStub.java
@@ -39,10 +39,9 @@ public class OzoneVolumeStub extends OzoneVolume {
   private Map<String, OzoneBucketStub> buckets = new HashMap<>();
 
   public OzoneVolumeStub(String name, String admin, String owner,
-      long quotaInBytes, long creationTime,
-      long modificationTime, List<OzoneAcl> acls) {
+      long quotaInBytes, long creationTime, List<OzoneAcl> acls) {
     super(name, admin, owner, quotaInBytes,
-        creationTime, modificationTime, acls);
+        creationTime, acls);
   }
 
   @Override
@@ -55,13 +54,12 @@ public class OzoneVolumeStub extends OzoneVolume {
 
   @Override
   public void createBucket(String bucketName, BucketArgs bucketArgs) {
-    long initialTime = Time.now();
     buckets.put(bucketName, new OzoneBucketStub(
         getName(),
         bucketName,
         bucketArgs.getStorageType(),
         bucketArgs.getVersioning(),
-        initialTime, initialTime));
+        Time.now()));
   }
 
   @Override

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/UpdateVolumeHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/UpdateVolumeHandler.java
@@ -63,6 +63,8 @@ public class UpdateVolumeHandler extends VolumeHandler {
       }
     }
 
-    printObjectAsJson(volume);
+    // For printing newer modificationTime.
+    OzoneVolume updatedVolume = client.getObjectStore().getVolume(volumeName);
+    printObjectAsJson(updatedVolume);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
We would update the `modificationTime` of `volume` when
- `volume create`
- `volume update (set owner/quota)`

And we would update the `modificationTime` of `bucket` when
- `bucket create`

So we focus on these items.
#### Proposed fix.
This PR aims to add filed of `modificationTime` to volume and bucket.

For volume part, besides adding field in volume, we have 3 requests to be fixed that are
`OMVolumeCreateRequest`, `OMVolumeSetOwnerRequest` and `OMVolumeSetQuotaRequest`.

Because `modificationTime` should be consistent among OM, 
we refer [Handling Write Requests with OM HA](https://issues.apache.org/jira/secure/attachment/12973260/Handling%20Write%20Requests%20with%20OM%20HA.pdf) to fix these requests. (By setting `modificationTime` in `preExecute()`, and using it for late validation.)

- note
After setting Owner/Quota of volume, the original `UpdateVolumeHandler` would print old `modificationTime` cause its volume is not updated volume(just updated owner/quota).
We should get volume again for getting newer `modification`.

For bucket part, we should fix `OMBucketCreateRequest`.
And for consistent,
we set `modificationTime` of creating bucket in `OMBucketCreateRequest#preExecute()`.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-426

## How was this patch tested?
- [Github Actions](https://github.com/apache/hadoop-ozone/runs/417809068)
- `modificationTime` field snapshots uploaded in [JIRA](https://issues.apache.org/jira/browse/HDDS-426
).