### PR TITLE
HDDS-2659. KeyValueHandler#handleCreateContainer should log the exception on container creation failure

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
@@ -143,10 +143,10 @@ public final class ContainerUtils {
   public static ContainerCommandResponseProto logAndReturnError(
       Logger log, StorageContainerException ex,
       ContainerCommandRequestProto request) {
-    log.info("Operation: {} , Trace ID: {} , Message: {} , Result: {}",
-        request.getCmdType().name(), request.getTraceID(),
-        ex.getMessage(), ex.getResult().getValueDescriptor().getName());
-    log.error("StorageContainerException Occurred!", ex);
+    String logInfo = "Operation: {} , Trace ID: {} , Message: {} , " +
+        "Result: {} , StorageContainerException Occurred.";
+    log.info(logInfo, request.getCmdType().name(), request.getTraceID(),
+        ex.getMessage(), ex.getResult().getValueDescriptor().getName(), ex);
     return getContainerCommandResponse(request, ex.getResult(), ex.getMessage())
         .build();
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
@@ -146,6 +146,7 @@ public final class ContainerUtils {
     log.info("Operation: {} , Trace ID: {} , Message: {} , Result: {}",
         request.getCmdType().name(), request.getTraceID(),
         ex.getMessage(), ex.getResult().getValueDescriptor().getName());
+    log.error("StorageContainerException Occurred!", ex);
     return getContainerCommandResponse(request, ex.getResult(), ex.getMessage())
         .build();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Let the ```StorageContainerException``` cause of ```KeyValueHandler#handleCreateContaine``` be logged.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2659

## How was this patch tested?
Just build and compile.