### PR TITLE
HDDS-2247. Delete FileEncryptionInfo from KeyInfo when a Key is deleted

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -510,12 +510,13 @@ public final class OmUtils {
   public static RepeatedOmKeyInfo prepareKeyForDelete(OmKeyInfo keyInfo,
       RepeatedOmKeyInfo repeatedOmKeyInfo) throws IOException{
     // If this key is in a GDPR enforced bucket, then before moving
-    // KeyInfo to deletedTable, remove the GDPR related metadata from
-    // KeyInfo.
+    // KeyInfo to deletedTable, remove the GDPR related metadata and
+    // FileEncryptionInfo from KeyInfo.
     if(Boolean.valueOf(keyInfo.getMetadata().get(OzoneConsts.GDPR_FLAG))) {
       keyInfo.getMetadata().remove(OzoneConsts.GDPR_FLAG);
       keyInfo.getMetadata().remove(OzoneConsts.GDPR_ALGORITHM);
       keyInfo.getMetadata().remove(OzoneConsts.GDPR_SECRET);
+      keyInfo.clearFileEncryptionInfo();
     }
 
     if(repeatedOmKeyInfo == null) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -469,4 +469,15 @@ public final class OmKeyInfo extends WithMetadata {
 
     return builder.build();
   }
+
+  /**
+   * Method to clear the fileEncryptionInfo.
+   * This method is called when a KeyDelete operation is performed.
+   * This ensures that when TDE is enabled and GDPR is enforced on a bucket,
+   * the encryption info is deleted from Key Metadata before the key is moved
+   * to deletedTable in OM Metadata.
+   */
+  public void clearFileEncryptionInfo() {
+    this.encInfo = null;
+  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -277,7 +277,8 @@ public class TestOzoneAtRestEncryption extends TestOzoneRpcClient {
     Assert.assertFalse(deletedKeyMetadata.containsKey(OzoneConsts.GDPR_SECRET));
     Assert.assertFalse(
         deletedKeyMetadata.containsKey(OzoneConsts.GDPR_ALGORITHM));
-    Assert.assertNull(deletedKeys.getOmKeyInfoList().get(0).getFileEncryptionInfo());
+    Assert.assertNull(
+        deletedKeys.getOmKeyInfoList().get(0).getFileEncryptionInfo());
   }
 
   private boolean verifyRatisReplication(String volumeName, String bucketName,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.CertificateClientTestImpl;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -37,13 +38,16 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneKey;
+import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
 import org.junit.AfterClass;
@@ -55,6 +59,7 @@ import java.io.File;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
@@ -194,6 +199,85 @@ public class TestOzoneAtRestEncryption extends TestOzoneRpcClient {
       Assert.assertTrue(key.getCreationTime() >= currentTime);
       Assert.assertTrue(key.getModificationTime() >= currentTime);
     }
+  }
+
+  /**
+   * Test PutKey & DeleteKey with Encryption and GDPR.
+   * 1. Create a GDPR enforced bucket
+   * 2. PutKey with Encryption in above bucket and verify.
+   * 3. DeleteKey and confirm the metadata does not have encryption key.
+   * @throws Exception
+   */
+  @Test
+  public void testKeyWithEncryptionAndGdpr() throws Exception {
+    //Step 1
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    long currentTime = Time.now();
+
+    String value = "sample value";
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    //Bucket with Encryption & GDPR enforced
+    BucketArgs bucketArgs = BucketArgs.newBuilder()
+        .setBucketEncryptionKey(TEST_KEY)
+        .addMetadata(OzoneConsts.GDPR_FLAG, "true").build();
+    volume.createBucket(bucketName, bucketArgs);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+    Assert.assertEquals(bucketName, bucket.getName());
+    Assert.assertNotNull(bucket.getMetadata());
+    Assert.assertEquals("true",
+        bucket.getMetadata().get(OzoneConsts.GDPR_FLAG));
+
+    //Step 2
+    String keyName = UUID.randomUUID().toString();
+
+    try (OzoneOutputStream out = bucket.createKey(keyName,
+        value.getBytes("UTF-8").length, ReplicationType.STAND_ALONE,
+        ReplicationFactor.ONE, new HashMap<>())) {
+      out.write(value.getBytes("UTF-8"));
+    }
+
+    OzoneKeyDetails key = bucket.getKey(keyName);
+    Assert.assertEquals(keyName, key.getName());
+    byte[] fileContent;
+    int len = 0;
+
+    try(OzoneInputStream is = bucket.readKey(keyName)) {
+      fileContent = new byte[value.getBytes("UTF-8").length];
+      len = is.read(fileContent);
+    }
+
+    Assert.assertEquals(len, value.length());
+    Assert.assertTrue(verifyRatisReplication(volumeName, bucketName,
+        keyName, ReplicationType.STAND_ALONE,
+        ReplicationFactor.ONE));
+    Assert.assertEquals(value, new String(fileContent, "UTF-8"));
+    Assert.assertTrue(key.getCreationTime() >= currentTime);
+    Assert.assertTrue(key.getModificationTime() >= currentTime);
+    Assert.assertEquals("true", key.getMetadata().get(OzoneConsts.GDPR_FLAG));
+    //As TDE is enabled, the GDPR encryption will be skipped and only TDE
+    // will take place. So the GDPR encryption details should be null in the
+    // metadata and the TDE encryption details should not be null.
+    Assert.assertNull(key.getMetadata().get(OzoneConsts.GDPR_ALGORITHM));
+    Assert.assertNull(key.getMetadata().get(OzoneConsts.GDPR_SECRET));
+    Assert.assertNotNull(key.getFileEncryptionInfo());
+
+    //Step 3
+    bucket.deleteKey(key.getName());
+
+    OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
+    String objectKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
+        keyName);
+    RepeatedOmKeyInfo deletedKeys =
+        omMetadataManager.getDeletedTable().get(objectKey);
+    Map<String, String> deletedKeyMetadata =
+        deletedKeys.getOmKeyInfoList().get(0).getMetadata();
+    Assert.assertFalse(deletedKeyMetadata.containsKey(OzoneConsts.GDPR_FLAG));
+    Assert.assertFalse(deletedKeyMetadata.containsKey(OzoneConsts.GDPR_SECRET));
+    Assert.assertFalse(
+        deletedKeyMetadata.containsKey(OzoneConsts.GDPR_ALGORITHM));
+    Assert.assertNull(deletedKeys.getOmKeyInfoList().get(0).getFileEncryptionInfo());
   }
 
   private boolean verifyRatisReplication(String volumeName, String bucketName,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -231,10 +231,11 @@ public class TestOzoneAtRestEncryption extends TestOzoneRpcClient {
 
     //Step 2
     String keyName = UUID.randomUUID().toString();
-
+    Map<String, String> keyMetadata = new HashMap<>();
+    keyMetadata.put(OzoneConsts.GDPR_FLAG, "true");
     try (OzoneOutputStream out = bucket.createKey(keyName,
         value.getBytes("UTF-8").length, ReplicationType.STAND_ALONE,
-        ReplicationFactor.ONE, new HashMap<>())) {
+        ReplicationFactor.ONE, keyMetadata)) {
       out.write(value.getBytes("UTF-8"));
     }
 
@@ -256,11 +257,7 @@ public class TestOzoneAtRestEncryption extends TestOzoneRpcClient {
     Assert.assertTrue(key.getCreationTime() >= currentTime);
     Assert.assertTrue(key.getModificationTime() >= currentTime);
     Assert.assertEquals("true", key.getMetadata().get(OzoneConsts.GDPR_FLAG));
-    //As TDE is enabled, the GDPR encryption will be skipped and only TDE
-    // will take place. So the GDPR encryption details should be null in the
-    // metadata and the TDE encryption details should not be null.
-    Assert.assertNull(key.getMetadata().get(OzoneConsts.GDPR_ALGORITHM));
-    Assert.assertNull(key.getMetadata().get(OzoneConsts.GDPR_SECRET));
+    //As TDE is enabled, the TDE encryption details should not be null.
     Assert.assertNotNull(key.getFileEncryptionInfo());
 
     //Step 3


### PR DESCRIPTION
## What changes were proposed in this pull request?
As part of HDDS-2174 we are deleting GDPR Encryption Key on delete file operation.
However, if KMS is enabled, we are skipping GDPR Encryption Key approach when writing file in a GDPR enforced Bucket.
In such scenario, when KMS is enabled & GDPR enforced on a bucket, if user deletes a file, we should delete the FileEncryptionInfo from KeyInfo, before moving it to deletedTable, else we cannot guarantee Right to Erasure.

Changes proposed:
- Delete FileEncryptionInfo from KeyInfo when a Key is deleted
- Added new test to verify this scenario

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2247


## How was this patch tested?
New test contributed as part of the PR
