### PR TITLE
HDDS-2510. Use isEmpty() to check whether the collection is empty or not in Ozone Manager module

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyDeletingService.java
@@ -152,7 +152,7 @@ public class KeyDeletingService extends BackgroundService {
           long startTime = Time.monotonicNow();
           List<BlockGroup> keyBlocksList = manager
               .getPendingDeletionKeys(keyLimitPerTask);
-          if (keyBlocksList != null && keyBlocksList.size() > 0) {
+          if (keyBlocksList != null && !keyBlocksList.isEmpty()) {
             List<DeleteBlockGroupResult> results =
                 scmClient.deleteKeyBlocks(keyBlocksList);
             if (results != null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -948,7 +948,7 @@ public class KeyManagerImpl implements KeyManager {
               keyArgs.getBucketName() + OZONE_URI_DELIMITER +
               keyArgs.getKeyName());
 
-      if(prefixList.size() > 0) {
+      if (!prefixList.isEmpty()) {
         // Add all acls from direct parent to key.
         OmPrefixInfo prefixInfo = prefixList.get(prefixList.size() - 1);
         if(prefixInfo  != null) {
@@ -2125,7 +2125,7 @@ public class KeyManagerImpl implements KeyManager {
       for (OmKeyLocationInfoGroup key : keyInfo.getKeyLocationVersions()) {
         key.getLocationList().forEach(k -> {
           List<DatanodeDetails> nodes = k.getPipeline().getNodes();
-          if (nodes == null || nodes.size() == 0) {
+          if (nodes == null || nodes.isEmpty()) {
             LOG.warn("Datanodes for pipeline {} is empty",
                 k.getPipeline().getId().toString());
             return;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Replace an O(n) .size() check with the O(1) isEmpty() check in Ozone Manager module.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2510

## How was this patch tested?
Ran relevant unit tests.