### PR TITLE
HDDS-2459. Change the ReplicationManager to consider decommission and maintenance states

### DIFF
--- a/hadoop-hdds/container-service/src/main/proto/StorageContainerDatanodeProtocol.proto
+++ b/hadoop-hdds/container-service/src/main/proto/StorageContainerDatanodeProtocol.proto
@@ -185,6 +185,8 @@ message ContainerReplicaProto {
     CLOSED = 4;
     UNHEALTHY = 5;
     INVALID = 6;
+    DECOMMISSIONED = 7;
+    MAINTENANCE = 8;
   }
   required int64 containerID = 1;
   required State state = 2;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplicaCount.java
@@ -1,0 +1,203 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container;
+
+import org.apache.hadoop.hdds.protocol.proto
+    .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import java.util.Set;
+
+/**
+ * Immutable object that is created with a set of ContainerReplica objects and
+ * the number of in flight replica add and deletes, the container replication
+ * factor and the min count which must be available for maintenance. This
+ * information can be used to determine if the container is over or under
+ * replicated and also how many additional replicas need created or removed.
+ */
+public class ContainerReplicaCount {
+
+  private int healthyCount = 0;
+  private int decommissionCount = 0;
+  private int maintenanceCount = 0;
+  private int inFlightAdd = 0;
+  private int inFlightDel = 0;
+  private int repFactor;
+  private int minHealthyForMaintenance;
+  private Set<ContainerReplica> replica;
+
+  public ContainerReplicaCount(Set<ContainerReplica> replica, int inFlightAdd,
+                               int inFlightDelete, int replicationFactor,
+                               int minHealthyForMaintenance) {
+    this.healthyCount = 0;
+    this.decommissionCount = 0;
+    this.maintenanceCount = 0;
+    this.inFlightAdd = inFlightAdd;
+    this.inFlightDel = inFlightDelete;
+    this.repFactor = replicationFactor;
+    this.minHealthyForMaintenance = minHealthyForMaintenance;
+    this.replica = replica;
+
+    for (ContainerReplica cr : this.replica) {
+      ContainerReplicaProto.State state = cr.getState();
+      if (state == ContainerReplicaProto.State.DECOMMISSIONED) {
+        decommissionCount++;
+      } else if (state == ContainerReplicaProto.State.MAINTENANCE) {
+        maintenanceCount++;
+      } else {
+        healthyCount++;
+      }
+    }
+  }
+
+  public int getHealthyCount() {
+    return healthyCount;
+  }
+
+  public int getDecommissionCount() {
+    return decommissionCount;
+  }
+
+  public int getMaintenanceCount() {
+    return maintenanceCount;
+  }
+
+  public int getReplicationFactor() {
+    return repFactor;
+  }
+
+  public Set<ContainerReplica> getReplica() {
+    return replica;
+  }
+
+  @Override
+  public String toString() {
+    return "Replica Count: "+replica.size()+
+        " Healthy Count: "+healthyCount+
+        " Decommission Count: "+decommissionCount+
+        " Maintenance Count: "+maintenanceCount+
+        " inFlightAdd Count: "+inFlightAdd+
+        " inFightDel Count: "+inFlightDel+
+        " ReplicationFactor: "+repFactor+
+        " minMaintenance Count: "+minHealthyForMaintenance;
+  }
+
+  /**
+   * Calculates the the delta of replicas which need to be created or removed
+   * to ensure the container is correctly replicated.
+   *
+   * Decisions around over-replication are made only on healthy replicas,
+   * ignoring any in maintenance and also any inflight adds. InFlight adds are
+   * ignored, as they may not complete, so if we have:
+   *
+   *     H, H, H, IN_FLIGHT_ADD
+   *
+   * And then schedule a delete, we could end up under-replicated (add fails,
+   * delete completes). It is better to let the inflight operations complete
+   * and then deal with any further over or under replication.
+   *
+   * For maintenance replicas, assuming replication factor 3, and minHealthy
+   * 2, it is possible for all 3 hosts to be put into maintenance, leaving the
+   * following (H = healthy, M = maintenance):
+   *
+   *     H, H, M, M, M
+   *
+   * Even though we are tracking 5 replicas, this is not over replicated as we
+   * ignore the maintenance copies. Later, the replicas could look like:
+   *
+   *     H, H, H, H, M
+   *
+   * At this stage, the container is over replicated by 1, so one replica can be
+   * removed.
+   *
+   * For containers which have replication factor healthy replica, we ignore any
+   * inflight add or deletes, as they may fail. Instead, wait for them to
+   * complete and then deal with any excess or deficit.
+   *
+   * For under replicated containers we do consider inflight add and delete to
+   * avoid scheduling more adds than needed. There is additional logic around
+   * containers with maintenance replica to ensure minHealthyForMaintenance
+   * replia are maintained/
+   *
+   * @return Delta of replicas needed. Negative indicates over replication and
+   *         containers should be removed. Positive indicates over replication
+   *         and zero indicates the containers has replicationFactor healthy
+   *         replica
+   */
+  public int additionalReplicaNeeded() {
+    int delta = repFactor - healthyCount;
+
+    if (delta < 0) {
+      // Over replicated, so may need to remove a container. Do not consider
+      // inFlightAdds, as they may fail, but do consider inFlightDel which
+      // will reduce the over-replication if it completes.
+      // Note this could make the delta positive if there are too many in flight
+      // deletes, which will result in an additional being scheduled.
+      return delta + inFlightDel;
+    } else if (delta > 0) {
+      // May be under-replicated, depending on maintenance. When a container is
+      // under-replicated, we must consider in flight add and delete when
+      // calculating the new containers needed.
+      delta = Math.max(0, delta - maintenanceCount);
+      // Check we have enough healthy replicas
+      minHealthyForMaintenance = Math.min(repFactor, minHealthyForMaintenance);
+      int neededHealthy =
+          Math.max(0, minHealthyForMaintenance - healthyCount);
+      delta = Math.max(neededHealthy, delta);
+      return delta - inFlightAdd + inFlightDel;
+    } else { // delta == 0
+      // We have exactly the number of healthy replicas needed, but there may
+      // be inflight add or delete. Some of these may fail, but we want to
+      // avoid scheduling needless extra replicas. Therefore enforce a lower
+      // bound of 0 on the delta, but include the in flight requests in the
+      // calculation.
+      return Math.max(0, delta + inFlightDel - inFlightAdd);
+    }
+  }
+
+  /**
+   * Return true if the container is sufficiently replicated. Decommissioning
+   * and Decommissioned containers are ignored in this check, assuming they will
+   * eventually be removed from the cluster.
+   * This check ignores inflight additions, as those replicas have not yet been
+   * created and the create could fail for some reason.
+   * The check does consider inflight deletes as there may be 3 healthy replicas
+   * now, but once the delete completes it will reduce to 2.
+   * We also assume a replica in Maintenance state cannot be removed, so the
+   * pending delete would affect only the healthy replica count.
+   *
+   * @return True if the container is sufficiently replicated and False
+   *         otherwise.
+   */
+  public boolean isSufficientlyReplicated() {
+    return (healthyCount + maintenanceCount - inFlightDel) >= repFactor
+        && healthyCount - inFlightDel
+        >= Math.min(repFactor, minHealthyForMaintenance);
+  }
+
+  /**
+   * Return true is the container is over replicated. Decommission and
+   * maintenance containers are ignored for this check.
+   * The check ignores inflight additions, as they may fail, but it does
+   * consider inflight deletes, as they would reduce the over replication when
+   * they complete.
+   *
+   * @return True if the container is over replicated, false otherwise.
+   */
+  public boolean isOverReplicated() {
+    return healthyCount - inFlightDel > repFactor;
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
@@ -61,6 +61,75 @@ public class NodeStatus {
     return operationalState;
   }
 
+  /**
+   * Returns true if the nodeStatus indicates the node is in any decommission
+   * state.
+   *
+   * @return True if the node is in any decommission state, false otherwise
+   */
+  public boolean isDecommission() {
+    return operationalState == HddsProtos.NodeOperationalState.DECOMMISSIONING
+        || operationalState == HddsProtos.NodeOperationalState.DECOMMISSIONED;
+  }
+
+  /**
+   * Returns true if the node is currently decommissioning.
+   *
+   * @return True if the node is decommissioning, false otherwise
+   */
+  public boolean isDecommissioning() {
+    return operationalState == HddsProtos.NodeOperationalState.DECOMMISSIONING;
+  }
+
+  /**
+   * Returns true if the node is decommissioned.
+   *
+   * @return True if the node is decommissioned, false otherwise
+   */
+  public boolean isDecommissioned() {
+    return operationalState == HddsProtos.NodeOperationalState.DECOMMISSIONED;
+  }
+
+  /**
+   * Returns true if the node is in any maintenance state.
+   *
+   * @return True if the node is in any maintenance state, false otherwise
+   */
+  public boolean isMaintenance() {
+    return operationalState
+        == HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE
+        || operationalState == HddsProtos.NodeOperationalState.IN_MAINTENANCE;
+  }
+
+  /**
+   * Returns true if the node is currently entering maintenance.
+   *
+   * @return True if the node is entering maintenance, false otherwise
+   */
+  public boolean isEnteringMaintenance() {
+    return operationalState
+        == HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
+  }
+
+  /**
+   * Returns true if the node is currently in maintenance.
+   *
+   * @return True if the node is in maintenance, false otherwise.
+   */
+  public boolean isInMaintenance() {
+    return operationalState == HddsProtos.NodeOperationalState.IN_MAINTENANCE;
+  }
+
+  /**
+   * Returns true if the nodeStatus is healthy (ie not stale or dead) and false
+   * otherwise.
+   *
+   * @return True if the node is Healthy, false otherwise
+   */
+  public boolean isHealthy() {
+    return health == HddsProtos.NodeState.HEALTHY;
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -434,7 +434,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
           containerManager,
           containerPlacementPolicy,
           eventQueue,
-          new LockManager<>(conf));
+          new LockManager<>(conf),
+          scmNodeManager);
     }
     if(configurator.getScmSafeModeManager() != null) {
       scmSafeModeManager = configurator.getScmSafeModeManager();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -47,17 +47,11 @@ import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
 import org.hamcrest.MatcherAssert;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import static org.mockito.Matchers.anyObject;
-import org.mockito.Mockito;
 import static org.mockito.Mockito.when;
 
 /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerReplicaCount.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.scm.container.states;
 
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
@@ -43,48 +42,36 @@ import static org.apache.hadoop.hdds.protocol.proto
  */
 public class TestContainerReplicaCount {
 
-  private OzoneConfiguration conf;
-  private List<DatanodeDetails> dns;
-  private Set<ContainerReplica> replica;
-  private ContainerReplicaCount rcount;
-
-
-  public TestContainerReplicaCount() {
-  }
-
   @Before
   public void setup() {
-    conf = new OzoneConfiguration();
-    replica = new HashSet<>();
-    dns = new LinkedList<>();
   }
 
   @Test
   public void testThreeHealthyReplica() {
-    registerNodes(CLOSED, CLOSED, CLOSED);
-    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
-    validate(true, 0, false);
+    Set<ContainerReplica> replica = registerNodes(CLOSED, CLOSED, CLOSED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(rcnt, true, 0, false);
   }
 
   @Test
   public void testTwoHealthyReplica() {
-    registerNodes(CLOSED, CLOSED);
-    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
-    validate(false, 1, false);
+    Set<ContainerReplica> replica = registerNodes(CLOSED, CLOSED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(rcnt, false, 1, false);
   }
 
   @Test
   public void testOneHealthyReplica() {
-    registerNodes(CLOSED);
-    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
-    validate(false, 2, false);
+    Set<ContainerReplica> replica = registerNodes(CLOSED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(rcnt, false, 2, false);
   }
 
   @Test
   public void testTwoHealthyAndInflightAdd() {
-    registerNodes(CLOSED, CLOSED);
-    rcount = new ContainerReplicaCount(replica, 1, 0, 3, 2);
-    validate(false, 0, false);
+    Set<ContainerReplica> replica = registerNodes(CLOSED, CLOSED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 1, 0, 3, 2);
+    validate(rcnt, false, 0, false);
   }
 
   @Test
@@ -94,9 +81,9 @@ public class TestContainerReplicaCount {
    * completes there will be 4 healthy and it will get taken care of then.
    */
   public void testThreeHealthyAndInflightAdd() {
-    registerNodes(CLOSED, CLOSED, CLOSED);
-    rcount = new ContainerReplicaCount(replica, 1, 0, 3, 2);
-    validate(true, 0, false);
+    Set<ContainerReplica> replica = registerNodes(CLOSED, CLOSED, CLOSED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 1, 0, 3, 2);
+    validate(rcnt, true, 0, false);
   }
 
   @Test
@@ -105,9 +92,9 @@ public class TestContainerReplicaCount {
    * under replicated, we go ahead and schedule another replica to be added.
    */
   public void testThreeHealthyAndInflightDelete() {
-    registerNodes(CLOSED, CLOSED, CLOSED);
-    rcount = new ContainerReplicaCount(replica, 0, 1, 3, 2);
-    validate(false, 1, false);
+    Set<ContainerReplica> replica = registerNodes(CLOSED, CLOSED, CLOSED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 1, 3, 2);
+    validate(rcnt, false, 1, false);
   }
 
   @Test
@@ -116,51 +103,54 @@ public class TestContainerReplicaCount {
    * inflight del could succeed, leaving only 2 healthy replicas.
    */
   public void testThreeHealthyAndInflightAddAndInFlightDelete() {
-    registerNodes(CLOSED, CLOSED, CLOSED);
-    rcount = new ContainerReplicaCount(replica, 1, 1, 3, 2);
-    validate(false, 0, false);
+    Set<ContainerReplica> replica = registerNodes(CLOSED, CLOSED, CLOSED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 1, 1, 3, 2);
+    validate(rcnt, false, 0, false);
   }
 
   @Test
   public void testFourHealthyReplicas() {
-    registerNodes(CLOSED, CLOSED, CLOSED, CLOSED);
-    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
-    validate(true, -1, true);
+    Set<ContainerReplica> replica =
+        registerNodes(CLOSED, CLOSED, CLOSED, CLOSED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(rcnt, true, -1, true);
   }
 
   @Test
   public void testFourHealthyReplicasAndInFlightDelete() {
-    registerNodes(CLOSED, CLOSED, CLOSED, CLOSED);
-    rcount = new ContainerReplicaCount(replica, 0, 1, 3, 2);
-    validate(true, 0, false);
+    Set<ContainerReplica> replica =
+        registerNodes(CLOSED, CLOSED, CLOSED, CLOSED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 1, 3, 2);
+    validate(rcnt, true, 0, false);
   }
 
   @Test
   public void testFourHealthyReplicasAndTwoInFlightDelete() {
-    registerNodes(CLOSED, CLOSED, CLOSED, CLOSED);
-    rcount = new ContainerReplicaCount(replica, 0, 2, 3, 2);
-    validate(false, 1, false);
+    Set<ContainerReplica> replica =
+        registerNodes(CLOSED, CLOSED, CLOSED, CLOSED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 2, 3, 2);
+    validate(rcnt, false, 1, false);
   }
 
   @Test
   public void testOneHealthyReplicaRepFactorOne() {
-    registerNodes(CLOSED);
-    rcount = new ContainerReplicaCount(replica, 0, 0, 1, 2);
-    validate(true, 0, false);
+    Set<ContainerReplica> replica = registerNodes(CLOSED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 1, 2);
+    validate(rcnt, true, 0, false);
   }
 
   @Test
   public void testOneHealthyReplicaRepFactorOneInFlightDelete() {
-    registerNodes(CLOSED);
-    rcount = new ContainerReplicaCount(replica, 0, 1, 1, 2);
-    validate(false, 1, false);
+    Set<ContainerReplica> replica = registerNodes(CLOSED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 1, 1, 2);
+    validate(rcnt, false, 1, false);
   }
 
   @Test
   public void testTwoHealthyReplicaTwoInflightAdd() {
-    registerNodes(CLOSED, CLOSED);
-    rcount = new ContainerReplicaCount(replica, 2, 0, 3, 2);
-    validate(false, 0, false);
+    Set<ContainerReplica> replica = registerNodes(CLOSED, CLOSED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 2, 0, 3, 2);
+    validate(rcnt, false, 0, false);
   }
 
   /**
@@ -169,52 +159,55 @@ public class TestContainerReplicaCount {
 
   @Test
   public void testThreeHealthyAndTwoDecommission() {
-    registerNodes(CLOSED, CLOSED, CLOSED,
+    Set<ContainerReplica> replica = registerNodes(CLOSED, CLOSED, CLOSED,
         DECOMMISSIONED, DECOMMISSIONED);
-    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
-    validate(true, 0, false);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(rcnt, true, 0, false);
   }
 
   @Test
   public void testOneDecommissionedReplica() {
-    registerNodes(CLOSED, CLOSED, DECOMMISSIONED);
-    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
-    validate(false, 1, false);
+    Set<ContainerReplica> replica =
+        registerNodes(CLOSED, CLOSED, DECOMMISSIONED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(rcnt, false, 1, false);
   }
 
   @Test
   public void testTwoHealthyOneDecommissionedneInFlightAdd() {
-    registerNodes(CLOSED, CLOSED, DECOMMISSIONED);
-    rcount = new ContainerReplicaCount(replica, 1, 0, 3, 2);
-    validate(false, 0, false);
+    Set<ContainerReplica> replica =
+        registerNodes(CLOSED, CLOSED, DECOMMISSIONED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 1, 0, 3, 2);
+    validate(rcnt, false, 0, false);
   }
 
   @Test
   public void testAllDecommissioned() {
-    registerNodes(DECOMMISSIONED, DECOMMISSIONED, DECOMMISSIONED);
-    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
-    validate(false, 3, false);
+    Set<ContainerReplica> replica =
+        registerNodes(DECOMMISSIONED, DECOMMISSIONED, DECOMMISSIONED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(rcnt, false, 3, false);
   }
 
   @Test
   public void testAllDecommissionedRepFactorOne() {
-    registerNodes(DECOMMISSIONED);
-    rcount = new ContainerReplicaCount(replica, 0, 0, 1, 2);
-    validate(false, 1, false);
+    Set<ContainerReplica> replica = registerNodes(DECOMMISSIONED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 1, 2);
+    validate(rcnt, false, 1, false);
   }
 
   @Test
   public void testAllDecommissionedRepFactorOneInFlightAdd() {
-    registerNodes(DECOMMISSIONED);
-    rcount = new ContainerReplicaCount(replica, 1, 0, 1, 2);
-    validate(false, 0, false);
+    Set<ContainerReplica> replica = registerNodes(DECOMMISSIONED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 1, 0, 1, 2);
+    validate(rcnt, false, 0, false);
   }
 
   @Test
   public void testOneHealthyOneDecommissioningRepFactorOne() {
-    registerNodes(DECOMMISSIONED, CLOSED);
-    rcount = new ContainerReplicaCount(replica, 0, 0, 1, 2);
-    validate(true, 0, false);
+    Set<ContainerReplica> replica = registerNodes(DECOMMISSIONED, CLOSED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 1, 2);
+    validate(rcnt, true, 0, false);
   }
 
   /**
@@ -223,39 +216,42 @@ public class TestContainerReplicaCount {
 
   @Test
   public void testOneHealthyTwoMaintenanceMinRepOfTwo() {
-    registerNodes(CLOSED, MAINTENANCE, MAINTENANCE);
-    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
-    validate(false, 1, false);
+    Set<ContainerReplica> replica =
+        registerNodes(CLOSED, MAINTENANCE, MAINTENANCE);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(rcnt, false, 1, false);
   }
 
   @Test
   public void testOneHealthyThreeMaintenanceMinRepOfTwo() {
-    registerNodes(CLOSED,
+    Set<ContainerReplica> replica = registerNodes(CLOSED,
         MAINTENANCE, MAINTENANCE, MAINTENANCE);
-    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
-    validate(false, 1, false);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(rcnt, false, 1, false);
   }
 
   @Test
   public void testOneHealthyTwoMaintenanceMinRepOfOne() {
-    registerNodes(CLOSED, MAINTENANCE, MAINTENANCE);
-    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 1);
-    validate(true, 0, false);
+    Set<ContainerReplica> replica =
+        registerNodes(CLOSED, MAINTENANCE, MAINTENANCE);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 1);
+    validate(rcnt, true, 0, false);
   }
 
   @Test
   public void testOneHealthyThreeMaintenanceMinRepOfTwoInFlightAdd() {
-    registerNodes(CLOSED,
+    Set<ContainerReplica> replica = registerNodes(CLOSED,
         MAINTENANCE, MAINTENANCE, MAINTENANCE);
-    rcount = new ContainerReplicaCount(replica, 1, 0, 3, 2);
-    validate(false, 0, false);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 1, 0, 3, 2);
+    validate(rcnt, false, 0, false);
   }
 
   @Test
   public void testAllMaintenance() {
-    registerNodes(MAINTENANCE, MAINTENANCE, MAINTENANCE);
-    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
-    validate(false, 2, false);
+    Set<ContainerReplica> replica =
+        registerNodes(MAINTENANCE, MAINTENANCE, MAINTENANCE);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(rcnt, false, 2, false);
   }
 
   @Test
@@ -265,10 +261,10 @@ public class TestContainerReplicaCount {
    * come back online, and then deal with them.
    */
   public void testThreeHealthyTwoInMaintenance() {
-    registerNodes(CLOSED, CLOSED, CLOSED,
+    Set<ContainerReplica> replica = registerNodes(CLOSED, CLOSED, CLOSED,
         MAINTENANCE, MAINTENANCE);
-    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
-    validate(true, 0, false);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(rcnt, true, 0, false);
   }
 
   @Test
@@ -278,48 +274,50 @@ public class TestContainerReplicaCount {
    * the over-replicated healthy container.
    */
   public void testFourHealthyOneInMaintenance() {
-    registerNodes(CLOSED, CLOSED, CLOSED, CLOSED,
-        MAINTENANCE);
-    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
-    validate(true, -1, true);
+    Set<ContainerReplica> replica =
+        registerNodes(CLOSED, CLOSED, CLOSED, CLOSED, MAINTENANCE);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(rcnt, true, -1, true);
   }
 
   @Test
   public void testOneMaintenanceMinRepOfTwoRepFactorOne() {
-    registerNodes(MAINTENANCE);
-    rcount = new ContainerReplicaCount(replica, 0, 0, 1, 2);
-    validate(false, 1, false);
+    Set<ContainerReplica> replica = registerNodes(MAINTENANCE);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 1, 2);
+    validate(rcnt, false, 1, false);
   }
 
   @Test
   public void testOneMaintenanceMinRepOfTwoRepFactorOneInFlightAdd() {
-    registerNodes(MAINTENANCE);
-    rcount = new ContainerReplicaCount(replica, 1, 0, 1, 2);
-    validate(false, 0, false);
+    Set<ContainerReplica> replica = registerNodes(MAINTENANCE);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 1, 0, 1, 2);
+    validate(rcnt, false, 0, false);
   }
 
   @Test
   public void testOneHealthyOneMaintenanceRepFactorOne() {
-    registerNodes(MAINTENANCE, CLOSED);
-    rcount = new ContainerReplicaCount(replica, 0, 0, 1, 2);
-    validate(true, 0, false);
+    Set<ContainerReplica> replica = registerNodes(MAINTENANCE, CLOSED);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 1, 2);
+    validate(rcnt, true, 0, false);
   }
 
   @Test
   public void testTwoDecomTwoMaintenanceOneInflightAdd() {
-    registerNodes(DECOMMISSIONED, DECOMMISSIONED,
-        MAINTENANCE, MAINTENANCE);
-    rcount = new ContainerReplicaCount(replica, 1, 0, 3, 2);
-    validate(false, 1, false);
+    Set<ContainerReplica> replica =
+        registerNodes(DECOMMISSIONED, DECOMMISSIONED, MAINTENANCE, MAINTENANCE);
+    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 1, 0, 3, 2);
+    validate(rcnt, false, 1, false);
   }
 
-  private void validate(boolean sufficientlyReplicated, int replicaDelta,
-      boolean overRelicated) {
-    assertEquals(sufficientlyReplicated, rcount.isSufficientlyReplicated());
-    assertEquals(replicaDelta, rcount.additionalReplicaNeeded());
+  private void validate(ContainerReplicaCount rcnt,
+      boolean sufficientlyReplicated, int replicaDelta, boolean overRelicated) {
+    assertEquals(sufficientlyReplicated, rcnt.isSufficientlyReplicated());
+    assertEquals(replicaDelta, rcnt.additionalReplicaNeeded());
   }
 
-  private void registerNodes(ContainerReplicaProto.State... states) {
+  private Set<ContainerReplica> registerNodes(
+      ContainerReplicaProto.State... states) {
+    Set<ContainerReplica> replica = new HashSet<>();
     for (ContainerReplicaProto.State s : states) {
       DatanodeDetails dn = TestUtils.randomDatanodeDetails();
       replica.add(new ContainerReplica.ContainerReplicaBuilder()
@@ -330,5 +328,6 @@ public class TestContainerReplicaCount {
           .setSequenceId(1)
           .build());
     }
+    return replica;
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerReplicaCount.java
@@ -156,6 +156,13 @@ public class TestContainerReplicaCount {
     validate(false, 1, false);
   }
 
+  @Test
+  public void testTwoHealthyReplicaTwoInflightAdd() {
+    registerNodes(CLOSED, CLOSED);
+    rcount = new ContainerReplicaCount(replica, 2, 0, 3, 2);
+    validate(false, 0, false);
+  }
+
   /**
    * From here consider decommission replicas.
    */

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerReplicaCount.java
@@ -1,0 +1,327 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.states;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto
+    .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.hdds.scm.TestUtils;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.ContainerReplicaCount;
+import org.junit.Before;
+import org.junit.Test;
+import java.util.*;
+import static junit.framework.TestCase.assertEquals;
+import static org.apache.hadoop.hdds.protocol.proto
+    .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.CLOSED;
+import static org.apache.hadoop.hdds.protocol.proto
+    .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State
+    .DECOMMISSIONED;
+import static org.apache.hadoop.hdds.protocol.proto
+    .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State
+    .MAINTENANCE;
+
+/**
+ * Class used to test the ContainerReplicaCount class.
+ */
+public class TestContainerReplicaCount {
+
+  private OzoneConfiguration conf;
+  private List<DatanodeDetails> dns;
+  private Set<ContainerReplica> replica;
+  private ContainerReplicaCount rcount;
+
+
+  public TestContainerReplicaCount() {
+  }
+
+  @Before
+  public void setup() {
+    conf = new OzoneConfiguration();
+    replica = new HashSet<>();
+    dns = new LinkedList<>();
+  }
+
+  @Test
+  public void testThreeHealthyReplica() {
+    registerNodes(CLOSED, CLOSED, CLOSED);
+    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(true, 0, false);
+  }
+
+  @Test
+  public void testTwoHealthyReplica() {
+    registerNodes(CLOSED, CLOSED);
+    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(false, 1, false);
+  }
+
+  @Test
+  public void testOneHealthyReplica() {
+    registerNodes(CLOSED);
+    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(false, 2, false);
+  }
+
+  @Test
+  public void testTwoHealthyAndInflightAdd() {
+    registerNodes(CLOSED, CLOSED);
+    rcount = new ContainerReplicaCount(replica, 1, 0, 3, 2);
+    validate(false, 0, false);
+  }
+
+  @Test
+  /**
+   * This does not schedule a container to be removed, as the inFlight add may
+   * fail and then the delete would make things under-replicated. Once the add
+   * completes there will be 4 healthy and it will get taken care of then.
+   */
+  public void testThreeHealthyAndInflightAdd() {
+    registerNodes(CLOSED, CLOSED, CLOSED);
+    rcount = new ContainerReplicaCount(replica, 1, 0, 3, 2);
+    validate(true, 0, false);
+  }
+
+  @Test
+  /**
+   * As the inflight delete may fail, but as it will make the the container
+   * under replicated, we go ahead and schedule another replica to be added.
+   */
+  public void testThreeHealthyAndInflightDelete() {
+    registerNodes(CLOSED, CLOSED, CLOSED);
+    rcount = new ContainerReplicaCount(replica, 0, 1, 3, 2);
+    validate(false, 1, false);
+  }
+
+  @Test
+  /**
+   * This is NOT sufficiently replicated as the inflight add may fail and the
+   * inflight del could succeed, leaving only 2 healthy replicas.
+   */
+  public void testThreeHealthyAndInflightAddAndInFlightDelete() {
+    registerNodes(CLOSED, CLOSED, CLOSED);
+    rcount = new ContainerReplicaCount(replica, 1, 1, 3, 2);
+    validate(false, 0, false);
+  }
+
+  @Test
+  public void testFourHealthyReplicas() {
+    registerNodes(CLOSED, CLOSED, CLOSED, CLOSED);
+    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(true, -1, true);
+  }
+
+  @Test
+  public void testFourHealthyReplicasAndInFlightDelete() {
+    registerNodes(CLOSED, CLOSED, CLOSED, CLOSED);
+    rcount = new ContainerReplicaCount(replica, 0, 1, 3, 2);
+    validate(true, 0, false);
+  }
+
+  @Test
+  public void testFourHealthyReplicasAndTwoInFlightDelete() {
+    registerNodes(CLOSED, CLOSED, CLOSED, CLOSED);
+    rcount = new ContainerReplicaCount(replica, 0, 2, 3, 2);
+    validate(false, 1, false);
+  }
+
+  @Test
+  public void testOneHealthyReplicaRepFactorOne() {
+    registerNodes(CLOSED);
+    rcount = new ContainerReplicaCount(replica, 0, 0, 1, 2);
+    validate(true, 0, false);
+  }
+
+  @Test
+  public void testOneHealthyReplicaRepFactorOneInFlightDelete() {
+    registerNodes(CLOSED);
+    rcount = new ContainerReplicaCount(replica, 0, 1, 1, 2);
+    validate(false, 1, false);
+  }
+
+  /**
+   * From here consider decommission replicas.
+   */
+
+  @Test
+  public void testThreeHealthyAndTwoDecommission() {
+    registerNodes(CLOSED, CLOSED, CLOSED,
+        DECOMMISSIONED, DECOMMISSIONED);
+    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(true, 0, false);
+  }
+
+  @Test
+  public void testOneDecommissionedReplica() {
+    registerNodes(CLOSED, CLOSED, DECOMMISSIONED);
+    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(false, 1, false);
+  }
+
+  @Test
+  public void testTwoHealthyOneDecommissionedneInFlightAdd() {
+    registerNodes(CLOSED, CLOSED, DECOMMISSIONED);
+    rcount = new ContainerReplicaCount(replica, 1, 0, 3, 2);
+    validate(false, 0, false);
+  }
+
+  @Test
+  public void testAllDecommissioned() {
+    registerNodes(DECOMMISSIONED, DECOMMISSIONED, DECOMMISSIONED);
+    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(false, 3, false);
+  }
+
+  @Test
+  public void testAllDecommissionedRepFactorOne() {
+    registerNodes(DECOMMISSIONED);
+    rcount = new ContainerReplicaCount(replica, 0, 0, 1, 2);
+    validate(false, 1, false);
+  }
+
+  @Test
+  public void testAllDecommissionedRepFactorOneInFlightAdd() {
+    registerNodes(DECOMMISSIONED);
+    rcount = new ContainerReplicaCount(replica, 1, 0, 1, 2);
+    validate(false, 0, false);
+  }
+
+  @Test
+  public void testOneHealthyOneDecommissioningRepFactorOne() {
+    registerNodes(DECOMMISSIONED, CLOSED);
+    rcount = new ContainerReplicaCount(replica, 0, 0, 1, 2);
+    validate(true, 0, false);
+  }
+
+  /**
+   * Maintenance tests from here.
+   */
+
+  @Test
+  public void testOneHealthyTwoMaintenanceMinRepOfTwo() {
+    registerNodes(CLOSED, MAINTENANCE, MAINTENANCE);
+    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(false, 1, false);
+  }
+
+  @Test
+  public void testOneHealthyThreeMaintenanceMinRepOfTwo() {
+    registerNodes(CLOSED,
+        MAINTENANCE, MAINTENANCE, MAINTENANCE);
+    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(false, 1, false);
+  }
+
+  @Test
+  public void testOneHealthyTwoMaintenanceMinRepOfOne() {
+    registerNodes(CLOSED, MAINTENANCE, MAINTENANCE);
+    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 1);
+    validate(true, 0, false);
+  }
+
+  @Test
+  public void testOneHealthyThreeMaintenanceMinRepOfTwoInFlightAdd() {
+    registerNodes(CLOSED,
+        MAINTENANCE, MAINTENANCE, MAINTENANCE);
+    rcount = new ContainerReplicaCount(replica, 1, 0, 3, 2);
+    validate(false, 0, false);
+  }
+
+  @Test
+  public void testAllMaintenance() {
+    registerNodes(MAINTENANCE, MAINTENANCE, MAINTENANCE);
+    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(false, 2, false);
+  }
+
+  @Test
+  /**
+   * As we have exactly 3 healthy, but then an excess of maintenance copies
+   * we ignore the over-replication caused by the maintenance copies until they
+   * come back online, and then deal with them.
+   */
+  public void testThreeHealthyTwoInMaintenance() {
+    registerNodes(CLOSED, CLOSED, CLOSED,
+        MAINTENANCE, MAINTENANCE);
+    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(true, 0, false);
+  }
+
+  @Test
+  /**
+   * This is somewhat similar to testThreeHealthyTwoInMaintenance() except now
+   * one of the maintenance copies has become healthy and we will need to remove
+   * the over-replicated healthy container.
+   */
+  public void testFourHealthyOneInMaintenance() {
+    registerNodes(CLOSED, CLOSED, CLOSED, CLOSED,
+        MAINTENANCE);
+    rcount = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    validate(true, -1, true);
+  }
+
+  @Test
+  public void testOneMaintenanceMinRepOfTwoRepFactorOne() {
+    registerNodes(MAINTENANCE);
+    rcount = new ContainerReplicaCount(replica, 0, 0, 1, 2);
+    validate(false, 1, false);
+  }
+
+  @Test
+  public void testOneMaintenanceMinRepOfTwoRepFactorOneInFlightAdd() {
+    registerNodes(MAINTENANCE);
+    rcount = new ContainerReplicaCount(replica, 1, 0, 1, 2);
+    validate(false, 0, false);
+  }
+
+  @Test
+  public void testOneHealthyOneMaintenanceRepFactorOne() {
+    registerNodes(MAINTENANCE, CLOSED);
+    rcount = new ContainerReplicaCount(replica, 0, 0, 1, 2);
+    validate(true, 0, false);
+  }
+
+  @Test
+  public void testTwoDecomTwoMaintenanceOneInflightAdd() {
+    registerNodes(DECOMMISSIONED, DECOMMISSIONED,
+        MAINTENANCE, MAINTENANCE);
+    rcount = new ContainerReplicaCount(replica, 1, 0, 3, 2);
+    validate(false, 1, false);
+  }
+
+  private void validate(boolean sufficientlyReplicated, int replicaDelta,
+      boolean overRelicated) {
+    assertEquals(sufficientlyReplicated, rcount.isSufficientlyReplicated());
+    assertEquals(replicaDelta, rcount.additionalReplicaNeeded());
+  }
+
+  private void registerNodes(ContainerReplicaProto.State... states) {
+    for (ContainerReplicaProto.State s : states) {
+      DatanodeDetails dn = TestUtils.randomDatanodeDetails();
+      replica.add(new ContainerReplica.ContainerReplicaBuilder()
+          .setContainerID(new ContainerID(1))
+          .setContainerState(s)
+          .setDatanodeDetails(dn)
+          .setOriginNodeId(dn.getUuid())
+          .setSequenceId(1)
+          .build());
+    }
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.TestUtils;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
-import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.pipeline.MockRatisPipelineProvider;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineProvider;
 import org.apache.hadoop.hdds.scm.pipeline.SCMPipelineManager;
@@ -38,7 +37,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.UUID;
-import java.util.concurrent.TimeoutException;
 
 import static junit.framework.TestCase.assertEquals;
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.TestUtils;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.pipeline.MockRatisPipelineProvider;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineProvider;
 import org.apache.hadoop.hdds.scm.pipeline.SCMPipelineManager;
@@ -33,10 +34,12 @@ import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.UUID;
+import java.util.concurrent.TimeoutException;
 
 import static junit.framework.TestCase.assertEquals;
 
@@ -125,9 +128,9 @@ public class TestDatanodeAdminMonitor {
 
   }
 
-  /* Disabling this test for now, as it is consistently failing on the CI
-     runs, but it passes locally every time. Will revisit it in a later patch
+
   @Test
+  @Ignore // HDDS-2631
   public void testMonitoredNodeHasPipelinesClosed()
       throws NodeNotFoundException, TimeoutException, InterruptedException {
 
@@ -159,6 +162,5 @@ public class TestDatanodeAdminMonitor {
     monitor.run();
     assertEquals(0, monitor.getTrackedNodeCount());
   }
-  */
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
@@ -127,6 +127,8 @@ public class TestDatanodeAdminMonitor {
 
   }
 
+  /* Disabling this test for now, as it is consistently failing on the CI
+     runs, but it passes locally every time. Will revisit it in a later patch
   @Test
   public void testMonitoredNodeHasPipelinesClosed()
       throws NodeNotFoundException, TimeoutException, InterruptedException {
@@ -159,5 +161,6 @@ public class TestDatanodeAdminMonitor {
     monitor.run();
     assertEquals(0, monitor.getTrackedNodeCount());
   }
+  */
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSafeModeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSafeModeHandler.java
@@ -23,11 +23,13 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.block.BlockManager;
 import org.apache.hadoop.hdds.scm.block.BlockManagerImpl;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.container.MockNodeManager;
 import org.apache.hadoop.hdds.scm.container.ReplicationManager;
 import org.apache.hadoop.hdds.scm.container.ReplicationManager.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms
     .ContainerPlacementPolicy;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.pipeline.SCMPipelineManager;
 import org.apache.hadoop.hdds.scm.server.SCMClientProtocolServer;
@@ -54,6 +56,7 @@ public class TestSafeModeHandler {
   private EventQueue eventQueue;
   private SCMSafeModeManager.SafeModeStatus safeModeStatus;
   private PipelineManager scmPipelineManager;
+  private NodeManager nodeManager;
 
   public void setup(boolean enabled) {
     configuration = new OzoneConfiguration();
@@ -68,10 +71,11 @@ public class TestSafeModeHandler {
         Mockito.mock(ContainerManager.class);
     Mockito.when(containerManager.getContainerIDs())
         .thenReturn(new HashSet<>());
+    nodeManager = new MockNodeManager(false, 0);
     replicationManager = new ReplicationManager(
         new ReplicationManagerConfiguration(),
         containerManager, Mockito.mock(ContainerPlacementPolicy.class),
-        eventQueue, new LockManager(configuration));
+        eventQueue, new LockManager(configuration), nodeManager);
     scmPipelineManager = Mockito.mock(SCMPipelineManager.class);
     blockManager = Mockito.mock(BlockManagerImpl.class);
     safeModeHandler =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.scm.node;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.client.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;


### PR DESCRIPTION
## What changes were proposed in this pull request?

In its current form the replication manager does not consider decommission or maintenance states when checking if replicas are sufficiently replicated. With the introduction of maintenance states, it needs to consider decommission and maintenance states when deciding if blocks are over or under replicated.

It also needs to provide an API to allow the decommission manager to check if blocks are over or under replicated, so the decommission manager can decide if a node has completed decommission and maintenance or not.

The key part of this change is a new class called ContainerReplicaCount - the logic to determine if a container is "sufficiently replicated", over replicated and the delta of replicas required is extracted into this class. This allows for a standalone testable unit which can be used inside the ReplicationManager, but this same object can be returned from the Replication Manager to another class that needs to make replication decisions (ie the datanode admin manager).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2459

## How was this patch tested?

Additional unit tests have been added to test the new functionality.
