### PR TITLE
HDDS-2565. Handle InterruptedException in VolumeSet

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeSet.java
@@ -211,6 +211,7 @@ public class VolumeSet {
     try {
       failedVolumes = volumeChecker.checkAllVolumes(allVolumes);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new IOException("Interrupted while running disk check", e);
     }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSet.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSet.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 
 import java.io.File;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -243,4 +244,27 @@ public class TestVolumeSet {
     }
 
   }
+
+  @Test
+  public void testInterrupt() throws Exception {
+    Method method = this.volumeSet.getClass()
+        .getDeclaredMethod("checkAllVolumes");
+    method.setAccessible(true);
+    String exceptionMessage = "";
+
+    try {
+      Thread.currentThread().interrupt();
+      method.invoke(this.volumeSet);
+      if (Thread.currentThread().isInterrupted()) {
+        throw new InterruptedException("Interruption Occur");
+      }
+    } catch (InterruptedException interruptedException) {
+      exceptionMessage = "InterruptedException Occur.";
+    }
+
+    assertEquals(
+        "InterruptedException Occur.",
+        exceptionMessage);
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Re-Interrupt when catching the ```InterruptedException```.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2565

## How was this patch tested?
UT Updating to validate the behavior.