### PR TITLE
HDDS-2593. DatanodeAdminMonitor should track under replicated containers and complete the admin workflow accordingly

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitor.java
@@ -20,19 +20,24 @@ package org.apache.hadoop.hdds.scm.node;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
+import org.apache.hadoop.hdds.scm.container.ContainerReplicaCount;
+import org.apache.hadoop.hdds.scm.container.ReplicationManager;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
+import org.apache.hadoop.ozone.common.statemachine
+    .InvalidStateTransitionException;
 import org.apache.hadoop.ozone.common.statemachine.StateMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Queue;
-import java.util.ArrayDeque;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Monitor thread which watches for nodes to be decommissioned, recommissioned
@@ -61,9 +66,11 @@ public class DatanodeAdminMonitor implements DatanodeAdminMonitorInterface {
   private EventPublisher eventQueue;
   private NodeManager nodeManager;
   private PipelineManager pipelineManager;
+  private ReplicationManager replicationManager;
   private Queue<DatanodeAdminNodeDetails> pendingNodes = new ArrayDeque();
   private Queue<DatanodeAdminNodeDetails> cancelledNodes = new ArrayDeque();
   private Set<DatanodeAdminNodeDetails> trackedNodes = new HashSet<>();
+  private Queue<DatanodeAdminNodeDetails> completedNodes = new ArrayDeque<>();
   private StateMachine<States, Transitions> workflowSM;
 
   /**
@@ -72,10 +79,9 @@ public class DatanodeAdminMonitor implements DatanodeAdminMonitorInterface {
    */
   public enum States {
     CLOSE_PIPELINES(1),
-    GET_CONTAINERS(2),
-    REPLICATE_CONTAINERS(3),
-    AWAIT_MAINTENANCE_END(4),
-    COMPLETE(5);
+    REPLICATE_CONTAINERS(2),
+    AWAIT_MAINTENANCE_END(3),
+    COMPLETE(4);
 
     private int sequenceNumber;
 
@@ -123,6 +129,11 @@ public class DatanodeAdminMonitor implements DatanodeAdminMonitorInterface {
     pipelineManager = pm;
   }
 
+  @Override
+  public void setReplicationManager(ReplicationManager rm) {
+    replicationManager = rm;
+  }
+
   /**
    * Add a node to the decommission or maintenance workflow. The node will be
    * queued and added to the workflow after a defined interval.
@@ -161,7 +172,8 @@ public class DatanodeAdminMonitor implements DatanodeAdminMonitorInterface {
    *
    * 1. Check for any cancelled nodes and process them
    * 2. Check for any newly added nodes and add them to the workflow
-   * 3. Wait for any nodes which have completed closing pipelines
+   * 3. Perform checks on the transitioning nodes and move them through the
+   *    workflow until they have completed decommission or maintenance
    */
   @Override
   public void run() {
@@ -170,7 +182,7 @@ public class DatanodeAdminMonitor implements DatanodeAdminMonitorInterface {
         processCancelledNodes();
         processPendingNodes();
       }
-      checkPipelinesClosed();
+      processTransitioningNodes();
       if (trackedNodes.size() > 0 || pendingNodes.size() > 0) {
         LOG.info("There are {} nodes tracked for decommission and "+
             "maintenance. {} pending nodes.",
@@ -178,6 +190,8 @@ public class DatanodeAdminMonitor implements DatanodeAdminMonitorInterface {
       }
     } catch (Exception e) {
       LOG.error("Caught an error in the DatanodeAdminMonitor", e);
+      // Intentionally do not re-throw, as if we do the monitor thread
+      // will not get rescheduled.
     }
   }
 
@@ -213,46 +227,220 @@ public class DatanodeAdminMonitor implements DatanodeAdminMonitorInterface {
 
   private void processCancelledNodes() {
     while(!cancelledNodes.isEmpty()) {
-      DatanodeAdminNodeDetails dn = cancelledNodes.poll();
-      trackedNodes.remove(dn);
+      stopTrackingNode(cancelledNodes.poll());
       // TODO - fire event to bring node back into service?
     }
   }
 
   private void processPendingNodes() {
     while(!pendingNodes.isEmpty()) {
-      DatanodeAdminNodeDetails dn = pendingNodes.poll();
-      // Trigger event to async close the node pipelines.
-      eventQueue.fireEvent(SCMEvents.START_ADMIN_ON_NODE,
-          dn.getDatanodeDetails());
-      trackedNodes.add(dn);
+      startTrackingNode(pendingNodes.poll());
     }
   }
 
-  private void checkPipelinesClosed() {
+  private void processTransitioningNodes() {
     for (DatanodeAdminNodeDetails dn : trackedNodes) {
-      if (dn.getCurrentState() != States.CLOSE_PIPELINES) {
-        continue;
-      }
-      DatanodeDetails dnd = dn.getDatanodeDetails();
-      Set<PipelineID> pipelines = nodeManager.getPipelines(dnd);
-      if (pipelines == null || pipelines.size() == 0) {
-        NodeStatus nodeStatus = nodeManager.getNodeStatus(dnd);
-        try {
-          dn.transitionState(workflowSM, nodeStatus.getOperationalState());
-        } catch (InvalidStateTransitionException e) {
-          LOG.warn("Unexpected state transition", e);
-          // TODO - how to handle this? This means the node is not in
-          //        an expected state, eg it is IN_SERVICE when it should be
-          //        decommissioning, so should we abort decom altogether for it?
-          //        This could happen if a node is queued for cancel and not yet
-          //        processed.
+      try {
+        if (!shouldContinueWorkflow(dn)) {
+          abortWorkflow(dn);
+          continue;
         }
-      } else {
-        LOG.info("Waiting for pipelines to close for {}. There are {} "+
-            "pipelines", dnd, pipelines.size());
+        if (dn.getCurrentState() == States.CLOSE_PIPELINES) {
+          checkPipelinesClosedOnNode(dn);
+        }
+        if (dn.getCurrentState() == States.REPLICATE_CONTAINERS) {
+          checkContainersOnNode(dn);
+        }
+        if (dn.getCurrentState() == States.AWAIT_MAINTENANCE_END) {
+          checkMaintenanceEndOnNode(dn);
+        }
+        if (dn.getCurrentState() == States.COMPLETE) {
+          handleCompletedNode(dn);
+        }
+      } catch (NodeNotFoundException | InvalidStateTransitionException e) {
+        LOG.error("An unexpected error occurred processing datanode {}. "+
+            "Aborting the admin workflow", dn.getDatanodeDetails(), e);
+        abortWorkflow(dn);
       }
     }
+    while(!completedNodes.isEmpty()) {
+      DatanodeAdminNodeDetails dn = completedNodes.poll();
+      stopTrackingNode(dn);
+    }
+  }
+
+  /**
+   * Checks if a node is in an unexpected state or has gone dead while
+   * decommissioning or entering maintenance. If the node is not in a valid
+   * state to continue the admin workflow, return false, otherwise return true.
+   * @param dn The Datanode for which to check the current state
+   * @return True if admin can continue, false otherwise
+   * @throws NodeNotFoundException
+   */
+  private boolean shouldContinueWorkflow(DatanodeAdminNodeDetails dn)
+      throws NodeNotFoundException {
+    NodeStatus nodeStatus = getNodeStatus(dn.getDatanodeDetails());
+    if (!nodeStatus.isDecommission() && !nodeStatus.isMaintenance()) {
+      LOG.warn("Datanode {} has an operational state of {} when it should "+
+              "be undergoing decommission or maintenance. Aborting admin for "+
+              "this node.",
+          dn.getDatanodeDetails(), nodeStatus.getOperationalState());
+      return false;
+    }
+    if (nodeStatus.isDead() && !nodeStatus.isInMaintenance()) {
+      LOG.error("Datanode {} is dead but is not IN_MAINTENANCE. Aborting the "+
+          "admin workflow for this node", dn.getDatanodeDetails());
+      return false;
+    }
+    return true;
+  }
+
+  private void checkPipelinesClosedOnNode(DatanodeAdminNodeDetails dn)
+      throws InvalidStateTransitionException, NodeNotFoundException {
+    DatanodeDetails dnd = dn.getDatanodeDetails();
+    Set<PipelineID> pipelines = nodeManager.getPipelines(dnd);
+    if (pipelines == null || pipelines.size() == 0
+        || dn.shouldMaintenanceEnd()) {
+      completeStage(dn);
+    } else {
+      LOG.info("Waiting for pipelines to close for {}. There are {} "+
+          "pipelines", dnd, pipelines.size());
+    }
+  }
+
+  private void checkContainersOnNode(DatanodeAdminNodeDetails dn)
+      throws NodeNotFoundException, InvalidStateTransitionException {
+    int sufficientlyReplicated = 0;
+    int underReplicated = 0;
+    int unhealthy = 0;
+    Set<ContainerID> containers =
+        nodeManager.getContainers(dn.getDatanodeDetails());
+    for(ContainerID cid : containers) {
+      try {
+        ContainerReplicaCount replicaSet =
+            replicationManager.getContainerReplicaCount(cid);
+        if (replicaSet.isSufficientlyReplicated()) {
+          sufficientlyReplicated++;
+        } else {
+          underReplicated++;
+        }
+        if (!replicaSet.isHealthy()) {
+          unhealthy++;
+        }
+      } catch (ContainerNotFoundException e) {
+        LOG.warn("ContainerID {} present in node list for {} but not found "+
+            "in containerManager", cid, dn.getDatanodeDetails());
+      }
+    }
+    dn.setSufficientlyReplicatedContainers(sufficientlyReplicated);
+    dn.setUnderReplicatedContainers(underReplicated);
+    dn.setUnHealthyContainers(unhealthy);
+    if (getNodeStatus(dn.getDatanodeDetails()).isDead()) {
+      // If the node is dead, we cannot continue decommission so we abort
+      LOG.warn("Datanode {} has been marked as dead and the decommission "+
+          "workflow cannot continue.", dn.getDatanodeDetails());
+      abortWorkflow(dn);
+    } else if ((underReplicated == 0 && unhealthy == 0)
+        || dn.shouldMaintenanceEnd()) {
+      completeStage(dn);
+    }
+  }
+
+  private void checkMaintenanceEndOnNode(DatanodeAdminNodeDetails dn)
+      throws InvalidStateTransitionException, NodeNotFoundException {
+    // Move the node to IN_MAINTENANCE if it is not already at that state
+    if (!getNodeStatus(dn.getDatanodeDetails()).isInMaintenance()) {
+      setNodeOpState(dn, NodeOperationalState.IN_MAINTENANCE);
+    }
+    if (dn.shouldMaintenanceEnd()) {
+      completeStage(dn);
+    }
+  }
+
+  private void handleCompletedNode(DatanodeAdminNodeDetails dn)
+      throws NodeNotFoundException {
+    DatanodeDetails dnd = dn.getDatanodeDetails();
+    NodeStatus nodeStatus = getNodeStatus(dnd);
+    if (nodeStatus.isDecommission()) {
+      completeDecommission(dn, nodeStatus);
+    } else if (nodeStatus.isMaintenance()) {
+      completeMaintenance(dn, nodeStatus);
+    } else {
+      // Node must already be IN_SERVICE
+      LOG.warn("Datanode {} has completed the admin workflow but already has "+
+          "an operationalState of {}", dnd, nodeStatus.getOperationalState());
+    }
+    completedNodes.add(dn);
+  }
+
+  private void completeDecommission(DatanodeAdminNodeDetails dn,
+      NodeStatus nodeStatus) throws NodeNotFoundException{
+    if (nodeStatus.isAlive()) {
+      setNodeOpState(dn, NodeOperationalState.DECOMMISSIONED);
+      LOG.info("Datanode {} has completed the admin workflow. The operational "+
+          "state has been set to {}", dn.getDatanodeDetails(),
+          NodeOperationalState.DECOMMISSIONED);
+    } else {
+      // We cannot move a dead node to decommissioned, as it may not have
+      // replicated all its containers before it was marked as dead and they
+      // were all removed from the node manager. The node will have been
+      // handled as a dead node and here we should set it back to IN_SERVICE
+      LOG.warn("Datanode {} is not alive and therefore cannot complete "+
+          "decommission. The operational state has been set to {}",
+          dn.getDatanodeDetails(), NodeOperationalState.IN_SERVICE);
+      putNodeBackInService(dn);
+    }
+  }
+
+  private void completeMaintenance(DatanodeAdminNodeDetails dn,
+      NodeStatus nodeStatus) throws NodeNotFoundException {
+    // The end state of Maintenance is to put the node back IN_SERVICE, whether
+    // it is dead or not.
+    // TODO - if the node is dead do we trigger a dead node event here or leave
+    //        it to the heartbeat manager?
+    putNodeBackInService(dn);
+  }
+
+  private void startTrackingNode(DatanodeAdminNodeDetails dn) {
+    eventQueue.fireEvent(SCMEvents.START_ADMIN_ON_NODE,
+        dn.getDatanodeDetails());
+    trackedNodes.add(dn);
+  }
+
+  private void stopTrackingNode(DatanodeAdminNodeDetails dn) {
+    trackedNodes.remove(dn);
+  }
+
+  /**
+   * If we encounter an unexpected condition in maintenance, we must abort the
+   * workflow by setting the node operationalState back to IN_SERVICE and then
+   * remove the node from tracking.
+   * @param dn The datanode for which to abort tracking
+   */
+  private void abortWorkflow(DatanodeAdminNodeDetails dn) {
+    try {
+      putNodeBackInService(dn);
+    } catch (NodeNotFoundException e) {
+      LOG.error("Unable to set the node OperationalState for {} while "+
+          "aborting the datanode admin workflow", dn.getDatanodeDetails());
+    }
+    completedNodes.add(dn);
+  }
+
+  private void completeStage(DatanodeAdminNodeDetails dn)
+      throws InvalidStateTransitionException, NodeNotFoundException {
+    NodeStatus nodeStatus = getNodeStatus(dn.getDatanodeDetails());
+    dn.transitionState(workflowSM, nodeStatus.getOperationalState());
+  }
+
+  private void putNodeBackInService(DatanodeAdminNodeDetails dn)
+      throws NodeNotFoundException {
+    setNodeOpState(dn, NodeOperationalState.IN_SERVICE);
+  }
+
+  private void setNodeOpState(DatanodeAdminNodeDetails dn,
+      HddsProtos.NodeOperationalState state) throws NodeNotFoundException {
+    nodeManager.setNodeOperationalState(dn.getDatanodeDetails(), state);
   }
 
   /**
@@ -263,20 +451,28 @@ public class DatanodeAdminMonitor implements DatanodeAdminMonitorInterface {
     Set<States> finalStates = new HashSet<>();
     workflowSM = new StateMachine<>(States.CLOSE_PIPELINES, finalStates);
     workflowSM.addTransition(States.CLOSE_PIPELINES,
-        States.GET_CONTAINERS, Transitions.COMPLETE_DECOM_STAGE);
-    workflowSM.addTransition(States.GET_CONTAINERS, States.REPLICATE_CONTAINERS,
-        Transitions.COMPLETE_DECOM_STAGE);
+        States.REPLICATE_CONTAINERS, Transitions.COMPLETE_DECOM_STAGE);
     workflowSM.addTransition(States.REPLICATE_CONTAINERS, States.COMPLETE,
         Transitions.COMPLETE_DECOM_STAGE);
 
     workflowSM.addTransition(States.CLOSE_PIPELINES,
-        States.GET_CONTAINERS, Transitions.COMPLETE_MAINT_STAGE);
-    workflowSM.addTransition(States.GET_CONTAINERS, States.REPLICATE_CONTAINERS,
-        Transitions.COMPLETE_MAINT_STAGE);
+        States.REPLICATE_CONTAINERS, Transitions.COMPLETE_MAINT_STAGE);
     workflowSM.addTransition(States.REPLICATE_CONTAINERS,
         States.AWAIT_MAINTENANCE_END, Transitions.COMPLETE_MAINT_STAGE);
     workflowSM.addTransition(States.AWAIT_MAINTENANCE_END,
         States.COMPLETE, Transitions.COMPLETE_MAINT_STAGE);
+  }
+
+  // TODO - The nodeManager.getNodeStatus call should really throw
+  //        NodeNotFoundException rather than having to handle it here as all
+  //        registered nodes must have a status.
+  private NodeStatus getNodeStatus(DatanodeDetails dnd)
+      throws NodeNotFoundException {
+    NodeStatus nodeStatus = nodeManager.getNodeStatus(dnd);
+    if (nodeStatus == null) {
+      throw new NodeNotFoundException("Unable to retrieve the nodeStatus");
+    }
+    return nodeStatus;
   }
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorInterface.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorInterface.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.node;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.container.ReplicationManager;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 
@@ -32,6 +33,7 @@ public interface DatanodeAdminMonitorInterface extends Runnable {
   void setEventQueue(EventPublisher scm);
   void setNodeManager(NodeManager nm);
   void setPipelineManager(PipelineManager pm);
+  void setReplicationManager(ReplicationManager rm);
   void startMonitoring(DatanodeDetails dn, int endInHours);
   void stopMonitoring(DatanodeDetails dn);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminNodeDetails.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminNodeDetails.java
@@ -19,9 +19,6 @@ package org.apache.hadoop.hdds.scm.node;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
-import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
-import org.apache.hadoop.ozone.common.statemachine.StateMachine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +31,6 @@ import org.slf4j.LoggerFactory;
 public class DatanodeAdminNodeDetails {
   private DatanodeDetails datanodeDetails;
   private long maintenanceEndTime;
-  private DatanodeAdminMonitor.States currentState;
   private long enteredStateAt = 0;
   private int unHealthyContainers = 0;
   private int underReplicatedContainers = 0;
@@ -51,11 +47,9 @@ public class DatanodeAdminNodeDetails {
    *                       should end automatically. Passing zero indicates
    *                       indicates maintenance will never end automatically.
    */
-  DatanodeAdminNodeDetails(DatanodeDetails dn,
-      DatanodeAdminMonitor.States initialState, long maintenanceEnd) {
+  DatanodeAdminNodeDetails(DatanodeDetails dn, long maintenanceEnd) {
     datanodeDetails = dn;
     setMaintenanceEnd(maintenanceEnd);
-    currentState = initialState;
     enteredStateAt = System.currentTimeMillis();
   }
 
@@ -95,14 +89,6 @@ public class DatanodeAdminNodeDetails {
   }
 
   /**
-   * Get the current admin workflow state for this node.
-   * @return The current Admin workflow state for this node
-   */
-  public DatanodeAdminMonitor.States getCurrentState() {
-    return currentState;
-  }
-
-  /**
    * Set the number of hours after which maintenance should end. Passing zero
    * indicates maintenance will never end automatically. It is possible to pass
    * a negative number of hours can be passed for testing purposes.
@@ -118,47 +104,6 @@ public class DatanodeAdminNodeDetails {
     // Convert hours to ms
     long msFromNow = hoursFromNow * 60L * 60L * 1000L;
     maintenanceEndTime = System.currentTimeMillis() + msFromNow;
-  }
-
-  /**
-   * Given the workflow stateMachine and the current node status
-   * (DECOMMISSIONING or ENTERING_MAINTENANCE) move the node to the next
-   * admin workflow state.
-   * @param sm The stateMachine which controls the state flow
-   * @param nodeOperationalState The current operational state for the node, eg
-   *                             decommissioning or entering_maintenance
-   * @return
-   * @throws InvalidStateTransitionException
-   */
-  public DatanodeAdminMonitor.States transitionState(
-      StateMachine<DatanodeAdminMonitor.States,
-          DatanodeAdminMonitor.Transitions> sm,
-      NodeOperationalState nodeOperationalState)
-      throws InvalidStateTransitionException {
-
-    DatanodeAdminMonitor.States newState = sm.getNextState(currentState,
-        getTransition(nodeOperationalState));
-    long currentTime = System.currentTimeMillis();
-    LOG.info("Datanode {} moved from admin workflow state {} to {} after {} "+
-        "seconds", datanodeDetails, currentState, newState,
-        (currentTime - enteredStateAt)/1000L);
-    currentState = newState;
-    enteredStateAt = currentTime;
-    return currentState;
-  }
-
-  private DatanodeAdminMonitor.Transitions getTransition(
-      NodeOperationalState nodeState) {
-    if (nodeState == NodeOperationalState.DECOMMISSIONED ||
-        nodeState == NodeOperationalState.DECOMMISSIONING) {
-      return DatanodeAdminMonitor.Transitions.COMPLETE_DECOM_STAGE;
-    } else if (nodeState ==
-        NodeOperationalState.ENTERING_MAINTENANCE ||
-        nodeState == NodeOperationalState.IN_MAINTENANCE) {
-      return DatanodeAdminMonitor.Transitions.COMPLETE_MAINT_STAGE;
-    } else {
-      return DatanodeAdminMonitor.Transitions.UNEXPECTED_NODE_STATE;
-    }
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminNodeDetails.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminNodeDetails.java
@@ -36,6 +36,9 @@ public class DatanodeAdminNodeDetails {
   private long maintenanceEndTime;
   private DatanodeAdminMonitor.States currentState;
   private long enteredStateAt = 0;
+  private int unHealthyContainers = 0;
+  private int underReplicatedContainers = 0;
+  private int sufficientlyReplicatedContainers = 0;
 
   private static final Logger LOG =
       LoggerFactory.getLogger(DatanodeAdminNodeDetails.class);
@@ -65,6 +68,30 @@ public class DatanodeAdminNodeDetails {
 
   public DatanodeDetails getDatanodeDetails() {
     return datanodeDetails;
+  }
+
+  public void setUnHealthyContainers(int val) {
+    this.unHealthyContainers = val;
+  }
+
+  public void setUnderReplicatedContainers(int val) {
+    this.underReplicatedContainers = val;
+  }
+
+  public void setSufficientlyReplicatedContainers(int val) {
+    this.sufficientlyReplicatedContainers = val;
+  }
+
+  public int getUnHealthyContainers()  {
+    return unHealthyContainers;
+  }
+
+  public int getUnderReplicatedContainers() {
+    return underReplicatedContainers;
+  }
+
+  public int getSufficientlyReplicatedContainers() {
+    return sufficientlyReplicatedContainers;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStatus.java
@@ -130,6 +130,26 @@ public class NodeStatus {
     return health == HddsProtos.NodeState.HEALTHY;
   }
 
+  /**
+   * Returns true if the nodeStatus is either healthy or stale and false
+   * otherwise.
+   *
+   * @return True is the node is Healthy or Stale, false otherwise.
+   */
+  public boolean isAlive() {
+    return health == HddsProtos.NodeState.HEALTHY
+        || health == HddsProtos.NodeState.STALE;
+  }
+
+  /**
+   * Returns true if the nodeStatus is dead and false otherwise.
+   *
+   * @return True is the node is Dead, false otherwise.
+   */
+  public boolean isDead() {
+    return health == HddsProtos.NodeState.DEAD;
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -340,7 +340,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
         pipelineManager);
 
     scmDecommissionManager = new NodeDecommissionManager(conf, scmNodeManager,
-        pipelineManager, containerManager, eventQueue);
+        pipelineManager, containerManager, eventQueue, replicationManager);
 
     eventQueue.addHandler(SCMEvents.DATANODE_COMMAND, scmNodeManager);
     eventQueue.addHandler(SCMEvents.RETRIABLE_DATANODE_COMMAND, scmNodeManager);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -315,7 +315,8 @@ public class TestBlockManager {
 
     // create pipelines
     for (int i = 0;
-         i < nodeManager.getNodes(NodeStatus.inServiceHealthy()).size(); i++) {
+         i < nodeManager.getNodes(NodeStatus.inServiceHealthy()).size()
+             / factor.getNumber(); i++) {
       pipelineManager.createPipeline(type, factor);
     }
     TestUtils.openAllRatisPipelines(pipelineManager);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -1,0 +1,284 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container;
+
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
+import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeMetric;
+import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.apache.hadoop.ozone.protocol.VersionResponse;
+import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
+import org.apache.hadoop.ozone.protocol.commands.RegisteredCommand;
+import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Basic implementation of the NodeManager interface which can be used in tests.
+ *
+ * TODO - Merge the functionality with MockNodeManager, as it needs refactored
+ *        after the introduction of decommission and maintenance states.
+ */
+public class SimpleMockNodeManager implements NodeManager {
+
+  private Map<UUID, DatanodeInfo> nodeMap = new ConcurrentHashMap<>();
+  private Map<UUID, Set<PipelineID>> pipelineMap = new ConcurrentHashMap<>();
+  private Map<UUID, Set<ContainerID>> containerMap = new ConcurrentHashMap<>();
+
+  public void register(DatanodeDetails dd, NodeStatus status) {
+    nodeMap.put(dd.getUuid(), new DatanodeInfo(dd, status));
+  }
+
+  public void setNodeStatus(DatanodeDetails dd, NodeStatus status) {
+    DatanodeInfo dni = nodeMap.get(dd.getUuid());
+    dni.setNodeStatus(status);
+  }
+
+  /**
+   * Set the number of pipelines for the given node. This simply generates
+   * new PipelineID objects and places them in a set. No actual pipelines are
+   * created.
+   *
+   * Setting the count to zero effectively deletes the pipelines for the node
+   *
+   * @param dd The DatanodeDetails for which to create the pipelines
+   * @param count The number of pipelines to create or zero to delete all
+   *              pipelines
+   */
+  public void setPipelines(DatanodeDetails dd, int count) {
+    Set<PipelineID> pipelines = new HashSet<>();
+    for (int i=0; i<count; i++) {
+      pipelines.add(PipelineID.randomId());
+    }
+    pipelineMap.put(dd.getUuid(), pipelines);
+  }
+
+  /**
+   * If the given node was registed with the nodeManager, return the
+   * NodeStatus for the node. Otherwise return a NodeStatus of "In Service
+   * and Healthy".
+   * @param datanodeDetails DatanodeDetails
+   * @return The NodeStatus of the node if it is registered, otherwise an
+   *         Inservice and Healthy NodeStatus.
+   */
+  @Override
+  public NodeStatus getNodeStatus(DatanodeDetails datanodeDetails) {
+    DatanodeInfo dni = nodeMap.get(datanodeDetails.getUuid());
+    if (dni != null) {
+      return dni.getNodeStatus();
+    } else {
+      return NodeStatus.inServiceHealthy();
+    }
+  }
+
+  @Override
+  public void setNodeOperationalState(DatanodeDetails dn,
+      HddsProtos.NodeOperationalState newState) throws NodeNotFoundException {
+    DatanodeInfo dni = nodeMap.get(dn.getUuid());
+    if (dni == null) {
+      throw new NodeNotFoundException();
+    }
+    dni.setNodeStatus(
+        new NodeStatus(newState, dni.getNodeStatus().getHealth()));
+  }
+
+  /**
+   * Return the set of PipelineID associated with the given DatanodeDetails.
+   *
+   * If there are no pipelines, null is return, to mirror the behaviour of
+   * SCMNodeManager.
+   *
+   * @param datanodeDetails The datanode for which to return the pipelines
+   * @return A set of PipelineID or null if there are none
+   */
+  @Override
+  public Set<PipelineID> getPipelines(DatanodeDetails datanodeDetails) {
+    Set<PipelineID> p = pipelineMap.get(datanodeDetails.getUuid());
+    if (p == null || p.size() == 0) {
+      return null;
+    } else {
+      return p;
+    }
+  }
+
+  @Override
+  public void setContainers(DatanodeDetails dn,
+      Set<ContainerID> containerIds) throws NodeNotFoundException {
+    containerMap.put(dn.getUuid(), containerIds);
+  }
+
+  /**
+   * Return the set of ContainerID associated with the datanode. If there are no
+   * container present, an empty set is return to mirror the behaviour of
+   * SCMNodeManaer
+   *
+   * @param dn The datanodeDetails for which to return the containers
+   * @return A Set of ContainerID or an empty Set if none are present
+   * @throws NodeNotFoundException
+   */
+  @Override
+  public Set<ContainerID> getContainers(DatanodeDetails dn)
+      throws NodeNotFoundException {
+    // The concrete implementation of this method in SCMNodeManager will return
+    // an empty set if there are no containers, and will never return null.
+    return containerMap
+        .computeIfAbsent(dn.getUuid(), key -> new HashSet<>());
+  }
+
+  /**
+   * Below here, are all auto-generate placeholder methods to implement the
+   * interface.
+   */
+
+  @Override
+  public List<DatanodeDetails> getNodes(NodeStatus nodeStatus) {
+    return null;
+  }
+
+  @Override
+  public List<DatanodeDetails> getNodes(
+      HddsProtos.NodeOperationalState opState, HddsProtos.NodeState health) {
+    return null;
+  }
+
+  @Override
+  public int getNodeCount(NodeStatus nodeStatus) {
+    return 0;
+  }
+
+  @Override
+  public int getNodeCount(HddsProtos.NodeOperationalState opState,
+                          HddsProtos.NodeState health) {
+    return 0;
+  }
+
+  @Override
+  public List<DatanodeDetails> getAllNodes() {
+    return null;
+  }
+
+  @Override
+  public SCMNodeStat getStats() {
+    return null;
+  }
+
+  @Override
+  public Map<DatanodeDetails, SCMNodeStat> getNodeStats() {
+    return null;
+  }
+
+  @Override
+  public SCMNodeMetric getNodeStat(DatanodeDetails datanodeDetails) {
+    return null;
+  }
+
+  @Override
+  public void addPipeline(Pipeline pipeline) {
+  }
+
+  @Override
+  public void removePipeline(Pipeline pipeline) {
+  }
+
+  @Override
+  public void addContainer(DatanodeDetails datanodeDetails,
+      ContainerID containerId) throws NodeNotFoundException {
+  }
+
+
+
+  @Override
+  public void addDatanodeCommand(UUID dnId, SCMCommand command) {
+  }
+
+  @Override
+  public void processNodeReport(DatanodeDetails datanodeDetails,
+      StorageContainerDatanodeProtocolProtos.NodeReportProto nodeReport) {
+  }
+
+  @Override
+  public List<SCMCommand> getCommandQueue(UUID dnID) {
+    return null;
+  }
+
+  @Override
+  public DatanodeDetails getNodeByUuid(String uuid) {
+    return null;
+  }
+
+  @Override
+  public List<DatanodeDetails> getNodesByAddress(String address) {
+    return null;
+  }
+
+  @Override
+  public void close() throws IOException {
+
+  }
+
+  @Override
+  public Map<String, Integer> getNodeCount() {
+    return null;
+  }
+
+  @Override
+  public Map<String, Long> getNodeInfo() {
+    return null;
+  }
+
+  @Override
+  public void onMessage(CommandForDatanode commandForDatanode,
+                        EventPublisher publisher) {
+  }
+
+  @Override
+  public VersionResponse getVersion(
+      StorageContainerDatanodeProtocolProtos.SCMVersionRequestProto
+          versionRequest) {
+    return null;
+  }
+
+  @Override
+  public RegisteredCommand register(DatanodeDetails datanodeDetails,
+      StorageContainerDatanodeProtocolProtos.NodeReportProto nodeReport,
+      StorageContainerDatanodeProtocolProtos.PipelineReportsProto
+      pipelineReport) {
+    return null;
+  }
+
+  @Override
+  public List<SCMCommand> processHeartbeat(DatanodeDetails datanodeDetails) {
+    return null;
+  }
+
+  @Override
+  public Boolean isNodeRegistered(DatanodeDetails datanodeDetails) {
+    return null;
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerReplicaCount.java
@@ -18,24 +18,30 @@
 package org.apache.hadoop.hdds.scm.container.states;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.TestUtils;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.ContainerReplicaCount;
 import org.junit.Before;
 import org.junit.Test;
 import java.util.*;
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
 import static org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.CLOSED;
+import static org.apache.hadoop.hdds.protocol.proto
+    .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.OPEN;
 import static org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State
     .DECOMMISSIONED;
 import static org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State
     .MAINTENANCE;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Class used to test the ContainerReplicaCount class.
@@ -49,28 +55,37 @@ public class TestContainerReplicaCount {
   @Test
   public void testThreeHealthyReplica() {
     Set<ContainerReplica> replica = registerNodes(CLOSED, CLOSED, CLOSED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 3, 2);
     validate(rcnt, true, 0, false);
   }
 
   @Test
   public void testTwoHealthyReplica() {
     Set<ContainerReplica> replica = registerNodes(CLOSED, CLOSED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 3, 2);
     validate(rcnt, false, 1, false);
   }
 
   @Test
   public void testOneHealthyReplica() {
     Set<ContainerReplica> replica = registerNodes(CLOSED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 3, 2);
     validate(rcnt, false, 2, false);
   }
 
   @Test
   public void testTwoHealthyAndInflightAdd() {
+
     Set<ContainerReplica> replica = registerNodes(CLOSED, CLOSED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 1, 0, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 1, 0, 3, 2);
     validate(rcnt, false, 0, false);
   }
 
@@ -82,7 +97,9 @@ public class TestContainerReplicaCount {
    */
   public void testThreeHealthyAndInflightAdd() {
     Set<ContainerReplica> replica = registerNodes(CLOSED, CLOSED, CLOSED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 1, 0, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 1, 0, 3, 2);
     validate(rcnt, true, 0, false);
   }
 
@@ -93,7 +110,9 @@ public class TestContainerReplicaCount {
    */
   public void testThreeHealthyAndInflightDelete() {
     Set<ContainerReplica> replica = registerNodes(CLOSED, CLOSED, CLOSED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 1, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 1, 3, 2);
     validate(rcnt, false, 1, false);
   }
 
@@ -104,7 +123,9 @@ public class TestContainerReplicaCount {
    */
   public void testThreeHealthyAndInflightAddAndInFlightDelete() {
     Set<ContainerReplica> replica = registerNodes(CLOSED, CLOSED, CLOSED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 1, 1, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 1, 1, 3, 2);
     validate(rcnt, false, 0, false);
   }
 
@@ -112,7 +133,9 @@ public class TestContainerReplicaCount {
   public void testFourHealthyReplicas() {
     Set<ContainerReplica> replica =
         registerNodes(CLOSED, CLOSED, CLOSED, CLOSED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 3, 2);
     validate(rcnt, true, -1, true);
   }
 
@@ -120,7 +143,9 @@ public class TestContainerReplicaCount {
   public void testFourHealthyReplicasAndInFlightDelete() {
     Set<ContainerReplica> replica =
         registerNodes(CLOSED, CLOSED, CLOSED, CLOSED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 1, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 1, 3, 2);
     validate(rcnt, true, 0, false);
   }
 
@@ -128,28 +153,36 @@ public class TestContainerReplicaCount {
   public void testFourHealthyReplicasAndTwoInFlightDelete() {
     Set<ContainerReplica> replica =
         registerNodes(CLOSED, CLOSED, CLOSED, CLOSED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 2, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 2, 3, 2);
     validate(rcnt, false, 1, false);
   }
 
   @Test
   public void testOneHealthyReplicaRepFactorOne() {
     Set<ContainerReplica> replica = registerNodes(CLOSED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 1, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 1, 2);
     validate(rcnt, true, 0, false);
   }
 
   @Test
   public void testOneHealthyReplicaRepFactorOneInFlightDelete() {
     Set<ContainerReplica> replica = registerNodes(CLOSED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 1, 1, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 1, 1, 2);
     validate(rcnt, false, 1, false);
   }
 
   @Test
   public void testTwoHealthyReplicaTwoInflightAdd() {
     Set<ContainerReplica> replica = registerNodes(CLOSED, CLOSED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 2, 0, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 2, 0, 3, 2);
     validate(rcnt, false, 0, false);
   }
 
@@ -161,7 +194,9 @@ public class TestContainerReplicaCount {
   public void testThreeHealthyAndTwoDecommission() {
     Set<ContainerReplica> replica = registerNodes(CLOSED, CLOSED, CLOSED,
         DECOMMISSIONED, DECOMMISSIONED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 3, 2);
     validate(rcnt, true, 0, false);
   }
 
@@ -169,7 +204,9 @@ public class TestContainerReplicaCount {
   public void testOneDecommissionedReplica() {
     Set<ContainerReplica> replica =
         registerNodes(CLOSED, CLOSED, DECOMMISSIONED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 3, 2);
     validate(rcnt, false, 1, false);
   }
 
@@ -177,7 +214,9 @@ public class TestContainerReplicaCount {
   public void testTwoHealthyOneDecommissionedneInFlightAdd() {
     Set<ContainerReplica> replica =
         registerNodes(CLOSED, CLOSED, DECOMMISSIONED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 1, 0, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 1, 0, 3, 2);
     validate(rcnt, false, 0, false);
   }
 
@@ -185,28 +224,37 @@ public class TestContainerReplicaCount {
   public void testAllDecommissioned() {
     Set<ContainerReplica> replica =
         registerNodes(DECOMMISSIONED, DECOMMISSIONED, DECOMMISSIONED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 3, 2);
     validate(rcnt, false, 3, false);
   }
 
   @Test
   public void testAllDecommissionedRepFactorOne() {
     Set<ContainerReplica> replica = registerNodes(DECOMMISSIONED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 1, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 1, 2);
     validate(rcnt, false, 1, false);
+
   }
 
   @Test
   public void testAllDecommissionedRepFactorOneInFlightAdd() {
     Set<ContainerReplica> replica = registerNodes(DECOMMISSIONED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 1, 0, 1, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 1, 0, 1, 2);
     validate(rcnt, false, 0, false);
   }
 
   @Test
   public void testOneHealthyOneDecommissioningRepFactorOne() {
     Set<ContainerReplica> replica = registerNodes(DECOMMISSIONED, CLOSED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 1, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 1, 2);
     validate(rcnt, true, 0, false);
   }
 
@@ -218,7 +266,9 @@ public class TestContainerReplicaCount {
   public void testOneHealthyTwoMaintenanceMinRepOfTwo() {
     Set<ContainerReplica> replica =
         registerNodes(CLOSED, MAINTENANCE, MAINTENANCE);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 3, 2);
     validate(rcnt, false, 1, false);
   }
 
@@ -226,7 +276,9 @@ public class TestContainerReplicaCount {
   public void testOneHealthyThreeMaintenanceMinRepOfTwo() {
     Set<ContainerReplica> replica = registerNodes(CLOSED,
         MAINTENANCE, MAINTENANCE, MAINTENANCE);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 3, 2);
     validate(rcnt, false, 1, false);
   }
 
@@ -234,7 +286,9 @@ public class TestContainerReplicaCount {
   public void testOneHealthyTwoMaintenanceMinRepOfOne() {
     Set<ContainerReplica> replica =
         registerNodes(CLOSED, MAINTENANCE, MAINTENANCE);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 1);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 3, 1);
     validate(rcnt, true, 0, false);
   }
 
@@ -242,7 +296,9 @@ public class TestContainerReplicaCount {
   public void testOneHealthyThreeMaintenanceMinRepOfTwoInFlightAdd() {
     Set<ContainerReplica> replica = registerNodes(CLOSED,
         MAINTENANCE, MAINTENANCE, MAINTENANCE);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 1, 0, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 1, 0, 3, 2);
     validate(rcnt, false, 0, false);
   }
 
@@ -250,7 +306,9 @@ public class TestContainerReplicaCount {
   public void testAllMaintenance() {
     Set<ContainerReplica> replica =
         registerNodes(MAINTENANCE, MAINTENANCE, MAINTENANCE);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 3, 2);
     validate(rcnt, false, 2, false);
   }
 
@@ -263,7 +321,9 @@ public class TestContainerReplicaCount {
   public void testThreeHealthyTwoInMaintenance() {
     Set<ContainerReplica> replica = registerNodes(CLOSED, CLOSED, CLOSED,
         MAINTENANCE, MAINTENANCE);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 3, 2);
     validate(rcnt, true, 0, false);
   }
 
@@ -276,28 +336,36 @@ public class TestContainerReplicaCount {
   public void testFourHealthyOneInMaintenance() {
     Set<ContainerReplica> replica =
         registerNodes(CLOSED, CLOSED, CLOSED, CLOSED, MAINTENANCE);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 3, 2);
     validate(rcnt, true, -1, true);
   }
 
   @Test
   public void testOneMaintenanceMinRepOfTwoRepFactorOne() {
     Set<ContainerReplica> replica = registerNodes(MAINTENANCE);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 1, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 1, 2);
     validate(rcnt, false, 1, false);
   }
 
   @Test
   public void testOneMaintenanceMinRepOfTwoRepFactorOneInFlightAdd() {
     Set<ContainerReplica> replica = registerNodes(MAINTENANCE);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 1, 0, 1, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 1, 0, 1, 2);
     validate(rcnt, false, 0, false);
   }
 
   @Test
   public void testOneHealthyOneMaintenanceRepFactorOne() {
     Set<ContainerReplica> replica = registerNodes(MAINTENANCE, CLOSED);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 0, 0, 1, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 1, 2);
     validate(rcnt, true, 0, false);
   }
 
@@ -305,13 +373,47 @@ public class TestContainerReplicaCount {
   public void testTwoDecomTwoMaintenanceOneInflightAdd() {
     Set<ContainerReplica> replica =
         registerNodes(DECOMMISSIONED, DECOMMISSIONED, MAINTENANCE, MAINTENANCE);
-    ContainerReplicaCount rcnt = new ContainerReplicaCount(replica, 1, 0, 3, 2);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 1, 0, 3, 2);
     validate(rcnt, false, 1, false);
   }
 
+  @Test
+  public void testHealthyContainerIsHealthy() {
+    Set<ContainerReplica> replica =
+        registerNodes(CLOSED, CLOSED, CLOSED);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 3, 2);
+    assertTrue(rcnt.isHealthy());
+  }
+
+  @Test
+  public void testIsHealthyWithDifferentReplicaStateNotHealthy() {
+    Set<ContainerReplica> replica =
+        registerNodes(CLOSED, CLOSED, OPEN);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 3, 2);
+    assertFalse(rcnt.isHealthy());
+  }
+
+  @Test
+  public void testIsHealthyWithMaintReplicaIsHealthy() {
+    Set<ContainerReplica> replica =
+        registerNodes(CLOSED, CLOSED, MAINTENANCE, MAINTENANCE);
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 3, 2);
+    assertTrue(rcnt.isHealthy());
+  }
+
   private void validate(ContainerReplicaCount rcnt,
-      boolean sufficientlyReplicated, int replicaDelta, boolean overRelicated) {
+      boolean sufficientlyReplicated, int replicaDelta,
+      boolean overReplicated) {
     assertEquals(sufficientlyReplicated, rcnt.isSufficientlyReplicated());
+    assertEquals(overReplicated, rcnt.isOverReplicated());
     assertEquals(replicaDelta, rcnt.additionalReplicaNeeded());
   }
 
@@ -329,5 +431,12 @@ public class TestContainerReplicaCount {
           .build());
     }
     return replica;
+  }
+
+  private ContainerInfo createContainer(HddsProtos.LifeCycleState state) {
+    return new ContainerInfo.Builder()
+        .setContainerID(new ContainerID(1).getId())
+        .setState(state)
+        .build();
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
@@ -55,12 +55,13 @@ public class TestDatanodeAdminMonitor {
   private DatanodeAdminMonitor monitor;
   private DatanodeAdminHandler startAdminHandler;
   private ReplicationManager repManager;
+  private EventQueue eventQueue;
 
   @Before
   public void setup() throws IOException, AuthenticationException {
     conf = new OzoneConfiguration();
 
-    EventQueue eventQueue = new EventQueue();
+    eventQueue = new EventQueue();
     startAdminHandler = new DatanodeAdminHandler();
     eventQueue.addHandler(SCMEvents.START_ADMIN_ON_NODE, startAdminHandler);
 
@@ -111,6 +112,7 @@ public class TestDatanodeAdminMonitor {
     monitor.startMonitoring(dn1, 0);
     monitor.run();
     // Ensure a StartAdmin event was fired
+    eventQueue.processAll(20000);
     assertEquals(1, startAdminHandler.getInvocation());
     // Ensure a node is now tracked for decommission
     assertEquals(1, monitor.getTrackedNodeCount());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
@@ -17,95 +17,61 @@
  */
 package org.apache.hadoop.hdds.scm.node;
 
-import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
-import org.apache.hadoop.hdds.scm.HddsTestUtils;
+import org.apache.hadoop.hdds.protocol.proto
+    .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.TestUtils;
-import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.container.*;
+import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
-import org.apache.hadoop.hdds.scm.pipeline.MockRatisPipelineProvider;
-import org.apache.hadoop.hdds.scm.pipeline.PipelineProvider;
-import org.apache.hadoop.hdds.scm.pipeline.SCMPipelineManager;
-import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.hdds.server.events.EventHandler;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-
+import org.mockito.Mockito;
 import java.io.IOException;
-import java.util.UUID;
-import java.util.concurrent.TimeoutException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.mockito.Mockito.reset;
 
 /**
- * Tests to ensure the DatanodeAdminMonitor is working correctly.
+ * Tests to ensure the DatanodeAdminMonitor is working correctly. This class
+ * uses mocks or basic implementations of the key classes outside of the
+ * datanodeAdminMonitor to allow it to be tested in isolation.
  */
 public class TestDatanodeAdminMonitor {
 
-  private StorageContainerManager scm;
-  private NodeManager nodeManager;
-  private ContainerManager containerManager;
-  private SCMPipelineManager pipelineManager;
+  private SimpleMockNodeManager nodeManager;
   private OzoneConfiguration conf;
   private DatanodeAdminMonitor monitor;
-  private DatanodeDetails datanode1;
-  private DatanodeDetails datanode2;
-  private DatanodeDetails datanode3;
+  private DatanodeAdminHandler startAdminHandler;
+  private ReplicationManager repManager;
 
   @Before
   public void setup() throws IOException, AuthenticationException {
-    // This creates a mocked cluster of 6 nodes, where there are mock pipelines
-    // etc. Borrows heavily from TestDeadNodeHandler.
     conf = new OzoneConfiguration();
-    String storageDir = GenericTestUtils.getTempPath(
-        TestDeadNodeHandler.class.getSimpleName() + UUID.randomUUID());
-    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, storageDir);
 
-    scm = HddsTestUtils.getScm(conf);
-    nodeManager = scm.getScmNodeManager();
-    pipelineManager = (SCMPipelineManager)scm.getPipelineManager();
-    containerManager = scm.getContainerManager();
+    EventQueue eventQueue = new EventQueue();
+    startAdminHandler = new DatanodeAdminHandler();
+    eventQueue.addHandler(SCMEvents.START_ADMIN_ON_NODE, startAdminHandler);
+
+    nodeManager = new SimpleMockNodeManager();
+
+    repManager = Mockito.mock(ReplicationManager.class);
 
     monitor = new DatanodeAdminMonitor(conf);
-    monitor.setEventQueue(scm.getEventQueue());
+    monitor.setEventQueue(eventQueue);
     monitor.setNodeManager(nodeManager);
-    monitor.setPipelineManager(pipelineManager);
-
-    PipelineProvider mockRatisProvider =
-        new MockRatisPipelineProvider(nodeManager,
-            pipelineManager.getStateManager(), conf);
-    pipelineManager.setPipelineProvider(HddsProtos.ReplicationType.RATIS,
-        mockRatisProvider);
-
-    datanode1 = TestUtils.randomDatanodeDetails();
-    datanode2 = TestUtils.randomDatanodeDetails();
-    datanode3 = TestUtils.randomDatanodeDetails();
-
-    String storagePath = GenericTestUtils.getRandomizedTempPath()
-        .concat("/" + datanode1.getUuidString());
-
-    StorageContainerDatanodeProtocolProtos.StorageReportProto
-        storageOne = TestUtils.createStorageReport(
-        datanode1.getUuid(), storagePath, 100, 10, 90, null);
-
-    nodeManager.register(datanode1,
-        TestUtils.createNodeReport(storageOne), null);
-    nodeManager.register(datanode2,
-        TestUtils.createNodeReport(storageOne), null);
-    nodeManager.register(datanode3,
-        TestUtils.createNodeReport(storageOne), null);
-    nodeManager.register(TestUtils.randomDatanodeDetails(),
-        TestUtils.createNodeReport(storageOne), null);
-    nodeManager.register(TestUtils.randomDatanodeDetails(),
-        TestUtils.createNodeReport(storageOne), null);
-    nodeManager.register(TestUtils.randomDatanodeDetails(),
-        TestUtils.createNodeReport(storageOne), null);
+    monitor.setReplicationManager(repManager);
   }
 
   @After
@@ -125,42 +91,428 @@ public class TestDatanodeAdminMonitor {
     monitor.startMonitoring(dn, 0);
     assertEquals(1, monitor.getPendingCount());
     assertEquals(0, monitor.getCancelledCount());
-
   }
 
-
+  /**
+   * In this test we ensure there are some pipelines for the node being
+   * decommissioned, but there are no containers. Therefore the workflow
+   * must wait until the piplines have closed before completing the decommission
+   * flow.
+   */
   @Test
-  @Ignore // HDDS-2631
-  public void testMonitoredNodeHasPipelinesClosed()
-      throws NodeNotFoundException, TimeoutException, InterruptedException {
-
-    GenericTestUtils.waitFor(() -> nodeManager
-        .getPipelines(datanode1).size() == 2, 100, 20000);
-
-    nodeManager.setNodeOperationalState(datanode1,
-        HddsProtos.NodeOperationalState.DECOMMISSIONING);
-    monitor.startMonitoring(datanode1, 0);
+  public void testClosePipelinesEventFiredWhenAdminStarted() {
+    DatanodeDetails dn1 = TestUtils.randomDatanodeDetails();
+    nodeManager.register(dn1,
+        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+            HddsProtos.NodeState.HEALTHY));
+    // Ensure the node has some pipelines
+    nodeManager.setPipelines(dn1, 2);
+    // Add the node to the monitor
+    monitor.startMonitoring(dn1, 0);
     monitor.run();
-    // Ensure the node moves from pending to tracked
-    assertEquals(0, monitor.getPendingCount());
+    // Ensure a StartAdmin event was fired
+    assertEquals(1, startAdminHandler.getInvocation());
+    // Ensure a node is now tracked for decommission
     assertEquals(1, monitor.getTrackedNodeCount());
-
-    // Ensure the pipelines are closed, as this is the first step in the admin
-    // workflow
-    GenericTestUtils.waitFor(() -> nodeManager
-        .getPipelines(datanode1).size() == 0, 100, 20000);
-
-    // Run the run loop again and ensure the tracked node is moved to the next
-    // state
+    // Ensure the node at the CLOSE_PIPELINES state
+    assertEquals(DatanodeAdminMonitor.States.CLOSE_PIPELINES,
+        getFirstTrackedNode().getCurrentState());
+    // Run the monitor again, and it should remain in CLOSE_PIPELINES state
     monitor.run();
-    for (DatanodeAdminNodeDetails node : monitor.getTrackedNodes()) {
-      assertEquals(
-          DatanodeAdminMonitor.States.GET_CONTAINERS, node.getCurrentState());
-    }
-    // Finally, cancel decommission and see the node is removed from tracking
-    monitor.stopMonitoring(datanode1);
+    assertEquals(DatanodeAdminMonitor.States.CLOSE_PIPELINES,
+        getFirstTrackedNode().getCurrentState());
+    // Clear the pipelines and the node should transition to the next state
+    nodeManager.setPipelines(dn1, 0);
     monitor.run();
     assertEquals(0, monitor.getTrackedNodeCount());
+    NodeStatus newStatus = nodeManager.getNodeStatus(dn1);
+    assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONED,
+        newStatus.getOperationalState());
   }
 
+  /**
+   * In this test, there are no open pipelines and no containers on the node.
+   * Therefore, we expect the decommission flow to finish on the first run
+   * on the monitor, leaving zero nodes tracked and the node in DECOMMISSIONED
+   * state.
+   */
+  @Test
+  public void testDecommissionNodeTransitionsToCompleteWhenNoContainers() {
+    DatanodeDetails dn1 = TestUtils.randomDatanodeDetails();
+    nodeManager.register(dn1,
+        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+            HddsProtos.NodeState.HEALTHY));
+
+    // Add the node to the monitor. By default we have zero pipelines and
+    // zero containers in the test setup, so the node should immediately
+    // transition to COMPLETED state
+    monitor.startMonitoring(dn1, 0);
+    monitor.run();
+    assertEquals(0, monitor.getTrackedNodeCount());
+    NodeStatus newStatus = nodeManager.getNodeStatus(dn1);
+    assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONED,
+        newStatus.getOperationalState());
+  }
+
+  @Test
+  public void testDecommissionNodeWaitsForContainersToReplicate()
+      throws NodeNotFoundException, ContainerNotFoundException {
+    DatanodeDetails dn1 = TestUtils.randomDatanodeDetails();
+    nodeManager.register(dn1,
+        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+            HddsProtos.NodeState.HEALTHY));
+
+    nodeManager.setContainers(dn1, generateContainers(3));
+    // Mock Replication Manager to return ContainerReplicaCount's which
+    // always have a DECOMMISSIONED replica.
+    mockGetContainerReplicaCount(
+        HddsProtos.LifeCycleState.CLOSED,
+        ContainerReplicaProto.State.DECOMMISSIONED,
+        ContainerReplicaProto.State.CLOSED,
+        ContainerReplicaProto.State.CLOSED);
+
+    // Run the monitor for the first time and the node will transition to
+    // REPLICATE_CONTAINERS as there are no pipelines to close.
+    monitor.startMonitoring(dn1, 0);
+    monitor.run();
+    DatanodeAdminNodeDetails node = getFirstTrackedNode();
+    assertEquals(1, monitor.getTrackedNodeCount());
+    assertEquals(DatanodeAdminMonitor.States.REPLICATE_CONTAINERS,
+        node.getCurrentState());
+
+    // Running the monitor again causes it to remain at replicate_containers
+    // as nothing has changed.
+    monitor.run();
+    assertEquals(DatanodeAdminMonitor.States.REPLICATE_CONTAINERS,
+        node.getCurrentState());
+    assertEquals(0, node.getSufficientlyReplicatedContainers());
+    assertEquals(0, node.getUnHealthyContainers());
+    assertEquals(3, node.getUnderReplicatedContainers());
+
+    // Now change the replicationManager mock to return 3 CLOSED replicas
+    // and the node should complete the REPLICATE_CONTAINERS step, moving to
+    // complete which will end the decommission workflow
+    mockGetContainerReplicaCount(
+        HddsProtos.LifeCycleState.CLOSED,
+        ContainerReplicaProto.State.CLOSED,
+        ContainerReplicaProto.State.CLOSED,
+        ContainerReplicaProto.State.CLOSED);
+
+    monitor.run();
+
+    assertEquals(0, monitor.getTrackedNodeCount());
+    assertEquals(3, node.getSufficientlyReplicatedContainers());
+    assertEquals(0, node.getUnHealthyContainers());
+    assertEquals(0, node.getUnderReplicatedContainers());
+    NodeStatus newStatus = nodeManager.getNodeStatus(dn1);
+    assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONED,
+        newStatus.getOperationalState());
+  }
+
+  @Test
+  public void testDecommissionAbortedWhenNodeInUnexpectedState()
+      throws NodeNotFoundException, ContainerNotFoundException {
+    DatanodeDetails dn1 = TestUtils.randomDatanodeDetails();
+    nodeManager.register(dn1,
+        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+            HddsProtos.NodeState.HEALTHY));
+
+    nodeManager.setContainers(dn1, generateContainers(3));
+    mockGetContainerReplicaCount(
+        HddsProtos.LifeCycleState.CLOSED,
+        ContainerReplicaProto.State.DECOMMISSIONED,
+        ContainerReplicaProto.State.CLOSED,
+        ContainerReplicaProto.State.CLOSED);
+
+    // Add the node to the monitor, it should have 3 under-replicated containers
+    // after the first run
+    monitor.startMonitoring(dn1, 0);
+    monitor.run();
+    assertEquals(1, monitor.getTrackedNodeCount());
+    DatanodeAdminNodeDetails node = getFirstTrackedNode();
+    assertEquals(DatanodeAdminMonitor.States.REPLICATE_CONTAINERS,
+        node.getCurrentState());
+    assertEquals(3, node.getUnderReplicatedContainers());
+
+    // Set the node to dead, and then the workflow should get aborted, setting
+    // the node state back to IN_SERVICE on the next run.
+    nodeManager.setNodeStatus(dn1,
+        new NodeStatus(HddsProtos.NodeOperationalState.IN_SERVICE,
+            HddsProtos.NodeState.HEALTHY));
+    monitor.run();
+    assertEquals(0, monitor.getTrackedNodeCount());
+    NodeStatus newStatus = nodeManager.getNodeStatus(dn1);
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        newStatus.getOperationalState());
+  }
+
+  @Test
+  public void testDecommissionAbortedWhenNodeGoesDead()
+      throws NodeNotFoundException, ContainerNotFoundException {
+    DatanodeDetails dn1 = TestUtils.randomDatanodeDetails();
+    nodeManager.register(dn1,
+        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+            HddsProtos.NodeState.HEALTHY));
+
+    nodeManager.setContainers(dn1, generateContainers(3));
+    mockGetContainerReplicaCount(
+        HddsProtos.LifeCycleState.CLOSED,
+        ContainerReplicaProto.State.DECOMMISSIONED,
+        ContainerReplicaProto.State.CLOSED,
+        ContainerReplicaProto.State.CLOSED);
+
+    // Add the node to the monitor, it should have 3 under-replicated containers
+    // after the first run
+    monitor.startMonitoring(dn1, 0);
+    monitor.run();
+    assertEquals(1, monitor.getTrackedNodeCount());
+    DatanodeAdminNodeDetails node = getFirstTrackedNode();
+    assertEquals(DatanodeAdminMonitor.States.REPLICATE_CONTAINERS,
+        node.getCurrentState());
+    assertEquals(3, node.getUnderReplicatedContainers());
+
+    // Set the node to dead, and then the workflow should get aborted, setting
+    // the node state back to IN_SERVICE.
+    nodeManager.setNodeStatus(dn1,
+        new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
+            HddsProtos.NodeState.DEAD));
+    monitor.run();
+    assertEquals(0, monitor.getTrackedNodeCount());
+    NodeStatus newStatus = nodeManager.getNodeStatus(dn1);
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        newStatus.getOperationalState());
+  }
+
+  @Test
+  public void testMaintenanceWaitsForMaintenanceToComplete() {
+    DatanodeDetails dn1 = TestUtils.randomDatanodeDetails();
+    nodeManager.register(dn1,
+        new NodeStatus(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+            HddsProtos.NodeState.HEALTHY));
+
+    // Add the node to the monitor, it should transiting to
+    // AWAIT_MAINTENANCE_END as there are no under-replicated containers.
+    // The operational state should also goto IN_MAINTENANCE
+    monitor.startMonitoring(dn1, 1);
+    monitor.run();
+    assertEquals(1, monitor.getTrackedNodeCount());
+    DatanodeAdminNodeDetails node = getFirstTrackedNode();
+    assertEquals(DatanodeAdminMonitor.States.AWAIT_MAINTENANCE_END,
+        node.getCurrentState());
+    assertEquals(0, node.getUnderReplicatedContainers());
+    assertTrue(nodeManager.getNodeStatus(dn1).isInMaintenance());
+
+    // Running the monitor again causes the node to remain in maintenance
+    monitor.run();
+    assertEquals(1, monitor.getTrackedNodeCount());
+    assertEquals(DatanodeAdminMonitor.States.AWAIT_MAINTENANCE_END,
+        node.getCurrentState());
+    assertTrue(nodeManager.getNodeStatus(dn1).isInMaintenance());
+
+    // Set the maintenance end time to a time in the past and then the node
+    // should complete the workflow and transition to IN_SERVICE
+    node.setMaintenanceEnd(-1);
+    monitor.run();
+    assertEquals(0, monitor.getTrackedNodeCount());
+    NodeStatus newStatus = nodeManager.getNodeStatus(dn1);
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        newStatus.getOperationalState());
+  }
+
+  @Test
+  public void testMaintenanceEndsClosingPipelines() {
+    DatanodeDetails dn1 = TestUtils.randomDatanodeDetails();
+    nodeManager.register(dn1,
+        new NodeStatus(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+            HddsProtos.NodeState.HEALTHY));
+    // Ensure the node has some pipelines
+    nodeManager.setPipelines(dn1, 2);
+    // Add the node to the monitor
+    monitor.startMonitoring(dn1, 1);
+    monitor.run();
+    DatanodeAdminNodeDetails node = getFirstTrackedNode();
+    assertEquals(1, monitor.getTrackedNodeCount());
+    assertEquals(DatanodeAdminMonitor.States.CLOSE_PIPELINES,
+        node.getCurrentState());
+
+    // Set the maintenance end time to the past and the node should complete
+    // the workflow and return to IN_SERVICE
+    node.setMaintenanceEnd(-1);
+    monitor.run();
+    assertEquals(0, monitor.getTrackedNodeCount());
+    NodeStatus newStatus = nodeManager.getNodeStatus(dn1);
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        newStatus.getOperationalState());
+  }
+
+  @Test
+  public void testMaintenanceEndsWhileReplicatingContainers()
+      throws ContainerNotFoundException, NodeNotFoundException {
+    DatanodeDetails dn1 = TestUtils.randomDatanodeDetails();
+    nodeManager.register(dn1,
+        new NodeStatus(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+            HddsProtos.NodeState.HEALTHY));
+
+    nodeManager.setContainers(dn1, generateContainers(3));
+    mockGetContainerReplicaCount(
+        HddsProtos.LifeCycleState.CLOSED,
+        ContainerReplicaProto.State.MAINTENANCE,
+        ContainerReplicaProto.State.MAINTENANCE,
+        ContainerReplicaProto.State.MAINTENANCE);
+
+    // Add the node to the monitor, it should transiting to
+    // REPLICATE_CONTAINERS as the containers are under-replicated for
+    // maintenance.
+    monitor.startMonitoring(dn1, 1);
+    monitor.run();
+    assertEquals(1, monitor.getTrackedNodeCount());
+    DatanodeAdminNodeDetails node = getFirstTrackedNode();
+    assertEquals(DatanodeAdminMonitor.States.REPLICATE_CONTAINERS,
+        node.getCurrentState());
+    assertEquals(3, node.getUnderReplicatedContainers());
+
+    node.setMaintenanceEnd(-1);
+    monitor.run();
+    assertEquals(0, monitor.getTrackedNodeCount());
+    NodeStatus newStatus = nodeManager.getNodeStatus(dn1);
+    assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
+        newStatus.getOperationalState());
+  }
+
+  @Test
+  public void testDeadMaintenanceNodeDoesNotAbortWorkflow() {
+    DatanodeDetails dn1 = TestUtils.randomDatanodeDetails();
+    nodeManager.register(dn1,
+        new NodeStatus(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
+            HddsProtos.NodeState.HEALTHY));
+
+    // Add the node to the monitor, it should transiting to
+    // AWAIT_MAINTENANCE_END as there are no under-replicated containers.
+    monitor.startMonitoring(dn1, 1);
+    monitor.run();
+    assertEquals(1, monitor.getTrackedNodeCount());
+    DatanodeAdminNodeDetails node = getFirstTrackedNode();
+    assertEquals(DatanodeAdminMonitor.States.AWAIT_MAINTENANCE_END,
+        node.getCurrentState());
+    assertEquals(0, node.getUnderReplicatedContainers());
+
+    // Set the node dead and ensure the workflow does not end
+    NodeStatus status = nodeManager.getNodeStatus(dn1);
+    nodeManager.setNodeStatus(dn1, new NodeStatus(
+        status.getOperationalState(), HddsProtos.NodeState.DEAD));
+
+    // Running the monitor again causes the node to remain in maintenance
+    monitor.run();
+    assertEquals(1, monitor.getTrackedNodeCount());
+    assertEquals(DatanodeAdminMonitor.States.AWAIT_MAINTENANCE_END,
+        node.getCurrentState());
+  }
+
+  /**
+   * Generate a set of ContainerID, starting from an ID of zero up to the given
+   * count minus 1.
+   * @param count The number of ContainerID objects to generate.
+   * @return A Set of ContainerID objects.
+   */
+  private Set<ContainerID> generateContainers(int count) {
+    Set<ContainerID> containers = new HashSet<>();
+    for (int i=0; i<count; i++) {
+      containers.add(new ContainerID(i));
+    }
+    return containers;
+  }
+
+  /**
+   * Create a ContainerReplicaCount object, including a container with the
+   * requested ContainerID and state, along with a set of replicas of the given
+   * states.
+   * @param containerID The ID of the container to create an included
+   * @param containerState The state of the container
+   * @param states Create a replica for each of the given states.
+   * @return A ContainerReplicaCount containing the generated container and
+   *         replica set
+   */
+  private ContainerReplicaCount generateReplicaCount(ContainerID containerID,
+      HddsProtos.LifeCycleState containerState,
+      ContainerReplicaProto.State... states) {
+    Set<ContainerReplica> replicas = new HashSet<>();
+    for (ContainerReplicaProto.State s : states) {
+      replicas.add(generateReplica(containerID, s));
+    }
+    ContainerInfo container = new ContainerInfo.Builder()
+        .setContainerID(containerID.getId())
+        .setState(containerState)
+        .build();
+
+    return new ContainerReplicaCount(container, replicas, 0, 0, 3, 2);
+  }
+
+  /**
+   * Generate a new ContainerReplica with the given containerID and State.
+   * @param containerID The ID the replica is associated with
+   * @param state The state of the generated replica.
+   * @return A containerReplica with the given ID and state
+   */
+  private ContainerReplica generateReplica(ContainerID containerID,
+      ContainerReplicaProto.State state) {
+    return ContainerReplica.newBuilder()
+        .setContainerState(state)
+        .setContainerID(containerID)
+        .setSequenceId(1)
+        .setDatanodeDetails(TestUtils.randomDatanodeDetails())
+        .build();
+  }
+
+  /**
+   * Helper method to get the first node from the set of trackedNodes within
+   * the monitor.
+   * @return DatanodeAdminNodeDetails for the first tracked node found.
+   */
+  private DatanodeAdminNodeDetails getFirstTrackedNode() {
+    return
+        monitor.getTrackedNodes().toArray(new DatanodeAdminNodeDetails[0])[0];
+  }
+
+  /**
+   * The only interaction the DatanodeAdminMonitor has with the
+   * ReplicationManager, is to request a ContainerReplicaCount object for each
+   * container on nodes being deocmmissioned or moved to maintenance. This
+   * method mocks that interface to return a ContainerReplicaCount with a
+   * container in the given containerState and a set of replias in the given
+   * replicaStates.
+   * @param containerState
+   * @param replicaStates
+   * @throws ContainerNotFoundException
+   */
+  private void mockGetContainerReplicaCount(
+      HddsProtos.LifeCycleState containerState,
+      ContainerReplicaProto.State... replicaStates)
+      throws ContainerNotFoundException {
+    reset(repManager);
+    Mockito.when(repManager.getContainerReplicaCount(
+        Mockito.any(ContainerID.class)))
+        .thenAnswer(invocation ->
+            generateReplicaCount((ContainerID)invocation.getArguments()[0],
+                containerState, replicaStates));
+  }
+
+  /**
+   * This simple internal class is used to track and handle any DatanodeAdmin
+   * events fired by the DatanodeAdminMonitor during tests.
+   */
+  private class DatanodeAdminHandler implements
+      EventHandler<DatanodeDetails> {
+
+    private AtomicInteger invocation = new AtomicInteger(0);
+
+    @Override
+    public void onMessage(final DatanodeDetails dn,
+                          final EventPublisher publisher) {
+      invocation.incrementAndGet();
+    }
+
+    public int getInvocation() {
+      return invocation.get();
+    }
+  }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminNodeDetails.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminNodeDetails.java
@@ -93,12 +93,6 @@ public class TestDatanodeAdminNodeDetails {
     assertEquals(DatanodeAdminMonitor.States.CLOSE_PIPELINES,
         details.getCurrentState());
 
-    // Next State is GET_CONTAINERS
-    details.transitionState(monitor.getWorkflowStateMachine(),
-        NodeOperationalState.DECOMMISSIONING);
-    assertEquals(DatanodeAdminMonitor.States.GET_CONTAINERS,
-        details.getCurrentState());
-
     // Next State is REPLICATE_CONTAINERS
     details.transitionState(monitor.getWorkflowStateMachine(),
         NodeOperationalState.DECOMMISSIONING);
@@ -121,12 +115,6 @@ public class TestDatanodeAdminNodeDetails {
 
     // Initial state should be CLOSE_PIPELINES
     assertEquals(DatanodeAdminMonitor.States.CLOSE_PIPELINES,
-        details.getCurrentState());
-
-    // Next State is GET_CONTAINERS
-    details.transitionState(monitor.getWorkflowStateMachine(),
-        NodeOperationalState.ENTERING_MAINTENANCE);
-    assertEquals(DatanodeAdminMonitor.States.GET_CONTAINERS,
         details.getCurrentState());
 
     // Next State is REPLICATE_CONTAINER

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminNodeDetails.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminNodeDetails.java
@@ -20,9 +20,6 @@ package org.apache.hadoop.hdds.scm.node;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.TestUtils;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
-import
-    org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 
 import org.junit.After;
 import org.junit.Before;
@@ -39,8 +36,6 @@ public class TestDatanodeAdminNodeDetails {
 
   private OzoneConfiguration conf;
   private DatanodeAdminMonitor monitor;
-  private final DatanodeAdminMonitor.States initialState =
-      DatanodeAdminMonitor.States.CLOSE_PIPELINES;
 
   @Before
   public void setup() {
@@ -57,91 +52,23 @@ public class TestDatanodeAdminNodeDetails {
     DatanodeDetails dn1 = TestUtils.randomDatanodeDetails();
     DatanodeDetails dn2 = TestUtils.randomDatanodeDetails();
     DatanodeAdminNodeDetails details1 =
-        new DatanodeAdminNodeDetails(dn1, initialState, 0);
+        new DatanodeAdminNodeDetails(dn1, 0);
     DatanodeAdminNodeDetails details2 =
-        new DatanodeAdminNodeDetails(dn2, initialState, 0);
+        new DatanodeAdminNodeDetails(dn2, 0);
 
     assertNotEquals(details1, details2);
     assertEquals(details1,
-        new DatanodeAdminNodeDetails(dn1, initialState, 0));
+        new DatanodeAdminNodeDetails(dn1, 0));
     assertNotEquals(details1, dn1);
   }
 
-  @Test
-  public void testUnexpectedNodeStateGivesBadTransition() {
-    DatanodeDetails dn = TestUtils.randomDatanodeDetails();
-    DatanodeAdminNodeDetails details =
-        new DatanodeAdminNodeDetails(dn, initialState, 0);
 
-    try {
-      details.transitionState(monitor.getWorkflowStateMachine(),
-          NodeOperationalState.IN_SERVICE);
-      fail("InvalidStateTransitionException should be thrown");
-    } catch (InvalidStateTransitionException e) {
-
-    }
-  }
-
-  @Test
-  public void testWorkflowStatesTransitionCorrectlyForDecom()
-      throws InvalidStateTransitionException {
-    DatanodeDetails dn = TestUtils.randomDatanodeDetails();
-    DatanodeAdminNodeDetails details = new DatanodeAdminNodeDetails(dn,
-        initialState, 0);
-
-    // Initial state should be CLOSE_PIPELINES
-    assertEquals(DatanodeAdminMonitor.States.CLOSE_PIPELINES,
-        details.getCurrentState());
-
-    // Next State is REPLICATE_CONTAINERS
-    details.transitionState(monitor.getWorkflowStateMachine(),
-        NodeOperationalState.DECOMMISSIONING);
-    assertEquals(DatanodeAdminMonitor.States.REPLICATE_CONTAINERS,
-        details.getCurrentState());
-
-    // Next State is COMPLETE
-    details.transitionState(monitor.getWorkflowStateMachine(),
-        NodeOperationalState.DECOMMISSIONING);
-    assertEquals(DatanodeAdminMonitor.States.COMPLETE,
-        details.getCurrentState());
-  }
-
-  @Test
-  public void testWorkflowStatesTransitionCorrectlyForMaint()
-      throws InvalidStateTransitionException {
-    DatanodeDetails dn = TestUtils.randomDatanodeDetails();
-    DatanodeAdminNodeDetails details = new DatanodeAdminNodeDetails(dn,
-        initialState, 0);
-
-    // Initial state should be CLOSE_PIPELINES
-    assertEquals(DatanodeAdminMonitor.States.CLOSE_PIPELINES,
-        details.getCurrentState());
-
-    // Next State is REPLICATE_CONTAINER
-    details.transitionState(monitor.getWorkflowStateMachine(),
-        NodeOperationalState.ENTERING_MAINTENANCE);
-    assertEquals(DatanodeAdminMonitor.States.REPLICATE_CONTAINERS,
-        details.getCurrentState());
-
-    // Next State is AWAIT_MAINTENANCE_END
-    details.transitionState(monitor.getWorkflowStateMachine(),
-        NodeOperationalState.ENTERING_MAINTENANCE);
-    assertEquals(DatanodeAdminMonitor.States.AWAIT_MAINTENANCE_END,
-        details.getCurrentState());
-
-    // Next State is COMPLETE
-    details.transitionState(monitor.getWorkflowStateMachine(),
-        NodeOperationalState.ENTERING_MAINTENANCE);
-    assertEquals(DatanodeAdminMonitor.States.COMPLETE,
-        details.getCurrentState());
-  }
 
   @Test
   public void testMaintenanceEnd() {
     DatanodeDetails dn = TestUtils.randomDatanodeDetails();
     // End in zero hours - should never end.
-    DatanodeAdminNodeDetails details = new DatanodeAdminNodeDetails(dn,
-        initialState, 0);
+    DatanodeAdminNodeDetails details = new DatanodeAdminNodeDetails(dn, 0);
     assertFalse(details.shouldMaintenanceEnd());
 
     // End 1 hour - maintenance should not end yet.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
@@ -55,7 +55,8 @@ public class TestNodeDecommissionManager {
         TestDeadNodeHandler.class.getSimpleName() + UUID.randomUUID());
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, storageDir);
     nodeManager = createNodeManager(conf);
-    decom = new NodeDecommissionManager(conf, nodeManager, null, null, null);
+    decom = new NodeDecommissionManager(
+        conf, nodeManager, null, null, null, null);
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
@@ -162,6 +162,7 @@ public class TestNodeDecommissionManager {
     // Recommission all 3 hosts
     decom.recommissionNodes(Arrays.asList(
         multiAddr, dns.get(1).getIpAddress(), dns.get(2).getIpAddress()));
+    decom.getMonitor().run();
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
         nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
@@ -200,6 +201,7 @@ public class TestNodeDecommissionManager {
     // Recommission all 3 hosts
     decom.recommissionNodes(Arrays.asList(
         multiAddr, dns.get(1).getIpAddress(), dns.get(2).getIpAddress()));
+    decom.getMonitor().run();
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
         nodeManager.getNodeStatus(dns.get(1)).getOperationalState());
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR builds on HDDS-2459 and chances the DatanodeAdminMonitor to use the newly provided ContainerReplicaCount object to track the under replicated containers on a node and move the node to the next stages in the decommission / maintenance workflow when they are all sufficiently replicated.

Once the replication is completed, the node will be moved to either complete (ending the decommission process) or go into a pending state waiting on maintenance to complete.

This PR is a significant refactor of the DatanodeAdminMonitor, but previously it was incomplete so the bulk of the code is new.

There are also a few minor refactors to other classes:

 * Removed the isHealthy() method from ReplicationManager and put it into ContainerReplicaCounts.
 * Pulled SimpleMockNodeManager into its own class (previously an inner class in TestReplicationManager) and enhanced it somewhat. HDDS-2673 is raised to consider merging it with MockNodeManager
 * ContainerReplicaCount now also takes a container object inorder to implement the isHealthy method.
 * TestDatanodeAdminMonitor now mocks all dependencies to allow for simpler and faster tests, avoiding MiniCluster.

Note that these changes do not consider the new commands which must be sent to the Datanodes to change their admin state as part of HDDS-2592. Those enhancement will be made as part of that Jira.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2593

## How was this patch tested?

Various new unit tests have been added.
