### PR TITLE
HDDS-2573. Handle InterruptedException in KeyOutputStream.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -364,6 +364,7 @@ public class KeyOutputStream extends OutputStream {
       try {
         Thread.sleep(action.delayMillis);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw (IOException) new InterruptedIOException(
             "Interrupted: action=" + action + ", retry policy=" + retryPolicy)
             .initCause(e);


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://sonarcloud.io/project/issues?id=hadoop-ozone&issues=AW5md-m5KcVY8lQ4ZsAc&open=AW5md-m5KcVY8lQ4ZsAc

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2573

## How was this patch tested?
Simple change, no testing done.