### PR TITLE
HDDS-2570. Handle InterruptedException in ProfileServlet.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/ProfileServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/ProfileServlet.java
@@ -327,10 +327,8 @@ public class ProfileServlet extends HttpServlet {
           resp.getWriter().write(
               "Unable to acquire lock. Another instance of profiler might be "
                   + "running.");
-          LOG.warn(
-              "Unable to acquire lock in {} seconds. Another instance of "
-                  + "profiler might be running.",
-              lockTimeoutSecs);
+          LOG.warn("Unable to acquire lock in {} seconds. Another instance of "
+                  + "profiler might be running.", lockTimeoutSecs);
         }
       } catch (InterruptedException e) {
         LOG.warn("Interrupted while acquiring profile lock.", e);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/ProfileServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/ProfileServlet.java
@@ -335,6 +335,7 @@ public class ProfileServlet extends HttpServlet {
       } catch (InterruptedException e) {
         LOG.warn("Interrupted while acquiring profile lock.", e);
         resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        Thread.currentThread().interrupt();
       }
     } else {
       setResponseHeader(resp);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Handle InterruptedException in ProfileServlet - https://sonarcloud.io/project/issues?id=hadoop-ozone&issues=AW5md-x8KcVY8lQ4ZsIJ&open=AW5md-x8KcVY8lQ4ZsIJ

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2570

## How was this patch tested?
Minor fix, no testing done. 