### PR TITLE
HDDS-2475. Unregister ContainerMetadataScrubberMetrics on thread exit

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -855,6 +855,7 @@ public class ContainerStateMachine extends BaseStateMachine {
     for (ExecutorService executor : executors) {
       executor.shutdown();
     }
+    metrics.unRegister();
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerDataScrubberMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerDataScrubberMetrics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -34,8 +34,10 @@ import java.util.concurrent.ThreadLocalRandom;
 @InterfaceAudience.Private
 @Metrics(about="DataNode container data scrubber metrics", context="dfs")
 public final class ContainerDataScrubberMetrics {
+
   private final String name;
   private final MetricsSystem ms;
+
   @Metric("number of containers scanned in the current iteration")
   private MutableGaugeInt numContainersScanned;
   @Metric("number of unhealthy containers found in the current iteration")
@@ -95,6 +97,10 @@ public final class ContainerDataScrubberMetrics {
 
   public void unregister() {
     ms.unregisterSource(name);
+  }
+
+  public String getName() {
+    return name;
   }
 
   private ContainerDataScrubberMetrics(String name, MetricsSystem ms) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerMetadataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerMetadataScanner.java
@@ -66,6 +66,8 @@ public class ContainerMetadataScanner extends Thread {
           metrics.resetNumContainersScanned();
         }
       }
+    } catch (Exception e) {
+      LOG.error("{} exiting because of exception ", this, e);
     } finally {
       if (metrics != null) {
         metrics.unregister();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerMetadataScanner.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerMetadataScanner.java
@@ -58,11 +58,17 @@ public class ContainerMetadataScanner extends Thread {
      * the outer daemon loop exits on shutdown()
      */
     LOG.info("Background ContainerMetadataScanner starting up");
-    while (!stopping) {
-      runIteration();
-      if(!stopping) {
-        metrics.resetNumUnhealthyContainers();
-        metrics.resetNumContainersScanned();
+    try {
+      while (!stopping) {
+        runIteration();
+        if (!stopping) {
+          metrics.resetNumUnhealthyContainers();
+          metrics.resetNumContainersScanned();
+        }
+      }
+    } finally {
+      if (metrics != null) {
+        metrics.unregister();
       }
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerMetadataScrubberMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerMetadataScrubberMetrics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -32,8 +32,10 @@ import org.apache.hadoop.metrics2.lib.MutableGaugeInt;
 @InterfaceAudience.Private
 @Metrics(about="DataNode container data scrubber metrics", context="dfs")
 public final class ContainerMetadataScrubberMetrics {
+
   private final String name;
   private final MetricsSystem ms;
+
   @Metric("number of containers scanned in the current iteration")
   private MutableGaugeInt numContainersScanned;
   @Metric("number of unhealthy containers found in the current iteration")
@@ -75,6 +77,10 @@ public final class ContainerMetadataScrubberMetrics {
 
   public void unregister() {
     ms.unregisterSource(name);
+  }
+
+  public String getName() {
+    return name;
   }
 
   private ContainerMetadataScrubberMetrics(String name, MetricsSystem ms) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -191,6 +191,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   private final OzoneConfiguration configuration;
   private final SafeModeHandler safeModeHandler;
   private SCMContainerMetrics scmContainerMetrics;
+  private SCMContainerPlacementMetrics placementMetrics;
   private MetricsSystem ms;
 
   /**
@@ -390,8 +391,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
           conf, scmStorageConfig, eventQueue, clusterMap);
     }
 
-    SCMContainerPlacementMetrics placementMetrics =
-        SCMContainerPlacementMetrics.create();
+    placementMetrics = SCMContainerPlacementMetrics.create();
     ContainerPlacementPolicy containerPlacementPolicy =
         ContainerPlacementPolicyFactory.getPolicy(conf, scmNodeManager,
             clusterMap, true, placementMetrics);
@@ -863,6 +863,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     unregisterMXBean();
     if (scmContainerMetrics != null) {
       scmContainerMetrics.unRegister();
+    }
+    if (placementMetrics != null) {
+      placementMetrics.unRegister();
     }
 
     // Event queue must be stopped before the DB store is closed at the end.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Unregister `ContainerMetadataScrubberMetrics` when `ContainerMetadataScanner` thread exits to avoid leak.

https://issues.apache.org/jira/browse/HDDS-2475

## How was this patch tested?

Added unit test case.