### PR TITLE
HDDS-2482. Enable github actions for pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 name: Build
-on: push
+on:
+  - push
+  - pull_request
 jobs:
   build:
     name: compile


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-2400 introduced a github actions workflow for each "push" event. It turned out that pushing to a forked repository doesn't trigger this event even if it's part of a PR.

We need to enable the execution for pull_request events:

References:

 *  https://github.community/t5/GitHub-Actions/Run-a-GitHub-action-on-pull-request-for-PR-opened-from-a-forked/m-p/31147#M690
  * https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#pull-request-events-for-forked-repositories

> Note: By default, a workflow only runs when a pull_request's activity type is opened, synchronize, or reopened. To trigger workflows for more activity types, use the types keyword.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2482

## How was this patch tested?

1. I pushed this change to the master branch of elek/hadoop-ozone
2. I created a pull request by an *other* user (until know I tested everything with PR between branches by the same user)
3. Pull request has been started (https://github.com/elek/hadoop-ozone/pull/7) 