### PR TITLE
HDDS-2610. Fix the ObjectStore#listVolumes failure when argument is null

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -860,12 +860,21 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   }
 
   private List<String> getAllUsers() throws IOException {
-    TableIterator<String, ? extends KeyValue<String, UserVolumeInfo>> iterator
+    TableIterator<String, ? extends KeyValue<String, UserVolumeInfo>> dbIterator
         = getUserTable().iterator();
+    Iterator<Map.Entry<CacheKey<String>, CacheValue<UserVolumeInfo>>>
+        cacheIterator = getUserTable().cacheIterator();
     List<String> allUsers = Lists.newArrayList();
 
-    while (iterator.hasNext()) {
-      allUsers.add(iterator.next().getKey());
+    // Get users from DB.
+    while (dbIterator.hasNext()) {
+      allUsers.add(dbIterator.next().getKey());
+    }
+    // Get users from Cache.
+    while (cacheIterator.hasNext()) {
+      Map.Entry<CacheKey<String>, CacheValue<UserVolumeInfo>> entry =
+          cacheIterator.next();
+      allUsers.add(entry.getKey().getCacheKey());
     }
 
     return  allUsers;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -869,21 +869,21 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
     String volumeName;
     OmVolumeArgs omVolumeArgs;
     boolean prefixIsEmpty = Strings.isNullOrEmpty(prefix);
-    boolean startKeyFound = Strings.isNullOrEmpty(startKey);
+    boolean startKeyIsEmpty = Strings.isNullOrEmpty(startKey);
     while (cacheIterator.hasNext() && result.size() < maxKeys) {
       Map.Entry<CacheKey<String>, CacheValue<OmVolumeArgs>> entry =
           cacheIterator.next();
       omVolumeArgs = entry.getValue().getCacheValue();
       volumeName = omVolumeArgs.getVolume();
 
-      if (!prefixIsEmpty) {
-        if (!volumeName.startsWith(prefix)) {
-          continue;
-        }
+      if (!prefixIsEmpty && !volumeName.startsWith(prefix)) {
+        continue;
       }
-      if (!startKeyFound && volumeName.equals(startKey)) {
-        result.add(0, omVolumeArgs);
-        startKeyFound = true;
+
+      if (!startKeyIsEmpty) {
+        if (volumeName.equals(startKey)) {
+          startKeyIsEmpty = true;
+        }
         continue;
       }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -806,19 +806,16 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
 
   /**
    * @param userName volume owner, null for listing all volumes.
-   * @throws IOException
    */
   @Override
   public List<OmVolumeArgs> listVolumes(String userName,
       String prefix, String startKey, int maxKeys) throws IOException {
-    List<OmVolumeArgs> result = Lists.newArrayList();
-    List<UserVolumeInfo> volumes = Lists.newArrayList();
+
+    UserVolumeInfo volumes;
 
     if (StringUtil.isBlank(userName)) {
       // null userName represents listing all volumes in cluster.
       return listAllVolumes(maxKeys);
-    } else {
-      volumes.add(getVolumesByUser(userName));
     }
 
     final List<OmVolumeArgs> result = Lists.newArrayList();
@@ -850,6 +847,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
           throw new OMException("Volume info not found for " + volumeName,
               ResultCodes.VOLUME_NOT_FOUND);
         }
+        result.add(volumeArgs);
       }
       index++;
     }
@@ -859,9 +857,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
 
     /**
      * @return list of all volumes.
-     * @throws IOException
      */
-  private List<OmVolumeArgs> listAllVolumes(int maxKeys) throws IOException {
+  private List<OmVolumeArgs> listAllVolumes(int maxKeys) {
     List<OmVolumeArgs> result = Lists.newArrayList();
 
     /* volumeTable is full-cache, so we use cacheIterator. */

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -804,24 +804,16 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
     return deletedKeys;
   }
 
-  /**
-   * @param userName volume owner, null for listing all volumes.
-   * @throws IOException
-   */
   @Override
   public List<OmVolumeArgs> listVolumes(String userName,
       String prefix, String startKey, int maxKeys) throws IOException {
     List<OmVolumeArgs> result = Lists.newArrayList();
-    List<UserVolumeInfo> volumes = Lists.newArrayList();
-
+    UserVolumeInfo volumes;
     if (StringUtil.isBlank(userName)) {
-      // null userName represents listing all volumes in cluster.
-      for (String user : getAllUsers()) {
-        volumes.add(getVolumesByUser(user));
-      }
-    } else {
-      volumes.add(getVolumesByUser(userName));
+      throw new OMException("User name is required to list Volumes.",
+          ResultCodes.USER_NOT_FOUND);
     }
+    volumes = getVolumesByUser(userName);
 
     final List<OmVolumeArgs> result = Lists.newArrayList();
     final List<String> volumes = getVolumesByUser(userName)
@@ -852,23 +844,12 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
           throw new OMException("Volume info not found for " + volumeName,
               ResultCodes.VOLUME_NOT_FOUND);
         }
+        result.add(volumeArgs);
       }
       index++;
     }
 
     return result;
-  }
-
-  private List<String> getAllUsers() throws IOException {
-    TableIterator<String, ? extends KeyValue<String, UserVolumeInfo>> iterator
-        = getUserTable().iterator();
-    List<String> allUsers = Lists.newArrayList();
-
-    while (iterator.hasNext()) {
-      allUsers.add(iterator.next().getKey());
-    }
-
-    return  allUsers;
   }
 
   private UserVolumeInfo getVolumesByUser(String userNameKey)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -804,13 +804,23 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
     return deletedKeys;
   }
 
