### PR TITLE
HDDS-2488. Not enough arguments for log messages in GrpcXceiverService.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/GrpcXceiverService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/GrpcXceiverService.java
@@ -58,7 +58,7 @@ public class GrpcXceiverService extends
           responseObserver.onNext(resp);
         } catch (Throwable e) {
           LOG.error("Got exception when processing"
-                    + " ContainerCommandRequestProto {}: {}", request, e);
+                    + " ContainerCommandRequestProto {}: ", request, e);
           responseObserver.onError(e);
         }
       }
@@ -66,7 +66,7 @@ public class GrpcXceiverService extends
       @Override
       public void onError(Throwable t) {
         // for now we just log a msg
-        LOG.error("ContainerCommand send on error. Exception: {}", t);
+        LOG.error("ContainerCommand send on error. Exception: ", t);
       }
 
       @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/GrpcXceiverService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/GrpcXceiverService.java
@@ -58,7 +58,7 @@ public class GrpcXceiverService extends
           responseObserver.onNext(resp);
         } catch (Throwable e) {
           LOG.error("Got exception when processing"
-                    + " ContainerCommandRequestProto {}: ", request, e);
+                    + " ContainerCommandRequestProto {}", request, e);
           responseObserver.onError(e);
         }
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/GrpcXceiverService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/GrpcXceiverService.java
@@ -57,7 +57,7 @@ public class GrpcXceiverService extends
               dispatcher.dispatch(request, null);
           responseObserver.onNext(resp);
         } catch (Throwable e) {
-          LOG.error("{} got exception when processing"
+          LOG.error("Got exception when processing"
                     + " ContainerCommandRequestProto {}: {}", request, e);
           responseObserver.onError(e);
         }
@@ -66,13 +66,13 @@ public class GrpcXceiverService extends
       @Override
       public void onError(Throwable t) {
         // for now we just log a msg
-        LOG.error("{}: ContainerCommand send on error. Exception: {}", t);
+        LOG.error("ContainerCommand send on error. Exception: {}", t);
       }
 
       @Override
       public void onCompleted() {
         if (isClosed.compareAndSet(false, true)) {
-          LOG.debug("{}: ContainerCommand send completed");
+          LOG.debug("ContainerCommand send completed");
           responseObserver.onCompleted();
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

GrpcXceiverService has log messages with too few arguments for placeholders. Only one of them is flagged by Sonar, but all seem to have the same problem.

https://sonarcloud.io/project/issues?id=hadoop-ozone&issues=AW5md-69KcVY8lQ4ZsRZ&open=AW5md-69KcVY8lQ4ZsRZ

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2488

## How was this patch tested?
Simple log statement change. No testing done. 

Thanks to @adoroszlai for filing the sonar issue. 