### PR TITLE
HDDS-2608. Provide command to wait until SCM is out from the safe-mode

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
@@ -85,7 +85,7 @@ public class HealthyPipelineSafeModeRule
     healthyPipelineThresholdCount =
         (int) Math.ceil(healthyPipelinesPercent * pipelineCount);
 
-    LOG.info(" Total pipeline count is {}, healthy pipeline " +
+    LOG.info("Total pipeline count is {}, healthy pipeline " +
         "threshold count is {}", pipelineCount, healthyPipelineThresholdCount);
 
     getSafeModeMetrics().setNumHealthyPipelinesThreshold(

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeCommands.java
@@ -38,6 +38,7 @@ import picocli.CommandLine.ParentCommand;
     subcommands = {
         SafeModeCheckSubcommand.class,
         SafeModeExitSubcommand.class,
+        SafeModeWaitSubcommand.class
     })
 public class SafeModeCommands implements Callable<Void> {
 

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeWaitSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeWaitSubcommand.java
@@ -80,6 +80,7 @@ public class SafeModeWaitSubcommand implements Callable<Void> {
             "SCM is not available (yet?). Error is {}. Will retry in 1 sec. "
                 + "Remaining time (sec): {}",
             ex.getMessage(), getRemainingTimeInSec());
+        Thread.sleep(1000);
       }
     }
     throw new TimeoutException(

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeWaitSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeWaitSubcommand.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.cli;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.scm.client.ScmClient;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+/**
+ * This is the handler that process safe mode wait command.
+ */
+@Command(
+    name = "wait",
+    description = "Wait until the scm is out from the safe mode.",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class)
+public class SafeModeWaitSubcommand implements Callable<Void> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SafeModeWaitSubcommand.class);
+
+  @Option(description =
+      "Define timeout (in second) to wait until (exit code 1) "
+          + "or until safemode is ended (exit code 0).", defaultValue = "30",
+      required = false, names = {
+      "-t", "--timeout"})
+  private long timeoutSeconds;
+
+  private long startTestTime;
+
+  @ParentCommand
+  private SafeModeCommands parent;
+
+  @Override
+  public Void call() throws Exception {
+    startTestTime = System.currentTimeMillis();
+
+    while (getRemainingTimeInSec() > 0) {
+      try (ScmClient scmClient = parent.getParent().createScmClient()) {
+        while (getRemainingTimeInSec() > 0) {
+
+          boolean isSafeModeActive = scmClient.inSafeMode();
+
+          if (!isSafeModeActive) {
+            LOG.info("SCM is out of safe mode.");
+            return null;
+          } else {
+            LOG.info(
+                "SCM is in safe mode. Will retry in 1 sec. Remaining time "
+                    + "(sec): {}",
+                getRemainingTimeInSec());
+            Thread.sleep(1000);
+          }
+        }
+      } catch (Exception ex) {
+        LOG.info(
+            "SCM is not available (yet?). Error is {}. Will retry in 1 sec. "
+                + "Remaining time (sec): {}",
+            ex.getMessage(), getRemainingTimeInSec());
+      }
+    }
+    throw new TimeoutException(
+        "Safe mode is not ended within the timeout period.");
+  }
+
+  public long getRemainingTimeInSec() {
+    return timeoutSeconds - (System.currentTimeMillis() - startTestTime) / 1000;
+  }
+}

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeWaitSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SafeModeWaitSubcommand.java
@@ -87,7 +87,7 @@ public class SafeModeWaitSubcommand implements Callable<Void> {
         "Safe mode is not ended within the timeout period.");
   }
 
-  public long getRemainingTimeInSec() {
+  private long getRemainingTimeInSec() {
     return timeoutSeconds - (System.currentTimeMillis() - startTestTime) / 1000;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The safe mode can be checked with "ozone scmcli safemode status". But for acceptance tests there is no easy way to check if the cluster is ready to execute the tests (See HDDS-2606 for example).

One easy solution is to create a polling version from "safemode status".

"safemode wait --timeout ..." can be blocked until the scm is out from the safe mode.

Wit proper safe mode rules (min datanodes + min pipline numbers) it can help us to check if the acceptance tests are ready to test.

Same command can be used in k8s as well to test if the cluster is ready to start the freon commands...


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2608

## How was this patch tested?

Test it with the simple `compose/ozone` cluster but add

```
OZONE-SITE.XML_hdds.scm.safemode.min.datanode=3
```

to the docker-config.

1. Start the cluster with `docker-compose up -d`

2. Test the command 
```
docker-compose exec scm bash
ozone scmcli safemode wait -t 5
echo $?
ozone scmcli safemode wait -t 100
```

3. Start the missing datanodes from an other terminal

```
docker-compose scale datanode=3
```

Check if the safemode command returned.
