### PR TITLE
HDDS-2651 Make startId parameter non-mandatory while listing containe…

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ListSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/ListSubcommand.java
@@ -49,8 +49,8 @@ public class ListSubcommand implements Callable<Void> {
   private ContainerCommands parent;
 
   @Option(names = {"-s", "--start"},
-      description = "Container id to start the iteration", required = true)
-  private long startId = 1;
+      description = "Container id to start the iteration", required = false)
+  private long startId = 0;
 
   @Option(names = {"-c", "--count"},
       description = "Maximum number of containers to list",


### PR DESCRIPTION
…rs through shell command

## What changes were proposed in this pull request?

Currently  the startId  "--start | -s " is a mandatory parameter for container list shell command

Need to make it as non-mandatory parameter as the default value for startId parameter is already defined.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2651

## How was this patch tested?

Applied the patch and rebuilt ozone and then tested it by creating docker cluster using docker-compose
