### PR TITLE
HDDS-2284. XceiverClientMetrics should be initialised as part of XceiverClientManager constructor.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -94,7 +94,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
    * @param caCert   - SCM ca certificate.
    */
   public XceiverClientGrpc(Pipeline pipeline, Configuration config,
-      X509Certificate caCert) {
+      X509Certificate caCert, XceiverClientMetrics metrics) {
     super();
     Preconditions.checkNotNull(pipeline);
     Preconditions.checkNotNull(config);
@@ -103,7 +103,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     this.secConfig = new SecurityConfig(config);
     this.semaphore =
         new Semaphore(HddsClientUtils.getMaxOutstandingRequests(config));
-    this.metrics = XceiverClientManager.getXceiverClientMetrics();
+    this.metrics = metrics;
     this.channels = new HashMap<>();
     this.asyncStubs = new HashMap<>();
     this.topologyAwareRead = config.getBoolean(
@@ -121,7 +121,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
    * @param config   -- Ozone Config
    */
   public XceiverClientGrpc(Pipeline pipeline, Configuration config) {
-    this(pipeline, config, null);
+    this(pipeline, config, null, null);
   }
 
   /**
@@ -212,7 +212,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     for (ManagedChannel channel : channels.values()) {
       channel.shutdownNow();
       try {
-        channel.awaitTermination(60, TimeUnit.MINUTES);
+        channel.awaitTermination(5, TimeUnit.SECONDS);
       } catch (Exception e) {
         LOG.error("Unexpected exception while waiting for channel termination",
             e);

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -85,7 +85,8 @@ public final class XceiverClientRatis extends XceiverClientSpi {
 
   public static XceiverClientRatis newXceiverClientRatis(
       org.apache.hadoop.hdds.scm.pipeline.Pipeline pipeline,
-      Configuration ozoneConf, X509Certificate caCert, XceiverClientMetrics metrics) {
+      Configuration ozoneConf, X509Certificate caCert,
+      XceiverClientMetrics metrics) {
     final String rpcType = ozoneConf
         .get(ScmConfigKeys.DFS_CONTAINER_RATIS_RPC_TYPE_KEY,
             ScmConfigKeys.DFS_CONTAINER_RATIS_RPC_TYPE_DEFAULT);
@@ -119,7 +120,8 @@ public final class XceiverClientRatis extends XceiverClientSpi {
    */
   private XceiverClientRatis(Pipeline pipeline, RpcType rpcType,
       int maxOutStandingChunks, RetryPolicy retryPolicy,
-      GrpcTlsConfig tlsConfig, TimeDuration timeout, XceiverClientMetrics metrics) {
+      GrpcTlsConfig tlsConfig, TimeDuration timeout,
+      XceiverClientMetrics metrics) {
     super();
     this.pipeline = pipeline;
     this.rpcType = rpcType;

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -80,12 +80,12 @@ public final class XceiverClientRatis extends XceiverClientSpi {
   public static XceiverClientRatis newXceiverClientRatis(
       org.apache.hadoop.hdds.scm.pipeline.Pipeline pipeline,
       Configuration ozoneConf) {
-    return newXceiverClientRatis(pipeline, ozoneConf, null);
+    return newXceiverClientRatis(pipeline, ozoneConf, null, null);
   }
 
   public static XceiverClientRatis newXceiverClientRatis(
       org.apache.hadoop.hdds.scm.pipeline.Pipeline pipeline,
-      Configuration ozoneConf, X509Certificate caCert) {
+      Configuration ozoneConf, X509Certificate caCert, XceiverClientMetrics metrics) {
     final String rpcType = ozoneConf
         .get(ScmConfigKeys.DFS_CONTAINER_RATIS_RPC_TYPE_KEY,
             ScmConfigKeys.DFS_CONTAINER_RATIS_RPC_TYPE_DEFAULT);
@@ -98,7 +98,7 @@ public final class XceiverClientRatis extends XceiverClientSpi {
         SecurityConfig(ozoneConf), caCert);
     return new XceiverClientRatis(pipeline,
         SupportedRpcType.valueOfIgnoreCase(rpcType), maxOutstandingRequests,
-        retryPolicy, tlsConfig, clientRequestTimeout);
+        retryPolicy, tlsConfig, clientRequestTimeout, metrics);
   }
 
   private final Pipeline pipeline;
@@ -119,7 +119,7 @@ public final class XceiverClientRatis extends XceiverClientSpi {
    */
   private XceiverClientRatis(Pipeline pipeline, RpcType rpcType,
       int maxOutStandingChunks, RetryPolicy retryPolicy,
-      GrpcTlsConfig tlsConfig, TimeDuration timeout) {
+      GrpcTlsConfig tlsConfig, TimeDuration timeout, XceiverClientMetrics metrics) {
     super();
     this.pipeline = pipeline;
     this.rpcType = rpcType;
@@ -128,7 +128,7 @@ public final class XceiverClientRatis extends XceiverClientSpi {
     commitInfoMap = new ConcurrentHashMap<>();
     this.tlsConfig = tlsConfig;
     this.clientRequestTimeout = timeout;
-    metrics = XceiverClientManager.getXceiverClientMetrics();
+    this.metrics = metrics;
   }
 
   private void updateCommitInfosMap(

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
     .ChecksumType;
+import org.apache.hadoop.hdds.scm.XceiverClientMetrics;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.io.IOUtils;
@@ -830,8 +831,8 @@ public class RpcClient implements ClientProtocol {
   }
 
   @VisibleForTesting
-  public XceiverClientManager getXceiverClientManager() {
-    return xceiverClientManager;
+  public XceiverClientMetrics getXceiverClientMetrics() {
+    return xceiverClientManager.getMetrics();
   }
 
   @Override

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -829,6 +829,11 @@ public class RpcClient implements ClientProtocol {
     IOUtils.cleanupWithLogger(LOG, xceiverClientManager);
   }
 
+  @VisibleForTesting
+  public XceiverClientManager getXceiverClientManager() {
+    return xceiverClientManager;
+  }
+
   @Override
   public OmMultipartInfo initiateMultipartUpload(String volumeName,
                                                 String bucketName,

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -53,7 +53,7 @@ wait_for_safemode_exit(){
 
      echo $status
      if [[ "$status" ]]; then
-       if [[ ${status} == *"SCM is out of safe mode." ]]; then
+       if [[ ${status} == "SCM is out of safe mode." ]]; then
          #Safemode exits. Let's return from the function.
          echo "Safe mode is off"
          return

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -53,7 +53,7 @@ wait_for_safemode_exit(){
 
      echo $status
      if [[ "$status" ]]; then
-       if [[ ${status} == "SCM is out of safe mode." ]]; then
+       if [[ ${status} == *"SCM is out of safe mode." ]]; then
          #Safemode exits. Let's return from the function.
          echo "Safe mode is off"
          return

--- a/hadoop-ozone/dist/src/shell/conf/log4j.properties
+++ b/hadoop-ozone/dist/src/shell/conf/log4j.properties
@@ -135,3 +135,5 @@ log4j.logger.org.apache.hadoop.util.NativeCodeLoader=ERROR
 log4j.logger.org.apache.ratis.conf.ConfUtils=WARN
 log4j.logger.org.apache.hadoop.security.ShellBasedUnixGroupsMapping=ERROR
 log4j.logger.org.apache.ratis.grpc.client.GrpcClientProtocolClient=WARN
+log4j.logger.org.apache.hadoop.metrics2.impl.MetricsSystemImpl=WARN
+log4j.logger.org.apache.hadoop.metrics2.impl.MetricsConfig=WARN

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
@@ -116,6 +116,6 @@ public final class OzoneTestUtils {
   public static XceiverClientMetrics getXceiverClientMetrics(
           OzoneClient client) {
     RpcClient rpc = (RpcClient)client.getObjectStore().getClientProxy();
-    return rpc.getXceiverClientManager().getMetrics();
+    return rpc.getXceiverClientMetrics();
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
@@ -113,7 +113,8 @@ public final class OzoneTestUtils {
     }
   }
 
-  public static XceiverClientMetrics getXceiverClientMetrics(OzoneClient client) {
+  public static XceiverClientMetrics getXceiverClientMetrics(
+          OzoneClient client) {
     RpcClient rpc = (RpcClient)client.getObjectStore().getClientProxy();
     return rpc.getXceiverClientManager().getMetrics();
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/OzoneTestUtils.java
@@ -22,8 +22,11 @@ import java.util.List;
 
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.XceiverClientMetrics;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.rpc.RpcClient;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
@@ -108,5 +111,10 @@ public final class OzoneTestUtils {
     } catch (OMException ex) {
       Assert.assertEquals(code, ex.getResult());
     }
+  }
+
+  public static XceiverClientMetrics getXceiverClientMetrics(OzoneClient client) {
+    RpcClient rpc = (RpcClient)client.getObjectStore().getClientProxy();
+    return rpc.getXceiverClientManager().getMetrics();
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
@@ -21,11 +21,11 @@ import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
-import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientMetrics;
 import org.apache.hadoop.hdds.scm.storage.BlockOutputStream;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.OzoneTestUtils;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
@@ -102,11 +102,6 @@ public class TestBlockOutputStream {
     objectStore.getVolume(volumeName).createBucket(bucketName);
   }
 
-  private XceiverClientMetrics getXceiverClientMetrics() {
-    RpcClient rpc = (RpcClient)client.getObjectStore().getClientProxy();
-    return rpc.getXceiverClientManager().getMetrics();
-  }
-
   private String getKeyName() {
     return UUID.randomUUID().toString();
   }
@@ -123,7 +118,8 @@ public class TestBlockOutputStream {
 
   @Test
   public void testBufferCaching() throws Exception {
-    XceiverClientMetrics metrics = getXceiverClientMetrics();
+    XceiverClientMetrics metrics =
+            OzoneTestUtils.getXceiverClientMetrics(client);
     long writeChunkCount = metrics.getContainerOpCountMetrics(
         ContainerProtos.Type.WriteChunk);
     long putBlockCount = metrics.getContainerOpCountMetrics(
@@ -218,7 +214,8 @@ public class TestBlockOutputStream {
 
   @Test
   public void testFlushChunk() throws Exception {
-    XceiverClientMetrics metrics = getXceiverClientMetrics();
+    XceiverClientMetrics metrics =
+            OzoneTestUtils.getXceiverClientMetrics(client);
     long writeChunkCount = metrics.getContainerOpCountMetrics(
         ContainerProtos.Type.WriteChunk);
     long putBlockCount = metrics.getContainerOpCountMetrics(
@@ -312,7 +309,8 @@ public class TestBlockOutputStream {
 
   @Test
   public void testMultiChunkWrite() throws Exception {
-    XceiverClientMetrics metrics = getXceiverClientMetrics();
+    XceiverClientMetrics metrics =
+            OzoneTestUtils.getXceiverClientMetrics(client);
     long writeChunkCount = metrics.getContainerOpCountMetrics(
         ContainerProtos.Type.WriteChunk);
     long putBlockCount = metrics.getContainerOpCountMetrics(
@@ -406,7 +404,8 @@ public class TestBlockOutputStream {
 
   @Test
   public void testMultiChunkWrite2() throws Exception {
-    XceiverClientMetrics metrics = getXceiverClientMetrics();
+    XceiverClientMetrics metrics =
+            OzoneTestUtils.getXceiverClientMetrics(client);
     long writeChunkCount = metrics.getContainerOpCountMetrics(
         ContainerProtos.Type.WriteChunk);
     long putBlockCount = metrics.getContainerOpCountMetrics(
@@ -481,7 +480,8 @@ public class TestBlockOutputStream {
 
   @Test
   public void testFullBufferCondition() throws Exception {
-    XceiverClientMetrics metrics = getXceiverClientMetrics();
+    XceiverClientMetrics metrics =
+            OzoneTestUtils.getXceiverClientMetrics(client);
     long writeChunkCount = metrics.getContainerOpCountMetrics(
         ContainerProtos.Type.WriteChunk);
     long putBlockCount = metrics.getContainerOpCountMetrics(
@@ -580,7 +580,8 @@ public class TestBlockOutputStream {
 
   @Test
   public void testWriteWithExceedingMaxBufferLimit() throws Exception {
-    XceiverClientMetrics metrics = getXceiverClientMetrics();
+    XceiverClientMetrics metrics =
+            OzoneTestUtils.getXceiverClientMetrics(client);
     long writeChunkCount = metrics.getContainerOpCountMetrics(
         ContainerProtos.Type.WriteChunk);
     long putBlockCount = metrics.getContainerOpCountMetrics(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
@@ -102,6 +102,11 @@ public class TestBlockOutputStream {
     objectStore.getVolume(volumeName).createBucket(bucketName);
   }
 
+  private XceiverClientMetrics getXceiverClientMetrics() {
+    RpcClient rpc = (RpcClient)client.getObjectStore().getClientProxy();
+    return rpc.getXceiverClientManager().getMetrics();
+  }
+
   private String getKeyName() {
     return UUID.randomUUID().toString();
   }
@@ -118,8 +123,7 @@ public class TestBlockOutputStream {
 
   @Test
   public void testBufferCaching() throws Exception {
-    XceiverClientMetrics metrics =
-        XceiverClientManager.getXceiverClientMetrics();
+    XceiverClientMetrics metrics = getXceiverClientMetrics();
     long writeChunkCount = metrics.getContainerOpCountMetrics(
         ContainerProtos.Type.WriteChunk);
     long putBlockCount = metrics.getContainerOpCountMetrics(
@@ -156,11 +160,9 @@ public class TestBlockOutputStream {
     Assert.assertEquals(0, blockOutputStream.getTotalDataFlushedLength());
     Assert.assertEquals(0, blockOutputStream.getTotalAckDataLength());
     Assert.assertEquals(pendingWriteChunkCount,
-        XceiverClientManager.getXceiverClientMetrics()
-            .getContainerOpsMetrics(ContainerProtos.Type.WriteChunk));
+            metrics.getContainerOpsMetrics(ContainerProtos.Type.WriteChunk));
     Assert.assertEquals(pendingPutBlockCount,
-        XceiverClientManager.getXceiverClientMetrics()
-            .getContainerOpsMetrics(ContainerProtos.Type.PutBlock));
+            metrics.getContainerOpsMetrics(ContainerProtos.Type.PutBlock));
 
     // commitIndex2FlushedData Map will be empty here
     Assert.assertTrue(
@@ -216,8 +218,7 @@ public class TestBlockOutputStream {
 
   @Test
   public void testFlushChunk() throws Exception {
-    XceiverClientMetrics metrics =
-        XceiverClientManager.getXceiverClientMetrics();
+    XceiverClientMetrics metrics = getXceiverClientMetrics();
     long writeChunkCount = metrics.getContainerOpCountMetrics(
         ContainerProtos.Type.WriteChunk);
     long putBlockCount = metrics.getContainerOpCountMetrics(
@@ -311,8 +312,7 @@ public class TestBlockOutputStream {
 
   @Test
   public void testMultiChunkWrite() throws Exception {
-    XceiverClientMetrics metrics =
-        XceiverClientManager.getXceiverClientMetrics();
+    XceiverClientMetrics metrics = getXceiverClientMetrics();
     long writeChunkCount = metrics.getContainerOpCountMetrics(
         ContainerProtos.Type.WriteChunk);
     long putBlockCount = metrics.getContainerOpCountMetrics(
@@ -406,8 +406,7 @@ public class TestBlockOutputStream {
 
   @Test
   public void testMultiChunkWrite2() throws Exception {
-    XceiverClientMetrics metrics =
-        XceiverClientManager.getXceiverClientMetrics();
+    XceiverClientMetrics metrics = getXceiverClientMetrics();
     long writeChunkCount = metrics.getContainerOpCountMetrics(
         ContainerProtos.Type.WriteChunk);
     long putBlockCount = metrics.getContainerOpCountMetrics(
@@ -482,8 +481,7 @@ public class TestBlockOutputStream {
 
   @Test
   public void testFullBufferCondition() throws Exception {
-    XceiverClientMetrics metrics =
-        XceiverClientManager.getXceiverClientMetrics();
+    XceiverClientMetrics metrics = getXceiverClientMetrics();
     long writeChunkCount = metrics.getContainerOpCountMetrics(
         ContainerProtos.Type.WriteChunk);
     long putBlockCount = metrics.getContainerOpCountMetrics(
@@ -582,8 +580,7 @@ public class TestBlockOutputStream {
 
   @Test
   public void testWriteWithExceedingMaxBufferLimit() throws Exception {
-    XceiverClientMetrics metrics =
-        XceiverClientManager.getXceiverClientMetrics();
+    XceiverClientMetrics metrics = getXceiverClientMetrics();
     long writeChunkCount = metrics.getContainerOpCountMetrics(
         ContainerProtos.Type.WriteChunk);
     long putBlockCount = metrics.getContainerOpCountMetrics(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
@@ -106,6 +106,11 @@ public class TestBlockOutputStreamWithFailures {
     objectStore.getVolume(volumeName).createBucket(bucketName);
   }
 
+  private XceiverClientMetrics getXceiverClientMetrics() {
+    RpcClient rpc = (RpcClient)client.getObjectStore().getClientProxy();
+    return rpc.getXceiverClientManager().getMetrics();
+  }
+
   private String getKeyName() {
     return UUID.randomUUID().toString();
   }
@@ -123,8 +128,7 @@ public class TestBlockOutputStreamWithFailures {
   @Test
   public void testWatchForCommitWithCloseContainerException()
       throws Exception {
-    XceiverClientMetrics metrics =
-        XceiverClientManager.getXceiverClientMetrics();
+    XceiverClientMetrics metrics = getXceiverClientMetrics();
     long writeChunkCount =
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk);
     long putBlockCount =
@@ -263,8 +267,7 @@ public class TestBlockOutputStreamWithFailures {
 
   @Test
   public void testWatchForCommitDatanodeFailure() throws Exception {
-    XceiverClientMetrics metrics =
-        XceiverClientManager.getXceiverClientMetrics();
+    XceiverClientMetrics metrics = getXceiverClientMetrics();
     long writeChunkCount =
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk);
     long putBlockCount =
@@ -396,8 +399,7 @@ public class TestBlockOutputStreamWithFailures {
 
   @Test
   public void test2DatanodesFailure() throws Exception {
-    XceiverClientMetrics metrics =
-        XceiverClientManager.getXceiverClientMetrics();
+    XceiverClientMetrics metrics = getXceiverClientMetrics();
     long writeChunkCount =
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk);
     long putBlockCount =
@@ -544,8 +546,7 @@ public class TestBlockOutputStreamWithFailures {
 
   @Test
   public void testFailureWithPrimeSizedData() throws Exception {
-    XceiverClientMetrics metrics =
-        XceiverClientManager.getXceiverClientMetrics();
+    XceiverClientMetrics metrics = getXceiverClientMetrics();
     long writeChunkCount =
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk);
     long putBlockCount =
@@ -665,8 +666,7 @@ public class TestBlockOutputStreamWithFailures {
 
   @Test
   public void testExceptionDuringClose() throws Exception {
-    XceiverClientMetrics metrics =
-        XceiverClientManager.getXceiverClientMetrics();
+    XceiverClientMetrics metrics = getXceiverClientMetrics();
     long writeChunkCount =
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk);
     long putBlockCount =
@@ -780,8 +780,7 @@ public class TestBlockOutputStreamWithFailures {
 
   @Test
   public void testWatchForCommitWithSingleNodeRatis() throws Exception {
-    XceiverClientMetrics metrics =
-        XceiverClientManager.getXceiverClientMetrics();
+    XceiverClientMetrics metrics = getXceiverClientMetrics();
     long writeChunkCount =
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk);
     long putBlockCount =
@@ -921,8 +920,7 @@ public class TestBlockOutputStreamWithFailures {
 
   @Test
   public void testDatanodeFailureWithSingleNodeRatis() throws Exception {
-    XceiverClientMetrics metrics =
-        XceiverClientManager.getXceiverClientMetrics();
+    XceiverClientMetrics metrics = getXceiverClientMetrics();
     long writeChunkCount =
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk);
     long putBlockCount =
@@ -1061,8 +1059,7 @@ public class TestBlockOutputStreamWithFailures {
 
   @Test
   public void testDatanodeFailureWithPreAllocation() throws Exception {
-    XceiverClientMetrics metrics =
-        XceiverClientManager.getXceiverClientMetrics();
+    XceiverClientMetrics metrics = getXceiverClientMetrics();
     long writeChunkCount =
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk);
     long putBlockCount =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
-import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientMetrics;
 import org.apache.hadoop.hdds.scm.XceiverClientRatis;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
@@ -30,6 +29,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.BlockOutputStream;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.OzoneTestUtils;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
@@ -106,11 +106,6 @@ public class TestBlockOutputStreamWithFailures {
     objectStore.getVolume(volumeName).createBucket(bucketName);
   }
 
-  private XceiverClientMetrics getXceiverClientMetrics() {
-    RpcClient rpc = (RpcClient)client.getObjectStore().getClientProxy();
-    return rpc.getXceiverClientManager().getMetrics();
-  }
-
   private String getKeyName() {
     return UUID.randomUUID().toString();
   }
@@ -128,7 +123,8 @@ public class TestBlockOutputStreamWithFailures {
   @Test
   public void testWatchForCommitWithCloseContainerException()
       throws Exception {
-    XceiverClientMetrics metrics = getXceiverClientMetrics();
+    XceiverClientMetrics metrics =
+            OzoneTestUtils.getXceiverClientMetrics(client);
     long writeChunkCount =
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk);
     long putBlockCount =
@@ -267,7 +263,8 @@ public class TestBlockOutputStreamWithFailures {
 
   @Test
   public void testWatchForCommitDatanodeFailure() throws Exception {
-    XceiverClientMetrics metrics = getXceiverClientMetrics();
+    XceiverClientMetrics metrics =
+            OzoneTestUtils.getXceiverClientMetrics(client);
     long writeChunkCount =
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk);
     long putBlockCount =
@@ -399,7 +396,8 @@ public class TestBlockOutputStreamWithFailures {
 
   @Test
   public void test2DatanodesFailure() throws Exception {
-    XceiverClientMetrics metrics = getXceiverClientMetrics();
+    XceiverClientMetrics metrics =
+            OzoneTestUtils.getXceiverClientMetrics(client);
     long writeChunkCount =
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk);
     long putBlockCount =
@@ -546,7 +544,8 @@ public class TestBlockOutputStreamWithFailures {
 
   @Test
   public void testFailureWithPrimeSizedData() throws Exception {
-    XceiverClientMetrics metrics = getXceiverClientMetrics();
+    XceiverClientMetrics metrics =
+            OzoneTestUtils.getXceiverClientMetrics(client);
     long writeChunkCount =
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk);
     long putBlockCount =
@@ -666,7 +665,8 @@ public class TestBlockOutputStreamWithFailures {
 
   @Test
   public void testExceptionDuringClose() throws Exception {
-    XceiverClientMetrics metrics = getXceiverClientMetrics();
+    XceiverClientMetrics metrics =
+            OzoneTestUtils.getXceiverClientMetrics(client);
     long writeChunkCount =
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk);
     long putBlockCount =
@@ -780,7 +780,8 @@ public class TestBlockOutputStreamWithFailures {
 
   @Test
   public void testWatchForCommitWithSingleNodeRatis() throws Exception {
-    XceiverClientMetrics metrics = getXceiverClientMetrics();
+    XceiverClientMetrics metrics =
+            OzoneTestUtils.getXceiverClientMetrics(client);
     long writeChunkCount =
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk);
     long putBlockCount =
@@ -920,7 +921,8 @@ public class TestBlockOutputStreamWithFailures {
 
   @Test
   public void testDatanodeFailureWithSingleNodeRatis() throws Exception {
-    XceiverClientMetrics metrics = getXceiverClientMetrics();
+    XceiverClientMetrics metrics =
+            OzoneTestUtils.getXceiverClientMetrics(client);
     long writeChunkCount =
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk);
     long putBlockCount =
@@ -1059,7 +1061,8 @@ public class TestBlockOutputStreamWithFailures {
 
   @Test
   public void testDatanodeFailureWithPreAllocation() throws Exception {
-    XceiverClientMetrics metrics = getXceiverClientMetrics();
+    XceiverClientMetrics metrics =
+            OzoneTestUtils.getXceiverClientMetrics(client);
     long writeChunkCount =
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk);
     long putBlockCount =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestKeyInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestKeyInputStream.java
@@ -21,10 +21,10 @@ import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
-import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientMetrics;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.OzoneTestUtils;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
@@ -120,15 +120,8 @@ public class TestKeyInputStream {
         .createKey(keyName, type, size, objectStore, volumeName, bucketName);
   }
 
-  private XceiverClientMetrics getXceiverClientMetrics() {
-    RpcClient rpc = (RpcClient)client.getObjectStore().getClientProxy();
-    return rpc.getXceiverClientManager().getMetrics();
-  }
-
   @Test
   public void testSeekRandomly() throws Exception {
-    XceiverClientMetrics metrics = getXceiverClientMetrics();
-
     String keyName = getKeyName();
     OzoneOutputStream key = TestHelper.createKey(keyName,
         ReplicationType.RATIS, 0, objectStore, volumeName, bucketName);
@@ -226,7 +219,8 @@ public class TestKeyInputStream {
 
   @Test
   public void testSeek() throws Exception {
-    XceiverClientMetrics metrics = getXceiverClientMetrics();
+    XceiverClientMetrics metrics =
+            OzoneTestUtils.getXceiverClientMetrics(client);
     long writeChunkCount = metrics.getContainerOpCountMetrics(
         ContainerProtos.Type.WriteChunk);
     long readChunkCount = metrics.getContainerOpCountMetrics(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestKeyInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestKeyInputStream.java
@@ -120,11 +120,14 @@ public class TestKeyInputStream {
         .createKey(keyName, type, size, objectStore, volumeName, bucketName);
   }
 
+  private XceiverClientMetrics getXceiverClientMetrics() {
+    RpcClient rpc = (RpcClient)client.getObjectStore().getClientProxy();
+    return rpc.getXceiverClientManager().getMetrics();
+  }
 
   @Test
   public void testSeekRandomly() throws Exception {
-    XceiverClientMetrics metrics = XceiverClientManager
-        .getXceiverClientMetrics();
+    XceiverClientMetrics metrics = getXceiverClientMetrics();
 
     String keyName = getKeyName();
     OzoneOutputStream key = TestHelper.createKey(keyName,
@@ -223,8 +226,7 @@ public class TestKeyInputStream {
 
   @Test
   public void testSeek() throws Exception {
-    XceiverClientMetrics metrics = XceiverClientManager
-        .getXceiverClientMetrics();
+    XceiverClientMetrics metrics = getXceiverClientMetrics();
     long writeChunkCount = metrics.getContainerOpCountMetrics(
         ContainerProtos.Type.WriteChunk);
     long readChunkCount = metrics.getContainerOpCountMetrics(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdds.scm.storage.BlockOutputStream;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.OzoneTestUtils;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
@@ -130,11 +131,6 @@ public class TestWatchForCommit {
     return UUID.randomUUID().toString();
   }
 
-  private XceiverClientMetrics getXceiverClientMetrics() {
-    RpcClient rpc = (RpcClient)client.getObjectStore().getClientProxy();
-    return rpc.getXceiverClientManager().getMetrics();
-  }
-
   @Test
   public void testWatchForCommitWithKeyWrite() throws Exception {
     // in this case, watch request should fail with RaftRetryFailureException
@@ -148,7 +144,8 @@ public class TestWatchForCommit {
         OzoneConfigKeys.DFS_RATIS_LEADER_ELECTION_MINIMUM_TIMEOUT_DURATION_KEY,
         1, TimeUnit.SECONDS);
     startCluster(conf);
-    XceiverClientMetrics metrics = getXceiverClientMetrics();
+    XceiverClientMetrics metrics =
+            OzoneTestUtils.getXceiverClientMetrics(client);
     long writeChunkCount = metrics.getContainerOpCountMetrics(
         ContainerProtos.Type.WriteChunk);
     long putBlockCount = metrics.getContainerOpCountMetrics(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -130,6 +130,11 @@ public class TestWatchForCommit {
     return UUID.randomUUID().toString();
   }
 
+  private XceiverClientMetrics getXceiverClientMetrics() {
+    RpcClient rpc = (RpcClient)client.getObjectStore().getClientProxy();
+    return rpc.getXceiverClientManager().getMetrics();
+  }
+
   @Test
   public void testWatchForCommitWithKeyWrite() throws Exception {
     // in this case, watch request should fail with RaftRetryFailureException
@@ -143,8 +148,7 @@ public class TestWatchForCommit {
         OzoneConfigKeys.DFS_RATIS_LEADER_ELECTION_MINIMUM_TIMEOUT_DURATION_KEY,
         1, TimeUnit.SECONDS);
     startCluster(conf);
-    XceiverClientMetrics metrics =
-        XceiverClientManager.getXceiverClientMetrics();
+    XceiverClientMetrics metrics = getXceiverClientMetrics();
     long writeChunkCount = metrics.getContainerOpCountMetrics(
         ContainerProtos.Type.WriteChunk);
     long putBlockCount = metrics.getContainerOpCountMetrics(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
+import org.apache.hadoop.hdds.scm.XceiverClientMetrics;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
@@ -150,8 +151,9 @@ public class TestOzoneContainerWithTLS {
       //Set scmId and manually start ozone container.
       container.start(UUID.randomUUID().toString());
 
+      XceiverClientMetrics metrics = XceiverClientMetrics.create();
       XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf,
-          caClient.getCACertificate());
+          caClient.getCACertificate(), metrics);
 
       if (blockTokenEnabled) {
         secretManager.start(caClient);


### PR DESCRIPTION
## What changes were proposed in this pull request?
This jira moves the initialization of XceiverClientMetrics to XceiverClientManager, This helps in avoiding the static class object and also ensures that the metrics are initialized as part of the client intialization.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2284

## How was this patch tested?

TestBlockOutputStream & TestBlockOutputStreamWithFailures