### PR TITLE
HDDS-2532. Sonar : fix issues in OzoneQuota

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
@@ -92,11 +92,8 @@ public class OzoneQuota {
    * @param quotaString Quota String
    *
    * @return OzoneQuota object
-   *
-   * @throws IllegalArgumentException
    */
-  public static OzoneQuota parseQuota(String quotaString)
-      throws IllegalArgumentException {
+  public static OzoneQuota parseQuota(String quotaString) {
 
     if ((quotaString == null) || (quotaString.isEmpty())) {
       throw new IllegalArgumentException(
@@ -136,10 +133,11 @@ public class OzoneQuota {
       found = true;
     }
 
-    if (!found) {
-      throw new IllegalArgumentException(
-          "Quota unit not recognized. Supported values are BYTES, MB, GB and " +
-              "TB.");
+    if (Boolean.FALSE.equals(found)) {
+      String exceptionInfo =
+          "Quota unit not recognized. " +
+          "Supported values are BYTES, MB, GB and TB.";
+      throw new IllegalArgumentException(exceptionInfo);
     }
 
     nSize = Integer.parseInt(size);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
@@ -104,7 +104,7 @@ public class OzoneQuota {
     String size = "";
     int nSize;
     Units currUnit = Units.MB;
-    Boolean found = false;
+    boolean found = false;
     if (uppercase.endsWith(OZONE_QUOTA_MB)) {
       size = uppercase
           .substring(0, uppercase.length() - OZONE_QUOTA_MB.length());
@@ -133,7 +133,7 @@ public class OzoneQuota {
       found = true;
     }
 
-    if (Boolean.FALSE.equals(found)) {
+    if (!found) {
       String exceptionInfo =
           "Quota unit not recognized. " +
           "Supported values are BYTES, MB, GB and TB.";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
@@ -134,10 +134,8 @@ public class OzoneQuota {
     }
 
     if (!found) {
-      String exceptionInfo =
-          "Quota unit not recognized. " +
-          "Supported values are BYTES, MB, GB and TB.";
-      throw new IllegalArgumentException(exceptionInfo);
+      throw new IllegalArgumentException("Quota unit not recognized. " +
+          "Supported values are BYTES, MB, GB and TB.");
     }
 
     nSize = Integer.parseInt(size);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix 1.
```IllegalArgumentException``` extends ```RuntimeException```.
We can not throws it cause the kind of ```exception``` would not be checked while compiling.

Fix 2.
When boxed type ```Boolean``` is used as an expression it will throw ```NullPointerException``` if the value is null.
It is safer to avoid such conversion.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2532

## How was this patch tested?
Ran on my standalone cluster.