### PR TITLE
HDDS-2525. Sonar : replace lambda with method reference in SCM BufferPool

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
@@ -111,7 +111,7 @@ public class BufferPool {
   }
 
   public long computeBufferData() {
-    return bufferList.stream().mapToInt(value -> value.position())
+    return bufferList.stream().mapToInt(ChunkBuffer::position)
         .sum();
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-2525

TestBlockOutPutStream unit tests execute the changed function.