### PR TITLE
HDDS-2348.Remove log4j properties for package org.apache.hadoop.ozone

### DIFF
--- a/hadoop-ozone/dist/src/main/conf/log4j.properties
+++ b/hadoop-ozone/dist/src/main/conf/log4j.properties
@@ -128,7 +128,7 @@ log4j.logger.com.amazonaws.http.AmazonHttpClient=ERROR
 log4j.appender.EventCounter=org.apache.hadoop.log.metrics.EventCounter
 
 
-log4j.logger.org.apache.hadoop.ozone=DEBUG,OZONE,FILE
+#log4j.logger.org.apache.hadoop.ozone=DEBUG,OZONE,FILE
 
 # Do not log into datanode logs. Remove this line to have single log.
 log4j.additivity.org.apache.hadoop.ozone=false


### PR DESCRIPTION
## What changes were proposed in this pull request?

fix scmcli container delete not working

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2534

## How was this patch tested?

run with `bin/ozone scmcli container delete <containId>`