+  /**
+   * @param userName volume owner, null for listing all volumes.
+   * @throws IOException
+   */
   @Override
   public List<OmVolumeArgs> listVolumes(String userName,
       String prefix, String startKey, int maxKeys) throws IOException {
+    List<OmVolumeArgs> result = Lists.newArrayList();
+    List<UserVolumeInfo> volumes = Lists.newArrayList();
 
     if (StringUtil.isBlank(userName)) {
-      throw new OMException("User name is required to list Volumes.",
-          ResultCodes.USER_NOT_FOUND);
+      // null userName represents listing all volumes in cluster.
+      for (String user : getAllUsers()) {
+        volumes.add(getVolumesByUser(user));
+      }
+    } else {
+      volumes.add(getVolumesByUser(userName));
     }
 
     final List<OmVolumeArgs> result = Lists.newArrayList();
@@ -842,12 +852,23 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
           throw new OMException("Volume info not found for " + volumeName,
               ResultCodes.VOLUME_NOT_FOUND);
         }
-        result.add(volumeArgs);
       }
       index++;
     }
 
     return result;
+  }
+
+  private List<String> getAllUsers() throws IOException {
+    TableIterator<String, ? extends KeyValue<String, UserVolumeInfo>> iterator
+        = getUserTable().iterator();
+    List<String> allUsers = Lists.newArrayList();
+
+    while (iterator.hasNext()) {
+      allUsers.add(iterator.next().getKey());
+    }
+
+    return  allUsers;
   }
 
   private UserVolumeInfo getVolumesByUser(String userNameKey)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -811,8 +811,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   public List<OmVolumeArgs> listVolumes(String userName,
       String prefix, String startKey, int maxKeys) throws IOException {
 
-    UserVolumeInfo volumes;
-
     if (StringUtil.isBlank(userName)) {
       // null userName represents listing all volumes in cluster.
       return listAllVolumes(prefix, startKey, maxKeys);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1866,10 +1866,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       if (!ozAdmins.contains(ProtobufRpcEngine.Server.
           getRemoteUser().getUserName())
           && !ozAdmins.contains(OZONE_ADMINISTRATORS_WILDCARD)) {
-        LOG.error("Only admin users are authorized to list " +
-            "Ozone volumes.");
-        throw new OMException("Only admin users are authorized to list " +
-            "Ozone volumes.", ResultCodes.PERMISSION_DENIED);
+        String errMsg = "Only admin users are authorized to" +
+            " list Ozone volumes.";
+        LOG.error(errMsg);
+        throw new OMException(errMsg, ResultCodes.PERMISSION_DENIED);
       }
     }
     boolean auditSuccess = true;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1862,16 +1862,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   @Override
   public List<OmVolumeArgs> listAllVolumes(String prefix, String prevKey, int
       maxKeys) throws IOException {
-    if(isAclEnabled) {
-      if (!ozAdmins.contains(ProtobufRpcEngine.Server.
-          getRemoteUser().getUserName())
-          && !ozAdmins.contains(OZONE_ADMINISTRATORS_WILDCARD)) {
-        String errMsg = "Only admin users are authorized to" +
-            " list Ozone volumes.";
-        LOG.error(errMsg);
-        throw new OMException(errMsg, ResultCodes.PERMISSION_DENIED);
-      }
-    }
     boolean auditSuccess = true;
     Map<String, String> auditMap = new LinkedHashMap<>();
     auditMap.put(OzoneConsts.PREV_KEY, prevKey);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1862,6 +1862,16 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   @Override
   public List<OmVolumeArgs> listAllVolumes(String prefix, String prevKey, int
       maxKeys) throws IOException {
+    if(isAclEnabled) {
+      if (!ozAdmins.contains(ProtobufRpcEngine.Server.
+          getRemoteUser().getUserName())
+          && !ozAdmins.contains(OZONE_ADMINISTRATORS_WILDCARD)) {
+        LOG.error("Only admin users are authorized to list " +
+            "Ozone volumes.");
+        throw new OMException("Only admin users are authorized to list " +
+            "Ozone volumes.", ResultCodes.PERMISSION_DENIED);
+      }
+    }
     boolean auditSuccess = true;
     Map<String, String> auditMap = new LinkedHashMap<>();
     auditMap.put(OzoneConsts.PREV_KEY, prevKey);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -108,10 +108,9 @@ public class TestOmMetadataManager {
     String startKey = "";
 
     // Test list all volumes
-    List<OmVolumeArgs> volListA = omMetadataManager.listVolumes(null,
+    List<OmVolumeArgs> volList = omMetadataManager.listVolumes(null,
             prefix, startKey, 1000);
-    Assert.assertEquals(volListA.size(), 50);
-
+    Assert.assertEquals(volList.size(), 50);
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -90,6 +90,32 @@ public class TestOmMetadataManager {
   }
 
   @Test
+  public void testListVolumes() throws Exception {
+    OmVolumeArgs omVolumeArgs = OmVolumeArgs.newBuilder().setAdminName("admin")
+        .setOwnerName("ownerA").setVolume("volume").build();
+    for (int i = 0; i < 50; i++) {
+      String volName = "vol" + i;
+      String ownerName = "owner" + i;
+      omVolumeArgs = OmVolumeArgs.newBuilder()
+          .setAdminName("admin")
+          .setOwnerName(ownerName)
+          .setVolume(volName)
+          .build();
+      TestOMRequestUtils.addVolumeToOM(omMetadataManager, omVolumeArgs);
+      TestOMRequestUtils.addUserToDB(volName, ownerName, omMetadataManager);
+    }
+
+    String prefix = "";
+    String startKey = "";
+
+    // Test list all volumes
+    List<OmVolumeArgs> volListA = omMetadataManager.listVolumes(null,
+            prefix, startKey, 1000);
+    Assert.assertEquals(volListA.size(), 50);
+
+  }
+
+  @Test
   public void testListBuckets() throws Exception {
 
     String volumeName1 = "volumeA";

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -97,7 +97,15 @@ public class TestOmMetadataManager {
     String ownerName;
     for (int i = 0; i < 50; i++) {
       ownerName = "owner" + i;
-      volName = "vol" + i;
+      volName = "vola" + i;
+      OmVolumeArgs omVolumeArgs = argsBuilder.
+          setOwnerName(ownerName).setVolume(volName).build();
+      TestOMRequestUtils.addVolumeToOM(omMetadataManager, omVolumeArgs);
+      TestOMRequestUtils.addUserToDB(volName, ownerName, omMetadataManager);
+    }
+    for (int i = 0; i < 50; i++) {
+      ownerName = "owner" + i;
+      volName = "volb" + i;
       OmVolumeArgs omVolumeArgs = argsBuilder.
           setOwnerName(ownerName).setVolume(volName).build();
       TestOMRequestUtils.addVolumeToOM(omMetadataManager, omVolumeArgs);
@@ -108,9 +116,22 @@ public class TestOmMetadataManager {
     String startKey = "";
 
     // Test list all volumes
-    List<OmVolumeArgs> volList = omMetadataManager.listVolumes(null,
-            prefix, startKey, 1000);
-    Assert.assertEquals(volList.size(), 50);
+    List<OmVolumeArgs> volListA = omMetadataManager.listVolumes(null,
+        prefix, startKey, 1000);
+    Assert.assertEquals(volListA.size(), 100);
+
+    // Test list all volumes with prefix
+    prefix = "volb";
+    List<OmVolumeArgs> volListB = omMetadataManager.listVolumes(null,
+        prefix, startKey, 1000);
+    Assert.assertEquals(volListB.size(), 50);
+
+    // Test list all volumes with startKey
+    prefix = "";
+    startKey = "vola1";
+    List<OmVolumeArgs> volListC = omMetadataManager.listVolumes(null,
+        prefix, startKey, 1000);
+    Assert.assertEquals(volListC.size(), 100);
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -90,7 +90,7 @@ public class TestOmMetadataManager {
   }
 
   @Test
-  public void testListVolumes() throws Exception {
+  public void testListAllVolumes() throws Exception {
     OmVolumeArgs.Builder argsBuilder =
         OmVolumeArgs.newBuilder().setAdminName("admin");
     String volName;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -91,16 +91,15 @@ public class TestOmMetadataManager {
 
   @Test
   public void testListVolumes() throws Exception {
-    OmVolumeArgs omVolumeArgs = OmVolumeArgs.newBuilder().setAdminName("admin")
-        .setOwnerName("ownerA").setVolume("volume").build();
+    OmVolumeArgs.Builder argsBuilder =
+        OmVolumeArgs.newBuilder().setAdminName("admin");
+    String volName;
+    String ownerName;
     for (int i = 0; i < 50; i++) {
-      String volName = "vol" + i;
-      String ownerName = "owner" + i;
-      omVolumeArgs = OmVolumeArgs.newBuilder()
-          .setAdminName("admin")
-          .setOwnerName(ownerName)
-          .setVolume(volName)
-          .build();
+      ownerName = "owner" + i;
+      volName = "vol" + i;
+      OmVolumeArgs omVolumeArgs = argsBuilder.
+          setOwnerName(ownerName).setVolume(volName).build();
       TestOMRequestUtils.addVolumeToOM(omMetadataManager, omVolumeArgs);
       TestOMRequestUtils.addUserToDB(volName, ownerName, omMetadataManager);
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -126,12 +126,15 @@ public class TestOmMetadataManager {
         prefix, startKey, 1000);
     Assert.assertEquals(volListB.size(), 50);
 
-    // Test list all volumes with startKey
+    // Test list all volumes with setting startVolume
+    // that was not part of result.
     prefix = "";
-    startKey = "vola1";
+    int totalVol = volListB.size();
+    int startOrder = 0;
+    startKey = "volb" + startOrder;
     List<OmVolumeArgs> volListC = omMetadataManager.listVolumes(null,
         prefix, startKey, 1000);
-    Assert.assertEquals(volListC.size(), 100);
+    Assert.assertEquals(volListC.size(), totalVol - startOrder - 1);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix the ```OmMetadataManagerImpl#listVolumes``` to list all volumes when the userName is null.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2610

## How was this patch tested?
UT Updating, and build & run on cluster.