### PR TITLE
HDDS-2655. Use pre-compiled Pattern in NetUtils#normalize

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
@@ -25,14 +25,19 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
  * Utility class to facilitate network topology functions.
  */
 public final class NetUtils {
-  public static final Logger LOG = LoggerFactory.getLogger(NetUtils.class);
-  
+
+  private static final Logger LOG = LoggerFactory.getLogger(NetUtils.class);
+
+  private static final Pattern TRAILING_PATH_SEPARATOR =
+      Pattern.compile(NetConstants.PATH_SEPARATOR_STR + "+$");
+
   private NetUtils() {
     // Prevent instantiation
   }
@@ -56,7 +61,7 @@ public final class NetUtils {
 
     // Remove any trailing NetConstants.PATH_SEPARATOR
     return path.length() == 1 ? path :
-        path.replaceAll(NetConstants.PATH_SEPARATOR_STR + "+$", "");
+        TRAILING_PATH_SEPARATOR.matcher(path).replaceAll("");
   }
 
   /**
@@ -88,8 +93,8 @@ public final class NetUtils {
       Node node = iterator.next();
       Node ancestor = topology.getAncestor(node, ancestorGen);
       if (ancestor == null) {
-        LOG.warn("Fail to get ancestor generation " + ancestorGen +
-            " of node :" + node);
+        LOG.warn("Fail to get ancestor generation {} of node :{}",
+            ancestorGen, node);
         continue;
       }
       // excludedScope is child of ancestor
@@ -128,8 +133,8 @@ public final class NetUtils {
       Node node = iterator.next();
       Node ancestor = topology.getAncestor(node, generation);
       if (ancestor == null) {
-        LOG.warn("Fail to get ancestor generation " + generation +
-            " of node :" + node);
+        LOG.warn("Fail to get ancestor generation {} of node :{}",
+            generation, node);
         continue;
       }
       if (!ancestorList.contains(ancestor)) {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.net;
+
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for {@link NetUtils}.
+ */
+public class TestNetUtils {
+
+  @Test
+  public void testNormalize() {
+    assertEquals("", NetUtils.normalize(null));
+    assertEquals("", NetUtils.normalize(""));
+    assertEquals("/", NetUtils.normalize("/"));
+    assertThrows(IllegalArgumentException.class, () -> NetUtils.normalize("x"));
+    assertEquals("/a/b/c", NetUtils.normalize("/a/b/c"));
+    assertEquals("/a/b/c", NetUtils.normalize("/a/b/c////"));
+    assertEquals("/a/b/c/$", NetUtils.normalize("/a/b/c/$"));
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace `String#replaceAll` in `NetUtils#normalize` with a pre-compiled `Pattern`, which is better for performance.

https://issues.apache.org/jira/browse/HDDS-2655

## How was this patch tested?

Added unit test (`TestNetUtils`).