### PR TITLE
HDDS-2662. Update gRPC and datanode protobuf version in Ozone.

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -181,7 +181,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <extensions>true</extensions>
         <configuration>
           <protocArtifact>
-            com.google.protobuf:protoc:${protobuf-compile.version}:exe:${os.detected.classifier}
+            com.google.protobuf:protoc:${datanode.protobuf-compile.version}:exe:${os.detected.classifier}
           </protocArtifact>
           <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
           <includes>
@@ -202,7 +202,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               <configuration>
                 <pluginId>grpc-java</pluginId>
                 <pluginArtifact>
-                  io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}
+                  io.grpc:protoc-gen-grpc-java:${datanode.grpc-compile.version}:exe:${os.detected.classifier}
                 </pluginArtifact>
               </configuration>
           </execution>

--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -29,7 +29,8 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <packaging>jar</packaging>
 
   <properties>
-    <grpc.version>1.17.1</grpc.version>
+    <grpc-compile.version>1.17.1</grpc-compile.version>
+    <protobuf-compile.version>3.5.0</protobuf-compile.version>
   </properties>
   <dependencies>
     <dependency>
@@ -70,7 +71,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty</artifactId>
-      <version>${grpc.version}</version>
+      <version>${grpc-compile.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
@@ -85,7 +86,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
-      <version>${grpc.version}</version>
+      <version>${grpc-compile.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.protobuf</groupId>
@@ -96,7 +97,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
-      <version>${grpc.version}</version>
+      <version>${grpc-compile.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -160,7 +161,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
             <configuration>
               <pluginId>grpc-java</pluginId>
               <pluginArtifact>
-                io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}
+                io.grpc:protoc-gen-grpc-java:${grpc-compile.version}:exe:${os.detected.classifier}
               </pluginArtifact>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -174,8 +174,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <!-- Maven protoc compiler -->
     <protobuf-maven-plugin.version>0.5.1</protobuf-maven-plugin.version>
-    <protobuf-compile.version>3.5.0</protobuf-compile.version>
-    <grpc.version>1.10.0</grpc.version>
+    <datanode.protobuf-compile.version>3.10.0</datanode.protobuf-compile.version>
+    <datanode.grpc-compile.version>1.24.0</datanode.grpc-compile.version>
     <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
 
     <!-- define the Java language version used by the compiler -->


### PR DESCRIPTION
## What changes were proposed in this pull request?
This jira updates the gRPC and protobuf version to be same as the ratis-thirdparty versions.
This is needed after HDDS-2637

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2662

## How was this patch tested?
Ran MiniOzoneChaosCluster and verified that read/writes were working correctly.
