### PR TITLE
HDDS-2656. Prefer execute() over submit() if the returned Future is ignored

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCacheImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCacheImpl.java
@@ -101,7 +101,7 @@ public class TableCacheImpl<CACHEKEY extends CacheKey,
   }
 
   public void cleanup(List<Long> epochs) {
-    executorService.submit(() -> evictCache(epochs));
+    executorService.execute(() -> evictCache(epochs));
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -81,7 +81,7 @@ public class ReplicationSupervisor {
    */
   public void addTask(ReplicationTask task) {
     if (containersInFlight.add(task.getContainerId())) {
-      executor.submit(new TaskRunner(task));
+      executor.execute(new TaskRunner(task));
     }
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
@@ -78,7 +78,7 @@ public class TestChunkUtils {
       AtomicBoolean failed = new AtomicBoolean();
       for (int i = 0; i < threads; i++) {
         final int threadNumber = i;
-        executor.submit(() -> {
+        executor.execute(() -> {
           try {
             ByteBuffer readBuffer = ChunkUtils.readData(file, chunkInfo, stats);
             LOG.info("Read data ({}): {}", threadNumber,
@@ -120,7 +120,7 @@ public class TestChunkUtils {
       for (int i = 0; i < threads; i++) {
         Path path = Files.createTempFile(PREFIX, String.valueOf(i));
         paths.add(path);
-        executor.submit(() -> {
+        executor.execute(() -> {
           ChunkUtils.processFileExclusively(path, () -> {
             try {
               Thread.sleep(perThreadWait);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -292,7 +292,7 @@ public final class RandomKeyGenerator implements Callable<Void> {
     LOG.info("Buffer size: {} bytes", bufferSize);
     LOG.info("validateWrites : {}", validateWrites);
     for (int i = 0; i < numOfThreads; i++) {
-      executor.submit(new ObjectCreator());
+      executor.execute(new ObjectCreator());
     }
 
     Thread validator = null;


### PR DESCRIPTION
## What changes were proposed in this pull request?

`Future submit(Runnable)` and `void execute(Runnable)` in `ExecutorService` have the same result.  If the returned `Future` is ignored, `execute` can be used instead of `submit` to avoid creating some objects.

https://issues.apache.org/jira/browse/HDDS-2656

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/333081135