### PR TITLE
HDDS-2636. Refresh pipeline information in OzoneManager lookupFile call.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -174,7 +174,7 @@ public class KeyManagerImpl implements KeyManager {
   }
 
   @SuppressWarnings("parameternumber")
-  private KeyManagerImpl(OzoneManager om, ScmClient scmClient,
+  public KeyManagerImpl(OzoneManager om, ScmClient scmClient,
       OMMetadataManager metadataManager, OzoneConfiguration conf, String omId,
       OzoneBlockTokenSecretManager secretManager,
       KeyProviderCryptoExtension kmsProvider, PrefixManager prefixManager) {
@@ -1855,6 +1855,9 @@ public class KeyManagerImpl implements KeyManager {
     try {
       OzoneFileStatus fileStatus = getFileStatus(args);
       if (fileStatus.isFile()) {
+        if (args.getRefreshPipeline()) {
+          refreshPipeline(fileStatus.getKeyInfo());
+        }
         if (args.getSortDatanodes()) {
           sortDatanodeInPipeline(fileStatus.getKeyInfo(), clientAddress);
         }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -1129,6 +1129,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setVolumeName(keyArgs.getVolumeName())
         .setBucketName(keyArgs.getBucketName())
         .setKeyName(keyArgs.getKeyName())
+        .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(keyArgs.getSortDatanodes())
         .build();
     return LookupFileResponse.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -30,21 +32,32 @@ import java.util.UUID;
 import com.google.common.base.Optional;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
+import org.apache.hadoop.hdds.scm.TestUtils;
+import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs.Builder;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUpload;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadList;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadListParts;
+import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.security.OzoneBlockTokenSecretManager;
@@ -61,6 +74,7 @@ import org.mockito.Mockito;
  */
 public class TestKeyManagerUnit {
 
+  private OzoneConfiguration configuration;
   private OmMetadataManagerImpl metadataManager;
   private KeyManagerImpl keyManager;
 
@@ -68,7 +82,7 @@ public class TestKeyManagerUnit {
 
   @Before
   public void setup() throws IOException {
-    OzoneConfiguration configuration = new OzoneConfiguration();
+    configuration = new OzoneConfiguration();
     configuration.set(HddsConfigKeys.OZONE_METADATA_DIRS,
         GenericTestUtils.getRandomizedTestDir().toString());
     metadataManager = new OmMetadataManagerImpl(configuration);
@@ -297,6 +311,124 @@ public class TestKeyManagerUnit {
         new CacheKey<>(metadataManager.getMultipartKey(volume, bucket, key,
             uploadID)), new CacheValue<>(Optional.absent(),
             RandomUtils.nextInt()));
+  }
+
+  @Test
+  public void testLookupFileWithDnFailure() throws IOException {
+    final StorageContainerLocationProtocol containerClient =
+        Mockito.mock(StorageContainerLocationProtocol.class);
+    final KeyManager manager = new KeyManagerImpl(null,
+        new ScmClient(Mockito.mock(ScmBlockLocationProtocol.class),
+            containerClient), metadataManager, configuration, "test-om",
+        Mockito.mock(OzoneBlockTokenSecretManager.class), null, null);
+
+    final DatanodeDetails dnOne = TestUtils.randomDatanodeDetails();
+    final DatanodeDetails dnTwo = TestUtils.randomDatanodeDetails();
+    final DatanodeDetails dnThree = TestUtils.randomDatanodeDetails();
+
+    final DatanodeDetails dnFour = TestUtils.randomDatanodeDetails();
+    final DatanodeDetails dnFive = TestUtils.randomDatanodeDetails();
+    final DatanodeDetails dnSix = TestUtils.randomDatanodeDetails();
+
+    final Pipeline pipelineOne = Pipeline.newBuilder()
+        .setId(PipelineID.randomId())
+        .setType(ReplicationType.RATIS)
+        .setFactor(ReplicationFactor.THREE)
+        .setState(Pipeline.PipelineState.OPEN)
+        .setLeaderId(dnOne.getUuid())
+        .setNodes(Arrays.asList(dnOne, dnTwo, dnThree))
+        .build();
+
+    final Pipeline pipelineTwo = Pipeline.newBuilder()
+        .setId(PipelineID.randomId())
+        .setType(ReplicationType.RATIS)
+        .setFactor(ReplicationFactor.THREE)
+        .setState(Pipeline.PipelineState.OPEN)
+        .setLeaderId(dnFour.getUuid())
+        .setNodes(Arrays.asList(dnFour, dnFive, dnSix))
+        .build();
+
+    Mockito.when(containerClient.getContainerWithPipeline(1L))
+        .thenReturn(new ContainerWithPipeline(null, pipelineTwo));
+
+    final OmVolumeArgs volumeArgs = OmVolumeArgs.newBuilder()
+        .setVolume("volumeOne")
+        .setAdminName("admin")
+        .setOwnerName("admin")
+        .build();
+    TestOMRequestUtils.addVolumeToOM(metadataManager, volumeArgs);
+
+    final OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
+          .setVolumeName("volumeOne")
+          .setBucketName("bucketOne")
+          .build();
+    TestOMRequestUtils.addBucketToOM(metadataManager, bucketInfo);
+
+    final OmKeyLocationInfo keyLocationInfo = new OmKeyLocationInfo.Builder()
+        .setBlockID(new BlockID(1L, 1L))
+        .setPipeline(pipelineOne)
+        .setOffset(0)
+        .setLength(256000)
+        .build();
+
+    final OmKeyInfo keyInfo = new OmKeyInfo.Builder()
+        .setVolumeName("volumeOne")
+        .setBucketName("bucketOne")
+        .setKeyName("keyOne")
+        .setOmKeyLocationInfos(Collections.singletonList(
+            new OmKeyLocationInfoGroup(0,
+                Collections.singletonList(keyLocationInfo))))
+        .setCreationTime(Time.now())
+        .setModificationTime(Time.now())
+        .setDataSize(256000)
+        .setReplicationType(ReplicationType.RATIS)
+        .setReplicationFactor(ReplicationFactor.THREE)
+        .setAcls(Collections.emptyList())
+        .build();
+    TestOMRequestUtils.addKeyToOM(metadataManager, keyInfo);
+
+    final OmKeyArgs.Builder keyArgs = new OmKeyArgs.Builder()
+        .setVolumeName("volumeOne")
+        .setBucketName("bucketOne")
+        .setKeyName("keyOne");
+
+    keyArgs.setRefreshPipeline(false);
+    final OmKeyInfo oldKeyInfo = manager
+        .lookupFile(keyArgs.build(), "test");
+
+    final OmKeyLocationInfo oldBlockLocation = oldKeyInfo
+        .getLatestVersionLocations().getBlocksLatestVersionOnly().get(0);
+
+    Assert.assertEquals(1L, oldBlockLocation.getContainerID());
+    Assert.assertEquals(1L, oldBlockLocation
+        .getBlockID().getLocalID());
+    Assert.assertEquals(pipelineOne.getId(),
+        oldBlockLocation.getPipeline().getId());
+    Assert.assertTrue(oldBlockLocation.getPipeline()
+        .getNodes().contains(dnOne));
+    Assert.assertTrue(oldBlockLocation.getPipeline()
+        .getNodes().contains(dnTwo));
+    Assert.assertTrue(oldBlockLocation.getPipeline()
+        .getNodes().contains(dnThree));
+
+    keyArgs.setRefreshPipeline(true);
+    final OmKeyInfo newKeyInfo = manager
+        .lookupFile(keyArgs.build(), "test");
+
+    final OmKeyLocationInfo newBlockLocation = newKeyInfo
+        .getLatestVersionLocations().getBlocksLatestVersionOnly().get(0);
+
+    Assert.assertEquals(1L, newBlockLocation.getContainerID());
+    Assert.assertEquals(1L, newBlockLocation
+        .getBlockID().getLocalID());
+    Assert.assertEquals(pipelineTwo.getId(),
+        newBlockLocation.getPipeline().getId());
+    Assert.assertTrue(newBlockLocation.getPipeline()
+        .getNodes().contains(dnFour));
+    Assert.assertTrue(newBlockLocation.getPipeline()
+        .getNodes().contains(dnFive));
+    Assert.assertTrue(newBlockLocation.getPipeline()
+        .getNodes().contains(dnSix));
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -545,6 +545,23 @@ public final class TestOMRequestUtils {
   }
 
   /**
+   * Add the Key information to OzoneManager DB and cache.
+   * @param omMetadataManager
+   * @param omKeyInfo
+   * @throws IOException
+   */
+  public static void addKeyToOM(final OMMetadataManager omMetadataManager,
+                                final OmKeyInfo omKeyInfo) throws IOException {
+    final String dbKey = omMetadataManager.getOzoneKey(
+        omKeyInfo.getVolumeName(), omKeyInfo.getBucketName(),
+        omKeyInfo.getKeyName());
+    omMetadataManager.getKeyTable().put(dbKey, omKeyInfo);
+    omMetadataManager.getKeyTable().addCacheEntry(
+        new CacheKey<>(dbKey),
+        new CacheValue<>(Optional.of(omKeyInfo), 1L));
+  }
+
+  /**
    * Add the Bucket information to OzoneManager DB and cache.
    * @param omMetadataManager
    * @param omBucketInfo


### PR DESCRIPTION
## What changes were proposed in this pull request?

lookupFile call in OzoneManager doesn't refresh the pipeline information. As a result of this, wrong pipeline information is returned to the client and the client fails eventually. This change brings in support to refresh pipeline in lookupFile call.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2636

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?
* Added unit test to validate the change.
* Manually installed a 3 node cluster and tested it.
