### PR TITLE
HDDS-2637. Handle LeaderNot ready exception in OzoneManager StateMachine and upgrade ratis to latest version.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/DBCheckpoint.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/DBCheckpoint.java
@@ -71,4 +71,16 @@ public interface DBCheckpoint {
    * log index applied to the DB checkpoint.
    */
   long getRatisSnapshotIndex();
+
+  /**
+   * Set the term index for the corresponding OM DB checkpoint.
+   * @param omRatisSnapshotTermIndex
+   */
+  void setRatisSnapshotTermIndex(long omRatisSnapshotTermIndex);
+
+  /**
+   * Get the OM Ratis snapshot term index corresponding to the OM DB checkpoint.
+   * @return
+   */
+  long getRatisSnapshotTermIndex();
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/DBCheckpoint.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/DBCheckpoint.java
@@ -73,14 +73,14 @@ public interface DBCheckpoint {
   long getRatisSnapshotIndex();
 
   /**
-   * Set the term index for the corresponding OM DB checkpoint.
-   * @param omRatisSnapshotTermIndex
+   * Set the Ratis snapshot term for the corresponding OM DB checkpoint.
+   * @param omRatisSnapshotTerm
    */
-  void setRatisSnapshotTermIndex(long omRatisSnapshotTermIndex);
+  void setRatisSnapshotTerm(long omRatisSnapshotTerm);
 
   /**
-   * Get the OM Ratis snapshot term index corresponding to the OM DB checkpoint.
+   * Get the OM Ratis snapshot term corresponding to the OM DB checkpoint.
    * @return
    */
-  long getRatisSnapshotTermIndex();
+  long getRatisSnapshotTerm();
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBCheckpoint.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBCheckpoint.java
@@ -93,12 +93,12 @@ public class RocksDBCheckpoint implements DBCheckpoint {
   }
 
   @Override
-  public void setRatisSnapshotTermIndex(long omRatisSnapshotTermIndex) {
+  public void setRatisSnapshotTerm(long omRatisSnapshotTermIndex) {
     this.ratisSnapShotTermIndex = omRatisSnapshotTermIndex;
   }
 
   @Override
-  public long getRatisSnapshotTermIndex() {
+  public long getRatisSnapshotTerm() {
     return ratisSnapShotTermIndex;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBCheckpoint.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBCheckpoint.java
@@ -39,6 +39,7 @@ public class RocksDBCheckpoint implements DBCheckpoint {
   private long latestSequenceNumber = -1;
   private long checkpointCreationTimeTaken = 0L;
   private long ratisSnapshotIndex = 0L;
+  private long ratisSnapShotTermIndex = 0L;
 
   public RocksDBCheckpoint(Path checkpointLocation) {
     this.checkpointLocation = checkpointLocation;
@@ -89,5 +90,15 @@ public class RocksDBCheckpoint implements DBCheckpoint {
   @Override
   public long getRatisSnapshotIndex() {
     return ratisSnapshotIndex;
+  }
+
+  @Override
+  public void setRatisSnapshotTermIndex(long omRatisSnapshotTermIndex) {
+    this.ratisSnapShotTermIndex = omRatisSnapshotTermIndex;
+  }
+
+  @Override
+  public long getRatisSnapshotTermIndex() {
+    return ratisSnapShotTermIndex;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBCheckpoint.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDBCheckpoint.java
@@ -39,7 +39,7 @@ public class RocksDBCheckpoint implements DBCheckpoint {
   private long latestSequenceNumber = -1;
   private long checkpointCreationTimeTaken = 0L;
   private long ratisSnapshotIndex = 0L;
-  private long ratisSnapShotTermIndex = 0L;
+  private long ratisSnapShotTerm = 0L;
 
   public RocksDBCheckpoint(Path checkpointLocation) {
     this.checkpointLocation = checkpointLocation;
@@ -94,11 +94,11 @@ public class RocksDBCheckpoint implements DBCheckpoint {
 
   @Override
   public void setRatisSnapshotTerm(long omRatisSnapshotTermIndex) {
-    this.ratisSnapShotTermIndex = omRatisSnapshotTermIndex;
+    this.ratisSnapShotTerm = omRatisSnapshotTermIndex;
   }
 
   @Override
   public long getRatisSnapshotTerm() {
-    return ratisSnapShotTermIndex;
+    return ratisSnapShotTerm;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -305,6 +305,9 @@ public final class OzoneConsts {
   // OM Ratis snapshot file to store the last applied index
   public static final String OM_RATIS_SNAPSHOT_INDEX = "ratisSnapshotIndex";
 
+  public static final String OM_RATIS_SNAPSHOT_TERM_INDEX =
+      "ratisSnapShotTermIndex";
+
   // OM Http request parameter to be used while downloading DB checkpoint
   // from OM leader to follower
   public static final String OM_RATIS_SNAPSHOT_BEFORE_DB_CHECKPOINT =

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -305,8 +305,7 @@ public final class OzoneConsts {
   // OM Ratis snapshot file to store the last applied index
   public static final String OM_RATIS_SNAPSHOT_INDEX = "ratisSnapshotIndex";
 
-  public static final String OM_RATIS_SNAPSHOT_TERM_INDEX =
-      "ratisSnapShotTermIndex";
+  public static final String OM_RATIS_SNAPSHOT_TERM = "ratisSnapshotTerm";
 
   // OM Http request parameter to be used while downloading DB checkpoint
   // from OM leader to follower

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -219,7 +219,7 @@ public class ContainerStateMachine extends BaseStateMachine {
       throws IOException {
     if (snapshot == null) {
       TermIndex empty =
-          TermIndex.newTermIndex(0, 0);
+          TermIndex.newTermIndex(0, RaftLog.INVALID_LOG_INDEX);
       LOG.info("{}: The snapshot info is null. Setting the last applied index" +
               "to:{}", gid, empty);
       setLastAppliedTermIndex(empty);
@@ -681,6 +681,12 @@ public class ContainerStateMachine extends BaseStateMachine {
   @Override
   public void notifyIndexUpdate(long term, long index) {
     applyTransactionCompletionMap.put(index, term);
+    // We need to call updateLastApplied here because now in ratis when a
+    // node becomes leader, it is checking stateMachineIndex >=
+    // placeHolderIndex (when a node becomes leader, it writes a conf entry
+    // with some information like its peers and termIndex). So, calling
+    // updateLastApplied updates lastAppliedTermIndex.
+    updateLastApplied();
   }
 
   /*

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -219,7 +219,7 @@ public class ContainerStateMachine extends BaseStateMachine {
       throws IOException {
     if (snapshot == null) {
       TermIndex empty =
-          TermIndex.newTermIndex(0, RaftLog.INVALID_LOG_INDEX);
+          TermIndex.newTermIndex(0, 0);
       LOG.info("{}: The snapshot info is null. Setting the last applied index" +
               "to:{}", gid, empty);
       setLastAppliedTermIndex(empty);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMLeaderNotReadyException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMLeaderNotReadyException.java
@@ -24,11 +24,11 @@ import java.io.IOException;
  * Exception thrown by
  * {@link org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB} when
  * OM leader is not ready to serve requests. This error is thrown when Raft
- * Server returns RatisLeaderNotReadyException.
+ * Server returns {@link org.apache.ratis.protocol.LeaderNotReadyException}.
  */
-public class RatisLeaderNotReadyException extends IOException  {
+public class OMLeaderNotReadyException extends IOException  {
 
-  public RatisLeaderNotReadyException(String message) {
+  public OMLeaderNotReadyException(String message) {
     super(message);
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/RatisLeaderNotReadyException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/RatisLeaderNotReadyException.java
@@ -1,0 +1,16 @@
+package org.apache.hadoop.ozone.om.exceptions;
+
+import java.io.IOException;
+
+/**
+ * Exception thrown by
+ * {@link org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB} when
+ * OM leader is not ready to serve requests. This error is thrown when Raft
+ * Server returns RatisLeaderNotReadyException.
+ */
+public class RatisLeaderNotReadyException extends IOException  {
+
+  public RatisLeaderNotReadyException(String message) {
+    super(message);
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/RatisLeaderNotReadyException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/RatisLeaderNotReadyException.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.ozone.om.exceptions;
 
 import java.io.IOException;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -224,7 +224,7 @@ public class OMFailoverProxyProvider implements
    * In {@link OzoneManagerProtocolClientSideTranslatorPB}, we first
    * manually failover and then call the RetryAction FAILOVER_AND_RETRY. This
    * is done because we do not want to always failover to the next proxy. If we
-   * get a NotLeaderException with a suggested leader, then we want to
+   * get a OMNotLeaderException with a suggested leader, then we want to
    * failover to that OM proxy instead. Hence, we failover manually and the
    * {@link FailoverProxyProvider#performFailover(Object)} call should not do
    * failover again.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerHAProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerHAProtocol.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.ozone.om.protocol;
 
+import org.apache.ratis.server.protocol.TermIndex;
+
 import java.io.IOException;
 
 /**
@@ -29,9 +31,9 @@ public interface OzoneManagerHAProtocol {
   /**
    * Store the snapshot index i.e. the raft log index, corresponding to the
    * last transaction applied to the OM RocksDB, in OM metadata dir on disk.
-   * @return the snapshot index
+   * @return the snapshot term index which has both term and index.
    * @throws IOException
    */
-  long saveRatisSnapshot() throws IOException;
+  TermIndex saveRatisSnapshot() throws IOException;
 
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -158,6 +158,7 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
 
+import org.apache.zookeeper.server.quorum.Leader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -399,9 +400,13 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
       NotLeaderException notLeaderException = getNotLeaderException(e);
       if (notLeaderException == null) {
         throw ProtobufHelper.getRemoteException(e);
-      } else {
-        throw new IOException("Could not determine or connect to OM Leader.");
       }
+      RatisLeaderNotReadyException leaderNotReadyException =
+          getLeaderNotReadyException(e);
+      if (leaderNotReadyException == null) {
+        throw ProtobufHelper.getRemoteException(e);
+      }
+      throw new IOException("Could not determine or connect to OM Leader.");
     }
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -158,7 +158,6 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
 
-import org.apache.zookeeper.server.quorum.Leader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -158,7 +158,6 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
 
-import org.apache.ratis.protocol.LeaderNotReadyException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -123,11 +123,11 @@ class TestDBCheckpoint implements DBCheckpoint {
   }
 
   @Override
-  public void setRatisSnapshotTermIndex(long omRatisSnapshotTermIndex) {
+  public void setRatisSnapshotTerm(long omRatisSnapshotTermIndex) {
   }
 
   @Override
-  public long getRatisSnapshotTermIndex() {
+  public long getRatisSnapshotTerm() {
     return 0;
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -121,4 +121,13 @@ class TestDBCheckpoint implements DBCheckpoint {
   public long getRatisSnapshotIndex() {
     return 0;
   }
+
+  @Override
+  public void setRatisSnapshotTermIndex(long omRatisSnapshotTermIndex) {
+  }
+
+  @Override
+  public long getRatisSnapshotTermIndex() {
+    return 0;
+  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -136,13 +136,13 @@ public class TestOMRatisSnapshots {
     OzoneBucket ozoneBucket = retVolumeinfo.getBucket(bucketName);
 
     long leaderOMappliedLogIndex =
-        leaderRatisServer.getStateMachineLastAppliedIndex();
+        leaderRatisServer.getLastAppliedTermIndex().getIndex();
 
     List<String> keys = new ArrayList<>();
     while (leaderOMappliedLogIndex < 2000) {
       keys.add(createKey(ozoneBucket));
       leaderOMappliedLogIndex =
-          leaderRatisServer.getStateMachineLastAppliedIndex();
+          leaderRatisServer.getLastAppliedTermIndex().getIndex();
     }
 
     // Get the latest db checkpoint from the leader OM.
@@ -158,7 +158,7 @@ public class TestOMRatisSnapshots {
 
     // The recently started OM should be lagging behind the leader OM.
     long followerOMLastAppliedIndex =
-        followerOM.getOmRatisServer().getStateMachineLastAppliedIndex();
+        followerOM.getOmRatisServer().getLastAppliedTermIndex().getIndex();
     Assert.assertTrue(
         followerOMLastAppliedIndex < leaderOMSnaphsotIndex);
 
@@ -177,7 +177,7 @@ public class TestOMRatisSnapshots {
     // follower OM lastAppliedIndex must match the snapshot index of the
     // checkpoint.
     followerOMLastAppliedIndex = followerOM.getOmRatisServer()
-        .getStateMachineLastAppliedIndex();
+        .getLastAppliedTermIndex().getIndex();
     Assert.assertEquals(leaderOMSnaphsotIndex, followerOMLastAppliedIndex);
     Assert.assertEquals(leaderOMSnapshotTermIndex,
         followerOM.getOmRatisServer().getLastAppliedTermIndex().getTerm());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -112,7 +112,7 @@ public class TestOzoneManagerHA {
   private static final long SNAPSHOT_THRESHOLD = 50;
   private static final int LOG_PURGE_GAP = 50;
   /* Reduce max number of retries to speed up unit test. */
-  private static final int OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS = 30;
+  private static final int OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS = 5;
   private static final int IPC_CLIENT_CONNECT_MAX_RETRIES = 4;
 
   @Rule
@@ -581,7 +581,7 @@ public class TestOzoneManagerHA {
         // last running OM as it would fail to get a quorum.
         if (e instanceof RemoteException) {
           GenericTestUtils.assertExceptionContains(
-              "NotLeaderException", e);
+              "OMNotLeaderException", e);
         }
       } else {
         throw e;
@@ -622,7 +622,7 @@ public class TestOzoneManagerHA {
         // last running OM as it would fail to get a quorum.
         if (e instanceof RemoteException) {
           GenericTestUtils.assertExceptionContains(
-              "NotLeaderException", e);
+              "OMNotLeaderException", e);
         }
       } else {
         throw e;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -1114,7 +1114,7 @@ public class TestOzoneManagerHA {
     while (appliedLogIndex <= SNAPSHOT_THRESHOLD) {
       createKey(ozoneBucket);
       appliedLogIndex = ozoneManager.getOmRatisServer()
-          .getStateMachineLastAppliedIndex();
+          .getLastAppliedTermIndex().getIndex();
     }
 
     GenericTestUtils.waitFor(() -> {
@@ -1127,7 +1127,7 @@ public class TestOzoneManagerHA {
     // The current lastAppliedLogIndex on the state machine should be greater
     // than or equal to the saved snapshot index.
     long smLastAppliedIndex =
-        ozoneManager.getOmRatisServer().getStateMachineLastAppliedIndex();
+        ozoneManager.getOmRatisServer().getLastAppliedTermIndex().getIndex();
     long ratisSnapshotIndex = ozoneManager.getRatisSnapshotIndex();
     Assert.assertTrue("LastAppliedIndex on OM State Machine ("
             + smLastAppliedIndex + ") is less than the saved snapshot index("
@@ -1138,7 +1138,7 @@ public class TestOzoneManagerHA {
     while (appliedLogIndex <= (smLastAppliedIndex + SNAPSHOT_THRESHOLD)) {
       createKey(ozoneBucket);
       appliedLogIndex = ozoneManager.getOmRatisServer()
-          .getStateMachineLastAppliedIndex();
+          .getLastAppliedTermIndex().getIndex();
     }
 
     GenericTestUtils.waitFor(() -> {
@@ -1205,7 +1205,7 @@ public class TestOzoneManagerHA {
     }
 
     long lastAppliedTxOnFollowerOM =
-        followerOM1.getOmRatisServer().getStateMachineLastAppliedIndex();
+        followerOM1.getOmRatisServer().getLastAppliedTermIndex().getIndex();
 
     // Stop one follower OM
     followerOM1.stop();
@@ -1216,13 +1216,13 @@ public class TestOzoneManagerHA {
     // restarted.
     long minNewTxIndex = lastAppliedTxOnFollowerOM + (LOG_PURGE_GAP * 10);
     long leaderOMappliedLogIndex = leaderOM.getOmRatisServer()
-        .getStateMachineLastAppliedIndex();
+        .getLastAppliedTermIndex().getIndex();
 
     List<String> missedKeys = new ArrayList<>();
     while (leaderOMappliedLogIndex < minNewTxIndex) {
       missedKeys.add(createKey(ozoneBucket));
       leaderOMappliedLogIndex = leaderOM.getOmRatisServer()
-          .getStateMachineLastAppliedIndex();
+          .getLastAppliedTermIndex().getIndex();
     }
 
     // Restart the stopped OM.
@@ -1233,14 +1233,14 @@ public class TestOzoneManagerHA {
 
     // The recently started OM should be lagging behind the leader OM.
     long followerOMLastAppliedIndex =
-        followerOM1.getOmRatisServer().getStateMachineLastAppliedIndex();
+        followerOM1.getOmRatisServer().getLastAppliedTermIndex().getIndex();
     Assert.assertTrue(
         followerOMLastAppliedIndex < leaderOMSnaphsotIndex);
 
     // Wait for the follower OM to catch up
     GenericTestUtils.waitFor(() -> {
       long lastAppliedIndex =
-          followerOM1.getOmRatisServer().getStateMachineLastAppliedIndex();
+          followerOM1.getOmRatisServer().getLastAppliedTermIndex().getIndex();
       if (lastAppliedIndex >= leaderOMSnaphsotIndex) {
         return true;
       }
@@ -1254,14 +1254,14 @@ public class TestOzoneManagerHA {
       createKey(ozoneBucket);
     }
     long followerOM1lastAppliedIndex = followerOM1.getOmRatisServer()
-        .getStateMachineLastAppliedIndex();
+        .getLastAppliedTermIndex().getIndex();
     Assert.assertTrue(followerOM1lastAppliedIndex >
         leaderOMSnaphsotIndex);
 
     // The follower OMs should be in sync. There can be a small lag between
     // leader OM and follower OMs as txns are applied first on leader OM.
     long followerOM2lastAppliedIndex = followerOM1.getOmRatisServer()
-        .getStateMachineLastAppliedIndex();
+        .getLastAppliedTermIndex().getIndex();
     Assert.assertEquals(followerOM1lastAppliedIndex,
         followerOM2lastAppliedIndex);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -1229,7 +1229,7 @@ public class TestOzoneManagerHA {
     followerOM1.restart();
 
     // Get the latest snapshotIndex from the leader OM.
-    long leaderOMSnaphsotIndex = leaderOM.saveRatisSnapshot();
+    long leaderOMSnaphsotIndex = leaderOM.saveRatisSnapshot().getIndex();
 
     // The recently started OM should be lagging behind the leader OM.
     long followerOMLastAppliedIndex =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -112,7 +112,7 @@ public class TestOzoneManagerHA {
   private static final long SNAPSHOT_THRESHOLD = 50;
   private static final int LOG_PURGE_GAP = 50;
   /* Reduce max number of retries to speed up unit test. */
-  private static final int OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS = 5;
+  private static final int OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS = 30;
   private static final int IPC_CLIENT_CONNECT_MAX_RETRIES = 4;
 
   @Rule

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OM_RATIS_SNAPSHOT_BEFORE_DB_CHECKPOINT;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_RATIS_SNAPSHOT_INDEX;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_RATIS_SNAPSHOT_TERM_INDEX;
 import static org.apache.hadoop.ozone.OzoneConsts.
     OZONE_DB_CHECKPOINT_REQUEST_FLUSH;
 
@@ -40,6 +41,7 @@ import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
+import org.apache.ratis.server.protocol.TermIndex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,15 +117,22 @@ public class OMDBCheckpointServlet extends HttpServlet {
         takeRatisSnapshot = Boolean.valueOf(snapshotBeforeCheckpointParam);
       }
 
-      long ratisSnapshotIndex;
+      long ratisSnapshotIndex = -1L;
+      long ratisSnapshotTermIndex = -1L;
+      boolean setBothHeaders = false;
       if (takeRatisSnapshot) {
         // If OM follower is downloading the checkpoint, we should save a
         // ratis snapshot first. This step also included flushing the OM DB.
         // Hence, we can set flush to false.
         flush = false;
-        ratisSnapshotIndex = om.saveRatisSnapshot();
+        TermIndex lastAppliedTermIndex = om.saveRatisSnapshot();
+        ratisSnapshotTermIndex = lastAppliedTermIndex.getTerm();
+        ratisSnapshotIndex = lastAppliedTermIndex.getIndex();
+        setBothHeaders = true;
       } else {
         ratisSnapshotIndex = om.getRatisSnapshotIndex();
+        response.setHeader(OM_RATIS_SNAPSHOT_INDEX,
+            String.valueOf(ratisSnapshotIndex));
       }
 
       checkpoint = omDbStore.getCheckpoint(flush);
@@ -144,9 +153,20 @@ public class OMDBCheckpointServlet extends HttpServlet {
       response.setHeader("Content-Disposition",
           "attachment; filename=\"" +
                file.toString() + ".tgz\"");
-      // Ratis snapshot index used when downloading DB checkpoint to OM follower
-      response.setHeader(OM_RATIS_SNAPSHOT_INDEX,
-          String.valueOf(ratisSnapshotIndex));
+
+      if (setBothHeaders) {
+        // Ratis snapshot index and term index is used when downloading DB
+        // checkpoint to OM follower.
+        response.setHeader(OM_RATIS_SNAPSHOT_INDEX,
+            String.valueOf(ratisSnapshotIndex));
+        response.setHeader(OM_RATIS_SNAPSHOT_TERM_INDEX,
+            String.valueOf(ratisSnapshotTermIndex));
+      } else {
+        // Ratis snapshot index used when downloading DB checkpoint to OM
+        // follower.
+        response.setHeader(OM_RATIS_SNAPSHOT_INDEX,
+            String.valueOf(ratisSnapshotIndex));
+      }
 
       Instant start = Instant.now();
       OmUtils.writeOmDBCheckpointToStream(checkpoint,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -124,6 +124,8 @@ public class OMDBCheckpointServlet extends HttpServlet {
         // If OM follower is downloading the checkpoint, we should save a
         // ratis snapshot first. This step also included flushing the OM DB.
         // Hence, we can set flush to false.
+
+        // We need to set both snapshot term index and snapshot index.
         flush = false;
         TermIndex lastAppliedTermIndex = om.saveRatisSnapshot();
         ratisSnapshotTermIndex = lastAppliedTermIndex.getTerm();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3261,7 +3261,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * All the classes which use/ store MetadataManager should also be updated
    * with the new MetadataManager instance.
    */
-  void reloadOMState(long newSnapshotIndex, long newSnapShotTermIndex) throws IOException {
+  void reloadOMState(long newSnapshotIndex,
+      long newSnapShotTermIndex) throws IOException {
 
     instantiateServices();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3137,7 +3137,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     long lastAppliedIndex = omRatisServer.getLastAppliedTermIndex().getIndex();
     long checkpointSnapshotIndex = omDBcheckpoint.getRatisSnapshotIndex();
     long checkpointSnapshotTermIndex =
-        omDBcheckpoint.getRatisSnapshotTermIndex();
+        omDBcheckpoint.getRatisSnapshotTerm();
     if (checkpointSnapshotIndex <= lastAppliedIndex) {
       LOG.error("Failed to install checkpoint from OM leader: {}. The last " +
           "applied index: {} is greater than or equal to the checkpoint's " +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1255,8 +1255,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   @Override
-  public long saveRatisSnapshot() throws IOException {
-    long snapshotIndex = omRatisServer.getStateMachineLastAppliedIndex();
+  public TermIndex saveRatisSnapshot() throws IOException {
+    TermIndex snapshotIndex = omRatisServer.getLastAppliedTermIndex();
 
     // Flush the OM state to disk
     metadataManager.getStore().flush();
@@ -3134,8 +3134,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     // snapshot index. If yes, proceed by stopping the ratis server so that
     // the OM state can be re-initialized. If no, then do not proceed with
     // installSnapshot.
-    long lastAppliedIndex = omRatisServer.getStateMachineLastAppliedIndex();
+    long lastAppliedIndex = omRatisServer.getLastAppliedTermIndex().getIndex();
     long checkpointSnapshotIndex = omDBcheckpoint.getRatisSnapshotIndex();
+    long checkpointSnapshotTermIndex =
+        omDBcheckpoint.getRatisSnapshotTermIndex();
     if (checkpointSnapshotIndex <= lastAppliedIndex) {
       LOG.error("Failed to install checkpoint from OM leader: {}. The last " +
           "applied index: {} is greater than or equal to the checkpoint's " +
@@ -3174,8 +3176,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     // Restart (unpause) the state machine and update its last applied index
     // to the installed checkpoint's snapshot index.
     try {
-      reloadOMState(checkpointSnapshotIndex);
-      omRatisServer.getOmStateMachine().unpause(checkpointSnapshotIndex);
+      reloadOMState(checkpointSnapshotIndex, checkpointSnapshotTermIndex);
+      omRatisServer.getOmStateMachine().unpause(checkpointSnapshotIndex,
+          checkpointSnapshotTermIndex);
     } catch (IOException e) {
       LOG.error("Failed to reload OM state with new DB checkpoint.", e);
       return null;
@@ -3190,7 +3193,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     // TODO: We should only return the snpashotIndex to the leader.
     //  Should be fixed after RATIS-586
-    TermIndex newTermIndex = TermIndex.newTermIndex(0,
+    TermIndex newTermIndex = TermIndex.newTermIndex(checkpointSnapshotTermIndex,
         checkpointSnapshotIndex);
 
     return newTermIndex;
@@ -3258,7 +3261,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * All the classes which use/ store MetadataManager should also be updated
    * with the new MetadataManager instance.
    */
-  void reloadOMState(long newSnapshotIndex) throws IOException {
+  void reloadOMState(long newSnapshotIndex, long newSnapShotTermIndex) throws IOException {
 
     instantiateServices();
 
@@ -3281,7 +3284,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     // Update OM snapshot index with the new snapshot index (from the new OM
     // DB state) and save the snapshot index to disk
-    omRatisSnapshotInfo.saveRatisSnapshotToDisk(newSnapshotIndex);
+    omRatisSnapshotInfo.saveRatisSnapshotToDisk(
+        TermIndex.newTermIndex(newSnapShotTermIndex, newSnapshotIndex));
   }
 
   public static  Logger getLogger() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OMRatisSnapshotInfo.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OMRatisSnapshotInfo.java
@@ -60,10 +60,6 @@ public class OMRatisSnapshotInfo implements SnapshotInfo {
     term = newTerm;
   }
 
-  private void updateSnapshotIndex(long newSnapshotIndex) {
-    snapshotIndex = newSnapshotIndex;
-  }
-
   private void updateTermIndex(long newTerm, long newIndex) {
     this.term = newTerm;
     this.snapshotIndex = newIndex;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OMRatisSnapshotInfo.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OMRatisSnapshotInfo.java
@@ -98,13 +98,16 @@ public class OMRatisSnapshotInfo implements SnapshotInfo {
 
   /**
    * Update and persist the snapshot index and term to disk.
-   * @param index new snapshot index to be persisted to disk.
+   * @param lastAppliedTermIndex new snapshot index to be persisted to disk.
    * @throws IOException
    */
-  public void saveRatisSnapshotToDisk(long index) throws IOException {
-    updateSnapshotIndex(index);
+  public void saveRatisSnapshotToDisk(TermIndex lastAppliedTermIndex)
+      throws IOException {
+    updateTermIndex(lastAppliedTermIndex.getTerm(),
+        lastAppliedTermIndex.getIndex());
     writeRatisSnapshotYaml();
-    LOG.info("Saved Ratis Snapshot on the OM with snapshotIndex {}", index);
+    LOG.info("Saved Ratis Snapshot on the OM with snapshotIndex {}",
+        lastAppliedTermIndex);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.exceptions.RatisLeaderNotReadyException;
 import org.apache.hadoop.ozone.om.ha.OMNodeDetails;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
@@ -60,6 +61,7 @@ import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.GroupInfoReply;
 import org.apache.ratis.protocol.GroupInfoRequest;
+import org.apache.ratis.protocol.LeaderNotReadyException;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.NotLeaderException;
 import org.apache.ratis.protocol.RaftClientReply;
@@ -158,24 +160,45 @@ public final class OzoneManagerRatisServer {
     // NotLeader exception is thrown only when the raft server to which the
     // request is submitted is not the leader. This can happen first time
     // when client is submitting request to OM.
-    NotLeaderException notLeaderException = reply.getNotLeaderException();
-    if (notLeaderException != null) {
-      throw new ServiceException(notLeaderException);
-    }
-    StateMachineException stateMachineException =
-        reply.getStateMachineException();
-    if (stateMachineException != null) {
-      OMResponse.Builder omResponse = OMResponse.newBuilder();
-      omResponse.setCmdType(omRequest.getCmdType());
-      omResponse.setSuccess(false);
-      omResponse.setMessage(stateMachineException.getCause().getMessage());
-      omResponse.setStatus(parseErrorStatus(
-          stateMachineException.getCause().getMessage()));
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Error while executing ratis request. " +
-            "stateMachineException: ", stateMachineException);
+
+    if (!reply.isSuccess()) {
+      NotLeaderException notLeaderException = reply.getNotLeaderException();
+      if (notLeaderException != null) {
+        RaftPeerId suggestedLeader =
+            notLeaderException.getSuggestedLeader() != null ?
+                notLeaderException.getSuggestedLeader().getId() : null;
+        org.apache.hadoop.ozone.om.exceptions.NotLeaderException notLeaderException1;
+        if (suggestedLeader != null) {
+          notLeaderException1 = new org.apache.hadoop.ozone.om.exceptions.NotLeaderException(getRaftPeerId(), suggestedLeader);
+        } else {
+          notLeaderException1 =
+              new org.apache.hadoop.ozone.om.exceptions.NotLeaderException(getRaftPeerId());
+        }
+        throw new ServiceException(notLeaderException1);
       }
-      return omResponse.build();
+
+      LeaderNotReadyException leaderNotReadyException =
+          reply.getLeaderNotReadyException();
+      if (leaderNotReadyException != null) {
+        throw new ServiceException(new RatisLeaderNotReadyException(
+            leaderNotReadyException.getMessage()));
+      }
+
+      StateMachineException stateMachineException =
+          reply.getStateMachineException();
+      if (stateMachineException != null) {
+        OMResponse.Builder omResponse = OMResponse.newBuilder();
+        omResponse.setCmdType(omRequest.getCmdType());
+        omResponse.setSuccess(false);
+        omResponse.setMessage(stateMachineException.getCause().getMessage());
+        omResponse.setStatus(parseErrorStatus(
+            stateMachineException.getCause().getMessage()));
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Error while executing ratis request. " +
+              "stateMachineException: ", stateMachineException);
+        }
+        return omResponse.build();
+      }
     }
 
     try {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -75,6 +75,7 @@ import org.apache.ratis.rpc.RpcType;
 import org.apache.ratis.rpc.SupportedRpcType;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.SizeInBytes;
@@ -673,7 +674,6 @@ public final class OzoneManagerRatisServer {
   public long getStateMachineLastAppliedIndex() {
     return omStateMachine.getLastAppliedIndex();
   }
-
   /**
    * Get the local directory where ratis logs will be stored.
    */
@@ -694,5 +694,9 @@ public final class OzoneManagerRatisServer {
           "snapshot").toString();
     }
     return snapshotDir;
+  }
+
+  public TermIndex getLastAppliedTermIndex() {
+    return omStateMachine.getLastAppliedTermIndex();
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -42,7 +42,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
-import org.apache.hadoop.ozone.om.exceptions.RatisLeaderNotReadyException;
+import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;
+import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
 import org.apache.hadoop.ozone.om.ha.OMNodeDetails;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
@@ -165,26 +166,15 @@ public final class OzoneManagerRatisServer {
     if (!reply.isSuccess()) {
       NotLeaderException notLeaderException = reply.getNotLeaderException();
       if (notLeaderException != null) {
-        RaftPeerId suggestedLeader =
-            notLeaderException.getSuggestedLeader() != null ?
-                notLeaderException.getSuggestedLeader().getId() : null;
-        org.apache.hadoop.ozone.om.exceptions.NotLeaderException
-            notLeaderException1;
-        if (suggestedLeader != null) {
-          notLeaderException1 = new org.apache.hadoop.ozone.om.exceptions
-              .NotLeaderException(getRaftPeerId(), suggestedLeader);
-        } else {
-          notLeaderException1 =
-              new org.apache.hadoop.ozone.om.exceptions
-                  .NotLeaderException(getRaftPeerId());
-        }
-        throw new ServiceException(notLeaderException1);
+        throw new ServiceException(
+            OMNotLeaderException.convertToOMNotLeaderException(
+                  notLeaderException, getRaftPeerId()));
       }
 
       LeaderNotReadyException leaderNotReadyException =
           reply.getLeaderNotReadyException();
       if (leaderNotReadyException != null) {
-        throw new ServiceException(new RatisLeaderNotReadyException(
+        throw new ServiceException(new OMLeaderNotReadyException(
             leaderNotReadyException.getMessage()));
       }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -167,12 +167,15 @@ public final class OzoneManagerRatisServer {
         RaftPeerId suggestedLeader =
             notLeaderException.getSuggestedLeader() != null ?
                 notLeaderException.getSuggestedLeader().getId() : null;
-        org.apache.hadoop.ozone.om.exceptions.NotLeaderException notLeaderException1;
+        org.apache.hadoop.ozone.om.exceptions.NotLeaderException
+            notLeaderException1;
         if (suggestedLeader != null) {
-          notLeaderException1 = new org.apache.hadoop.ozone.om.exceptions.NotLeaderException(getRaftPeerId(), suggestedLeader);
+          notLeaderException1 = new org.apache.hadoop.ozone.om.exceptions
+              .NotLeaderException(getRaftPeerId(), suggestedLeader);
         } else {
           notLeaderException1 =
-              new org.apache.hadoop.ozone.om.exceptions.NotLeaderException(getRaftPeerId());
+              new org.apache.hadoop.ozone.om.exceptions
+                  .NotLeaderException(getRaftPeerId());
         }
         throw new ServiceException(notLeaderException1);
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -671,9 +671,6 @@ public final class OzoneManagerRatisServer {
     return UUID.nameUUIDFromBytes(omServiceId.getBytes(StandardCharsets.UTF_8));
   }
 
-  public long getStateMachineLastAppliedIndex() {
-    return omStateMachine.getLastAppliedIndex();
-  }
   /**
    * Get the local directory where ratis logs will be stored.
    */

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -72,7 +72,6 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
   private final OzoneManager ozoneManager;
   private OzoneManagerHARequestHandler handler;
   private RaftGroupId raftGroupId;
-  private volatile long lastAppliedIndex;
   private OzoneManagerDoubleBuffer ozoneManagerDoubleBuffer;
   private final OMRatisSnapshotInfo snapshotInfo;
   private final ExecutorService executorService;
@@ -360,12 +359,10 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
     }
     if (appliedTerm != null) {
       updateLastAppliedTermIndex(appliedTerm, appliedIndex);
-      this.lastAppliedIndex = appliedIndex;
     }
   }
 
   public void updateLastAppliedIndexWithSnaphsotIndex() {
-    this.lastAppliedIndex = snapshotInfo.getIndex();
     // This is done, as we have a check in Ratis for not throwing
     // LeaderNotReadyException, it checks stateMachineIndex >= raftLog
     // nextIndex (placeHolderIndex).
@@ -386,7 +383,7 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
   }
 
   public long getLastAppliedIndex() {
-    return lastAppliedIndex;
+    return getLastAppliedTermIndex().getIndex();
   }
 
   private static <T> CompletableFuture<T> completeExceptionally(Exception e) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -346,8 +346,12 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
     return OMRatisHelper.convertResponseToMessage(response);
   }
 
-  @SuppressWarnings("HiddenField")
-  public void updateLastAppliedIndex(long lastFlushedIndex) {
+  /**
+   * Update lastAppliedIndex term and it's corresponding term in the
+   * stateMachine.
+   * @param lastFlushedIndex
+   */
+  public synchronized void updateLastAppliedIndex(long lastFlushedIndex) {
     Long appliedTerm = null;
     long appliedIndex = -1;
     for(long i = getLastAppliedTermIndex().getIndex() + 1;
@@ -382,10 +386,6 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
   private Message queryCommand(OMRequest request) {
     OMResponse response = handler.handle(request);
     return OMRatisHelper.convertResponseToMessage(response);
-  }
-
-  public long getLastAppliedIndex() {
-    return getLastAppliedTermIndex().getIndex();
   }
 
   private static <T> CompletableFuture<T> completeExceptionally(Exception e) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -248,12 +248,14 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
    * lastAppliedIndex. This should be done after uploading new state to the
    * StateMachine.
    */
-  public void unpause(long newLastAppliedSnaphsotIndex) {
+  public void unpause(long newLastAppliedSnaphsotIndex,
+      long newLastAppliedSnapShotTermIndex) {
     lifeCycle.startAndTransition(() -> {
       this.ozoneManagerDoubleBuffer =
           new OzoneManagerDoubleBuffer(ozoneManager.getMetadataManager(),
               this::updateLastAppliedIndex);
-      this.updateLastAppliedIndex(newLastAppliedSnaphsotIndex);
+      this.setLastAppliedTermIndex(TermIndex.newTermIndex(
+          newLastAppliedSnapShotTermIndex, newLastAppliedSnaphsotIndex));
     });
   }
 
@@ -269,7 +271,7 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
   public long takeSnapshot() throws IOException {
     LOG.info("Saving Ratis snapshot on the OM.");
     if (ozoneManager != null) {
-      return ozoneManager.saveRatisSnapshot();
+      return ozoneManager.saveRatisSnapshot().getIndex();
     }
     return 0;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OzoneManagerSnapshotProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OzoneManagerSnapshotProvider.java
@@ -180,7 +180,7 @@ public class OzoneManagerSnapshotProvider {
         header = response.getFirstHeader(OM_RATIS_SNAPSHOT_TERM_INDEX);
         if (header == null) {
           throw new IOException("The HTTP response header " +
-              OM_RATIS_SNAPSHOT_INDEX + " is missing.");
+              OM_RATIS_SNAPSHOT_TERM_INDEX + " is missing.");
         }
 
         long snapshotTermIndex = Long.parseLong(header.getValue());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OzoneManagerSnapshotProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OzoneManagerSnapshotProvider.java
@@ -51,6 +51,7 @@ import java.util.concurrent.TimeUnit;
 import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_RATIS_SNAPSHOT_INDEX;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_RATIS_SNAPSHOT_TERM_INDEX;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_PROVIDER_CONNECTION_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_PROVIDER_REQUEST_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_PROVIDER_REQUEST_TIMEOUT_KEY;
@@ -176,6 +177,14 @@ public class OzoneManagerSnapshotProvider {
 
         long snapshotIndex = Long.parseLong(header.getValue());
 
+        header = response.getFirstHeader(OM_RATIS_SNAPSHOT_TERM_INDEX);
+        if (header == null) {
+          throw new IOException("The HTTP response header " +
+              OM_RATIS_SNAPSHOT_INDEX + " is missing.");
+        }
+
+        long snapshotTermIndex = Long.parseLong(header.getValue());
+
         try (InputStream inputStream = entity.getContent()) {
           FileUtils.copyInputStreamToFile(inputStream, targetFile);
         }
@@ -191,6 +200,7 @@ public class OzoneManagerSnapshotProvider {
 
         RocksDBCheckpoint omCheckpoint = new RocksDBCheckpoint(untarredDbDir);
         omCheckpoint.setRatisSnapshotIndex(snapshotIndex);
+        omCheckpoint.setRatisSnapshotTermIndex(snapshotTermIndex);
         return omCheckpoint;
       }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OzoneManagerSnapshotProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OzoneManagerSnapshotProvider.java
@@ -51,7 +51,7 @@ import java.util.concurrent.TimeUnit;
 import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_RATIS_SNAPSHOT_INDEX;
-import static org.apache.hadoop.ozone.OzoneConsts.OM_RATIS_SNAPSHOT_TERM_INDEX;
+import static org.apache.hadoop.ozone.OzoneConsts.OM_RATIS_SNAPSHOT_TERM;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_PROVIDER_CONNECTION_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_PROVIDER_REQUEST_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SNAPSHOT_PROVIDER_REQUEST_TIMEOUT_KEY;
@@ -177,13 +177,13 @@ public class OzoneManagerSnapshotProvider {
 
         long snapshotIndex = Long.parseLong(header.getValue());
 
-        header = response.getFirstHeader(OM_RATIS_SNAPSHOT_TERM_INDEX);
+        header = response.getFirstHeader(OM_RATIS_SNAPSHOT_TERM);
         if (header == null) {
           throw new IOException("The HTTP response header " +
-              OM_RATIS_SNAPSHOT_TERM_INDEX + " is missing.");
+              OM_RATIS_SNAPSHOT_TERM + " is missing.");
         }
 
-        long snapshotTermIndex = Long.parseLong(header.getValue());
+        long snapshotTerm = Long.parseLong(header.getValue());
 
         try (InputStream inputStream = entity.getContent()) {
           FileUtils.copyInputStreamToFile(inputStream, targetFile);
@@ -200,7 +200,7 @@ public class OzoneManagerSnapshotProvider {
 
         RocksDBCheckpoint omCheckpoint = new RocksDBCheckpoint(untarredDbDir);
         omCheckpoint.setRatisSnapshotIndex(snapshotIndex);
-        omCheckpoint.setRatisSnapshotTermIndex(snapshotTermIndex);
+        omCheckpoint.setRatisSnapshotTerm(snapshotTerm);
         return omCheckpoint;
       }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -21,7 +21,7 @@ import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.server.OzoneProtocolMessageDispatcher;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OzoneManager;
-import org.apache.hadoop.ozone.om.exceptions.NotLeaderException;
+import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
@@ -182,12 +182,12 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
     Optional<RaftPeerId> leaderRaftPeerId = omRatisServer
         .getCachedLeaderPeerId();
 
-    NotLeaderException notLeaderException;
+    OMNotLeaderException notLeaderException;
     if (leaderRaftPeerId.isPresent()) {
-      notLeaderException = new NotLeaderException(
+      notLeaderException = new OMNotLeaderException(
           raftPeerId, leaderRaftPeerId.get());
     } else {
-      notLeaderException = new NotLeaderException(raftPeerId);
+      notLeaderException = new OMNotLeaderException(raftPeerId);
     }
 
     if (LOG.isDebugEnabled()) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOMRatisSnapshotInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOMRatisSnapshotInfo.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.ozone.om.ratis;
 
+import org.apache.ratis.server.protocol.TermIndex;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,8 +48,8 @@ public class TestOMRatisSnapshotInfo {
     int termIndex = random.nextInt(10);
 
     // Save snapshotInfo to disk
-    omRatisSnapshotInfo.updateTerm(termIndex);
-    omRatisSnapshotInfo.saveRatisSnapshotToDisk(snapshotIndex);
+    omRatisSnapshotInfo.saveRatisSnapshotToDisk(
+        TermIndex.newTermIndex(termIndex, snapshotIndex));
 
     Assert.assertEquals(termIndex, omRatisSnapshotInfo.getTerm());
     Assert.assertEquals(snapshotIndex, omRatisSnapshotInfo.getIndex());

--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>0.5.0-d6d58d0-SNAPSHOT</ratis.version>
-
+    <ratis.version>0.5.0-ce699ba3-SNAPSHOT</ratis.version>
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>
     <distMgmtSnapshotsUrl>https://repository.apache.org/content/repositories/snapshots</distMgmtSnapshotsUrl>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Handle leader not ready exception in OM.
Upgrade ratis to latest snapshot version.
And also done few changes required to handle RATIS-614

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2637


## How was this patch tested?

Ran a few integration tests related to the change and also updated tests with new code changes.
