### PR TITLE
HDDS-2633. Let findbugs.sh skip frontend plugin for Recon

### DIFF
--- a/hadoop-ozone/dev-support/checks/findbugs.sh
+++ b/hadoop-ozone/dev-support/checks/findbugs.sh
@@ -16,12 +16,16 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
+MAVEN_OPTIONS='-B -fae -Dskip.yarn -Dskip.installyarn'
+
 if ! type unionBugs >/dev/null 2>&1 || ! type convertXmlToText >/dev/null 2>&1; then
-  mvn -B -fae compile spotbugs:check
+  #shellcheck disable=SC2086
+  mvn ${MAVEN_OPTIONS} compile spotbugs:check
   exit $?
 fi
 
-mvn -B -fae compile spotbugs:spotbugs
+#shellcheck disable=SC2086
+mvn ${MAVEN_OPTIONS} compile spotbugs:spotbugs
 
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/findbugs"}
 mkdir -p "$REPORT_DIR"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Findbugs/Spotbugs only checks Java code.  We can skip frontend plugin execution for Recon to save ~2 minutes.  Makes a difference mostly when running it locally.

https://issues.apache.org/jira/browse/HDDS-2633

## How was this patch tested?

Ran `findbugs.sh`, verified Ozone Recon is checked, but its `frontend-maven-plugin` executions are skipped.

```
[INFO] --- frontend-maven-plugin:1.6:install-node-and-yarn (Install node and yarn locally to the project) @ hadoop-ozone-recon ---
[INFO] Skipping execution.
[INFO] 
[INFO] --- frontend-maven-plugin:1.6:yarn (yarn install) @ hadoop-ozone-recon ---
[INFO] Skipping execution.
[INFO] 
[INFO] --- frontend-maven-plugin:1.6:yarn (Build frontend) @ hadoop-ozone-recon ---
[INFO] Skipping execution.
...
[INFO] --- spotbugs-maven-plugin:3.1.12:spotbugs (default-cli) @ hadoop-ozone-recon ---
[INFO] Fork Value is true
[INFO] Done SpotBugs Analysis....
...
[INFO] Total time:  05:12 min
```

vs. earlier:

```
[INFO] Total time:  07:56 min
```