### PR TITLE
HDDS-2548. Refactored return type as interface rather then impl.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -212,7 +213,7 @@ public final class XceiverClientRatis extends XceiverClientSpi {
 
 
   @VisibleForTesting
-  public ConcurrentHashMap<UUID, Long> getCommitInfoMap() {
+  public ConcurrentMap<UUID, Long> getCommitInfoMap() {
     return commitInfoMap;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed Return Type as an interface. Verified by code refs lookup and no place impl specific method is being used so this change should be good. Also, builds were successful. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2548

## How was this patch tested?

mvn builds and unit test