### PR TITLE
HDDS-2493. Sonar: Locking on a parameter in NetUtils.removeOutscope.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
@@ -32,6 +32,8 @@ import java.util.stream.Collectors;
  */
 public final class NetUtils {
   public static final Logger LOG = LoggerFactory.getLogger(NetUtils.class);
+  private static final Object excludeNodesLock = new Object();
+
   private NetUtils() {
     // Prevent instantiation
   }
@@ -112,19 +114,14 @@ public final class NetUtils {
    *  Please noted that mutableExcludedNodes content might be changed after the
    *  function call.
    */
-  public static void removeOutscope(Collection<Node> mutableExcludedNodes,
-      String scope) {
+  public static void removeOutOfScope(Collection<Node> mutableExcludedNodes,
+                                      String scope) {
     if (CollectionUtils.isEmpty(mutableExcludedNodes) || scope == null) {
       return;
     }
-    synchronized (mutableExcludedNodes) {
-      Iterator<Node> iterator = mutableExcludedNodes.iterator();
-      while (iterator.hasNext()) {
-        Node next = iterator.next();
-        if (!next.getNetworkFullPath().startsWith(scope)) {
-          iterator.remove();
-        }
-      }
+    synchronized (excludeNodesLock) {
+      mutableExcludedNodes.removeIf(
+          next -> !next.getNetworkFullPath().startsWith(scope));
     }
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
  */
 public final class NetUtils {
   public static final Logger LOG = LoggerFactory.getLogger(NetUtils.class);
-  private static final Object excludeNodesLock = new Object();
+  private static final Object EXCLUDE_NODES_LOCK = new Object();
 
   private NetUtils() {
     // Prevent instantiation
@@ -119,7 +119,7 @@ public final class NetUtils {
     if (CollectionUtils.isEmpty(mutableExcludedNodes) || scope == null) {
       return;
     }
-    synchronized (excludeNodesLock) {
+    synchronized (EXCLUDE_NODES_LOCK) {
       mutableExcludedNodes.removeIf(
           next -> !next.getNetworkFullPath().startsWith(scope));
     }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
@@ -32,8 +32,7 @@ import java.util.stream.Collectors;
  */
 public final class NetUtils {
   public static final Logger LOG = LoggerFactory.getLogger(NetUtils.class);
-  private static final Object EXCLUDE_NODES_LOCK = new Object();
-
+  
   private NetUtils() {
     // Prevent instantiation
   }
@@ -106,22 +105,6 @@ public final class NetUtils {
           iterator.remove();
         }
       });
-    }
-  }
-
-  /**
-   *  Remove node from mutableExcludedNodes if it's not part of scope
-   *  Please noted that mutableExcludedNodes content might be changed after the
-   *  function call.
-   */
-  public static void removeOutOfScope(Collection<Node> mutableExcludedNodes,
-                                      String scope) {
-    if (CollectionUtils.isEmpty(mutableExcludedNodes) || scope == null) {
-      return;
-    }
-    synchronized (EXCLUDE_NODES_LOCK) {
-      mutableExcludedNodes.removeIf(
-          next -> !next.getNetworkFullPath().startsWith(scope));
     }
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -511,8 +511,7 @@ public class NetworkTopologyImpl implements NetworkTopology{
         }
         // excludeScope and finalScope share nothing case
         if (s.startsWith(finalScope)) {
-          if (!mutableExcludedScopes.stream().anyMatch(
-              e -> s.startsWith(e))) {
+          if (mutableExcludedScopes.stream().noneMatch(s::startsWith)) {
             mutableExcludedScopes.add(s);
           }
         }
@@ -694,7 +693,10 @@ public class NetworkTopologyImpl implements NetworkTopology{
     if (scopeNode == null) {
       return 0;
     }
-    NetUtils.removeOutOfScope(mutableExcludedNodes, scope);
+    if (!CollectionUtils.isEmpty(mutableExcludedNodes)) {
+      mutableExcludedNodes.removeIf(
+          next -> !next.getNetworkFullPath().startsWith(scope));
+    }
     List<Node> excludedAncestorList =
         NetUtils.getAncestorList(this, mutableExcludedNodes, ancestorGen);
     for (Node ancestor : excludedAncestorList) {
@@ -717,7 +719,7 @@ public class NetworkTopologyImpl implements NetworkTopology{
       }
     }
     // excludedNodes is not null case
-    if (mutableExcludedNodes != null && (!mutableExcludedNodes.isEmpty())) {
+    if (!CollectionUtils.isEmpty(mutableExcludedNodes)) {
       if (ancestorGen == 0) {
         for (Node node: mutableExcludedNodes) {
           if (contains(node)) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -694,7 +694,7 @@ public class NetworkTopologyImpl implements NetworkTopology{
     if (scopeNode == null) {
       return 0;
     }
-    NetUtils.removeOutscope(mutableExcludedNodes, scope);
+    NetUtils.removeOutOfScope(mutableExcludedNodes, scope);
     List<Node> excludedAncestorList =
         NetUtils.getAncestorList(this, mutableExcludedNodes, ancestorGen);
     for (Node ancestor : excludedAncestorList) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Since the parameter reference can change, the locking should be on a shared object that is final.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2493

## How was this patch tested?
This does not change the logic around remove out of scope, waiting for unit and acceptance test results to analyze.