### PR TITLE
HDDS-2405. int2ByteString unnecessary byte array allocation

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
@@ -19,8 +19,6 @@ package org.apache.hadoop.ozone.common;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -29,6 +27,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import com.google.common.primitives.Ints;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
     .ChecksumType;
@@ -62,14 +61,7 @@ public class Checksum {
   }
 
   public static ByteString int2ByteString(int n) {
-    final ByteString.Output out = ByteString.newOutput();
-    try(DataOutputStream dataOut = new DataOutputStream(out)) {
-      dataOut.writeInt(n);
-    } catch (IOException e) {
-      throw new IllegalStateException(
-          "Failed to write integer n = " + n + " to a ByteString", e);
-    }
-    return out.toByteString();
+    return ByteString.copyFrom(Ints.toByteArray(n));
   }
 
   private static Function<ByteBuffer, ByteString> newChecksumByteBufferFunction(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Simplify `int` to `ByteString` conversion.  Avoid allocating ~7x memory overhead (vs. the size of the `ByteString` created).

https://issues.apache.org/jira/browse/HDDS-2405

## How was this patch tested?

Tested memory usage of various methods:

1. previous implementation
2. using `ByteString.Output` with restricted initial capacity (4 bytes instead of default 128)
3. eliminating `DataOutputStream` by writing directly to `ByteString.Output`
4. proposed implementation (simple `copyFrom`)

The last one uses the least amount of memory.