### PR TITLE
HDDS-2468. scmcli close pipeline command not working.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -172,6 +172,20 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setActivatePipelineResponse(activatePipeline(
                 request.getActivatePipelineRequest()))
             .build();
+      case DeactivatePipeline:
+        return ScmContainerLocationResponse.newBuilder()
+            .setCmdType(request.getCmdType())
+            .setStatus(Status.OK)
+            .setDeactivatePipelineResponse(deactivatePipeline(
+                request.getDeactivatePipelineRequest()))
+            .build();
+      case ClosePipeline:
+        return ScmContainerLocationResponse.newBuilder()
+            .setCmdType(request.getCmdType())
+            .setStatus(Status.OK)
+            .setClosePipelineResponse(closePipeline(
+                request.getClosePipelineRequest()))
+            .build();
       case GetScmInfo:
         return ScmContainerLocationResponse.newBuilder()
             .setCmdType(request.getCmdType())
@@ -332,7 +346,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
   }
 
   public ClosePipelineResponseProto closePipeline(
-      RpcController controller, ClosePipelineRequestProto request)
+      ClosePipelineRequestProto request)
       throws IOException {
 
     impl.closePipeline(request.getPipelineID());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed `scmcli pipeline close` and `scmcli pipeline deactivate` commands.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2468

## How was this patch tested?

Deployed a three node cluster and manually tested the commands.
