### PR TITLE
HDDS-2605. Use LongSupplier to avoid boxing

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -34,7 +34,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Supplier;
+import java.util.function.LongSupplier;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.opentracing.Scope;
@@ -307,7 +307,7 @@ public final class RandomKeyGenerator implements Callable<Void> {
       LOG.info("Data validation is enabled.");
     }
 
-    Supplier<Long> currentValue = numberOfKeysAdded::get;
+    LongSupplier currentValue = numberOfKeysAdded::get;
     progressbar = new ProgressBar(System.out, totalKeyCount, currentValue);
 
     LOG.info("Starting progress bar Thread.");

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestProgressBar.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestProgressBar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with this
  * work for additional information regarding copyright ownership.  The ASF
@@ -23,45 +23,37 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.PrintStream;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Supplier;
+import java.util.function.LongSupplier;
 import java.util.stream.LongStream;
 
 import static org.mockito.Mockito.*;
 
 /**
- * Using Mockito runner.
- */
-@RunWith(MockitoJUnitRunner.class)
-/**
  * Tests for the Progressbar class for Freon.
  */
+@RunWith(MockitoJUnitRunner.class)
 public class TestProgressBar {
 
   private PrintStream stream;
   private AtomicLong numberOfKeysAdded;
-  private Supplier<Long> currentValue;
+  private LongSupplier currentValue;
 
   @Before
   public void setupMock() {
     numberOfKeysAdded = new AtomicLong(0L);
-    currentValue = () -> numberOfKeysAdded.get();
+    currentValue = numberOfKeysAdded::get;
     stream = mock(PrintStream.class);
   }
 
   @Test
   public void testWithRunnable() {
 
-    Long maxValue = 10L;
+    long maxValue = 10L;
 
     ProgressBar progressbar = new ProgressBar(stream, maxValue, currentValue);
 
-    Runnable task = () -> {
-      LongStream.range(0, maxValue).forEach(
-          counter -> {
-            numberOfKeysAdded.getAndIncrement();
-          }
-      );
-    };
+    Runnable task = () -> LongStream.range(0, maxValue)
+        .forEach(counter -> numberOfKeysAdded.getAndIncrement());
 
     progressbar.start();
     task.run();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Freon's `ProgressBar` uses `Supplier<Long>`, which could be replaced with `LongSupplier` to avoid boxing.

Additional cleanup:

 * re-`interrupt` after `InterruptedException`
 * avoid concatenation in `append()` call
 * avoid the name `progressBar` for a member in `ProgressBar` (per Sonar)

https://issues.apache.org/jira/browse/HDDS-2605

## How was this patch tested?

`ozone freon rk` and `TestProgressBar`.