### PR TITLE
HDDS-2632. Fix TestContainerPersistence#testDeleteChunk

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
@@ -575,7 +575,7 @@ public class TestContainerPersistence {
         getDispatcherContext());
     chunkManager.deleteChunk(container, blockID, info);
     exception.expect(StorageContainerException.class);
-    exception.expectMessage("Unable to find the chunk file.");
+    exception.expectMessage("Chunk file can't be found");
     chunkManager.readChunk(container, blockID, info, getDispatcherContext());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestContainerPersistence#testDeleteChunk` is failing due to unexpected exception message.  This is caused by mix of two commits:

 * fe7fccf2b changed actual message
 * 4a9174500 moved the test case from integration to unit

Each of these was tested without the other.

https://issues.apache.org/jira/browse/HDDS-2632

## How was this patch tested?

Ran `TestContainerPersistence` successfully.