### PR TITLE
HDDS-2536. Add ozone.om.internal.service.id to OM HA configuration.

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -485,8 +485,17 @@
     <description>
       Comma-separated list of OM service Ids.
 
-      If not set, the default value of "om-service-value" is assigned as the
+      If not set, the default value of "omServiceIdDefault" is assigned as the
       OM service ID.
+    </description>
+  </property>
+  <property>
+    <name>ozone.om.internal.service.ids</name>
+    <value></value>
+    <tag>OM, HA</tag>
+    <description>
+      Service ID of the Ozone Manager. If this is not set fall back to
+      ozone.om.service.ids to find the service ID it belongs to.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -490,7 +490,7 @@
     </description>
   </property>
   <property>
-    <name>ozone.om.internal.service.ids</name>
+    <name>ozone.om.internal.service.id</name>
     <value></value>
     <tag>OM, HA</tag>
     <description>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -39,8 +39,8 @@ public final class OMConfigKeys {
       "ozone.om.handler.count.key";
   public static final int OZONE_OM_HANDLER_COUNT_DEFAULT = 20;
 
-  public static final String OZONE_OM_INTERNAL_SERVICE_ID = "ozone.om" +
-      ".internal.service.id";
+  public static final String OZONE_OM_INTERNAL_SERVICE_ID =
+      "ozone.om.internal.service.id";
 
   public static final String OZONE_OM_SERVICE_IDS_KEY =
       "ozone.om.service.ids";

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -39,6 +39,9 @@ public final class OMConfigKeys {
       "ozone.om.handler.count.key";
   public static final int OZONE_OM_HANDLER_COUNT_DEFAULT = 20;
 
+  public static final String OZONE_OM_INTERNAL_SERVICE_ID = "ozone.om" +
+      ".internal.service.id";
+
   public static final String OZONE_OM_SERVICE_IDS_KEY =
       "ozone.om.service.ids";
   public static final String OZONE_OM_NODES_KEY =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -307,8 +307,12 @@ public final class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
      * Initialize HA related configurations.
      */
     private void initHAConfig(int basePort) throws IOException {
-      // Set configurations required for starting OM HA service
+      // Set configurations required for starting OM HA service, because that
+      // is the serviceID being passed to start Ozone HA cluster.
+      // Here setting internal service and OZONE_OM_SERVICE_IDS_KEY, in this
+      // way in OM start it uses internal service id to find it's service id.
       conf.set(OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY, omServiceId);
+      conf.set(OMConfigKeys.OZONE_OM_INTERNAL_SERVICE_ID, omServiceId);
       String omNodesKey = OmUtils.addKeySuffixes(
           OMConfigKeys.OZONE_OM_NODES_KEY, omServiceId);
       StringBuilder omNodesKeyValue = new StringBuilder();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
@@ -96,9 +96,9 @@ public class OMHANodeDetails {
 
     Collection<String> omServiceIds;
 
-    String omServiceId = conf.getTrimmed(OZONE_OM_INTERNAL_SERVICE_ID);
+    localOMServiceId = conf.getTrimmed(OZONE_OM_INTERNAL_SERVICE_ID);
 
-    if (omServiceId == null) {
+    if (localOMServiceId == null) {
       // There is no internal om service id is being set, fall back to ozone
       // .om.service.ids.
       LOG.info(OZONE_OM_INTERNAL_SERVICE_ID + " is not defined, falling back " +
@@ -107,8 +107,8 @@ public class OMHANodeDetails {
       omServiceIds = conf.getTrimmedStringCollection(
           OZONE_OM_SERVICE_IDS_KEY);
     } else {
-      LOG.info("ServiceID for OzoneManager is {}", omServiceId);
-      omServiceIds = Collections.singletonList(omServiceId);
+      LOG.info("ServiceID for OzoneManager is {}", localOMServiceId);
+      omServiceIds = Collections.singletonList(localOMServiceId);
     }
 
     String knownOMNodeId = conf.get(OZONE_OM_NODE_ID_KEY);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
@@ -30,9 +30,11 @@ import org.slf4j.LoggerFactory;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_INTERNAL_SERVICE_ID;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODE_ID_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_PORT_DEFAULT;
@@ -91,8 +93,23 @@ public class OMHANodeDetails {
     String localOMServiceId = null;
     String localOMNodeId = null;
     int localRatisPort = 0;
-    Collection<String> omServiceIds = conf.getTrimmedStringCollection(
-        OZONE_OM_SERVICE_IDS_KEY);
+
+    Collection<String> omServiceIds;
+
+    String omServiceId = conf.getTrimmed(OZONE_OM_INTERNAL_SERVICE_ID);
+
+    if (omServiceId == null) {
+      // There is no internal om service id is being set, fall back to ozone
+      // .om.service.ids.
+      LOG.info(OZONE_OM_INTERNAL_SERVICE_ID + " is not defined, falling back " +
+          "to " + OZONE_OM_SERVICE_IDS_KEY + " to find serviceID for " +
+          "OzoneManager if it is HA enabled cluster");
+      omServiceIds = conf.getTrimmedStringCollection(
+          OZONE_OM_SERVICE_IDS_KEY);
+    } else {
+      LOG.info("ServiceID for OzoneManager is {}", omServiceId);
+      omServiceIds = Collections.singletonList(omServiceId);
+    }
 
     String knownOMNodeId = conf.get(OZONE_OM_NODE_ID_KEY);
     int found = 0;


### PR DESCRIPTION
## What changes were proposed in this pull request?
This Jira is to add ozone.om.internal.serviceid to let OM knows it belongs to a particular service.

 
As now we have ozone.om.service.ids -≥ where we can define all service id's in a cluster.(This can happen if the same config is shared across the cluster)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2536

## How was this patch tested?

Modified MiniOzoneHAclusterImpl to set serviceID value for ozone.om.internal.service.id. And ran TestOzoneFSHAUrls.java, and test passed. And also verified that the new code path is being run.
