### PR TITLE
HDDS-2486. Sonar: Avoid empty test methods

### DIFF
--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBTableStore.java
@@ -95,10 +95,6 @@ public class TestRDBTableStore {
   }
 
   @Test
-  public void toIOException() {
-  }
-
-  @Test
   public void getHandle() throws Exception {
     try (Table testTable = rdbStore.getTable("First")) {
       Assert.assertNotNull(testTable);

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
@@ -92,10 +92,6 @@ public class TestTypedRDBTableStore {
   }
 
   @Test
-  public void toIOException() {
-  }
-
-  @Test
   public void putGetAndEmpty() throws Exception {
     try (Table<String, String> testTable = createTypedTable(
         "First")) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removed empty test methods `TestRDBTableStore#toIOException` and `TestTypedRDBTableStore#toIOException`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2486

## How was this patch tested?

N/A
