### PR TITLE
HDDS-2639. TestTableCacheImpl is flaky

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCacheImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCacheImpl.java
@@ -114,7 +114,8 @@ public class TableCacheImpl<CACHEKEY extends CacheKey,
     return cache.entrySet().iterator();
   }
 
-  private void evictCache(List<Long> epochs) {
+  @VisibleForTesting
+  protected void evictCache(List<Long> epochs) {
     EpochEntry<CACHEKEY> currentEntry;
     final AtomicBoolean removed = new AtomicBoolean();
     CACHEKEY cachekey;

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCacheImpl.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCacheImpl.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import com.google.common.base.Optional;
-import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -42,7 +41,7 @@ import static org.junit.Assert.fail;
 @RunWith(value = Parameterized.class)
 @Ignore("HDDS-2639")
 public class TestTableCacheImpl {
-  private TableCache<CacheKey<String>, CacheValue<String>> tableCache;
+  private TableCacheImpl<CacheKey<String>, CacheValue<String>> tableCache;
 
   private final TableCacheImpl.CacheCleanupPolicy cacheCleanupPolicy;
 
@@ -89,7 +88,7 @@ public class TestTableCacheImpl {
     epochs.add(3L);
     epochs.add(4L);
     // On a full table cache if some one calls cleanup it is a no-op.
-    tableCache.cleanup(epochs);
+    tableCache.evictCache(epochs);
 
     for (int i=5; i < 10; i++) {
       Assert.assertEquals(Integer.toString(i),
@@ -117,15 +116,13 @@ public class TestTableCacheImpl {
 
     Assert.assertEquals(totalCount, tableCache.size());
 
-    tableCache.cleanup(epochs);
+    tableCache.evictCache(epochs);
 
     final int count = totalCount;
 
     // If cleanup policy is manual entries should have been removed.
     if (cacheCleanupPolicy == TableCacheImpl.CacheCleanupPolicy.MANUAL) {
-      GenericTestUtils.waitFor(() -> {
-        return count - epochs.size() == tableCache.size();
-      }, 100, 10000);
+      Assert.assertEquals(count - epochs.size(), tableCache.size());
 
       // Check remaining entries exist or not and deleted entries does not
       // exist.
@@ -184,11 +181,10 @@ public class TestTableCacheImpl {
     epochs.add(4L);
 
     if (cacheCleanupPolicy == cacheCleanupPolicy.MANUAL) {
-      tableCache.cleanup(epochs);
 
-      GenericTestUtils.waitFor(() -> {
-        return 0 == tableCache.size();
-      }, 100, 10000);
+      tableCache.evictCache(epochs);
+
+      Assert.assertEquals(0, tableCache.size());
 
       // Epoch entries which are overrided still exist.
       Assert.assertEquals(2, tableCache.getEpochEntrySet().size());
@@ -201,11 +197,9 @@ public class TestTableCacheImpl {
     epochs = new ArrayList<>();
     epochs.add(5L);
     if (cacheCleanupPolicy == cacheCleanupPolicy.MANUAL) {
-      tableCache.cleanup(epochs);
+      tableCache.evictCache(epochs);
 
-      GenericTestUtils.waitFor(() -> {
-        return 0 == tableCache.size();
-      }, 100, 10000);
+      Assert.assertEquals(0, tableCache.size());
 
       // Overrided entries would have been deleted.
       Assert.assertEquals(0, tableCache.getEpochEntrySet().size());
@@ -261,20 +255,16 @@ public class TestTableCacheImpl {
 
 
     if (cacheCleanupPolicy == cacheCleanupPolicy.MANUAL) {
-      tableCache.cleanup(epochs);
+      tableCache.evictCache(epochs);
 
-      GenericTestUtils.waitFor(() -> {
-        return 0 == tableCache.size();
-      }, 100, 10000);
+      Assert.assertEquals(0, tableCache.size());
 
       // Epoch entries which are overrided still exist.
       Assert.assertEquals(4, tableCache.getEpochEntrySet().size());
     } else {
-      tableCache.cleanup(epochs);
+      tableCache.evictCache(epochs);
 
-      GenericTestUtils.waitFor(() -> {
-        return 1 == tableCache.size();
-      }, 100, 10000);
+      Assert.assertEquals(1, tableCache.size());
 
       // Epoch entries which are overrided still exist and one not deleted As
       // this cache clean up policy is NEVER.
@@ -289,21 +279,17 @@ public class TestTableCacheImpl {
     epochs.add(7L);
 
     if (cacheCleanupPolicy == cacheCleanupPolicy.MANUAL) {
-      tableCache.cleanup(epochs);
+      tableCache.evictCache(epochs);
 
-      GenericTestUtils.waitFor(() -> {
-        return 0 == tableCache.size();
-      }, 100, 10000);
+      Assert.assertEquals(0, tableCache.size());
 
       // Epoch entries which are overrided now would have been deleted.
       Assert.assertEquals(0, tableCache.getEpochEntrySet().size());
     } else {
-      tableCache.cleanup(epochs);
+      tableCache.evictCache(epochs);
 
       // 2 entries will be in cache, as 2 are not deleted.
-      GenericTestUtils.waitFor(() -> {
-        return 2 == tableCache.size();
-      }, 100, 10000);
+      Assert.assertEquals(2, tableCache.size());
 
       // Epoch entries which are not marked for delete will exist override
       // entries will be cleaned up.
@@ -364,12 +350,11 @@ public class TestTableCacheImpl {
       epochs.add(3L);
       epochs.add(4L);
       epochs.add(5L);
-      tableCache.cleanup(epochs);
+      tableCache.evictCache(epochs);
 
       // We should totalCount - deleted entries in cache.
       final int tc = totalCount;
-      GenericTestUtils.waitFor(() -> (tc - deleted == tableCache.size()), 100,
-          5000);
+      Assert.assertEquals(tc - deleted, tableCache.size());
       // Check if we have remaining entries.
       for (int i=6; i <= totalCount; i++) {
         Assert.assertEquals(Integer.toString(i), tableCache.get(
@@ -381,17 +366,16 @@ public class TestTableCacheImpl {
         epochs.add(i);
       }
 
-      tableCache.cleanup(epochs);
+      tableCache.evictCache(epochs);
 
       // Cleaned up all entries, so cache size should be zero.
-      GenericTestUtils.waitFor(() -> (0 == tableCache.size()), 100,
-          5000);
+      Assert.assertEquals(0, tableCache.size());
     } else {
       ArrayList<Long> epochs = new ArrayList<>();
       for (long i=0; i<= totalCount; i++) {
         epochs.add(i);
       }
-      tableCache.cleanup(epochs);
+      tableCache.evictCache(epochs);
       Assert.assertEquals(totalCount, tableCache.size());
     }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCacheImpl.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCacheImpl.java
@@ -28,7 +28,6 @@ import java.util.concurrent.CompletableFuture;
 import com.google.common.base.Optional;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -39,7 +38,6 @@ import static org.junit.Assert.fail;
  * Class tests partial table cache.
  */
 @RunWith(value = Parameterized.class)
-@Ignore("HDDS-2639")
 public class TestTableCacheImpl {
   private TableCacheImpl<CacheKey<String>, CacheValue<String>> tableCache;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Run(master): https://github.com/apache/hadoop-ozone/runs/324342299

```
-------------------------------------------------------------------------------
Test set: org.apache.hadoop.hdds.utils.db.cache.TestTableCacheImpl
-------------------------------------------------------------------------------
Tests run: 10, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.955 s <<< FAILURE! - in org.apache.hadoop.hdds.utils.db.cache.TestTableCacheImpl
testPartialTableCacheWithOverrideAndDelete[0](org.apache.hadoop.hdds.utils.db.cache.TestTableCacheImpl)  Time elapsed: 0.039 s  <<< FAILURE!
java.lang.AssertionError: expected:<2> but was:<6>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:743)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:555)
	at org.junit.Assert.assertEquals(Assert.java:542)
	at org.apache.hadoop.hdds.utils.db.cache.TestTableCacheImpl.testPartialTableCacheWithOverrideAndDelete(TestTableCacheImpl.java:308)
```
 
### How to reproduce it locally?

Replace the last `tableCache.cleanup` call of `testPartialTableCacheWithOverrideAndDelete` to `System.out.println(tableCache.size())`.

You will see that the cache size is `2` even before the cleanup therefore the next `GeneriTestUtils.waitFor` is useless (it doesn't guarantee that the cleanup is finished).

### Fix

I propose to call the cleanup sync (instead of async) with using `TableCacheImpl` reference instead of the interface. It simplifies the test but still validates the behavior.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2639

## How was this patch tested?

Problem an be reproduced locally as defined above. 

Fix can be tested with executing the `TestTableCacheImpl` unit test.