### PR TITLE
HDDS-2507. Remove the hard-coded exclusion of TestMiniChaosOzoneCluster

### DIFF
--- a/hadoop-ozone/dev-support/checks/integration.sh
+++ b/hadoop-ozone/dev-support/checks/integration.sh
@@ -18,8 +18,7 @@ cd "$DIR/../../.." || exit 1
 
 export MAVEN_OPTS="-Xmx4096m"
 mvn -B install -DskipTests
-mvn -B -fn test -pl :hadoop-ozone-integration-test,:hadoop-ozone-filesystem,:hadoop-ozone-tools \
-  -Dtest=\!TestMiniChaosOzoneCluster "$@"
+mvn -B -fn test -pl :hadoop-ozone-integration-test,:hadoop-ozone-filesystem,:hadoop-ozone-tools "$@"
 
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/integration"}
 mkdir -p "$REPORT_DIR"


### PR DESCRIPTION
## What changes were proposed in this pull request?

We excluded the execution of TestMiniChaosOzoneCluster from the `hadoop-ozone/dev-support/checks/integration.sh` because it was not stable enough.

Unfortunately this exclusion makes it impossible to use custom exclusion lists (`-Dsurefire.excludesFile=....`) as `excludesFile` can't be used if `-Dtest=!...` is already used.

I propose to remove this exclusion to make it possible to use different exclusion for different runs (pr check, daily, etc.)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2507

## How was this patch tested?

If you have time, you can test the with `integration.sh`. If you haven't, just wait for the results from the integration check by the ci build