### PR TITLE
HDDS-2658. Insight log level reset does not work

### DIFF
--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/LogSubcommand.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/LogSubcommand.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -66,7 +67,7 @@ public class LogSubcommand extends BaseInsightSubCommand
   private Map<String, String> filters;
 
   @Override
-  public Void call() throws Exception {
+  public Void call() {
     OzoneConfiguration conf =
         getInsightCommand().createOzoneConfiguration();
     InsightPoint insight =
@@ -74,22 +75,16 @@ public class LogSubcommand extends BaseInsightSubCommand
 
     List<LoggerSource> loggers = insight.getRelatedLoggers(verbose);
 
-    for (LoggerSource logger : loggers) {
-      setLogLevel(conf, logger.getLoggerName(), logger.getComponent(),
-          logger.getLevel());
-    }
+    setLogLevels(conf, loggers, LoggerSource::getLevel);
+    Runtime.getRuntime().addShutdownHook(new Thread(() ->
+        setLogLevels(conf, loggers, any -> Level.INFO)
+    ));
 
     Set<Component> sources = loggers.stream().map(LoggerSource::getComponent)
         .collect(Collectors.toSet());
-    try {
-      streamLog(conf, sources, loggers,
-          logLine -> insight.filterLog(filters, logLine));
-    } finally {
-      for (LoggerSource logger : loggers) {
-        setLogLevel(conf, logger.getLoggerName(), logger.getComponent(),
-            Level.INFO);
-      }
-    }
+    streamLog(conf, sources, loggers,
+        logLine -> insight.filterLog(filters, logLine));
+
     return null;
   }
 
@@ -158,6 +153,14 @@ public class LogSubcommand extends BaseInsightSubCommand
     }
     m.appendTail(sb);
     return sb.toString();
+  }
+
+  private void setLogLevels(OzoneConfiguration conf, List<LoggerSource> loggers,
+      Function<LoggerSource, Level> toLevel) {
+    for (LoggerSource logger : loggers) {
+      setLogLevel(conf, logger.getLoggerName(), logger.getComponent(),
+          toLevel.apply(logger));
+    }
   }
 
   private void setLogLevel(OzoneConfiguration conf, String name,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reset log level to INFO in a shutdown hook instead of `finally` block.

https://issues.apache.org/jira/browse/HDDS-2658

## How was this patch tested?

Tested on compose cluster:

```
# terminal 1
cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozone
docker-compose up -d
docker-compose logs -f om

# terminal 2
cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozone
docker-compose exec om bash
ozone insight logs -v om.protocol.client

# terminal 3
cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozone
docker-compose exec om ozone freon ockg -F ONE -n 1
```

Verified that `ozone insight` shows trace-level log.  Stopped `ozone insight` on terminal 2 (Ctrl-C).  Verified that creating another volume is logged in terminal 1 (ie. OM), but debug/trace-level messages are not:

```
# terminal 3
$ docker-compose exec om ozone freon ockg -F ONE -n 1 -v vol2

# terminal 1
om_1        | 2019-12-03 11:49:49,114 INFO volume.OMVolumeCreateRequest: created volume:vol2 for user:hadoop
```

https://github.com/adoroszlai/hadoop-ozone/runs/330882658