### PR TITLE
HDDS-2503. Close FlushOptions in RDBStore

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -199,11 +199,11 @@ public class RDBStore implements DBStore {
   }
 
   @Override
-  public <KEY, VALUE> void move(KEY key, Table<KEY, VALUE> source,
-                                Table<KEY, VALUE> dest) throws IOException {
+  public <K, V> void move(K key, Table<K, V> source,
+                                Table<K, V> dest) throws IOException {
     try (BatchOperation batchOperation = initBatchOperation()) {
 
-      VALUE value = source.get(key);
+      V value = source.get(key);
       dest.putWithBatch(batchOperation, key, value);
       source.deleteWithBatch(batchOperation, key);
       commitBatchOperation(batchOperation);
@@ -211,15 +211,15 @@ public class RDBStore implements DBStore {
   }
 
   @Override
-  public <KEY, VALUE> void move(KEY key, VALUE value, Table<KEY, VALUE> source,
-                                Table<KEY, VALUE> dest) throws IOException {
+  public <K, V> void move(K key, V value, Table<K, V> source,
+                                Table<K, V> dest) throws IOException {
     move(key, key, value, source, dest);
   }
 
   @Override
-  public <KEY, VALUE> void move(KEY sourceKey, KEY destKey, VALUE value,
-                                Table<KEY, VALUE> source,
-                                Table<KEY, VALUE> dest) throws IOException {
+  public <K, V> void move(K sourceKey, K destKey, V value,
+                                Table<K, V> source,
+                                Table<K, V> dest) throws IOException {
     try (BatchOperation batchOperation = initBatchOperation()) {
       dest.putWithBatch(batchOperation, destKey, value);
       source.deleteWithBatch(batchOperation, sourceKey);
@@ -263,15 +263,15 @@ public class RDBStore implements DBStore {
   }
 
   @Override
-  public <KEY, VALUE> Table<KEY, VALUE> getTable(String name,
-      Class<KEY> keyType, Class<VALUE> valueType) throws IOException {
+  public <K, V> Table<K, V> getTable(String name,
+      Class<K> keyType, Class<V> valueType) throws IOException {
     return new TypedTable<>(getTable(name), codecRegistry, keyType,
         valueType);
   }
 
   @Override
-  public <KEY, VALUE> Table<KEY, VALUE> getTable(String name,
-      Class<KEY> keyType, Class<VALUE> valueType,
+  public <K, V> Table<K, V> getTable(String name,
+      Class<K> keyType, Class<V> valueType,
       TableCacheImpl.CacheCleanupPolicy cleanupPolicy) throws IOException {
     return new TypedTable<>(getTable(name), codecRegistry, keyType,
         valueType, cleanupPolicy);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -62,7 +61,7 @@ public class RDBStore implements DBStore {
   private final WriteOptions writeOptions;
   private final DBOptions dbOptions;
   private final CodecRegistry codecRegistry;
-  private final Hashtable<String, ColumnFamilyHandle> handleTable;
+  private final Map<String, ColumnFamilyHandle> handleTable;
   private ObjectName statMBeanName;
   private RDBCheckpointManager checkPointManager;
   private String checkpointsParentDir;
@@ -81,8 +80,8 @@ public class RDBStore implements DBStore {
       throws IOException {
     Preconditions.checkNotNull(dbFile, "DB file location cannot be null");
     Preconditions.checkNotNull(families);
-    Preconditions.checkArgument(families.size() > 0);
-    handleTable = new Hashtable<>();
+    Preconditions.checkArgument(!families.isEmpty());
+    handleTable = new HashMap<>();
     codecRegistry = registry;
     final List<ColumnFamilyDescriptor> columnFamilyDescriptors =
         new ArrayList<>();
@@ -266,7 +265,7 @@ public class RDBStore implements DBStore {
   @Override
   public <KEY, VALUE> Table<KEY, VALUE> getTable(String name,
       Class<KEY> keyType, Class<VALUE> valueType) throws IOException {
-    return new TypedTable<KEY, VALUE>(getTable(name), codecRegistry, keyType,
+    return new TypedTable<>(getTable(name), codecRegistry, keyType,
         valueType);
   }
 
@@ -274,12 +273,12 @@ public class RDBStore implements DBStore {
   public <KEY, VALUE> Table<KEY, VALUE> getTable(String name,
       Class<KEY> keyType, Class<VALUE> valueType,
       TableCacheImpl.CacheCleanupPolicy cleanupPolicy) throws IOException {
-    return new TypedTable<KEY, VALUE>(getTable(name), codecRegistry, keyType,
+    return new TypedTable<>(getTable(name), codecRegistry, keyType,
         valueType, cleanupPolicy);
   }
 
   @Override
-  public ArrayList<Table> listTables() throws IOException {
+  public ArrayList<Table> listTables() {
     ArrayList<Table> returnList = new ArrayList<>();
     for (ColumnFamilyHandle handle : handleTable.values()) {
       returnList.add(new RDBTable(db, handle, writeOptions, rdbMetrics));

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -292,7 +292,6 @@ public class RDBStore implements DBStore {
       flushOptions.setWaitForFlush(true);
       db.flush(flushOptions);
     } catch (RocksDBException e) {
-      LOG.error("Unable to Flush RocksDB data", e);
       throw toIOException("Unable to Flush RocksDB data", e);
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

~Close `FlushOptions` in `RDBStore` after use~ (already done in #161).  ~Also~ fix other code issues reported by Sonar:

 * Use `<>` in instantiation
 * Use `isEmpty()`
 * Use `HashMap`, not `Hashtable`
 * Rename generic arguments to single-letter
 * Handle _or_ log exception, not both

https://issues.apache.org/jira/browse/HDDS-2503

## How was this patch tested?

Unit test (`TestRDBStore`), checkstyle.