### PR TITLE
HDDS-2657. Key get command creates the output file even in case of KEY_NOT_FOUND

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/GetKeyHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/keys/GetKeyHandler.java
@@ -96,8 +96,8 @@ public class GetKeyHandler extends Handler {
 
       OzoneVolume vol = client.getObjectStore().getVolume(volumeName);
       OzoneBucket bucket = vol.getBucket(bucketName);
-      try (OutputStream output = new FileOutputStream(dataFile);
-           InputStream input = bucket.readKey(keyName)) {
+      try (InputStream input = bucket.readKey(keyName);
+          OutputStream output = new FileOutputStream(dataFile)) {
         IOUtils.copyBytes(input, output, chunkSize);
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Prevent creation of Empty output file in case of KEY_NOT_FOUND

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2657

## How was this patch tested?

Verified : 
ayush@ayushpc:~/ozone/hadoop-ozone/hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/bin$ ./ozone sh key get "hive/bucket/key 21" "file 21"
KEY_NOT_FOUND Key not found
ayush@ayushpc:~/ozone/hadoop-ozone/hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/bin$ ll
total 24
drwxr-xr-x  2 ayush ayush  4096 Dec  2 22:55 ./
drwxr-xr-x 13 ayush ayush  4096 Dec  2 23:05 ../
-rwxr-xr-x  1 ayush ayush 12786 Dec  2 22:55 ozone*