### PR TITLE
HDDS-2521. Multipart upload failing with NPE

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -141,23 +141,17 @@ public class ObjectEndpoint extends EndpointBase {
       String copyHeader = headers.getHeaderString(COPY_SOURCE_HEADER);
       String storageType = headers.getHeaderString(STORAGE_CLASS_HEADER);
 
-      ReplicationType replicationType;
-      ReplicationFactor replicationFactor;
+      S3StorageType s3StorageType;
       boolean storageTypeDefault;
       if (storageType == null || storageType.equals("")) {
-        replicationType = S3StorageType.getDefault().getType();
-        replicationFactor = S3StorageType.getDefault().getFactor();
+        s3StorageType = S3StorageType.getDefault();
         storageTypeDefault = true;
       } else {
-        try {
-          replicationType = S3StorageType.valueOf(storageType).getType();
-          replicationFactor = S3StorageType.valueOf(storageType).getFactor();
-        } catch (IllegalArgumentException ex) {
-          throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT,
-              storageType);
-        }
+        s3StorageType = toS3StorageType(storageType);
         storageTypeDefault = false;
       }
+      ReplicationType replicationType = s3StorageType.getType();
+      ReplicationFactor replicationFactor = s3StorageType.getFactor();
 
       if (copyHeader != null) {
         //Copy object, as copy source available.
@@ -214,10 +208,7 @@ public class ObjectEndpoint extends EndpointBase {
 
       if (uploadId != null) {
         // When we have uploadId, this is the request for list Parts.
-        int partMarker = 0;
-        if (partNumberMarker != null) {
-          partMarker = Integer.parseInt(partNumberMarker);
-        }
+        int partMarker = parsePartNumberMarker(partNumberMarker);
         return listParts(bucketName, keyPath, uploadId,
             partMarker, maxParts);
       }
@@ -233,16 +224,12 @@ public class ObjectEndpoint extends EndpointBase {
       String rangeHeaderVal = headers.getHeaderString(RANGE_HEADER);
       RangeHeader rangeHeader = null;
 
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("range Header provided value is {}", rangeHeaderVal);
-      }
+      LOG.debug("range Header provided value: {}", rangeHeaderVal);
 
       if (rangeHeaderVal != null) {
         rangeHeader = RangeHeaderParserUtil.parseRangeHeader(rangeHeaderVal,
             length);
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("range Header provided value is {}", rangeHeader);
-        }
+        LOG.debug("range Header provided: {}", rangeHeader);
         if (rangeHeader.isInValidRange()) {
           throw S3ErrorTable.newError(
               S3ErrorTable.INVALID_RANGE, rangeHeaderVal);
@@ -261,20 +248,13 @@ public class ObjectEndpoint extends EndpointBase {
             .header(CONTENT_LENGTH, keyDetails.getDataSize());
 
       } else {
-        LOG.debug("range Header provided value is {}", rangeHeader);
         OzoneInputStream key = bucket.readKey(keyPath);
 
         long startOffset = rangeHeader.getStartOffset();
         long endOffset = rangeHeader.getEndOffset();
-        long copyLength;
-        if (startOffset == endOffset) {
-          // if range header is given as bytes=0-0, then we should return 1
-          // byte from start offset
-          copyLength = 1;
-        } else {
-          copyLength = rangeHeader.getEndOffset() - rangeHeader
-              .getStartOffset() + 1;
-        }
+        // eg. if range header is given as bytes=0-0, then we should return 1
+        // byte from start offset
+        long copyLength = endOffset - startOffset + 1;
         StreamingOutput output = dest -> {
           try (S3WrapperInputStream s3WrapperInputStream =
               new S3WrapperInputStream(
@@ -334,7 +314,8 @@ public class ObjectEndpoint extends EndpointBase {
   @HEAD
   public Response head(
       @PathParam("bucket") String bucketName,
-      @PathParam("path") String keyPath) throws Exception {
+      @PathParam("path") String keyPath) throws IOException, OS3Exception {
+
     OzoneKeyDetails key;
 
     try {
@@ -441,20 +422,14 @@ public class ObjectEndpoint extends EndpointBase {
       OzoneBucket ozoneBucket = getBucket(bucket);
       String storageType = headers.getHeaderString(STORAGE_CLASS_HEADER);
 
-      ReplicationType replicationType;
-      ReplicationFactor replicationFactor;
+      S3StorageType s3StorageType;
       if (storageType == null || storageType.equals("")) {
-        replicationType = S3StorageType.getDefault().getType();
-        replicationFactor = S3StorageType.getDefault().getFactor();
+        s3StorageType = S3StorageType.getDefault();
       } else {
-        try {
-          replicationType = S3StorageType.valueOf(storageType).getType();
-          replicationFactor = S3StorageType.valueOf(storageType).getFactor();
-        } catch (IllegalArgumentException ex) {
-          throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT,
-              storageType);
-        }
+        s3StorageType = toS3StorageType(storageType);
       }
+      ReplicationType replicationType = s3StorageType.getType();
+      ReplicationFactor replicationFactor = s3StorageType.getFactor();
 
       OmMultipartInfo multipartInfo = ozoneBucket
           .initiateMultipartUpload(key, replicationType, replicationFactor);
@@ -676,30 +651,28 @@ public class ObjectEndpoint extends EndpointBase {
     try {
       // Checking whether we trying to copying to it self.
 
-      if (sourceBucket.equals(destBucket)) {
-        if (sourceKey.equals(destkey)) {
-          // When copying to same storage type when storage type is provided,
-          // we should not throw exception, as aws cli checks if any of the
-          // options like storage type are provided or not when source and
-          // dest are given same
-          if (storageTypeDefault) {
-            OS3Exception ex = S3ErrorTable.newError(S3ErrorTable
-                .INVALID_REQUEST, copyHeader);
-            ex.setErrorMessage("This copy request is illegal because it is " +
-                "trying to copy an object to it self itself without changing " +
-                "the object's metadata, storage class, website redirect " +
-                "location or encryption attributes.");
-            throw ex;
-          } else {
-            // TODO: Actually here we should change storage type, as ozone
-            // still does not support this just returning dummy response
-            // for now
-            CopyObjectResponse copyObjectResponse = new CopyObjectResponse();
-            copyObjectResponse.setETag(OzoneUtils.getRequestID());
-            copyObjectResponse.setLastModified(Instant.ofEpochMilli(
-                Time.now()));
-            return copyObjectResponse;
-          }
+      if (sourceBucket.equals(destBucket) && sourceKey.equals(destkey)) {
+        // When copying to same storage type when storage type is provided,
+        // we should not throw exception, as aws cli checks if any of the
+        // options like storage type are provided or not when source and
+        // dest are given same
+        if (storageTypeDefault) {
+          OS3Exception ex = S3ErrorTable.newError(S3ErrorTable
+              .INVALID_REQUEST, copyHeader);
+          ex.setErrorMessage("This copy request is illegal because it is " +
+              "trying to copy an object to it self itself without changing " +
+              "the object's metadata, storage class, website redirect " +
+              "location or encryption attributes.");
+          throw ex;
+        } else {
+          // TODO: Actually here we should change storage type, as ozone
+          // still does not support this just returning dummy response
+          // for now
+          CopyObjectResponse copyObjectResponse = new CopyObjectResponse();
+          copyObjectResponse.setETag(OzoneUtils.getRequestID());
+          copyObjectResponse.setLastModified(Instant.ofEpochMilli(
+              Time.now()));
+          return copyObjectResponse;
         }
       }
 
@@ -769,5 +742,23 @@ public class ObjectEndpoint extends EndpointBase {
     }
 
     return Pair.of(header.substring(0, pos), header.substring(pos + 1));
+  }
+
+  private static S3StorageType toS3StorageType(String storageType)
+      throws OS3Exception {
+    try {
+      return S3StorageType.valueOf(storageType);
+    } catch (IllegalArgumentException ex) {
+      throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT,
+          storageType);
+    }
+  }
+
+  private static int parsePartNumberMarker(String partNumberMarker) {
+    int partMarker = 0;
+    if (partNumberMarker != null) {
+      partMarker = Integer.parseInt(partNumberMarker);
+    }
+    return partMarker;
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneOutputStreamStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneOutputStreamStub.java
@@ -32,6 +32,7 @@ import java.io.OutputStream;
 public class OzoneOutputStreamStub extends OzoneOutputStream {
 
   private final String partName;
+  private boolean closed;
 
   /**
    * Constructs OzoneOutputStreamStub with outputStream and partName.
@@ -62,12 +63,15 @@ public class OzoneOutputStreamStub extends OzoneOutputStream {
   @Override
   public synchronized void close() throws IOException {
     //commitKey can be done here, if needed.
-    getOutputStream().close();
+    if (!closed) {
+      getOutputStream().close();
+      closed = true;
+    }
   }
 
   @Override
   public OmMultipartCommitUploadPartInfo getCommitUploadPartInfo() {
-    return new OmMultipartCommitUploadPartInfo(partName);
+    return closed ? new OmMultipartCommitUploadPartInfo(partName) : null;
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Fixed NPE in `ObjectEndpoint`: `OzoneOutputStream` needs to be closed (to get the key committed) to make upload part info available.
 * Changed `OzoneOutputStreamStub` to simulate this "no part info before commit" properly.  This makes the unit test fail with the previous code.

https://issues.apache.org/jira/browse/HDDS-2521

## How was this patch tested?

Ran acceptance test `ozones3` and S3 Gateway unit tests.