### PR TITLE
HDDS-2645. Refactor MiniOzoneChaosCluster to a different package to add filesystem tests.

### DIFF
--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/pom.xml
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/pom.xml
@@ -18,19 +18,36 @@
 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
+    <artifactId>hadoop-ozone-fault-injection-test</artifactId>
     <groupId>org.apache.hadoop</groupId>
-    <artifactId>hadoop-ozone</artifactId>
     <version>0.5.0-SNAPSHOT</version>
   </parent>
-  <artifactId>hadoop-ozone-fault-injection-test</artifactId>
   <version>0.5.0-SNAPSHOT</version>
-  <description>Apache Hadoop Ozone Fault Injection Tests</description>
-  <name>Apache Hadoop Ozone Fault Injection Tests</name>
-  <packaging>pom</packaging>
+  <description>Apache Hadoop Ozone Mini Ozone Chaos Tests</description>
+  <name>Apache Hadoop Ozone Mini Ozone Chaos Tests</name>
 
-  <modules>
-    <module>network-tests</module>
-    <module>mini-chaos-tests</module>
-  </modules>
-
+  <artifactId>mini-chaos-tests</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-ozone-filesystem</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-ozone-integration-test</artifactId>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+  </dependencies>
 </project>

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/bin/start-chaos.sh
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/bin/start-chaos.sh
@@ -15,22 +15,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-date=$(date +"%Y-%m-%d--%H-%M-%S-%Z")
-fileformat=".MiniOzoneChaosCluster.log"
-heapformat=".dump"
-current="/tmp/"
-filename="${current}${date}${fileformat}"
-heapdumpfile="${current}${date}${heapformat}"
+date=$(date +"%Y-%m-%d-%H-%M-%S-%Z")
+logfiledirectory="/tmp/${date}/"
+completesuffix="complete.log"
+chaossuffix="chaos.log"
+compilesuffix="compile.log"
+heapformat="dump.hprof"
 
 #TODO: add gc log file details as well
 export MAVEN_OPTS="-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${heapdumpfile} -Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false -Dio.netty.leakDetection.level=advanced -Dio.netty.leakDetectionLevel=advanced -Dio.netty.threadLocalDirectBufferSize=0 -Djdk.nio.maxCachedBufferSize=33554432 -XX:NativeMemoryTracking=detail"
 
-echo "logging to ${filename}"
-echo "heapdump to ${heapdumpfile}"
+#log goes to something like /tmp/2019-12-04--00-01-26-IST/complete.log
+logfilename="${logfiledirectory}${completesuffix}"
+#log goes to something like /tmp/2019-12-04--00-01-26-IST/chaos.log
+chaosfilename="${logfiledirectory}${chaossuffix}"
+#compilation log goes to something like /tmp/2019-12-04--00-01-26-IST/compile.log
+compilefilename="${logfiledirectory}${compilesuffix}"
+#log goes to something like /tmp/2019-12-04--00-01-26-IST/dump.hprof
+heapdumpfile="${logfiledirectory}${heapformat}"
 
-echo "Starting MiniOzoneChaosCluster"
-mvn clean install -DskipTests > "${filename}" 2>&1
+mkdir -p ${logfiledirectory}
+echo "logging chaos logs and heapdump to ${logfiledirectory}"
+
+echo "Starting MiniOzoneChaosCluster with ${MAVEN_OPTS}"
+mvn clean install -DskipTests > "${compilefilename}" 2>&1
 mvn exec:java \
   -Dexec.mainClass="org.apache.hadoop.ozone.chaos.TestMiniChaosOzoneCluster" \
   -Dexec.classpathScope=test \
