### PR TITLE
HDDS-2506. Remove keyAllocationInfo and replication info from the auditLog

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
@@ -147,12 +147,6 @@ public final class OmKeyArgs implements Auditable {
     auditMap.put(OzoneConsts.BUCKET, this.bucketName);
     auditMap.put(OzoneConsts.KEY, this.keyName);
     auditMap.put(OzoneConsts.DATA_SIZE, String.valueOf(this.dataSize));
-    auditMap.put(OzoneConsts.REPLICATION_TYPE,
-        (this.type != null) ? this.type.name() : null);
-    auditMap.put(OzoneConsts.REPLICATION_FACTOR,
-        (this.factor != null) ? this.factor.name() : null);
-    auditMap.put(OzoneConsts.KEY_LOCATION_INFO,
-        (this.locationInfoList != null) ? locationInfoList.toString() : null);
     return auditMap;
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
@@ -147,6 +147,10 @@ public final class OmKeyArgs implements Auditable {
     auditMap.put(OzoneConsts.BUCKET, this.bucketName);
     auditMap.put(OzoneConsts.KEY, this.keyName);
     auditMap.put(OzoneConsts.DATA_SIZE, String.valueOf(this.dataSize));
+    auditMap.put(OzoneConsts.REPLICATION_TYPE,
+        (this.type != null) ? this.type.name() : null);
+    auditMap.put(OzoneConsts.REPLICATION_FACTOR,
+        (this.factor != null) ? this.factor.name() : null);
     return auditMap;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -86,8 +86,6 @@ import org.apache.hadoop.ozone.om.ratis.OMRatisSnapshotInfo;
 import org.apache.hadoop.ozone.om.snapshot.OzoneManagerSnapshotProvider;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DBUpdatesRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import org.apache.hadoop.ozone.protocolPB.ProtocolMessageMetrics;
 import org.apache.hadoop.ozone.security.OzoneSecurityException;
@@ -2038,23 +2036,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
             OMAction.ALLOCATE_KEY, (args == null) ? null : args.toAuditMap()));
       }
     }
-  }
-
-  private Map<String, String> toAuditMap(KeyArgs omKeyArgs) {
-    Map<String, String> auditMap = new LinkedHashMap<>();
-    auditMap.put(OzoneConsts.VOLUME, omKeyArgs.getVolumeName());
-    auditMap.put(OzoneConsts.BUCKET, omKeyArgs.getBucketName());
-    auditMap.put(OzoneConsts.KEY, omKeyArgs.getKeyName());
-    auditMap.put(OzoneConsts.DATA_SIZE,
-        String.valueOf(omKeyArgs.getDataSize()));
-    auditMap.put(OzoneConsts.REPLICATION_TYPE,
-        omKeyArgs.hasType() ? omKeyArgs.getType().name() : null);
-    auditMap.put(OzoneConsts.REPLICATION_FACTOR,
-        omKeyArgs.hasFactor() ? omKeyArgs.getFactor().name() : null);
-    auditMap.put(OzoneConsts.KEY_LOCATION_INFO,
-        (omKeyArgs.getKeyLocationsList() != null) ?
-            omKeyArgs.getKeyLocationsList().toString() : null);
-    return auditMap;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/RequestAuditor.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/RequestAuditor.java
@@ -68,6 +68,10 @@ public interface RequestAuditor {
       auditMap.put(OzoneConsts.KEY, keyArgs.getKeyName());
       auditMap.put(OzoneConsts.DATA_SIZE,
           String.valueOf(keyArgs.getDataSize()));
+      auditMap.put(OzoneConsts.REPLICATION_TYPE,
+          (keyArgs.getType() != null) ? keyArgs.getType().name() : null);
+      auditMap.put(OzoneConsts.REPLICATION_FACTOR,
+          (keyArgs.getFactor() != null) ? keyArgs.getFactor().name() : null);
       return auditMap;
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/RequestAuditor.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/RequestAuditor.java
@@ -68,13 +68,6 @@ public interface RequestAuditor {
       auditMap.put(OzoneConsts.KEY, keyArgs.getKeyName());
       auditMap.put(OzoneConsts.DATA_SIZE,
           String.valueOf(keyArgs.getDataSize()));
-      auditMap.put(OzoneConsts.REPLICATION_TYPE,
-          (keyArgs.getType() != null) ? keyArgs.getType().name() : null);
-      auditMap.put(OzoneConsts.REPLICATION_FACTOR,
-          (keyArgs.getFactor() != null) ? keyArgs.getFactor().name() : null);
-      auditMap.put(OzoneConsts.KEY_LOCATION_INFO,
-          (keyArgs.getKeyLocationsList() != null) ?
-              keyArgs.getKeyLocationsList().toString() : null);
       return auditMap;
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove key location info (and replication info) from audit log params.  The same information can be obtained (for debug purposes) from Ozone Insight.  This improves performance of audit logging, formatting a deeply nested proto message structure is expensive.  It also improves audit log structure, as each messages is expected to be a single line (except for stack traces).

https://issues.apache.org/jira/browse/HDDS-2506

## How was this patch tested?

Ran `ozonesecure` acceptance test.  Verified audit messages:

```
2019-12-02 12:10:43,616 | INFO  | OMAudit | user=HTTP/scm@EXAMPLE.COM | ip=172.31.0.4 | op=ALLOCATE_KEY {volume=vol-0-29689, bucket=bucket-0-44465, key=key-0-79381, dataSize=10240} | ret=SUCCESS |
2019-12-02 12:10:46,042 | INFO  | OMAudit | user=HTTP/scm@EXAMPLE.COM | ip=172.31.0.4 | op=COMMIT_KEY {volume=vol-0-29689, bucket=bucket-0-44465, key=key-0-79381, dataSize=10240} | ret=SUCCESS |
```

https://github.com/adoroszlai/hadoop-ozone/runs/330684634