### PR TITLE
HDDS-2520. Sonar: Avoid temporary variable scmSecurityClient

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
@@ -294,13 +294,11 @@ public final class HddsClientUtils {
         RPC.getProtocolVersion(ScmBlockLocationProtocolPB.class);
     InetSocketAddress scmSecurityProtoAdd =
         HddsUtils.getScmAddressForSecurityProtocol(conf);
-    SCMSecurityProtocolClientSideTranslatorPB scmSecurityClient =
-        new SCMSecurityProtocolClientSideTranslatorPB(
-            RPC.getProxy(SCMSecurityProtocolPB.class, scmVersion,
-                scmSecurityProtoAdd, ugi, conf,
-                NetUtils.getDefaultSocketFactory(conf),
-                Client.getRpcTimeout(conf)));
-    return scmSecurityClient;
+    return new SCMSecurityProtocolClientSideTranslatorPB(
+        RPC.getProxy(SCMSecurityProtocolPB.class, scmVersion,
+            scmSecurityProtoAdd, ugi, conf,
+            NetUtils.getDefaultSocketFactory(conf),
+            Client.getRpcTimeout(conf)));
   }
 
   // This will return the underlying exception after unwrapping


### PR DESCRIPTION
## What changes were proposed in this pull request?
Eliminated temporary variable which served no purpose.
Now, we return the created instance immediately without assigning it first to a temporary variable.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2520

## How was this patch tested?
No code logic was changed, just verified mvn install.
