### PR TITLE
HDDS-2481. Close streams in TarContainerPacker

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
@@ -88,7 +88,7 @@ public class TarContainerPacker
           Path destinationPath = chunksRoot
               .resolve(name.substring(CHUNKS_DIR_NAME.length() + 1));
           extractEntry(archiveInput, size, chunksRoot, destinationPath);
-        } else if (name.equals(CONTAINER_FILE_NAME)) {
+        } else if (CONTAINER_FILE_NAME.equals(name)) {
           //Don't do anything. Container file should be unpacked in a
           //separated step by unpackContainerDescriptor call.
           descriptorFileContent = readEntry(archiveInput, entry);
@@ -176,7 +176,7 @@ public class TarContainerPacker
       ArchiveEntry entry = archiveInput.getNextEntry();
       while (entry != null) {
         String name = entry.getName();
-        if (name.equals(CONTAINER_FILE_NAME)) {
+        if (CONTAINER_FILE_NAME.equals(name)) {
           return readEntry(archiveInput, entry);
         }
         entry = archiveInput.getNextEntry();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
@@ -220,8 +220,8 @@ public class TarContainerPacker
       ArchiveOutputStream archiveOutput) throws IOException {
     ArchiveEntry entry = archiveOutput.createArchiveEntry(file, entryName);
     archiveOutput.putArchiveEntry(entry);
-    try (InputStream fis = new FileInputStream(file)) {
-      IOUtils.copy(fis, archiveOutput);
+    try (InputStream input = new FileInputStream(file)) {
+      IOUtils.copy(input, archiveOutput);
     }
     archiveOutput.closeArchiveEntry();
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
@@ -75,7 +75,7 @@ public class TarContainerPacker
       InputStream decompressed = decompress(input);
 
       ArchiveInputStream archiveInput =
-          new TarArchiveInputStream(decompressed);
+          untar(decompressed);
 
       ArchiveEntry entry = archiveInput.getNextEntry();
       while (entry != null) {
@@ -152,8 +152,7 @@ public class TarContainerPacker
 
     try (OutputStream compressed = compress(output)) {
 
-      try (ArchiveOutputStream archiveOutput = new TarArchiveOutputStream(
-          compressed)) {
+      try (ArchiveOutputStream archiveOutput = tar(compressed)) {
 
         includePath(containerData.getDbFile().toString(), DB_DIR_NAME,
             archiveOutput);
@@ -178,9 +177,7 @@ public class TarContainerPacker
       throws IOException {
     try {
       InputStream decompressed = decompress(input);
-
-      ArchiveInputStream archiveInput =
-          new TarArchiveInputStream(decompressed);
+      ArchiveInputStream archiveInput = untar(decompressed);
 
       ArchiveEntry entry = archiveInput.getNextEntry();
       while (entry != null) {
@@ -235,6 +232,14 @@ public class TarContainerPacker
       IOUtils.copy(fis, archiveOutput);
     }
     archiveOutput.closeArchiveEntry();
+  }
+
+  private static ArchiveInputStream untar(InputStream input) {
+    return new TarArchiveInputStream(input);
+  }
+
+  private static ArchiveOutputStream tar(OutputStream output) {
+    return new TarArchiveOutputStream(output);
   }
 
   private static InputStream decompress(InputStream input)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
@@ -72,10 +72,7 @@ public class TarContainerPacker
     byte[] descriptorFileContent = null;
     try {
       KeyValueContainerData containerData = container.getContainerData();
-      InputStream compressorInputStream =
-          new CompressorStreamFactory()
-              .createCompressorInputStream(CompressorStreamFactory.GZIP,
-                  inputStream);
+      InputStream compressorInputStream = decompress(inputStream);
 
       ArchiveInputStream tarInput =
           new TarArchiveInputStream(compressorInputStream);
@@ -153,9 +150,7 @@ public class TarContainerPacker
 
     KeyValueContainerData containerData = container.getContainerData();
 
-    try (OutputStream gzippedOut = new CompressorStreamFactory()
-          .createCompressorOutputStream(CompressorStreamFactory.GZIP,
-              destination)) {
+    try (OutputStream gzippedOut = compress(destination)) {
 
       try (ArchiveOutputStream archiveOutputStream = new TarArchiveOutputStream(
           gzippedOut)) {
@@ -182,10 +177,7 @@ public class TarContainerPacker
   public byte[] unpackContainerDescriptor(InputStream inputStream)
       throws IOException {
     try {
-      InputStream compressorInputStream =
-          new CompressorStreamFactory()
-              .createCompressorInputStream(CompressorStreamFactory.GZIP,
-                  inputStream);
+      InputStream compressorInputStream = decompress(inputStream);
 
       ArchiveInputStream tarInput =
           new TarArchiveInputStream(compressorInputStream);
@@ -243,6 +235,18 @@ public class TarContainerPacker
       IOUtils.copy(fis, archiveOutputStream);
     }
     archiveOutputStream.closeArchiveEntry();
+  }
+
+  private static InputStream decompress(InputStream in)
+      throws CompressorException {
+    return new CompressorStreamFactory()
+        .createCompressorInputStream(CompressorStreamFactory.GZIP, in);
+  }
+
+  private static OutputStream compress(OutputStream out)
+      throws CompressorException {
+    return new CompressorStreamFactory()
+        .createCompressorOutputStream(CompressorStreamFactory.GZIP, out);
   }
 
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
@@ -91,7 +91,7 @@ public class TarContainerPacker
         } else if (CONTAINER_FILE_NAME.equals(name)) {
           //Don't do anything. Container file should be unpacked in a
           //separated step by unpackContainerDescriptor call.
-          descriptorFileContent = readEntry(archiveInput, entry);
+          descriptorFileContent = readEntry(archiveInput, size);
         } else {
           throw new IllegalArgumentException(
               "Unknown entry in the tar file: " + "" + name);
@@ -177,7 +177,7 @@ public class TarContainerPacker
       while (entry != null) {
         String name = entry.getName();
         if (CONTAINER_FILE_NAME.equals(name)) {
-          return readEntry(archiveInput, entry);
+          return readEntry(archiveInput, entry.getSize());
         }
         entry = archiveInput.getNextEntry();
       }
@@ -191,12 +191,12 @@ public class TarContainerPacker
         "Container descriptor is missing from the container archive.");
   }
 
-  private byte[] readEntry(InputStream input, ArchiveEntry entry)
+  private byte[] readEntry(InputStream input, final long size)
       throws IOException {
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     int bufferSize = 1024;
     byte[] buffer = new byte[bufferSize + 1];
-    long remaining = entry.getSize();
+    long remaining = size;
     while (remaining > 0) {
       int len = (int) Math.min(remaining, bufferSize);
       int read = input.read(buffer, 0, len);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make sure all streams are closed in `TarContainerPacker` (571fc9003b490db324ccd601893a18a6b5bcace3).  Plus various refactorings, see list of commits.

https://issues.apache.org/jira/browse/HDDS-2481

## How was this patch tested?

Ran `TestTarContainerPacker`.