### PR TITLE
HDDS-1722. Use the bindings in ReconSchemaGenerationModule to create …

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconControllerModule.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconControllerModule.java
@@ -45,8 +45,6 @@ import org.apache.hadoop.ozone.recon.spi.OzoneManagerServiceProvider;
 import org.apache.hadoop.ozone.recon.spi.impl.ReconContainerDBProvider;
 import org.apache.hadoop.ozone.recon.spi.impl.ContainerDBServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
-import org.apache.hadoop.ozone.recon.tasks.ContainerKeyMapperTask;
-import org.apache.hadoop.ozone.recon.tasks.FileSizeCountTask;
 import org.apache.hadoop.ozone.recon.tasks.ReconTaskController;
 import org.apache.hadoop.ozone.recon.tasks.ReconTaskControllerImpl;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -87,8 +85,6 @@ public class ReconControllerModule extends AbstractModule {
 
     bind(ReconTaskController.class)
         .to(ReconTaskControllerImpl.class).in(Singleton.class);
-    bind(ContainerKeyMapperTask.class);
-    bind(FileSizeCountTask.class);
   }
 
   @Provides

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconSchemaManager.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon;
+
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.hadoop.ozone.recon.schema.ReconSchemaDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Inject;
+
+/**
+ * Class used to create Recon SQL tables.
+ */
+public class ReconSchemaManager {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ReconSchemaManager.class);
+  private Set<ReconSchemaDefinition> reconSchemaDefinitions = new HashSet<>();
+
+  @Inject
+  public ReconSchemaManager(Set<ReconSchemaDefinition> reconSchemaDefinitions) {
+    this.reconSchemaDefinitions.addAll(reconSchemaDefinitions);
+  }
+
+  void createReconSchema() {
+    reconSchemaDefinitions.forEach(reconSchemaDefinition -> {
+      try {
+        reconSchemaDefinition.initializeSchema();
+      } catch (SQLException e) {
+        LOG.error("Error creating Recon schema {} : {}",
+            reconSchemaDefinition.getClass().getSimpleName(), e);
+      }
+    });
+  }
+}


### PR DESCRIPTION
…Recon SQL tables on startup.

## What changes were proposed in this pull request?

Currently the SQL table creation in Recon is done for each schema definition (table) one by one. Instead, we can use the injected bindings to automatically create all registered tables.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-1722

## How was this patch tested?
Manually tested on standalone cluster.