### PR TITLE
HDDS-2518. Ensure RATIS leader info is properly updated with pipeline…

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -313,6 +313,7 @@ public final class Pipeline {
       this.state = pipeline.state;
       this.nodeStatus = pipeline.nodeStatus;
       this.nodesInOrder = pipeline.nodesInOrder.get();
+      this.leaderId = pipeline.getLeaderId();
     }
 
     public Builder setId(PipelineID id1) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
@@ -362,6 +362,15 @@ public final class TestUtils {
     return new PipelineReportFromDatanode(dn, reportBuilder.build());
   }
 
+  public static PipelineReportFromDatanode getPipelineReportFromDatanode(
+      DatanodeDetails dn, PipelineID pipelineID, boolean isLeader) {
+    PipelineReportsProto.Builder reportBuilder =
+        PipelineReportsProto.newBuilder();
+    reportBuilder.addPipelineReport(PipelineReport.newBuilder()
+        .setPipelineID(pipelineID.getProtobuf()).setIsLeader(isLeader));
+    return new PipelineReportFromDatanode(dn, reportBuilder.build());
+  }
+
   public static void openAllRatisPipelines(PipelineManager pipelineManager)
       throws IOException {
     // Pipeline is created by background thread

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMPipelineManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMPipelineManager.java
@@ -177,14 +177,19 @@ public class TestSCMPipelineManager {
     // get pipeline report from each dn in the pipeline
     PipelineReportHandler pipelineReportHandler =
         new PipelineReportHandler(scmSafeModeManager, pipelineManager, conf);
+    Boolean isLeader = true;
     for (DatanodeDetails dn: pipeline.getNodes()) {
       PipelineReportFromDatanode pipelineReportFromDatanode =
-          TestUtils.getPipelineReportFromDatanode(dn, pipeline.getId());
+          TestUtils.getPipelineReportFromDatanode(dn, pipeline.getId(),
+              isLeader);
+      if (isLeader) {
+        isLeader = false;
+      }
       // pipeline is not healthy until all dns report
       Assert.assertFalse(
           pipelineManager.getPipeline(pipeline.getId()).isHealthy());
       pipelineReportHandler
-          .onMessage(pipelineReportFromDatanode, new EventQueue());
+          .onMessage(pipelineReportFromDatanode, eventQueue);
     }
 
     // pipeline is healthy when all dns report
@@ -197,12 +202,17 @@ public class TestSCMPipelineManager {
     // close the pipeline
     pipelineManager.finalizeAndDestroyPipeline(pipeline, false);
 
+    isLeader = true;
     for (DatanodeDetails dn: pipeline.getNodes()) {
       PipelineReportFromDatanode pipelineReportFromDatanode =
-          TestUtils.getPipelineReportFromDatanode(dn, pipeline.getId());
+          TestUtils.getPipelineReportFromDatanode(dn, pipeline.getId(),
+              isLeader);
+      if (isLeader) {
+        isLeader = false;
+      }
       // pipeline report for destroyed pipeline should be ignored
       pipelineReportHandler
-          .onMessage(pipelineReportFromDatanode, new EventQueue());
+          .onMessage(pipelineReportFromDatanode, eventQueue);
     }
 
     try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Properly populate the ratis pipeline leader id when handler pipeline report to change the pipeline state from allocate to open.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2518

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

Unit test failures in TestSCMPipelineManager are fixed with this patch. 