### PR TITLE
HDDS-2479. Sonar : replace instanceof with catch block in XceiverClientGrpc sendCommandWithRetry

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -328,19 +328,19 @@ public class XceiverClientGrpc extends XceiverClientSpi {
           getBlockDNcache.put(getBlockID, dn);
         }
         break;
-      } catch (ExecutionException | InterruptedException | IOException e) {
+      } catch (IOException e) {
+        ioException = e;
+        responseProto = null;
+      } catch (ExecutionException | InterruptedException e) {
         LOG.debug("Failed to execute command {} on datanode {}",
             request, dn.getUuid(), e);
-        if (!(e instanceof IOException)) {
-          if (Status.fromThrowable(e.getCause()).getCode()
-              == Status.UNAUTHENTICATED.getCode()) {
-            throw new SCMSecurityException("Failed to authenticate with "
-                + "GRPC XceiverServer with Ozone block token.");
-          }
-          ioException = new IOException(e);
-        } else {
-          ioException = (IOException) e;
+        if (Status.fromThrowable(e.getCause()).getCode()
+            == Status.UNAUTHENTICATED.getCode()) {
+          throw new SCMSecurityException("Failed to authenticate with "
+              + "GRPC XceiverServer with Ozone block token.");
         }
+
+        ioException = new IOException(e);
         responseProto = null;
       }
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-2479

exceptionHandling combines different exception types into a common catch block, then uses instanceof to do different handling.
Fix separates out IOException handling into a separate catch block.