-  -Dexec.args="$*" >> "${filename}" 2>&1
+  -Dchaoslogfilename=${chaosfilename} \
+  -Dexec.args="$*" > "${logfilename}" 2>&1

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.ozone.chaos;
+package org.apache.hadoop.ozone;
 
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.conf.StorageUnit;
@@ -26,13 +26,8 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
-import org.apache.hadoop.ozone.HddsDatanodeService;
-import org.apache.hadoop.ozone.MiniOzoneClusterImpl;
-import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.apache.hadoop.test.GenericTestUtils;
-import org.apache.ratis.grpc.client.GrpcClientProtocolClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,8 +66,6 @@ public class MiniOzoneChaosCluster extends MiniOzoneClusterImpl {
     this.executorService =  Executors.newSingleThreadScheduledExecutor();
     this.numDatanodes = getHddsDatanodes().size();
     LOG.info("Starting MiniOzoneChaosCluster with {} datanodes", numDatanodes);
-    GenericTestUtils.setLogLevel(GrpcClientProtocolClient.LOG,
-        org.slf4j.event.Level.WARN);
   }
 
   // Get the number of datanodes to fail in the cluster.

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/utils/LoadBucket.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/utils/LoadBucket.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.utils;
+
+import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.io.OzoneInputStream;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.HashMap;
+
+/**
+ * Bucket to perform read/write & delete ops.
+ */
+public class LoadBucket {
+  private static final Logger LOG =
+            LoggerFactory.getLogger(LoadBucket.class);
+
+  private final OzoneBucket bucket;
+
+  public LoadBucket(OzoneBucket bucket) {
+    this.bucket = bucket;
+  }
+
+  public void writeData(ByteBuffer buffer, String keyName) throws Exception {
+    int bufferCapacity = buffer.capacity();
+
+    LOG.debug("LOADGEN: Writing key {}", keyName);
+    try (OzoneOutputStream stream = bucket.createKey(keyName,
+        bufferCapacity, ReplicationType.RATIS, ReplicationFactor.THREE,
+            new HashMap<>())) {
+      stream.write(buffer.array());
+      LOG.trace("LOADGEN: Written key {}", keyName);
+    } catch (Throwable t) {
+      LOG.error("LOADGEN: Create key:{} failed with exception, skipping",
+              keyName, t);
+      throw t;
+    }
+  }
+
+  public void readData(ByteBuffer buffer, String keyName) throws Exception {
+    LOG.debug("LOADGEN: Reading key {}", keyName);
+
+    int bufferCapacity = buffer.capacity();
+
+    try (OzoneInputStream stream = bucket.readKey(keyName)) {
+      byte[] readBuffer = new byte[bufferCapacity];
+      int readLen = stream.read(readBuffer);
+
+      if (readLen < bufferCapacity) {
+        throw new IOException("Read mismatch, key:" + keyName +
+                " read data length:" + readLen + " is smaller than excepted:"
+                + bufferCapacity);
+      }
+
+      if (!Arrays.equals(readBuffer, buffer.array())) {
+        throw new IOException("Read mismatch, key:" + keyName +
+                " read data does not match the written data");
+      }
+      LOG.trace("LOADGEN: Read key {}", keyName);
+    } catch (Throwable t) {
+      LOG.error("LOADGEN: Read key:{} failed with exception", keyName, t);
+      throw t;
+    }
+  }
+
+  public void deleteKey(String keyName) throws Exception {
+    LOG.debug("LOADGEN: Deleting key {}", keyName);
+    try {
+      bucket.deleteKey(keyName);
+      LOG.trace("LOADGEN: Deleted key {}", keyName);
+    } catch (Throwable t) {
+      LOG.error("LOADGEN: Unable to delete key:{}", keyName, t);
+      throw t;
+    }
+  }
+}

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/utils/TestProbability.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/utils/TestProbability.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.ozone.chaos;
+package org.apache.hadoop.ozone.utils;
 
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.RandomUtils;

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.hadoop.fs.ozone.OzoneFileSystem

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/resources/log4j.properties
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/resources/log4j.properties
@@ -1,0 +1,31 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+# log4j configuration used during build and unit tests
+
+log4j.rootLogger=INFO,stdout
+log4j.threshold=ALL
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M(%L)) - %m%n
+
+log4j.logger.org.apache.hadoop.security.ShellBasedUnixGroupsMapping=ERROR
+log4j.logger.org.apache.hadoop.util.NativeCodeLoader=ERROR
+
+# Suppress info messages on every put key from Ratis
+log4j.logger.org.apache.ratis.grpc.client.GrpcClientProtocolClient=WARN
+
+log4j.logger.org.apache.hadoop.ozone.utils=DEBUG,stdout,CHAOS
+log4j.appender.CHAOS.File=${chaoslogfilename}
+log4j.appender.CHAOS=org.apache.log4j.FileAppender
+log4j.appender.CHAOS.layout=org.apache.log4j.PatternLayout
+log4j.appender.CHAOS.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M(%L)) - %m%n
+log4j.additivity.org.apache.hadoop.ozone.utils=false


### PR DESCRIPTION
## What changes were proposed in this pull request?

Moves MiniOzone Chaos Cluster to a new module so that dependency to ozone-filesystem can be added. Also updated some of the logging utilities for the test.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2645

## How was this patch tested?
Ran MiniOzoneChaos test locally after moving it to a new module and also verified that the files were created in the correct locations.