### PR TITLE
HDDS-2677. Acceptance test may fail despite success status

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/basic/basic.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/basic.robot
@@ -30,6 +30,6 @@ Check webui static resources
                        Should contain         ${result}    200
 
 Start freon testing
-    ${result} =        Execute              ozone freon randomkeys --numOfVolumes 5 --numOfBuckets 5 --numOfKeys 5 --numOfThreads 1 --replicationType RATIS --factor THREE
+    ${result} =        Execute              ozone freon randomkeys --numOfVolumes 5 --numOfBuckets 5 --numOfKeys 5 --numOfThreads 1 --replicationType RATIS --factor THREE --validateWrites
                        Wait Until Keyword Succeeds      3min       10sec     Should contain   ${result}   Number of Keys added: 125
-                       Should Not Contain               ${result}  ERROR
+                       Should Contain                   ${result}  Status: Success


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Let Freon-based acceptance test case pass/fail depending on Freon result (success/failure) instead of occurrence of `ERROR` in Freon output/log.
 * Enable `validateWrites` to double-check the keys are successfully written.

https://issues.apache.org/jira/browse/HDDS-2677

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/335194308