### PR TITLE
HDDS-2578. Handle InterruptedException in RandomKeyGenerator

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -1061,7 +1061,7 @@ public final class RandomKeyGenerator implements Callable<Void> {
             is.close();
           }
         } catch (IOException ex) {
-          LOG.error("Exception while validating write: " + ex.getMessage());
+          LOG.error("Exception while validating write.", ex);
         } catch (InterruptedException ex) {
           Thread.currentThread().interrupt();
         }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -1060,11 +1060,10 @@ public final class RandomKeyGenerator implements Callable<Void> {
             }
             is.close();
           }
-        } catch (IOException | InterruptedException ex) {
+        } catch (IOException ex) {
           LOG.error("Exception while validating write: " + ex.getMessage());
-          if(ex instanceof InterruptedException) {
-            Thread.currentThread().interrupt();
-          }
+        } catch (InterruptedException ex) {
+          Thread.currentThread().interrupt();
         }
       }
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -1062,6 +1062,9 @@ public final class RandomKeyGenerator implements Callable<Void> {
           }
         } catch (IOException | InterruptedException ex) {
           LOG.error("Exception while validating write: " + ex.getMessage());
+          if(ex instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+          }
         }
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix sonar issue.
Re-interrupt current thread when InterruptedException was encountered.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2578

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?
mvn install to ensure it builds cleanly.