### PR TITLE
HDDS-2629. Ozone CLI: CreationTime/modifyTime of volume/bucket/key in…

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -150,7 +150,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.9.8</version>
+      <version>${jackson2.version}</version>
     </dependency>
   </dependencies>
 

--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -147,6 +147,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>snakeyaml</artifactId>
       <version>1.16</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>2.9.8</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/web/utils/JsonUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/web/utils/JsonUtils.java
@@ -19,9 +19,10 @@
 package org.apache.hadoop.ozone.web.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.type.CollectionType;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import java.io.IOException;
 import java.util.List;
@@ -34,10 +35,14 @@ public final class JsonUtils {
   // Reuse ObjectMapper instance for improving performance.
   // ObjectMapper is thread safe as long as we always configure instance
   // before use.
-  private static final ObjectMapper MAPPER = new ObjectMapper();
-  private static final ObjectReader READER = MAPPER.readerFor(Object.class);
-  private static final ObjectWriter WRITTER =
-      MAPPER.writerWithDefaultPrettyPrinter();
+  private static final ObjectMapper MAPPER;
+  private static final ObjectWriter WRITTER;
+  static {
+    MAPPER = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+    WRITTER = MAPPER.writerWithDefaultPrettyPrinter();
+  }
 
   private JsonUtils() {
     // Never constructed

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -93,7 +94,7 @@ public class OzoneBucket extends WithMetadata {
   /**
    * Creation time of the bucket.
    */
-  private long creationTime;
+  private Instant creationTime;
 
   /**
    * Bucket Encryption key name if bucket encryption is enabled.
@@ -140,7 +141,7 @@ public class OzoneBucket extends WithMetadata {
     this.storageType = storageType;
     this.versioning = versioning;
     this.listCacheSize = HddsClientUtils.getListCacheSize(conf);
-    this.creationTime = creationTime;
+    this.creationTime = Instant.ofEpochMilli(creationTime);
     this.metadata = metadata;
     this.encryptionKeyName = encryptionKeyName;
   }
@@ -163,7 +164,7 @@ public class OzoneBucket extends WithMetadata {
     this.storageType = storageType;
     this.versioning = versioning;
     this.listCacheSize = HddsClientUtils.getListCacheSize(conf);
-    this.creationTime = creationTime;
+    this.creationTime = Instant.ofEpochMilli(creationTime);
     this.metadata = metadata;
   }
 
@@ -180,7 +181,7 @@ public class OzoneBucket extends WithMetadata {
     this.defaultReplicationType = defaultReplicationType;
     this.storageType = storageType;
     this.versioning = versioning;
-    this.creationTime = creationTime;
+    this.creationTime = Instant.ofEpochMilli(creationTime);
     this.ozoneObj = OzoneObjInfo.Builder.newBuilder()
         .setBucketName(name)
         .setVolumeName(volumeName)
@@ -240,7 +241,7 @@ public class OzoneBucket extends WithMetadata {
    *
    * @return creation time of the bucket
    */
-  public long getCreationTime() {
+  public Instant getCreationTime() {
     return creationTime;
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKey.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKey.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.ozone.client;
 
 import org.apache.hadoop.hdds.client.ReplicationType;
 
+import java.time.Instant;
+
 /**
  * A class that encapsulates OzoneKey.
  */
@@ -44,11 +46,11 @@ public class OzoneKey {
   /**
    * Creation time of the key.
    */
-  private long creationTime;
+  private Instant creationTime;
   /**
    * Modification time of the key.
    */
-  private long modificationTime;
+  private Instant modificationTime;
 
   private ReplicationType replicationType;
 
@@ -67,8 +69,8 @@ public class OzoneKey {
     this.bucketName = bucketName;
     this.name = keyName;
     this.dataSize = size;
-    this.creationTime = creationTime;
-    this.modificationTime = modificationTime;
+    this.creationTime = Instant.ofEpochMilli(creationTime);
+    this.modificationTime = Instant.ofEpochMilli(modificationTime);
     this.replicationType = type;
     this.replicationFactor = replicationFactor;
   }
@@ -114,7 +116,7 @@ public class OzoneKey {
    *
    * @return creation time
    */
-  public long getCreationTime() {
+  public Instant getCreationTime() {
     return creationTime;
   }
 
@@ -123,7 +125,7 @@ public class OzoneKey {
    *
    * @return modification time
    */
-  public long getModificationTime() {
+  public Instant getModificationTime() {
     return modificationTime;
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.client;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -66,7 +67,7 @@ public class OzoneVolume extends WithMetadata {
   /**
    * Creation time of the volume.
    */
-  private long creationTime;
+  private Instant creationTime;
   /**
    * Volume ACLs.
    */
@@ -97,7 +98,7 @@ public class OzoneVolume extends WithMetadata {
     this.admin = admin;
     this.owner = owner;
     this.quotaInBytes = quotaInBytes;
-    this.creationTime = creationTime;
+    this.creationTime = Instant.ofEpochMilli(creationTime);
     this.acls = acls;
     this.listCacheSize = HddsClientUtils.getListCacheSize(conf);
     this.metadata = metadata;
@@ -120,7 +121,7 @@ public class OzoneVolume extends WithMetadata {
     this.admin = admin;
     this.owner = owner;
     this.quotaInBytes = quotaInBytes;
-    this.creationTime = creationTime;
+    this.creationTime = Instant.ofEpochMilli(creationTime);
     this.acls = acls;
     this.metadata = new HashMap<>();
   }
@@ -166,7 +167,7 @@ public class OzoneVolume extends WithMetadata {
    *
    * @return creation time.
    */
-  public long getCreationTime() {
+  public Instant getCreationTime() {
     return creationTime;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -162,7 +162,7 @@ public class TestOzoneAtRestEncryption extends TestOzoneRpcClient {
   public void testPutKeyWithEncryption() throws Exception {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    Instant currentTime = Instant.now();
+    Instant testStartTime = Instant.now();
 
     String value = "sample value";
     store.createVolume(volumeName);
@@ -196,8 +196,8 @@ public class TestOzoneAtRestEncryption extends TestOzoneRpcClient {
           keyName, ReplicationType.STAND_ALONE,
           ReplicationFactor.ONE));
       Assert.assertEquals(value, new String(fileContent, "UTF-8"));
-      Assert.assertTrue(key.getCreationTime().compareTo(currentTime) >= 0);
-      Assert.assertTrue(key.getModificationTime().compareTo(currentTime) >= 0);
+      Assert.assertTrue(key.getCreationTime().isAfter(testStartTime));
+      Assert.assertTrue(key.getModificationTime().isAfter(testStartTime));
     }
   }
 
@@ -213,7 +213,7 @@ public class TestOzoneAtRestEncryption extends TestOzoneRpcClient {
     //Step 1
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    Instant currentTime = Instant.now();
+    Instant testStartTime = Instant.now();
 
     String value = "sample value";
     store.createVolume(volumeName);
@@ -254,8 +254,8 @@ public class TestOzoneAtRestEncryption extends TestOzoneRpcClient {
         keyName, ReplicationType.STAND_ALONE,
         ReplicationFactor.ONE));
     Assert.assertEquals(value, new String(fileContent, "UTF-8"));
-    Assert.assertTrue(key.getCreationTime().compareTo(currentTime) >= 0);
-    Assert.assertTrue(key.getModificationTime().compareTo(currentTime) >= 0);
+    Assert.assertTrue(key.getCreationTime().isAfter(testStartTime));
+    Assert.assertTrue(key.getModificationTime().isAfter(testStartTime));
     Assert.assertEquals("true", key.getMetadata().get(OzoneConsts.GDPR_FLAG));
     //As TDE is enabled, the TDE encryption details should not be null.
     Assert.assertNotNull(key.getFileEncryptionInfo());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -49,7 +49,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.apache.hadoop.util.Time;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -58,6 +57,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -162,7 +162,7 @@ public class TestOzoneAtRestEncryption extends TestOzoneRpcClient {
   public void testPutKeyWithEncryption() throws Exception {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    long currentTime = Time.now();
+    Instant currentTime = Instant.now();
 
     String value = "sample value";
     store.createVolume(volumeName);
@@ -196,8 +196,8 @@ public class TestOzoneAtRestEncryption extends TestOzoneRpcClient {
           keyName, ReplicationType.STAND_ALONE,
           ReplicationFactor.ONE));
       Assert.assertEquals(value, new String(fileContent, "UTF-8"));
-      Assert.assertTrue(key.getCreationTime() >= currentTime);
-      Assert.assertTrue(key.getModificationTime() >= currentTime);
+      Assert.assertTrue(key.getCreationTime().compareTo(currentTime) >= 0);
+      Assert.assertTrue(key.getModificationTime().compareTo(currentTime) >= 0);
     }
   }
 
@@ -213,7 +213,7 @@ public class TestOzoneAtRestEncryption extends TestOzoneRpcClient {
     //Step 1
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    long currentTime = Time.now();
+    Instant currentTime = Instant.now();
 
     String value = "sample value";
     store.createVolume(volumeName);
@@ -254,8 +254,8 @@ public class TestOzoneAtRestEncryption extends TestOzoneRpcClient {
         keyName, ReplicationType.STAND_ALONE,
         ReplicationFactor.ONE));
     Assert.assertEquals(value, new String(fileContent, "UTF-8"));
-    Assert.assertTrue(key.getCreationTime() >= currentTime);
-    Assert.assertTrue(key.getModificationTime() >= currentTime);
+    Assert.assertTrue(key.getCreationTime().compareTo(currentTime) >= 0);
+    Assert.assertTrue(key.getModificationTime().compareTo(currentTime) >= 0);
     Assert.assertEquals("true", key.getMetadata().get(OzoneConsts.GDPR_FLAG));
     //As TDE is enabled, the TDE encryption details should not be null.
     Assert.assertNotNull(key.getFileEncryptionInfo());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -299,7 +299,7 @@ public abstract class TestOzoneRpcClientAbstract {
   @Test
   public void testCreateBucket()
       throws IOException {
-    Instant currentTime = Instant.now();
+    Instant testStartTime = Instant.now();
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     store.createVolume(volumeName);
@@ -307,14 +307,14 @@ public abstract class TestOzoneRpcClientAbstract {
     volume.createBucket(bucketName);
     OzoneBucket bucket = volume.getBucket(bucketName);
     Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertTrue(bucket.getCreationTime().compareTo(currentTime) >= 0);
-    Assert.assertTrue(volume.getCreationTime().compareTo(currentTime) >= 0);
+    Assert.assertTrue(bucket.getCreationTime().isAfter(testStartTime));
+    Assert.assertTrue(volume.getCreationTime().isAfter(testStartTime));
   }
 
   @Test
   public void testCreateS3Bucket()
       throws IOException {
-    Instant currentTime = Instant.now();
+    Instant testStartTime = Instant.now();
     String userName = UserGroupInformation.getCurrentUser().getUserName();
     String bucketName = UUID.randomUUID().toString();
     store.createS3Bucket(userName, bucketName);
@@ -322,13 +322,13 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneVolume volume = store.getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket(bucketName);
     Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertTrue(bucket.getCreationTime().compareTo(currentTime) >= 0);
-    Assert.assertTrue(volume.getCreationTime().compareTo(currentTime) >= 0);
+    Assert.assertTrue(bucket.getCreationTime().isAfter(testStartTime));
+    Assert.assertTrue(volume.getCreationTime().isAfter(testStartTime));
   }
 
   @Test
   public void testCreateSecureS3Bucket() throws IOException {
-    Instant currentTime = Instant.now();
+    Instant testStartTime = Instant.now();
     String userName = "ozone/localhost@EXAMPLE.COM";
     String bucketName = UUID.randomUUID().toString();
     String s3VolumeName = OzoneS3Util.getVolumeName(userName);
@@ -339,8 +339,8 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneVolume volume = store.getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket(bucketName);
     Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertTrue(bucket.getCreationTime().compareTo(currentTime) >= 0);
-    Assert.assertTrue(volume.getCreationTime().compareTo(currentTime) >= 0);
+    Assert.assertTrue(bucket.getCreationTime().isAfter(testStartTime));
+    Assert.assertTrue(volume.getCreationTime().isAfter(testStartTime));
   }
 
 
@@ -375,7 +375,7 @@ public abstract class TestOzoneRpcClientAbstract {
   @Test
   public void testDeleteS3Bucket()
       throws Exception {
-    Instant currentTime = Instant.now();
+    Instant testStartTime = Instant.now();
     String userName = "ozone1";
     String bucketName = UUID.randomUUID().toString();
     store.createS3Bucket(userName, bucketName);
@@ -383,8 +383,8 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneVolume volume = store.getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket(bucketName);
     Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertTrue(bucket.getCreationTime().compareTo(currentTime) >= 0);
-    Assert.assertTrue(volume.getCreationTime().compareTo(currentTime) >= 0);
+    Assert.assertTrue(bucket.getCreationTime().isAfter(testStartTime));
+    Assert.assertTrue(volume.getCreationTime().isAfter(testStartTime));
     store.deleteS3Bucket(bucketName);
 
     OzoneTestUtils.expectOmException(ResultCodes.S3_BUCKET_NOT_FOUND,
@@ -679,7 +679,7 @@ public abstract class TestOzoneRpcClientAbstract {
   public void testPutKey() throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    Instant currentTime = Instant.now();
+    Instant testStartTime = Instant.now();
 
     String value = "sample value";
     store.createVolume(volumeName);
@@ -704,8 +704,8 @@ public abstract class TestOzoneRpcClientAbstract {
           keyName, STAND_ALONE,
           ONE));
       Assert.assertEquals(value, new String(fileContent));
-      Assert.assertTrue(key.getCreationTime().compareTo(currentTime) >= 0);
-      Assert.assertTrue(key.getModificationTime().compareTo(currentTime) >= 0);
+      Assert.assertTrue(key.getCreationTime().isAfter(testStartTime));
+      Assert.assertTrue(key.getModificationTime().isAfter(testStartTime));
     }
   }
 
@@ -746,7 +746,7 @@ public abstract class TestOzoneRpcClientAbstract {
   public void testPutKeyRatisOneNode() throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    Instant currentTime = Instant.now();
+    Instant testStartTime = Instant.now();
 
     String value = "sample value";
     store.createVolume(volumeName);
@@ -771,8 +771,8 @@ public abstract class TestOzoneRpcClientAbstract {
       Assert.assertTrue(verifyRatisReplication(volumeName, bucketName,
           keyName, ReplicationType.RATIS, ONE));
       Assert.assertEquals(value, new String(fileContent));
-      Assert.assertTrue(key.getCreationTime().compareTo(currentTime) >= 0);
-      Assert.assertTrue(key.getModificationTime().compareTo(currentTime) >= 0);
+      Assert.assertTrue(key.getCreationTime().isAfter(testStartTime));
+      Assert.assertTrue(key.getModificationTime().isAfter(testStartTime));
     }
   }
 
@@ -780,7 +780,7 @@ public abstract class TestOzoneRpcClientAbstract {
   public void testPutKeyRatisThreeNodes() throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    Instant currentTime = Instant.now();
+    Instant testStartTime = Instant.now();
 
     String value = "sample value";
     store.createVolume(volumeName);
@@ -806,8 +806,8 @@ public abstract class TestOzoneRpcClientAbstract {
           keyName, ReplicationType.RATIS,
           ReplicationFactor.THREE));
       Assert.assertEquals(value, new String(fileContent));
-      Assert.assertTrue(key.getCreationTime().compareTo(currentTime) >= 0);
-      Assert.assertTrue(key.getModificationTime().compareTo(currentTime) >= 0);
+      Assert.assertTrue(key.getCreationTime().isAfter(testStartTime));
+      Assert.assertTrue(key.getModificationTime().isAfter(testStartTime));
     }
   }
 
@@ -818,7 +818,7 @@ public abstract class TestOzoneRpcClientAbstract {
       InterruptedException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    Instant currentTime = Instant.now();
+    Instant testStartTime = Instant.now();
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
@@ -848,9 +848,8 @@ public abstract class TestOzoneRpcClientAbstract {
               keyName, ReplicationType.RATIS,
               ReplicationFactor.THREE));
           Assert.assertEquals(data, new String(fileContent));
-          Assert.assertTrue(key.getCreationTime().compareTo(currentTime) >= 0);
-          Assert.assertTrue(key.getModificationTime()
-              .compareTo(currentTime) >= 0);
+          Assert.assertTrue(key.getCreationTime().isAfter(testStartTime));
+          Assert.assertTrue(key.getModificationTime().isAfter(testStartTime));
         }
         latch.countDown();
       } catch (IOException ex) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.client.rpc;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -95,7 +96,6 @@ import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
-import org.apache.hadoop.util.Time;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import org.apache.commons.io.FileUtils;
@@ -281,7 +281,6 @@ public abstract class TestOzoneRpcClientAbstract {
   @Test
   public void testCreateBucketWithMetadata()
       throws IOException, OzoneClientException {
-    long currentTime = Time.now();
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     store.createVolume(volumeName);
@@ -299,8 +298,8 @@ public abstract class TestOzoneRpcClientAbstract {
 
   @Test
   public void testCreateBucket()
-      throws IOException, OzoneClientException {
-    long currentTime = Time.now();
+      throws IOException {
+    Instant currentTime = Instant.now();
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     store.createVolume(volumeName);
@@ -308,14 +307,14 @@ public abstract class TestOzoneRpcClientAbstract {
     volume.createBucket(bucketName);
     OzoneBucket bucket = volume.getBucket(bucketName);
     Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertTrue(bucket.getCreationTime() >= currentTime);
-    Assert.assertTrue(volume.getCreationTime() >= currentTime);
+    Assert.assertTrue(bucket.getCreationTime().compareTo(currentTime) >= 0);
+    Assert.assertTrue(volume.getCreationTime().compareTo(currentTime) >= 0);
   }
 
   @Test
   public void testCreateS3Bucket()
-      throws IOException, OzoneClientException {
-    long currentTime = Time.now();
+      throws IOException {
+    Instant currentTime = Instant.now();
     String userName = UserGroupInformation.getCurrentUser().getUserName();
     String bucketName = UUID.randomUUID().toString();
     store.createS3Bucket(userName, bucketName);
@@ -323,13 +322,13 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneVolume volume = store.getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket(bucketName);
     Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertTrue(bucket.getCreationTime() >= currentTime);
-    Assert.assertTrue(volume.getCreationTime() >= currentTime);
+    Assert.assertTrue(bucket.getCreationTime().compareTo(currentTime) >= 0);
+    Assert.assertTrue(volume.getCreationTime().compareTo(currentTime) >= 0);
   }
 
   @Test
   public void testCreateSecureS3Bucket() throws IOException {
-    long currentTime = Time.now();
+    Instant currentTime = Instant.now();
     String userName = "ozone/localhost@EXAMPLE.COM";
     String bucketName = UUID.randomUUID().toString();
     String s3VolumeName = OzoneS3Util.getVolumeName(userName);
@@ -340,14 +339,14 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneVolume volume = store.getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket(bucketName);
     Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertTrue(bucket.getCreationTime() >= currentTime);
-    Assert.assertTrue(volume.getCreationTime() >= currentTime);
+    Assert.assertTrue(bucket.getCreationTime().compareTo(currentTime) >= 0);
+    Assert.assertTrue(volume.getCreationTime().compareTo(currentTime) >= 0);
   }
 
 
   @Test
   public void testListS3Buckets()
-      throws IOException, OzoneClientException {
+      throws IOException {
     String userName = "ozone100";
     String bucketName1 = UUID.randomUUID().toString();
     String bucketName2 = UUID.randomUUID().toString();
@@ -364,8 +363,7 @@ public abstract class TestOzoneRpcClientAbstract {
   }
 
   @Test
-  public void testListS3BucketsFail()
-      throws IOException, OzoneClientException {
+  public void testListS3BucketsFail() {
     String userName = "randomUser";
     Iterator<? extends OzoneBucket> iterator = store.listS3Buckets(userName,
         null);
@@ -377,7 +375,7 @@ public abstract class TestOzoneRpcClientAbstract {
   @Test
   public void testDeleteS3Bucket()
       throws Exception {
-    long currentTime = Time.now();
+    Instant currentTime = Instant.now();
     String userName = "ozone1";
     String bucketName = UUID.randomUUID().toString();
     store.createS3Bucket(userName, bucketName);
@@ -385,8 +383,8 @@ public abstract class TestOzoneRpcClientAbstract {
     OzoneVolume volume = store.getVolume(volumeName);
     OzoneBucket bucket = volume.getBucket(bucketName);
     Assert.assertEquals(bucketName, bucket.getName());
-    Assert.assertTrue(bucket.getCreationTime() >= currentTime);
-    Assert.assertTrue(volume.getCreationTime() >= currentTime);
+    Assert.assertTrue(bucket.getCreationTime().compareTo(currentTime) >= 0);
+    Assert.assertTrue(volume.getCreationTime().compareTo(currentTime) >= 0);
     store.deleteS3Bucket(bucketName);
 
     OzoneTestUtils.expectOmException(ResultCodes.S3_BUCKET_NOT_FOUND,
@@ -404,8 +402,7 @@ public abstract class TestOzoneRpcClientAbstract {
 
   @Test
   public void testCreateS3BucketMapping()
-      throws IOException, OzoneClientException {
-    long currentTime = Time.now();
+      throws IOException {
     String userName = OzoneConsts.OZONE;
     String bucketName = UUID.randomUUID().toString();
     store.createS3Bucket(userName, bucketName);
@@ -438,7 +435,7 @@ public abstract class TestOzoneRpcClientAbstract {
 
   @Test
   public void testCreateBucketWithStorageType()
-      throws IOException, OzoneClientException {
+      throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     store.createVolume(volumeName);
@@ -453,7 +450,7 @@ public abstract class TestOzoneRpcClientAbstract {
 
   @Test
   public void testCreateBucketWithAcls()
-      throws IOException, OzoneClientException {
+      throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     OzoneAcl userAcl = new OzoneAcl(USER, "test",
@@ -472,7 +469,7 @@ public abstract class TestOzoneRpcClientAbstract {
 
   @Test
   public void testCreateBucketWithAllArgument()
-      throws IOException, OzoneClientException {
+      throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     OzoneAcl userAcl = new OzoneAcl(USER, "test",
@@ -509,7 +506,7 @@ public abstract class TestOzoneRpcClientAbstract {
 
   @Test
   public void testAddBucketAcl()
-      throws IOException, OzoneClientException {
+      throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     store.createVolume(volumeName);
@@ -528,7 +525,7 @@ public abstract class TestOzoneRpcClientAbstract {
 
   @Test
   public void testRemoveBucketAcl()
-      throws IOException, OzoneClientException {
+      throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     OzoneAcl userAcl = new OzoneAcl(USER, "test",
@@ -583,7 +580,7 @@ public abstract class TestOzoneRpcClientAbstract {
 
   @Test
   public void testSetBucketVersioning()
-      throws IOException, OzoneClientException {
+      throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     store.createVolume(volumeName);
@@ -620,7 +617,7 @@ public abstract class TestOzoneRpcClientAbstract {
 
   @Test
   public void testSetBucketStorageType()
-      throws IOException, OzoneClientException {
+      throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     store.createVolume(volumeName);
@@ -679,11 +676,10 @@ public abstract class TestOzoneRpcClientAbstract {
   }
 
   @Test
-  public void testPutKey()
-      throws IOException, OzoneClientException {
+  public void testPutKey() throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    long currentTime = Time.now();
+    Instant currentTime = Instant.now();
 
     String value = "sample value";
     store.createVolume(volumeName);
@@ -708,8 +704,8 @@ public abstract class TestOzoneRpcClientAbstract {
           keyName, STAND_ALONE,
           ONE));
       Assert.assertEquals(value, new String(fileContent));
-      Assert.assertTrue(key.getCreationTime() >= currentTime);
-      Assert.assertTrue(key.getModificationTime() >= currentTime);
+      Assert.assertTrue(key.getCreationTime().compareTo(currentTime) >= 0);
+      Assert.assertTrue(key.getModificationTime().compareTo(currentTime) >= 0);
     }
   }
 
@@ -747,11 +743,10 @@ public abstract class TestOzoneRpcClientAbstract {
   }
 
   @Test
-  public void testPutKeyRatisOneNode()
-      throws IOException, OzoneClientException {
+  public void testPutKeyRatisOneNode() throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    long currentTime = Time.now();
+    Instant currentTime = Instant.now();
 
     String value = "sample value";
     store.createVolume(volumeName);
@@ -776,17 +771,16 @@ public abstract class TestOzoneRpcClientAbstract {
       Assert.assertTrue(verifyRatisReplication(volumeName, bucketName,
           keyName, ReplicationType.RATIS, ONE));
       Assert.assertEquals(value, new String(fileContent));
-      Assert.assertTrue(key.getCreationTime() >= currentTime);
-      Assert.assertTrue(key.getModificationTime() >= currentTime);
+      Assert.assertTrue(key.getCreationTime().compareTo(currentTime) >= 0);
+      Assert.assertTrue(key.getModificationTime().compareTo(currentTime) >= 0);
     }
   }
 
   @Test
-  public void testPutKeyRatisThreeNodes()
-      throws IOException, OzoneClientException {
+  public void testPutKeyRatisThreeNodes() throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    long currentTime = Time.now();
+    Instant currentTime = Instant.now();
 
     String value = "sample value";
     store.createVolume(volumeName);
@@ -812,9 +806,8 @@ public abstract class TestOzoneRpcClientAbstract {
           keyName, ReplicationType.RATIS,
           ReplicationFactor.THREE));
       Assert.assertEquals(value, new String(fileContent));
-      Assert.assertTrue(key.getCreationTime() >= currentTime);
-      Assert.assertTrue(key.getModificationTime() >= currentTime);
-    }
+      Assert.assertTrue(key.getCreationTime().compareTo(currentTime) >= 0);
+      Assert.assertTrue(key.getModificationTime().compareTo(currentTime) >= 0);    }
   }
 
 
@@ -824,7 +817,7 @@ public abstract class TestOzoneRpcClientAbstract {
       InterruptedException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    long currentTime = Time.now();
+    Instant currentTime = Instant.now();
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
@@ -854,8 +847,9 @@ public abstract class TestOzoneRpcClientAbstract {
               keyName, ReplicationType.RATIS,
               ReplicationFactor.THREE));
           Assert.assertEquals(data, new String(fileContent));
-          Assert.assertTrue(key.getCreationTime() >= currentTime);
-          Assert.assertTrue(key.getModificationTime() >= currentTime);
+          Assert.assertTrue(key.getCreationTime().compareTo(currentTime) >= 0);
+          Assert.assertTrue(key.getModificationTime()
+              .compareTo(currentTime) >= 0);
         }
         latch.countDown();
       } catch (IOException ex) {
@@ -945,7 +939,7 @@ public abstract class TestOzoneRpcClientAbstract {
 
 
   private void readCorruptedKey(String volumeName, String bucketName,
-      String keyName, boolean verifyChecksum) throws IOException {
+      String keyName, boolean verifyChecksum) {
     try {
       Configuration configuration = cluster.getConf();
       configuration.setBoolean(OzoneConfigKeys.OZONE_CLIENT_VERIFY_CHECKSUM,
@@ -978,7 +972,7 @@ public abstract class TestOzoneRpcClientAbstract {
   }
 
   @Test
-  public void testGetKeyDetails() throws IOException, OzoneClientException {
+  public void testGetKeyDetails() throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -807,7 +807,8 @@ public abstract class TestOzoneRpcClientAbstract {
           ReplicationFactor.THREE));
       Assert.assertEquals(value, new String(fileContent));
       Assert.assertTrue(key.getCreationTime().compareTo(currentTime) >= 0);
-      Assert.assertTrue(key.getModificationTime().compareTo(currentTime) >= 0);    }
+      Assert.assertTrue(key.getModificationTime().compareTo(currentTime) >= 0);
+    }
   }
 
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
@@ -139,7 +139,7 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
   public void testPutKeySuccessWithBlockToken() throws Exception {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    Instant currentTime = Instant.now();
+    Instant testStartTime = Instant.now();
 
     String value = "sample value";
     store.createVolume(volumeName);
@@ -168,8 +168,8 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
           keyName, ReplicationType.STAND_ALONE,
           ReplicationFactor.ONE));
       Assert.assertEquals(value, new String(fileContent));
-      Assert.assertTrue(key.getCreationTime().compareTo(currentTime) >= 0);
-      Assert.assertTrue(key.getModificationTime().compareTo(currentTime) >= 0);
+      Assert.assertTrue(key.getCreationTime().isAfter(testStartTime));
+      Assert.assertTrue(key.getModificationTime().isAfter(testStartTime));
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
@@ -49,7 +49,6 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
-import org.apache.hadoop.util.Time;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -58,6 +57,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.UUID;
@@ -139,7 +139,7 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
   public void testPutKeySuccessWithBlockToken() throws Exception {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    long currentTime = Time.now();
+    Instant currentTime = Instant.now();
 
     String value = "sample value";
     store.createVolume(volumeName);
@@ -168,8 +168,8 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
           keyName, ReplicationType.STAND_ALONE,
           ReplicationFactor.ONE));
       Assert.assertEquals(value, new String(fileContent));
-      Assert.assertTrue(key.getCreationTime() >= currentTime);
-      Assert.assertTrue(key.getModificationTime() >= currentTime);
+      Assert.assertTrue(key.getCreationTime().compareTo(currentTime) >= 0);
+      Assert.assertTrue(key.getModificationTime().compareTo(currentTime) >= 0);
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scrubber/TestDataScrubber.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scrubber/TestDataScrubber.java
@@ -52,13 +52,13 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
-import org.apache.hadoop.util.Time;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Set;
 import java.util.UUID;
@@ -114,7 +114,7 @@ public class TestDataScrubber {
   public void testOpenContainerIntegrity() throws Exception {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    long currentTime = Time.now();
+    Instant currentTime = Instant.now();
 
     String value = "sample value";
     store.createVolume(volumeName);
@@ -139,8 +139,8 @@ public class TestDataScrubber {
           keyName, STAND_ALONE,
           ONE));
       Assert.assertEquals(value, new String(fileContent));
-      Assert.assertTrue(key.getCreationTime() >= currentTime);
-      Assert.assertTrue(key.getModificationTime() >= currentTime);
+      Assert.assertTrue(key.getCreationTime().compareTo(currentTime) >= 0);
+      Assert.assertTrue(key.getModificationTime().compareTo(currentTime) >= 0);
     }
 
     // wait for the container report to propagate to SCM

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scrubber/TestDataScrubber.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scrubber/TestDataScrubber.java
@@ -114,7 +114,7 @@ public class TestDataScrubber {
   public void testOpenContainerIntegrity() throws Exception {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    Instant currentTime = Instant.now();
+    Instant testStartTime = Instant.now();
 
     String value = "sample value";
     store.createVolume(volumeName);
@@ -139,8 +139,8 @@ public class TestDataScrubber {
           keyName, STAND_ALONE,
           ONE));
       Assert.assertEquals(value, new String(fileContent));
-      Assert.assertTrue(key.getCreationTime().compareTo(currentTime) >= 0);
-      Assert.assertTrue(key.getModificationTime().compareTo(currentTime) >= 0);
+      Assert.assertTrue(key.getCreationTime().isAfter(testStartTime));
+      Assert.assertTrue(key.getModificationTime().isAfter(testStartTime));
     }
 
     // wait for the container report to propagate to SCM

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -228,8 +228,7 @@ public class TestOzoneManagerHA {
     Assert.assertEquals(bucketName, ozoneBucket.getName());
     Assert.assertTrue(ozoneBucket.getVersioning());
     Assert.assertEquals(StorageType.DISK, ozoneBucket.getStorageType());
-    Assert.assertTrue(ozoneBucket.getCreationTime().compareTo(
-        Instant.now()) <= 0);
+    Assert.assertTrue(ozoneBucket.getCreationTime().isBefore(Instant.now()));
 
 
     // Change versioning to false

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
@@ -71,7 +72,6 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.VolumeArgs;
-import org.apache.hadoop.util.Time;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic
     .IPC_CLIENT_CONNECT_MAX_RETRIES_KEY;
@@ -228,7 +228,8 @@ public class TestOzoneManagerHA {
     Assert.assertEquals(bucketName, ozoneBucket.getName());
     Assert.assertTrue(ozoneBucket.getVersioning());
     Assert.assertEquals(StorageType.DISK, ozoneBucket.getStorageType());
-    Assert.assertTrue(ozoneBucket.getCreationTime() <= Time.now());
+    Assert.assertTrue(ozoneBucket.getCreationTime().compareTo(
+        Instant.now()) <= 0);
 
 
     // Change versioning to false

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/web/ozShell/TestObjectPrinter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/web/ozShell/TestObjectPrinter.java
@@ -40,7 +40,7 @@ public class TestObjectPrinter {
     OzoneConfiguration conf = new OzoneConfiguration();
     OzoneVolume volume =
         new OzoneVolume(conf, Mockito.mock(ClientProtocol.class), "name",
-            "admin", "owner", 1L, Instant.ofEpochMilli(0).toEpochMilli(),
+            "admin", "owner", 1L, Instant.EPOCH.toEpochMilli(),
             new ArrayList<>());
 
     String result = ObjectPrinter.getObjectAsJson(volume);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/web/ozShell/TestObjectPrinter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/web/ozShell/TestObjectPrinter.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.web.ozShell;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -25,7 +26,6 @@ import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 
 import org.junit.Assert;
-import static org.junit.Assert.*;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -40,11 +40,13 @@ public class TestObjectPrinter {
     OzoneConfiguration conf = new OzoneConfiguration();
     OzoneVolume volume =
         new OzoneVolume(conf, Mockito.mock(ClientProtocol.class), "name",
-            "admin", "owner", 1L, 0L,
+            "admin", "owner", 1L, Instant.ofEpochMilli(0).toEpochMilli(),
             new ArrayList<>());
 
     String result = ObjectPrinter.getObjectAsJson(volume);
     Assert.assertTrue("Result is not a proper json",
         result.contains("\"owner\""));
+    Assert.assertTrue("Result is not a proper json",
+        result.contains("\"1970-01-01T00:00:00Z\""));
   }
 }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -421,7 +421,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
       } else {
         return new BasicKeyInfo(
             next.getName(),
-            next.getModificationTime(),
+            next.getModificationTime().toEpochMilli(),
             next.getDataSize()
         );
       }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -34,7 +34,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import java.io.IOException;
 import java.io.InputStream;
-import java.time.Instant;
 import java.util.Iterator;
 
 import org.apache.hadoop.hdds.client.ReplicationType;
@@ -348,8 +347,7 @@ public class BucketEndpoint extends EndpointBase {
     } else {
       keyMetadata.setStorageClass(S3StorageType.STANDARD.toString());
     }
-    keyMetadata.setLastModified(Instant.ofEpochMilli(
-        next.getModificationTime()));
+    keyMetadata.setLastModified(next.getModificationTime());
     response.addKey(keyMetadata);
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -296,9 +296,8 @@ public class ObjectEndpoint extends EndpointBase {
   private void addLastModifiedDate(
       ResponseBuilder responseBuilder, OzoneKeyDetails key) {
 
-    ZonedDateTime lastModificationTime =
-        Instant.ofEpochMilli(key.getModificationTime())
-            .atZone(ZoneId.of("GMT"));
+    ZonedDateTime lastModificationTime = key.getModificationTime()
+        .atZone(ZoneId.of("GMT"));
 
     responseBuilder
         .header(LAST_MODIFIED,
@@ -700,8 +699,7 @@ public class ObjectEndpoint extends EndpointBase {
 
       CopyObjectResponse copyObjectResponse = new CopyObjectResponse();
       copyObjectResponse.setETag(OzoneUtils.getRequestID());
-      copyObjectResponse.setLastModified(Instant.ofEpochMilli(destKeyDetails
-          .getModificationTime()));
+      copyObjectResponse.setLastModified(destKeyDetails.getModificationTime());
       return copyObjectResponse;
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.KEY_NOT_FOUND) {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/RootEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/RootEndpoint.java
@@ -22,7 +22,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import java.io.IOException;
-import java.time.Instant;
 import java.util.Iterator;
 
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -74,8 +73,7 @@ public class RootEndpoint extends EndpointBase {
       OzoneBucket next = bucketIterator.next();
       BucketMetadata bucketMetadata = new BucketMetadata();
       bucketMetadata.setName(next.getName());
-      bucketMetadata.setCreationDate(Instant.ofEpochMilli(next
-          .getCreationTime()));
+      bucketMetadata.setCreationDate(next.getCreationTime());
       response.addBucket(bucketMetadata);
     }
 


### PR DESCRIPTION
…fo are not formatted.

## What changes were proposed in this pull request?
Format JSON output of volume/bucket/key info properly in a readable format. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2629

## How was this patch tested?
unit test and run ozone CLI in docker-compose and validate the output like below

`bash-4.2$ ozone sh vol info /vol1
{
  "metadata" : { },
  "name" : "vol1",
  "admin" : "hadoop",
  "owner" : "hadoop",
  "creationTime" : "2019-11-27T06:08:15.546Z",
  "acls" : [ {
    "type" : "USER",
    "name" : "hadoop",
    "aclScope" : "ACCESS",
    "aclList" : [ "ALL" ]
  }, {
    "type" : "GROUP",
    "name" : "users",
    "aclScope" : "ACCESS",
    "aclList" : [ "ALL" ]
  } ],
  "quota" : 1152921504606846976
}

bash-4.2$ ozone sh bucket info /vol1/bucket1
{
  "metadata" : { },
  "volumeName" : "vol1",
  "name" : "bucket1",
  "storageType" : "DISK",
  "versioning" : false,
  "creationTime" : "2019-11-27T06:08:21.148Z",
  "encryptionKeyName" : null
}


bash-4.2$ ozone sh key info /vol1/bucket1/key1
{
  "volumeName" : "vol1",
  "bucketName" : "bucket1",
  "name" : "key1",
  "dataSize" : 3813,
  "creationTime" : "2019-11-27T06:08:33.206Z",
  "modificationTime" : "2019-11-27T06:08:35.558Z",
  "replicationType" : "RATIS",
  "replicationFactor" : 3,
  "ozoneKeyLocations" : [ {
    "containerID" : 1,
    "localID" : 103208380870754304,
    "length" : 3813,
    "offset" : 0
  } ],
  "metadata" : { },
  "fileEncryptionInfo" : null
}
`

