### PR TITLE
HDDS-2442. Added support for service name in OM for CSR

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -167,6 +167,16 @@ public final class TestSecureOzoneCluster {
               ServerSocketUtil.getPort(ScmConfigKeys
                       .OZONE_SCM_SECURITY_SERVICE_PORT_DEFAULT, 100));
 
+      conf.set(OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY, "OMMarketingCluster001");
+      conf.set(OMConfigKeys.OZONE_OM_NODES_KEY+".OMMarketingCluster001",
+               "node1,node2,node3");
+      conf.set(OMConfigKeys.OZONE_OM_ADDRESS_KEY+".OMMarketingCluster001.node1",
+          "localhost:9862");
+      conf.set(OMConfigKeys.OZONE_OM_ADDRESS_KEY+".OMMarketingCluster001.node2",
+          "google.com:9863");
+      conf.set(OMConfigKeys.OZONE_OM_ADDRESS_KEY+".OMMarketingCluster001.node3",
+               "yahoo.com:9864");
+
       DefaultMetricsSystem.setMiniClusterMode(true);
       final String path = folder.newFolder().toString();
       metaDirPath = Paths.get(path, "om-meta");

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 
 import org.apache.commons.codec.digest.DigestUtils;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.crypto.key.KeyProvider;
@@ -1358,6 +1359,14 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         .setClusterID(omStore.getClusterID())
         .setSubject(subject)
         .addIpAddress(ip);
+
+
+    OMHANodeDetails haOMHANodeDetails = OMHANodeDetails.loadOMHAConfig(config);
+    String serviceName =
+        haOMHANodeDetails.getLocalNodeDetails().getOMServiceId();
+    if (!StringUtils.isEmpty(serviceName)) {
+      builder.addServiceName(serviceName);
+    }
 
     LOG.info("Creating csr for OM->dns:{},ip:{},scmId:{},clusterId:{}," +
             "subject:{}", hostname, ip,


### PR DESCRIPTION
## What changes were proposed in this pull request?

The SCM HA needs the ability to represent a group as a single entity. So that Tokens for each of the OM which is part of an HA group can be honored by the data nodes.
This patch adds service name support for CSR in OzomeManager. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2442

## How was this patch tested?
Updated corresponding unit tests and tested them by running those tests. 