### PR TITLE
HDDS-2541. CI builds should use merged code state instead of the forked branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - run: .github/workflows/rebase.sh
         - uses: ./.github/buildenv
           with:
              args: ./hadoop-ozone/dev-support/checks/build.sh
@@ -30,6 +31,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - run: .github/workflows/rebase.sh
         - uses: ./.github/buildenv
           with:
              args: ./hadoop-ozone/dev-support/checks/rat.sh
@@ -43,6 +45,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - run: .github/workflows/rebase.sh
         - uses: ./.github/buildenv
           with:
              args: ./hadoop-ozone/dev-support/checks/author.sh
@@ -56,6 +59,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - run: .github/workflows/rebase.sh
         - uses: ./.github/buildenv
           with:
              args: ./hadoop-ozone/dev-support/checks/unit.sh
@@ -69,6 +73,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - run: .github/workflows/rebase.sh
         - uses: ./.github/buildenv
           with:
              args: ./hadoop-ozone/dev-support/checks/checkstyle.sh
@@ -82,6 +87,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - run: .github/workflows/rebase.sh
         - uses: ./.github/buildenv
           with:
              args: ./hadoop-ozone/dev-support/checks/findbugs.sh
@@ -101,6 +107,7 @@ jobs:
        - findbugs
     steps:
         - uses: actions/checkout@master
+        - run: .github/workflows/rebase.sh
         - uses: ./.github/buildenv
           with:
             args: ./hadoop-ozone/dev-support/checks/build.sh

--- a/.github/workflows/rebase.sh
+++ b/.github/workflows/rebase.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+   echo "This is a pull request build. Trying to merge to the target branch."
+   TARGET_BRANCH=$(jq -r '.pull_request.base.ref' "$GITHUB_EVENT_PATH")
+   PR_HEAD=$(git rev-parse HEAD)
+   git checkout -b $TARGET_BRANCH origin/$TARGET_BRANCH
+   TARGET_HEAD=$(git rev-parse HEAD)
+   echo "PR head $PR_HEAD will be merged to the origin $TARGET_BRANCH ($TARGET_HEAD):"
+   git log -1
+   git merge --squash $PR_HEAD
+fi


### PR DESCRIPTION
## What changes were proposed in this pull request?

As of now the github actions based CI runs uses the branch of the PR which is the forked repo most of the time.

It would be better to force a rebase/merge (without push) before the builds to test the possible state after the merge not before.

For example if a PR branch uses elek/hadoop-ozone:HDDS-1234 and request a merge to apache/hadoop-ozone:master then the build should download the HDDS-1234 from elek/hadoop-ozone AND rebase/merge to the apache/hadoop-ozone before the build.

This merge is temporary just for the build/checks (no push at all).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2541

## How was this patch tested?

This is under testing with the current PR. With the following CI runs the rebase should be visible from the build output.