### PR TITLE
HDDS-2523. BufferPool.releaseBuffer may release a buffer different than the head of the list

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
@@ -94,7 +94,7 @@ public class BufferPool {
     // always remove from head of the list and append at last
     final ChunkBuffer buffer = bufferList.remove(0);
     // Ensure the buffer to be removed is always at the head of the list.
-    Preconditions.checkArgument(buffer.equals(chunkBuffer));
+    Preconditions.checkArgument(buffer == chunkBuffer);
     buffer.clear();
     bufferList.add(buffer);
     Preconditions.checkArgument(currentBufferIndex >= 0);

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/CommitWatcher.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/CommitWatcher.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -110,7 +111,8 @@ public class CommitWatcher {
   }
 
   public void updateCommitInfoMap(long index, List<ChunkBuffer> buffers) {
-    commitIndex2flushedDataMap.put(index, buffers);
+    commitIndex2flushedDataMap.computeIfAbsent(index, k -> new LinkedList<>())
+      .addAll(buffers);
   }
 
   int getCommitInfoMapSize() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitWatcher.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitWatcher.java
@@ -52,6 +52,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_SCM_WATCHER_TIMEOUT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 
@@ -140,13 +141,11 @@ public class TestCommitWatcher {
     XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
     CommitWatcher watcher = new CommitWatcher(bufferPool, ratisClient, 10000);
     BlockID blockID = ContainerTestHelper.getTestBlockID(containerId);
-    final List<ChunkBuffer> bufferList = new ArrayList<>();
     List<XceiverClientReply> replies = new ArrayList<>();
     long length = 0;
     List<CompletableFuture<ContainerProtos.ContainerCommandResponseProto>>
         futures = new ArrayList<>();
     for (int i = 0; i < capacity; i++) {
-      bufferList.clear();
       ContainerProtos.ContainerCommandRequestProto writeChunkRequest =
           ContainerTestHelper
               .getWriteChunkRequest(pipeline, blockID, chunkSize, null);
@@ -158,7 +157,7 @@ public class TestCommitWatcher {
           ContainerTestHelper
               .getPutBlockRequest(pipeline, writeChunkRequest.getWriteChunk());
       XceiverClientReply reply = ratisClient.sendCommandAsync(putBlockRequest);
-      bufferList.add(byteBuffer);
+      final List<ChunkBuffer> bufferList = singletonList(byteBuffer);
       length += byteBuffer.position();
       CompletableFuture<ContainerProtos.ContainerCommandResponseProto> future =
           reply.getResponse().thenApply(v -> {
@@ -216,13 +215,11 @@ public class TestCommitWatcher {
     XceiverClientRatis ratisClient = (XceiverClientRatis) xceiverClient;
     CommitWatcher watcher = new CommitWatcher(bufferPool, ratisClient, 10000);
     BlockID blockID = ContainerTestHelper.getTestBlockID(containerId);
-    final List<ChunkBuffer> bufferList = new ArrayList<>();
     List<XceiverClientReply> replies = new ArrayList<>();
     long length = 0;
     List<CompletableFuture<ContainerProtos.ContainerCommandResponseProto>>
         futures = new ArrayList<>();
     for (int i = 0; i < capacity; i++) {
-      bufferList.clear();
       ContainerProtos.ContainerCommandRequestProto writeChunkRequest =
           ContainerTestHelper
               .getWriteChunkRequest(pipeline, blockID, chunkSize, null);
@@ -234,7 +231,7 @@ public class TestCommitWatcher {
           ContainerTestHelper
               .getPutBlockRequest(pipeline, writeChunkRequest.getWriteChunk());
       XceiverClientReply reply = ratisClient.sendCommandAsync(putBlockRequest);
-      bufferList.add(byteBuffer);
+      final List<ChunkBuffer> bufferList = singletonList(byteBuffer);
       length += byteBuffer.position();
       CompletableFuture<ContainerProtos.ContainerCommandResponseProto> future =
           reply.getResponse().thenApply(v -> {


### PR DESCRIPTION
## What changes were proposed in this pull request?

For standalone replication type log index is always 0.  Each PutBlock's list of buffers are written to the same entry in the `commitIndex2flushedDataMap` map.  Thus only the last PutBlock's buffers are released during flush.

The problem was exposed during review of #205, where `IncrementalChunkBuffer` did not implement `equals()`, ie. it was the same as `==`.  This caused the precondition in `BufferPool.releaseBuffer` to fail for `TestContainerMapper` (which uses standalone replication).

https://issues.apache.org/jira/browse/HDDS-2523

## How was this patch tested?

`TestContainerMapper` passes with the fix, but fails with only the precondition change.

Clean CI in private branch: https://github.com/adoroszlai/hadoop-ozone/runs/310502460