### PR TITLE
HDDS-2628. Make AuditMessage parameters strongly typed

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditMessage.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with this
  * work for additional information regarding copyright ownership.  The ASF
@@ -97,8 +97,8 @@ public class AuditMessage implements Message {
       return this;
     }
 
-    public Builder forOperation(String operation){
-      this.op = operation;
+    public Builder forOperation(AuditAction action) {
+      this.op = action.getAction();
       return this;
     }
 
@@ -107,8 +107,8 @@ public class AuditMessage implements Message {
       return this;
     }
 
-    public Builder withResult(String result){
-      this.ret = result;
+    public Builder withResult(AuditEventStatus result) {
+      this.ret = result.getStatus();
       return this;
     }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditMessage.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditMessage.java
@@ -23,13 +23,14 @@ import java.util.Map;
 /**
  * Defines audit message structure.
  */
-public class AuditMessage implements Message {
+public final class AuditMessage implements Message {
 
-  private String message;
-  private Throwable throwable;
+  private final String message;
+  private final Throwable throwable;
 
-  public AuditMessage(){
-
+  private AuditMessage(String message, Throwable throwable) {
+    this.message = message;
+    this.throwable = throwable;
   }
 
   @Override
@@ -53,26 +54,6 @@ public class AuditMessage implements Message {
   }
 
   /**
-   * Use when there are custom string to be added to default msg.
-   * @param customMessage custom string
-   */
-  private void appendMessage(String customMessage) {
-    this.message += customMessage;
-  }
-
-  public String getMessage() {
-    return message;
-  }
-
-  public void setMessage(String message) {
-    this.message = message;
-  }
-
-  public void setThrowable(Throwable throwable) {
-    this.throwable = throwable;
-  }
-
-  /**
    * Builder class for AuditMessage.
    */
   public static class Builder {
@@ -82,10 +63,6 @@ public class AuditMessage implements Message {
     private String op;
     private Map<String, String> params;
     private String ret;
-
-    public Builder(){
-
-    }
 
     public Builder setUser(String usr){
       this.user = usr;
@@ -118,11 +95,9 @@ public class AuditMessage implements Message {
     }
 
     public AuditMessage build(){
-      AuditMessage auditMessage = new AuditMessage();
-      auditMessage.message = "user=" + this.user + " | ip=" + this.ip + " | " +
+      String message = "user=" + this.user + " | ip=" + this.ip + " | " +
           "op=" + this.op + " " + this.params + " | " + "ret=" + this.ret;
-      auditMessage.throwable = this.throwable;
-      return auditMessage;
+      return new AuditMessage(message, throwable);
     }
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -29,6 +29,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.hadoop.ozone.audit.AuditEventStatus.FAILURE;
+import static org.apache.hadoop.ozone.audit.AuditEventStatus.SUCCESS;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -42,9 +45,6 @@ public class TestOzoneAuditLogger {
   private static final AuditLogger AUDIT =
       new AuditLogger(AuditLoggerType.OMLOGGER);
 
-  private static final String SUCCESS = AuditEventStatus.SUCCESS.name();
-  private static final String FAILURE = AuditEventStatus.FAILURE.name();
-
   private static final Map<String, String> PARAMS =
       new DummyEntity().toAuditMap();
 
@@ -55,7 +55,7 @@ public class TestOzoneAuditLogger {
       new AuditMessage.Builder()
           .setUser(USER)
           .atIp(IP_ADDRESS)
-          .forOperation(DummyAction.CREATE_VOLUME.name())
+          .forOperation(DummyAction.CREATE_VOLUME)
           .withParams(PARAMS)
           .withResult(FAILURE)
           .withException(null).build();
@@ -64,7 +64,7 @@ public class TestOzoneAuditLogger {
       new AuditMessage.Builder()
           .setUser(USER)
           .atIp(IP_ADDRESS)
-          .forOperation(DummyAction.CREATE_VOLUME.name())
+          .forOperation(DummyAction.CREATE_VOLUME)
           .withParams(PARAMS)
           .withResult(SUCCESS)
           .withException(null).build();
@@ -73,7 +73,7 @@ public class TestOzoneAuditLogger {
       new AuditMessage.Builder()
           .setUser(USER)
           .atIp(IP_ADDRESS)
-          .forOperation(DummyAction.READ_VOLUME.name())
+          .forOperation(DummyAction.READ_VOLUME)
           .withParams(PARAMS)
           .withResult(FAILURE)
           .withException(null).build();
@@ -82,7 +82,7 @@ public class TestOzoneAuditLogger {
       new AuditMessage.Builder()
           .setUser(USER)
           .atIp(IP_ADDRESS)
-          .forOperation(DummyAction.READ_VOLUME.name())
+          .forOperation(DummyAction.READ_VOLUME)
           .withParams(PARAMS)
           .withResult(SUCCESS)
           .withException(null).build();
@@ -132,7 +132,7 @@ public class TestOzoneAuditLogger {
     assertTrue(message, message.contains(IP_ADDRESS));
     assertTrue(message, message.contains(DummyAction.CREATE_VOLUME.name()));
     assertTrue(message, message.contains(PARAMS.toString()));
-    assertTrue(message, message.contains(FAILURE));
+    assertTrue(message, message.contains(FAILURE.getStatus()));
   }
 
   /**
@@ -174,6 +174,6 @@ public class TestOzoneAuditLogger {
     File file = new File("audit.log");
     List<String> lines = FileUtils.readLines(file, (String)null);
     // When no log entry is expected, the log file must be empty
-    assertTrue(lines.size() == 0);
+    assertEquals(0, lines.size());
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
@@ -127,7 +127,7 @@ public class TestOzoneAuditLogger {
 
   @Test
   public void messageIncludesAllParts() {
-    String message = WRITE_FAIL_MSG.getMessage();
+    String message = WRITE_FAIL_MSG.getFormattedMessage();
     assertTrue(message, message.contains(USER));
     assertTrue(message, message.contains(IP_ADDRESS));
     assertTrue(message, message.contains(DummyAction.CREATE_VOLUME.name()));

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -608,13 +608,13 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
   @Override
   public AuditMessage buildAuditMessageForSuccess(AuditAction op,
       Map<String, String> auditMap) {
+
     return new AuditMessage.Builder()
         .setUser(null)
         .atIp(null)
-        .forOperation(op.getAction())
+        .forOperation(op)
         .withParams(auditMap)
-        .withResult(AuditEventStatus.SUCCESS.toString())
-        .withException(null)
+        .withResult(AuditEventStatus.SUCCESS)
         .build();
   }
 
@@ -622,12 +622,13 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
   @Override
   public AuditMessage buildAuditMessageForFailure(AuditAction op,
       Map<String, String> auditMap, Throwable throwable) {
+
     return new AuditMessage.Builder()
         .setUser(null)
         .atIp(null)
-        .forOperation(op.getAction())
+        .forOperation(op)
         .withParams(auditMap)
-        .withResult(AuditEventStatus.FAILURE.toString())
+        .withResult(AuditEventStatus.FAILURE)
         .withException(throwable)
         .build();
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ipc.RPC;
+import org.apache.hadoop.ipc.Server;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -223,5 +225,10 @@ public final class ServerUtils {
             + "Falling back to {} instead.", key,
         HddsConfigKeys.OZONE_METADATA_DIRS);
     return ServerUtils.getOzoneMetaDirPath(conf);
+  }
+
+  public static String getRemoteUserName() {
+    UserGroupInformation remoteUser = Server.getRemoteUser();
+    return remoteUser != null ? remoteUser.getUserName() : null;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license
  * agreements. See the NOTICE file distributed with this work for additional
@@ -65,6 +65,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_AD
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.hdds.scm.server.StorageContainerManager.startRpcServer;
+import static org.apache.hadoop.hdds.server.ServerUtils.getRemoteUserName;
 import static org.apache.hadoop.hdds.server.ServerUtils.updateRPCListenAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -336,29 +337,26 @@ public class SCMBlockProtocolServer implements
   @Override
   public AuditMessage buildAuditMessageForSuccess(
       AuditAction op, Map<String, String> auditMap) {
+
     return new AuditMessage.Builder()
-        .setUser((Server.getRemoteUser() == null) ? null :
-            Server.getRemoteUser().getUserName())
-        .atIp((Server.getRemoteIp() == null) ? null :
-            Server.getRemoteIp().getHostAddress())
-        .forOperation(op.getAction())
+        .setUser(getRemoteUserName())
+        .atIp(Server.getRemoteAddress())
+        .forOperation(op)
         .withParams(auditMap)
-        .withResult(AuditEventStatus.SUCCESS.toString())
-        .withException(null)
+        .withResult(AuditEventStatus.SUCCESS)
         .build();
   }
 
   @Override
   public AuditMessage buildAuditMessageForFailure(AuditAction op, Map<String,
       String> auditMap, Throwable throwable) {
+
     return new AuditMessage.Builder()
-        .setUser((Server.getRemoteUser() == null) ? null :
-            Server.getRemoteUser().getUserName())
-        .atIp((Server.getRemoteIp() == null) ? null :
-            Server.getRemoteIp().getHostAddress())
-        .forOperation(op.getAction())
+        .setUser(getRemoteUserName())
+        .atIp(Server.getRemoteAddress())
+        .forOperation(op)
         .withParams(auditMap)
-        .withResult(AuditEventStatus.FAILURE.toString())
+        .withResult(AuditEventStatus.FAILURE)
         .withException(throwable)
         .build();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license
  * agreements. See the NOTICE file distributed with this work for additional
@@ -63,7 +63,6 @@ import org.apache.hadoop.ozone.audit.Auditor;
 import org.apache.hadoop.ozone.audit.SCMAction;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocolServerSideTranslatorPB;
 import org.apache.hadoop.ozone.protocolPB.ProtocolMessageMetrics;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,6 +86,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys
     .OZONE_SCM_HANDLER_COUNT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys
     .OZONE_SCM_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.hdds.server.ServerUtils.getRemoteUserName;
 import static org.apache.hadoop.hdds.server.ServerUtils.updateRPCListenAddress;
 import static org.apache.hadoop.hdds.scm.server.StorageContainerManager
     .startRpcServer;
@@ -181,8 +181,7 @@ public class SCMClientProtocolServer implements
 
   @VisibleForTesting
   public String getRpcRemoteUsername() {
-    UserGroupInformation user = ProtobufRpcEngine.Server.getRemoteUser();
-    return user == null ? null : user.getUserName();
+    return getRemoteUserName();
   }
 
   @Override
@@ -564,29 +563,26 @@ public class SCMClientProtocolServer implements
   @Override
   public AuditMessage buildAuditMessageForSuccess(
       AuditAction op, Map<String, String> auditMap) {
+
     return new AuditMessage.Builder()
-        .setUser((Server.getRemoteUser() == null) ? null :
-            Server.getRemoteUser().getUserName())
-        .atIp((Server.getRemoteIp() == null) ? null :
-            Server.getRemoteIp().getHostAddress())
-        .forOperation(op.getAction())
+        .setUser(getRemoteUserName())
+        .atIp(Server.getRemoteAddress())
+        .forOperation(op)
         .withParams(auditMap)
-        .withResult(AuditEventStatus.SUCCESS.toString())
-        .withException(null)
+        .withResult(AuditEventStatus.SUCCESS)
         .build();
   }
 
   @Override
   public AuditMessage buildAuditMessageForFailure(AuditAction op, Map<String,
       String> auditMap, Throwable throwable) {
+
     return new AuditMessage.Builder()
-        .setUser((Server.getRemoteUser() == null) ? null :
-            Server.getRemoteUser().getUserName())
-        .atIp((Server.getRemoteIp() == null) ? null :
-            Server.getRemoteIp().getHostAddress())
-        .forOperation(op.getAction())
+        .setUser(getRemoteUserName())
+        .atIp(Server.getRemoteAddress())
+        .forOperation(op)
         .withParams(auditMap)
-        .withResult(AuditEventStatus.FAILURE.toString())
+        .withResult(AuditEventStatus.FAILURE)
         .withException(throwable)
         .build();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license
  * agreements. See the NOTICE file distributed with this work for additional
@@ -85,6 +85,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_K
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.CONTAINER_REPORT;
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.PIPELINE_REPORT;
 import static org.apache.hadoop.hdds.scm.server.StorageContainerManager.startRpcServer;
+import static org.apache.hadoop.hdds.server.ServerUtils.getRemoteUserName;
 import static org.apache.hadoop.hdds.server.ServerUtils.updateRPCListenAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -355,29 +356,26 @@ public class SCMDatanodeProtocolServer implements
   @Override
   public AuditMessage buildAuditMessageForSuccess(
       AuditAction op, Map<String, String> auditMap) {
+
     return new AuditMessage.Builder()
-        .setUser((Server.getRemoteUser() == null) ? null :
-            Server.getRemoteUser().getUserName())
-        .atIp((Server.getRemoteIp() == null) ? null :
-            Server.getRemoteIp().getHostAddress())
-        .forOperation(op.getAction())
+        .setUser(getRemoteUserName())
+        .atIp(Server.getRemoteAddress())
+        .forOperation(op)
         .withParams(auditMap)
-        .withResult(AuditEventStatus.SUCCESS.toString())
-        .withException(null)
+        .withResult(AuditEventStatus.SUCCESS)
         .build();
   }
 
   @Override
   public AuditMessage buildAuditMessageForFailure(AuditAction op, Map<String,
       String> auditMap, Throwable throwable) {
+
     return new AuditMessage.Builder()
-        .setUser((Server.getRemoteUser() == null) ? null :
-            Server.getRemoteUser().getUserName())
-        .atIp((Server.getRemoteIp() == null) ? null :
-            Server.getRemoteIp().getHostAddress())
-        .forOperation(op.getAction())
+        .setUser(getRemoteUserName())
+        .atIp(Server.getRemoteAddress())
+        .forOperation(op)
         .withParams(auditMap)
-        .withResult(AuditEventStatus.FAILURE.toString())
+        .withResult(AuditEventStatus.FAILURE)
         .withException(throwable)
         .build();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -189,6 +189,7 @@ import static org.apache.hadoop.hdds.HddsUtils.getScmAddressForBlockClients;
 import static org.apache.hadoop.hdds.HddsUtils.getScmAddressForClients;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY;
 import static org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest.getEncodedString;
+import static org.apache.hadoop.hdds.server.ServerUtils.getRemoteUserName;
 import static org.apache.hadoop.hdds.server.ServerUtils.updateRPCListenAddress;
 import static org.apache.hadoop.io.retry.RetryPolicies.retryUpToMaximumCountWithFixedSleep;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_RATIS_ENABLED_DEFAULT;
@@ -2352,29 +2353,26 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   @Override
   public AuditMessage buildAuditMessageForSuccess(AuditAction op,
       Map<String, String> auditMap) {
+
     return new AuditMessage.Builder()
-        .setUser((Server.getRemoteUser() == null) ? null :
-            Server.getRemoteUser().getUserName())
-        .atIp((Server.getRemoteIp() == null) ? null :
-            Server.getRemoteIp().getHostAddress())
-        .forOperation(op.getAction())
+        .setUser(getRemoteUserName())
+        .atIp(Server.getRemoteAddress())
+        .forOperation(op)
         .withParams(auditMap)
-        .withResult(AuditEventStatus.SUCCESS.toString())
-        .withException(null)
+        .withResult(AuditEventStatus.SUCCESS)
         .build();
   }
 
   @Override
   public AuditMessage buildAuditMessageForFailure(AuditAction op,
       Map<String, String> auditMap, Throwable throwable) {
+
     return new AuditMessage.Builder()
-        .setUser((Server.getRemoteUser() == null) ? null :
-            Server.getRemoteUser().getUserName())
-        .atIp((Server.getRemoteIp() == null) ? null :
-            Server.getRemoteIp().getHostAddress())
-        .forOperation(op.getAction())
+        .setUser(getRemoteUserName())
+        .atIp(Server.getRemoteAddress())
+        .forOperation(op)
         .withParams(auditMap)
-        .withResult(AuditEventStatus.FAILURE.toString())
+        .withResult(AuditEventStatus.FAILURE)
         .withException(throwable)
         .build();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -229,10 +229,10 @@ public abstract class OMClientRequest implements RequestAuditor {
     return new AuditMessage.Builder()
         .setUser(userInfo != null ? userInfo.getUserName() : null)
         .atIp(userInfo != null ? userInfo.getRemoteAddress() : null)
-        .forOperation(op.getAction())
+        .forOperation(op)
         .withParams(auditMap)
-        .withResult(throwable != null ? AuditEventStatus.FAILURE.toString() :
-            AuditEventStatus.SUCCESS.toString())
+        .withResult(throwable != null ? AuditEventStatus.FAILURE :
+            AuditEventStatus.SUCCESS)
         .withException(throwable)
         .build();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Improve type safety in `AuditMessage$Builder` for methods `forOperation` and `withResult` by using existing `interface AuditAction` and `enum AuditEventStatus` respectively instead of Strings.
2. Use existing `Server.getRemoteAddress()` instead of `Server.getRemoteIp().getHostAddress()` with null check
3. Define and use `getRemoteUserName()` along the same lines

https://issues.apache.org/jira/browse/HDDS-2628

## How was this patch tested?

Created keys using Freon, verified audit log entries.

```
2019-11-27 20:48:16,206 | INFO  | SCMAudit | user=hadoop | ip=172.23.0.3 | op=ALLOCATE_BLOCK {owner=88982149-2c09-4cd7-8e38-fba8f23cff5e, size=268435456, type=RATIS, factor=ONE} | ret=SUCCESS |
2019-11-27 20:48:45,879 | INFO  | SCMAudit | user=hadoop | ip=172.23.0.4 | op=SEND_HEARTBEAT {datanodeUUID=4e2ee488-6dc6-45f8-9f02-02f1a5cff554, command=[]} | ret=SUCCESS |
```

```
2019-11-27 20:48:16,208 | INFO  | OMAudit | user=hadoop | ip=172.23.0.2 | op=ALLOCATE_KEY {volume=vol1, bucket=bucket1, key=OkoBsDwxuj/9, dataSize=10240, replicationType=RATIS, replicationFactor=ONE, keyLocationInfo=[blockID {
  containerBlockID {
    containerID: 1
    localID: 103211840058556425
    ...
```

https://github.com/adoroszlai/hadoop-ozone/runs/323724573