### PR TITLE
HDDS-2640 Add leaderID information in pipeline list subcommand

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -274,7 +274,8 @@ public final class Pipeline {
     b.append(", Type:").append(getType());
     b.append(", Factor:").append(getFactor());
     b.append(", State:").append(getPipelineState());
-    b.append("]");
+    b.append(", leaderId:").append(getLeaderId());
+    b.append(" ]");
     return b.toString();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

scmcli pipeline list command does not display the leaderID information for each pipeline.
This change will include the leaderID information along with other details.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2640

## How was this patch tested?

Applied the patch and rebuilt ozone and then tested it by creating docker cluster using docker-compose
