### PR TITLE
HDDS-2500. Avoid fall-through in CloseContainerCommandHandler

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
@@ -109,8 +109,8 @@ public class CloseContainerCommandHandler implements CommandHandler {
       case QUASI_CLOSED:
         if (closeCommand.getForce()) {
           controller.closeContainer(containerId);
-          break;
         }
+        break;
       case CLOSED:
         break;
       case UNHEALTHY:
@@ -119,6 +119,7 @@ public class CloseContainerCommandHandler implements CommandHandler {
           LOG.debug("Cannot close the container #{}, the container is"
               + " in {} state.", containerId, container.getContainerState());
         }
+        break;
       default:
         break;
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added explicit break statements to avoid fallthrough warnings.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2500

## How was this patch tested?

Ran local tests + rat / checkstyle.