### PR TITLE
HDDS-2487. Ensure streams are closed

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerDataYaml.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerDataYaml.java
@@ -27,11 +27,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
     .ContainerType;
@@ -91,7 +93,7 @@ public final class ContainerDataYaml {
       // Write the ContainerData with checksum to Yaml file.
       out = new FileOutputStream(
           containerFile);
-      writer = new OutputStreamWriter(out, "UTF-8");
+      writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
       yaml.dump(containerData, writer);
     } finally {
       try {
@@ -105,6 +107,7 @@ public final class ContainerDataYaml {
         LOG.warn("Error occurred during closing the writer. ContainerID: " +
             containerData.getContainerID());
       }
+      IOUtils.closeQuietly(out);
     }
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with this
  * work for additional information regarding copyright ownership.  The ASF
@@ -34,6 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.google.common.base.Strings;
 
@@ -369,13 +370,14 @@ public final class OmUtils {
                new TarArchiveOutputStream(gzippedOut)) {
 
         Path checkpointPath = checkpoint.getCheckpointLocation();
-        for (Path path : Files.list(checkpointPath)
-            .collect(Collectors.toList())) {
-          if (path != null) {
-            Path fileName = path.getFileName();
-            if (fileName != null) {
-              includeFile(path.toFile(), fileName.toString(),
-                  archiveOutputStream);
+        try (Stream<Path> files = Files.list(checkpointPath)) {
+          for (Path path : files.collect(Collectors.toList())) {
+            if (path != null) {
+              Path fileName = path.getFileName();
+              if (fileName != null) {
+                includeFile(path.toFile(), fileName.toString(),
+                    archiveOutputStream);
+              }
             }
           }
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix two stream close-related issues spotted by Sonar.

https://issues.apache.org/jira/browse/HDDS-2487

## How was this patch tested?

Ran related unit tests (`TestContainerDataYaml` and `TestOmUtils`).