### PR TITLE
HDDS-2534. scmcli container delete not working

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -158,6 +158,13 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setScmCloseContainerResponse(closeContainer(
                 request.getScmCloseContainerRequest()))
             .build();
+      case DeleteContainer:
+        return ScmContainerLocationResponse.newBuilder()
+            .setCmdType(request.getCmdType())
+            .setStatus(Status.OK)
+            .setScmDeleteContainerResponse(deleteContainer(
+                request.getScmDeleteContainerRequest()))
+            .build();
       case ListPipelines:
         return ScmContainerLocationResponse.newBuilder()
             .setCmdType(request.getCmdType())


### PR DESCRIPTION
## What changes were proposed in this pull request?

fix scmcli container delete not working

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2534

## How was this patch tested?

exec `bin/ozone scmcli container delete <containerId>`
