### PR TITLE
HDDS-2667. Promethues reports invalid metric type

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/PrometheusMetricsSink.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/PrometheusMetricsSink.java
@@ -110,10 +110,11 @@ public class PrometheusMetricsSink implements MetricsSink {
   public String prometheusName(String recordName,
       String metricName) {
 
-    //RocksDB metric names already have underscores as delimiters.
+    // RocksDB metric names already have underscores as delimiters,
+    // but record name is from DB file name and '.' (as in 'om.db') is invalid
     if (StringUtils.isNotEmpty(recordName) &&
         recordName.startsWith(ROCKSDB_CONTEXT_PREFIX)) {
-      return recordName.toLowerCase() + "_" + metricName.toLowerCase();
+      return normalizeName(recordName) + "_" + metricName.toLowerCase();
     }
 
     String baseName = StringUtils.capitalize(recordName)

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestPrometheusMetricsSink.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestPrometheusMetricsSink.java
@@ -133,7 +133,7 @@ public class TestPrometheusMetricsSink {
   public void testNamingRocksDB() {
     //RocksDB metrics are handled differently.
     PrometheusMetricsSink sink = new PrometheusMetricsSink();
-    Assert.assertEquals("rocksdb_om.db_num_open_connections",
+    Assert.assertEquals("rocksdb_om_db_num_open_connections",
         sink.prometheusName("Rocksdb_om.db", "num_open_connections"));
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Normalize RocksDB metrics record name, which comes from DB file names (eg. `om.db -> Rocksdb_om.db`), because periods are not allowed in Prometheus metrics names.

https://issues.apache.org/jira/browse/HDDS-2667

## How was this patch tested?

Changed existing unit test.

Tested using `ozoneperf` environment after enabling RocksDB metrics in `docker-config`:

```
OZONE-SITE.XML_ozone.metastore.rocksdb.statistics=ALL
```

and creating test data with Freon:

```
docker-compose exec scm ozone freon ockg -t 1 -n 1
```

Verified that Prometheus shows all datanodes, OM, SCM as up.  Verified that `/prom` endpoint and Prometheus show RocksDB metrics with normalized names, eg:

```
# TYPE rocksdb_om_db_wal_file_bytes counter
rocksdb_om_db_wal_file_bytes{hostname="198e740b5533"} 1823
```