### PR TITLE
HDDS-2654. Conditionally enable profiling at the kernel level

### DIFF
--- a/hadoop-ozone/dist/src/main/dockerlibexec/entrypoint.sh
+++ b/hadoop-ozone/dist/src/main/dockerlibexec/entrypoint.sh
@@ -146,4 +146,12 @@ if [ -n "$BYTEMAN_SCRIPT" ] || [ -n "$BYTEMAN_SCRIPT_URL" ]; then
   echo "Process is instrumented with adding $AGENT_STRING to HADOOP_OPTS"
 fi
 
+if [[ -n "${ASYNC_PROFILER_HOME}" ]]; then
+  set +e
+  echo 1 | sudo tee /proc/sys/kernel/perf_event_paranoid > /dev/null \
+    && echo 0 | sudo tee /proc/sys/kernel/kptr_restrict > /dev/null \
+    && echo "Enabled profiling in kernel"
+  set -e
+fi
+
 exec "$@"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Extend `entrypoint.sh` to set the kernel parameters required for profiling if the `ASYNC_PROFILER_HOME` environment variable (used by `ProfileServlet`) is defined.

https://issues.apache.org/jira/browse/HDDS-2654

## How was this patch tested?

```
$ cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozone
$ docker-compose up -d
$ docker-compose logs scm | grep 'Enabled profiling'
scm_1       | Enabled profiling in kernel
# wait for OM
$ open http://localhost:9874/prof
```