### PR TITLE
HDDS-2070. Create insight point to debug one specific pipeline

### DIFF
--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/BaseInsightPoint.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/BaseInsightPoint.java
@@ -58,9 +58,12 @@ public abstract class BaseInsightPoint implements InsightPoint {
    * List the related loggers.
    *
    * @param verbose true if verbose logging is requested.
+   * @param filters additional key value pair to further filter the output.
+   *                (eg. datanode=123-2323-datanode-id)
    */
   @Override
-  public List<LoggerSource> getRelatedLoggers(boolean verbose) {
+  public List<LoggerSource> getRelatedLoggers(boolean verbose,
+      Map<String, String> filters) {
     List<LoggerSource> loggers = new ArrayList<>();
     return loggers;
   }

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/BaseInsightSubCommand.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/BaseInsightSubCommand.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.insight.Component.Type;
+import org.apache.hadoop.ozone.insight.datanode.RatisInsight;
 import org.apache.hadoop.ozone.insight.om.KeyManagerInsight;
 import org.apache.hadoop.ozone.insight.om.OmProtocolInsight;
 import org.apache.hadoop.ozone.insight.scm.EventQueueInsight;
@@ -96,6 +97,7 @@ public class BaseInsightSubCommand {
              new ScmProtocolSecurityInsight());
     insights.put("om.key-manager", new KeyManagerInsight());
     insights.put("om.protocol.client", new OmProtocolInsight());
+    insights.put("datanode.pipeline", new RatisInsight(configuration));
 
     return insights;
   }

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/InsightPoint.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/InsightPoint.java
@@ -33,7 +33,8 @@ public interface InsightPoint {
   /**
    * List of the related loggers.
    */
-  List<LoggerSource> getRelatedLoggers(boolean verbose);
+  List<LoggerSource> getRelatedLoggers(boolean verbose,
+      Map<String, String> filters);
 
   /**
    * List of the related metrics.

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/LogSubcommand.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/LogSubcommand.java
@@ -73,7 +73,7 @@ public class LogSubcommand extends BaseInsightSubCommand
     InsightPoint insight =
         getInsight(conf, insightName);
 
-    List<LoggerSource> loggers = insight.getRelatedLoggers(verbose);
+    List<LoggerSource> loggers = insight.getRelatedLoggers(verbose, filters);
 
     setLogLevels(conf, loggers, LoggerSource::getLevel);
     Runtime.getRuntime().addShutdownHook(new Thread(() ->

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/datanode/RatisInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/datanode/RatisInsight.java
@@ -49,12 +49,13 @@ public class RatisInsight extends BaseInsightPoint implements InsightPoint {
   @Override
   public List<LoggerSource> getRelatedLoggers(boolean verbose,
       Map<String, String> filters) {
-    if (filters == null || !filters.containsKey(PIPLINE_FILTER)) {
-      throw new IllegalArgumentException(PIPLINE_FILTER
-          + " filter should be specified (-f pipeline=<pipelineid)");
+    if (filters == null || !filters.containsKey(PIPELINE_FILTER)) {
+      throw new IllegalArgumentException(PIPELINE_FILTER
+          + " filter should be specified (-f " + PIPELINE_FILTER
+          + "=<pipelineid)");
     }
 
-    String pipelineId = filters.get(PIPLINE_FILTER);
+    String pipelineId = filters.get(PIPELINE_FILTER);
     List<LoggerSource> result = new ArrayList<>();
 
     try (ScmClient scmClient = createScmClient(conf)) {

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/datanode/RatisInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/datanode/RatisInsight.java
@@ -51,7 +51,7 @@ public class RatisInsight extends BaseInsightPoint implements InsightPoint {
       Map<String, String> filters) {
     if (filters == null || !filters.containsKey(PIPLINE_FILTER)) {
       throw new IllegalArgumentException(PIPLINE_FILTER
-          + " filter should be specified (-f pipline=<pipelineid)");
+          + " filter should be specified (-f pipeline=<pipelineid)");
     }
 
     String pipelineId = filters.get(PIPLINE_FILTER);

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/datanode/RatisInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/datanode/RatisInsight.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.ozone.insight.LoggerSource;
  */
 public class RatisInsight extends BaseInsightPoint implements InsightPoint {
 
+  public static final String PIPLINE_FILTER = "pipeline";
   private OzoneConfiguration conf;
 
   public RatisInsight(OzoneConfiguration conf) {
@@ -46,24 +47,35 @@ public class RatisInsight extends BaseInsightPoint implements InsightPoint {
   }
 
   @Override
-  public List<LoggerSource> getRelatedLoggers(boolean verbose) {
+  public List<LoggerSource> getRelatedLoggers(boolean verbose,
+      Map<String, String> filters) {
+    if (filters == null || !filters.containsKey(PIPLINE_FILTER)) {
+      throw new IllegalArgumentException(PIPLINE_FILTER
+          + " filter should be specified (-f pipline=<pipelineid)");
+    }
+
+    String pipelineId = filters.get(PIPLINE_FILTER);
     List<LoggerSource> result = new ArrayList<>();
-    try {
-      Optional<Pipeline> pipeline;
-      try (ScmClient scmClient = createScmClient(conf)) {
-        pipeline = scmClient.listPipelines()
-            .stream()
-            .filter(d -> d.getNodes().size() > 1)
-            .findFirst();
+
+    try (ScmClient scmClient = createScmClient(conf)) {
+      Optional<Pipeline> pipelineSelection = scmClient.listPipelines()
+          .stream()
+          .filter(d -> d.getNodes().size() > 1)
+          .filter(
+              pipline -> pipline.getId().getId().toString().equals(pipelineId))
+          .findFirst();
+
+      if (!pipelineSelection.isPresent()) {
+        throw new IllegalArgumentException("No such multi-node pipeline.");
       }
-      if (pipeline.isPresent()) {
-        for (DatanodeDetails datanode : pipeline.get().getNodes()) {
-          Component dn = new Component(
-              Type.DATANODE, datanode.getUuid().toString(),
-              datanode.getHostName(), 9882);
-          result.add(new LoggerSource(dn, "org.apache.ratis.server.impl",
-              defaultLevel(verbose)));
-        }
+      Pipeline pipeline = pipelineSelection.get();
+      for (DatanodeDetails datanode : pipeline.getNodes()) {
+        Component dn =
+            new Component(Type.DATANODE, datanode.getUuid().toString(),
+                datanode.getHostName(), 9882);
+        result
+            .add(new LoggerSource(dn, "org.apache.ratis.server.impl",
+                defaultLevel(verbose)));
       }
     } catch (IOException e) {
       throw new UncheckedIOException("Can't enumerate required logs", e);

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/datanode/RatisInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/datanode/RatisInsight.java
@@ -39,7 +39,7 @@ import org.apache.hadoop.ozone.insight.LoggerSource;
  */
 public class RatisInsight extends BaseInsightPoint implements InsightPoint {
 
-  public static final String PIPLINE_FILTER = "pipeline";
+  public static final String PIPELINE_FILTER = "pipeline";
   private OzoneConfiguration conf;
 
   public RatisInsight(OzoneConfiguration conf) {

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/datanode/RatisInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/datanode/RatisInsight.java
@@ -61,7 +61,6 @@ public class RatisInsight extends BaseInsightPoint implements InsightPoint {
     try (ScmClient scmClient = createScmClient(conf)) {
       Optional<Pipeline> pipelineSelection = scmClient.listPipelines()
           .stream()
-          .filter(d -> d.getNodes().size() > 1)
           .filter(
               pipline -> pipline.getId().getId().toString().equals(pipelineId))
           .findFirst();

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/om/KeyManagerInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/om/KeyManagerInsight.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.insight.om;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.ozone.insight.BaseInsightPoint;
 import org.apache.hadoop.ozone.insight.Component.Type;
@@ -62,7 +63,8 @@ public class KeyManagerInsight extends BaseInsightPoint {
   }
 
   @Override
-  public List<LoggerSource> getRelatedLoggers(boolean verbose) {
+  public List<LoggerSource> getRelatedLoggers(boolean verbose,
+      Map<String, String> filters) {
     List<LoggerSource> loggers = new ArrayList<>();
     loggers.add(
         new LoggerSource(Type.OM, KeyManagerImpl.class,

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/om/OmProtocolInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/om/OmProtocolInsight.java
@@ -35,7 +35,8 @@ import org.apache.hadoop.ozone.protocolPB.OzoneManagerProtocolServerSideTranslat
 public class OmProtocolInsight extends BaseInsightPoint {
 
   @Override
-  public List<LoggerSource> getRelatedLoggers(boolean verbose) {
+  public List<LoggerSource> getRelatedLoggers(boolean verbose,
+      Map<String, String> filters) {
     List<LoggerSource> loggers = new ArrayList<>();
     loggers.add(
         new LoggerSource(Type.OM,

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/EventQueueInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/EventQueueInsight.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.insight.scm;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.ozone.insight.BaseInsightPoint;
@@ -31,7 +32,8 @@ import org.apache.hadoop.ozone.insight.LoggerSource;
 public class EventQueueInsight extends BaseInsightPoint {
 
   @Override
-  public List<LoggerSource> getRelatedLoggers(boolean verbose) {
+  public List<LoggerSource> getRelatedLoggers(boolean verbose,
+      Map<String, String> filters) {
     List<LoggerSource> loggers = new ArrayList<>();
     loggers
         .add(new LoggerSource(Type.SCM, EventQueue.class,

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/NodeManagerInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/NodeManagerInsight.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.insight.scm;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.hdds.scm.node.SCMNodeManager;
 import org.apache.hadoop.ozone.insight.BaseInsightPoint;
@@ -33,7 +34,8 @@ import org.apache.hadoop.ozone.insight.MetricGroupDisplay;
 public class NodeManagerInsight extends BaseInsightPoint {
 
   @Override
-  public List<LoggerSource> getRelatedLoggers(boolean verbose) {
+  public List<LoggerSource> getRelatedLoggers(boolean verbose,
+      Map<String, String> filters) {
     List<LoggerSource> loggers = new ArrayList<>();
     loggers.add(
         new LoggerSource(Type.SCM, SCMNodeManager.class,

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/ReplicaManagerInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/ReplicaManagerInsight.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.insight.scm;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.hdds.scm.container.ReplicationManager;
 import org.apache.hadoop.ozone.insight.BaseInsightPoint;
@@ -32,7 +33,8 @@ import org.apache.hadoop.ozone.insight.MetricGroupDisplay;
 public class ReplicaManagerInsight extends BaseInsightPoint {
 
   @Override
-  public List<LoggerSource> getRelatedLoggers(boolean verbose) {
+  public List<LoggerSource> getRelatedLoggers(boolean verbose,
+      Map<String, String> filters) {
     List<LoggerSource> loggers = new ArrayList<>();
     loggers.add(new LoggerSource(Type.SCM, ReplicationManager.class,
         defaultLevel(verbose)));

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/ScmProtocolBlockLocationInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/ScmProtocolBlockLocationInsight.java
@@ -36,7 +36,8 @@ import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocolServerSideTra
 public class ScmProtocolBlockLocationInsight extends BaseInsightPoint {
 
   @Override
-  public List<LoggerSource> getRelatedLoggers(boolean verbose) {
+  public List<LoggerSource> getRelatedLoggers(boolean verbose,
+      Map<String, String> filters) {
     List<LoggerSource> loggers = new ArrayList<>();
     loggers.add(
         new LoggerSource(Type.SCM,

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/ScmProtocolContainerLocationInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/ScmProtocolContainerLocationInsight.java
@@ -36,7 +36,8 @@ import org.apache.hadoop.ozone.insight.MetricGroupDisplay;
 public class ScmProtocolContainerLocationInsight extends BaseInsightPoint {
 
   @Override
-  public List<LoggerSource> getRelatedLoggers(boolean verbose) {
+  public List<LoggerSource> getRelatedLoggers(boolean verbose,
+      Map<String, String> filters) {
     List<LoggerSource> loggers = new ArrayList<>();
     loggers.add(
         new LoggerSource(Type.SCM,

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/ScmProtocolDatanodeInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/ScmProtocolDatanodeInsight.java
@@ -36,7 +36,8 @@ import org.apache.hadoop.ozone.protocolPB.StorageContainerDatanodeProtocolServer
 public class ScmProtocolDatanodeInsight extends BaseInsightPoint {
 
   @Override
-  public List<LoggerSource> getRelatedLoggers(boolean verbose) {
+  public List<LoggerSource> getRelatedLoggers(boolean verbose,
+      Map<String, String> filters) {
     List<LoggerSource> loggers = new ArrayList<>();
     loggers.add(
         new LoggerSource(Type.SCM,

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/ScmProtocolSecurityInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/ScmProtocolSecurityInsight.java
@@ -36,7 +36,8 @@ import org.apache.hadoop.ozone.insight.MetricGroupDisplay;
 public class ScmProtocolSecurityInsight extends BaseInsightPoint {
 
   @Override
-  public List<LoggerSource> getRelatedLoggers(boolean verbose) {
+  public List<LoggerSource> getRelatedLoggers(boolean verbose,
+      Map<String, String> filters) {
     List<LoggerSource> loggers = new ArrayList<>();
     loggers.add(
         new LoggerSource(Type.SCM,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Wit the first implementation of ozone insight tool we had a demo insight-point to debug Ratis pipelines. It was not stable enough to include in the first patch, this patch is about fixing it.

The goal is to implement a new insight point (eg. datanode.pipeline) which can show information about one pipeline.

It can be done with retrieving the hosts of the pipeline and generate the loggers metrics (InsightPoint.getRelatedLoggers and InsightPoint.getMetrics) based on the pipeline information (same loggers should be displayed from all the three datanodes.

The pipeline id can be defined as a filter parameter which (in this case) should be required.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2070

## How was this patch tested?

 1. Start a docker-compose cluster with three datanodes.
 2. Get the id of the Ratis/THREE pipeline: `ozone scmcli pipeline list | grep THREE`
 3. Check the logs of this specific pipeline: `ozone insight logs -v -f=pipeline=1e0dce39-98fe-43b9-b8fe-68fd003f321f datanode.pipeline`