### PR TITLE
HDDS-2527. Sonar : remove redundant temporary assignment in HddsVersionProvider

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/HddsVersionProvider.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/HddsVersionProvider.java
@@ -27,9 +27,8 @@ import picocli.CommandLine.IVersionProvider;
 public class HddsVersionProvider implements IVersionProvider {
   @Override
   public String[] getVersion() throws Exception {
-    String[] result = new String[] {
+    return new String[] {
         HddsVersionInfo.HDDS_VERSION_INFO.getBuildVersion()
     };
-    return result;
   }
 }


### PR DESCRIPTION


## What changes were proposed in this pull request?
This Jira removes the use of redundant temporary String array 'result'.
Sonar report :
https://sonarcloud.io/project/issues?id=hadoop-ozone&issues=AW5md-4AKcVY8lQ4ZsO6&open=AW5md-4AKcVY8lQ4ZsO6

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2527

## How was this patch tested?
N/A
