### PR TITLE
HDDS-2480. Sonar : remove log spam for exceptions inside XceiverClientGrpc reconnect

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -468,8 +468,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       connectToDatanode(dn, encodedToken);
       channel = channels.get(dn.getUuid());
     } catch (Exception e) {
-      LOG.error("Error while connecting: ", e);
-      throw new IOException(e);
+      throw new IOException("Error while connecting", e);
     }
 
     if (channel == null || !isConnected(channel)) {


### PR DESCRIPTION
Sonar reported an issue where the Exception is error logged and also re-thrown wrapped into an IOException.

https://issues.apache.org/jira/browse/HDDS-2480
