### PR TITLE
HDDS-2535. TestOzoneManagerDoubleBufferWithOMResponse is flaky.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
@@ -381,13 +381,14 @@ public class TestOzoneManagerDoubleBufferWithOMResponse {
       }
 
       // We are doing +1 for volume transaction.
+      // Here not checking lastAppliedIndex because transactionIndex is
+      // shared across threads, and lastAppliedIndex cannot be always
+      // expectedTransactions. So, skipping that check here.
       long expectedTransactions = (bucketCount + 1) * iterations;
-      GenericTestUtils.waitFor(() -> lastAppliedIndex == expectedTransactions,
-          100, 500000);
 
-      Assert.assertEquals(expectedTransactions,
-          doubleBuffer.getFlushedTransactionCount()
-      );
+      GenericTestUtils.waitFor(() -> expectedTransactions ==
+              doubleBuffer.getFlushedTransactionCount(),
+          100, 500000);
 
       GenericTestUtils.waitFor(() -> {
         long count = 0L;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix testDoubleBuffer flakiness.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2535


## How was this patch tested?

Ran the test multiple times, I see now it is passing.
