### PR TITLE
HDDS-2627. Skip sonar check in forks

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -59,6 +59,7 @@ jobs:
           with:
              args: ./hadoop-ozone/dev-support/checks/unit.sh
         - uses: ./.github/buildenv
+          if: github.repository == 'apache/hadoop-ozone'
           with:
             args: ./hadoop-ozone/dev-support/checks/sonar.sh
           env:


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-2587 added Sonar check in post-commit workflow, publishing results to SonarCloud.  It does not work in forks, as it requires SonarCloud token.  This causes unit check to fail completely.  Example: https://github.com/bharatviswa504/hadoop-ozone/runs/316829850

This PR proposes to skip the check for forks.  (Ideally it would be skipped if `SONARCLOUD_TOKEN` is not set, but I could not add a condition based on that.)

https://issues.apache.org/jira/browse/HDDS-2627

## How was this patch tested?

Pushed to own fork: [unit check passed, sonar step skipped](https://github.com/adoroszlai/hadoop-ozone/runs/318237775).

It would be great if someone with write access to `apache/hadoop-ozone` could push the same to a "feature" branch and verify that Sonar check is executed as expected.