### PR TITLE
HDDS-2595. Update Ratis version to latest snapshot version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>0.5.0-d6d58d0-SNAPSHOT</ratis.version>
+    <ratis.version>0.5.0-ce699ba3-SNAPSHOT</ratis.version>
 
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update Ratis dependency version to latest snapshot ( ce699ba ), to avoid out of memory exceptions (RATIS-714).

## What is the link to the Apache JIRA

https://github.com/elek/hadoop-ozone/pull/new/HDDS-2595

## How was this patch tested?

We expect full green CI result before merge.