### PR TITLE
HDDS-2626. Avoid hostname lookup for invalid local IP addresses

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
@@ -90,28 +90,29 @@ public final class OzoneSecurityUtil {
 
     Enumeration<NetworkInterface> enumNI =
         NetworkInterface.getNetworkInterfaces();
-    if (enumNI != null) {
-      while (enumNI.hasMoreElements()) {
-        NetworkInterface ifc = enumNI.nextElement();
-        if (ifc.isUp()) {
-          Enumeration<InetAddress> enumAdds = ifc.getInetAddresses();
-          while (enumAdds.hasMoreElements()) {
-            InetAddress addr = enumAdds.nextElement();
+    if (enumNI == null) {
+      throw new IOException("Unable to get network interfaces.");
+    }
 
-            String hostAddress = addr.getHostAddress();
-            if (!INVALID_IPS.contains(hostAddress)
-                && ipValidator.isValid(hostAddress)) {
-              LOG.info("Adding ip:{},host:{}", hostAddress, addr.getHostName());
-              hostIps.add(addr);
-            } else {
-              LOG.info("ip:{} not returned.", hostAddress);
-            }
+    while (enumNI.hasMoreElements()) {
+      NetworkInterface ifc = enumNI.nextElement();
+      if (ifc.isUp()) {
+        Enumeration<InetAddress> enumAdds = ifc.getInetAddresses();
+        while (enumAdds.hasMoreElements()) {
+          InetAddress addr = enumAdds.nextElement();
+
+          String hostAddress = addr.getHostAddress();
+          if (!INVALID_IPS.contains(hostAddress)
+              && ipValidator.isValid(hostAddress)) {
+            LOG.info("Adding ip:{},host:{}", hostAddress, addr.getHostName());
+            hostIps.add(addr);
+          } else {
+            LOG.info("ip:{} not returned.", hostAddress);
           }
         }
       }
-      return hostIps;
-    } else {
-      throw new IOException("Unable to get network interfaces.");
     }
+
+    return hostIps;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
@@ -99,8 +99,8 @@ public final class OzoneSecurityUtil {
             InetAddress addr = enumAdds.nextElement();
 
             String hostAddress = addr.getHostAddress();
-            if (ipValidator.isValid(hostAddress)
-                && !INVALID_IPS.contains(hostAddress)) {
+            if (!INVALID_IPS.contains(hostAddress)
+                && ipValidator.isValid(hostAddress)) {
               LOG.info("Adding ip:{},host:{}", hostAddress, addr.getHostName());
               hostIps.add(addr);
             } else {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
@@ -48,10 +48,10 @@ import java.util.Set;
 @InterfaceStability.Evolving
 public final class OzoneSecurityUtil {
 
-  private final static Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(OzoneSecurityUtil.class);
   // List of ip's not recommended to be added to CSR.
-  private final static Set<String> INVALID_IPS = new HashSet<>(Arrays.asList(
+  private static final Set<String> INVALID_IPS = new HashSet<>(Arrays.asList(
       "0.0.0.0", "127.0.0.1"));
 
   private OzoneSecurityUtil() {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
@@ -104,8 +104,7 @@ public final class OzoneSecurityUtil {
                   addr.getHostName());
               hostIps.add(addr);
             } else {
-              LOG.info("ip:{},host:{} not returned.", addr.getHostAddress(),
-                  addr.getHostName());
+              LOG.info("ip:{} not returned.", addr.getHostAddress());
             }
           }
         }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
@@ -98,13 +98,13 @@ public final class OzoneSecurityUtil {
           while (enumAdds.hasMoreElements()) {
             InetAddress addr = enumAdds.nextElement();
 
-            if (ipValidator.isValid(addr.getHostAddress())
-                && !INVALID_IPS.contains(addr.getHostAddress())) {
-              LOG.info("Adding ip:{},host:{}", addr.getHostAddress(),
-                  addr.getHostName());
+            String hostAddress = addr.getHostAddress();
+            if (ipValidator.isValid(hostAddress)
+                && !INVALID_IPS.contains(hostAddress)) {
+              LOG.info("Adding ip:{},host:{}", hostAddress, addr.getHostName());
               hostIps.add(addr);
             } else {
-              LOG.info("ip:{} not returned.", addr.getHostAddress());
+              LOG.info("ip:{} not returned.", hostAddress);
             }
           }
         }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
@@ -68,11 +68,8 @@ public final class OzoneSecurityUtil {
    * @return True if the key files exist.
    */
   public static boolean checkIfFileExist(Path path, String fileName) {
-    if (Files.exists(path) && Files.exists(Paths.get(path.toString(),
-        fileName))) {
-      return true;
-    }
-    return false;
+    return Files.exists(path) && Files.exists(Paths.get(path.toString(),
+        fileName));
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneSecurityUtil.java
@@ -28,12 +28,11 @@ import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -68,8 +67,9 @@ public final class OzoneSecurityUtil {
    * @return True if the key files exist.
    */
   public static boolean checkIfFileExist(Path path, String fileName) {
-    return Files.exists(path) && Files.exists(Paths.get(path.toString(),
-        fileName));
+    File dir = path.toFile();
+    return dir.exists()
+        && new File(dir, fileName).exists();
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Skip hostname lookup for invalid IP addresses of the local host in `OzoneSecurityUtil#getValidInetsForCurrentHost`.  This only affects the log message, not any functionality.

https://issues.apache.org/jira/browse/HDDS-2626

## How was this patch tested?

Previously:

```
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 142.699 s - in org.apache.hadoop.ozone.TestHddsSecureDatanodeInit
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 74.919 s - in org.apache.hadoop.ozone.TestSecureOzoneCluster
```

After the change:

```
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.79 s - in org.apache.hadoop.ozone.TestHddsSecureDatanodeInit
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 35.065 s - in org.apache.hadoop.ozone.TestSecureOzoneCluster
```

CI is not improved, since it runs in a container without strange network interfaces:

```
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.158 s - in org.apache.hadoop.ozone.TestHddsSecureDatanodeInit
```