### PR TITLE
HDDS-2594. S3 RangeReads failing with NumberFormatException.

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/RangeHeaderParserUtil.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/RangeHeaderParserUtil.java
@@ -50,12 +50,12 @@ public final class RangeHeaderParserUtil {
     Matcher matcher = RANGE_HEADER_MATCH_PATTERN.matcher(rangeHeaderVal);
     if (matcher.matches()) {
       if (!matcher.group("start").equals("")) {
-        start = Integer.parseInt(matcher.group("start"));
+        start = Long.parseLong(matcher.group("start"));
       } else {
         noStart = true;
       }
       if (!matcher.group("end").equals("")) {
-        end = Integer.parseInt(matcher.group("end"));
+        end = Long.parseLong(matcher.group("end"));
       } else {
         end = length - 1;
       }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/util/TestRangeHeaderParserUtil.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/util/TestRangeHeaderParserUtil.java
@@ -86,7 +86,11 @@ public class TestRangeHeaderParserUtil {
     assertEquals(9, rangeHeader.getEndOffset());
     assertEquals(false, rangeHeader.isInValidRange());
 
-
+    rangeHeader = RangeHeaderParserUtil.parseRangeHeader("bytes=3977248768" +
+            "-4977248768", 4977248769L);
+    assertEquals(3977248768L, rangeHeader.getStartOffset());
+    assertEquals(4977248768L, rangeHeader.getEndOffset());
+    assertEquals(false, rangeHeader.isInValidRange());
 
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
RangerHeaderParserUtil throws NumberFormatException, because of using Integer.parseInt.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2594

## How was this patch tested?

Added UT for this.
