### PR TITLE
HDDS-2555. Handle InterruptedException in XceiverClientGrpc

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -234,6 +234,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     } catch (ExecutionException e) {
       throw new IOException("Failed to execute command " + request, e);
     } catch (InterruptedException e) {
+      LOG.error("Command execution was interrupted ", e);
       Thread.currentThread().interrupt();
       return null;
     }
@@ -250,6 +251,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     } catch (ExecutionException e) {
       throw new IOException("Failed to execute command " + request, e);
     } catch (InterruptedException e) {
+      LOG.error("Command execution was interrupted ", e);
       Thread.currentThread().interrupt();
       return null;
     }
@@ -345,6 +347,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
         ioException = new IOException(e);
         responseProto = null;
       } catch (InterruptedException e) {
+        LOG.error("Command execution was interrupted ", e);
         Thread.currentThread().interrupt();
         responseProto = null;
       }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -231,8 +231,11 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     try {
       return sendCommandWithTraceIDAndRetry(request, null).
           getResponse().get();
-    } catch (ExecutionException | InterruptedException e) {
+    } catch (ExecutionException e) {
       throw new IOException("Failed to execute command " + request, e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return null;
     }
   }
 
@@ -244,8 +247,11 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       XceiverClientReply reply;
       reply = sendCommandWithTraceIDAndRetry(request, validators);
       return reply.getResponse().get();
-    } catch (ExecutionException | InterruptedException e) {
+    } catch (ExecutionException e) {
       throw new IOException("Failed to execute command " + request, e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return null;
     }
   }
 
@@ -327,7 +333,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       } catch (IOException e) {
         ioException = e;
         responseProto = null;
-      } catch (ExecutionException | InterruptedException e) {
+      } catch (ExecutionException e) {
         LOG.debug("Failed to execute command {} on datanode {}",
             request, dn.getUuid(), e);
         if (Status.fromThrowable(e.getCause()).getCode()
@@ -337,6 +343,9 @@ public class XceiverClientGrpc extends XceiverClientSpi {
         }
 
         ioException = new IOException(e);
+        responseProto = null;
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         responseProto = null;
       }
     }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -235,6 +235,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     } catch (ExecutionException e) {
       throw new IOException("Failed to execute command " + request, e);
     } catch (InterruptedException e) {
+      LOG.error("Command execution was interrupted.");
       Thread.currentThread().interrupt();
       throw (IOException) new InterruptedIOException(
           "Command " + request + " was interrupted.")
@@ -253,6 +254,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     } catch (ExecutionException e) {
       throw new IOException("Failed to execute command " + request, e);
     } catch (InterruptedException e) {
+      LOG.error("Command execution was interrupted.");
       Thread.currentThread().interrupt();
       throw (IOException) new InterruptedIOException(
           "Command " + request + " was interrupted.")

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -234,9 +234,10 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     } catch (ExecutionException e) {
       throw new IOException("Failed to execute command " + request, e);
     } catch (InterruptedException e) {
-      LOG.error("Command execution was interrupted ", e);
       Thread.currentThread().interrupt();
-      return null;
+      throw (IOException) new InterruptedException(
+          "Command " + request + " was interrupted.")
+          .initCause(e);
     }
   }
 
@@ -251,9 +252,10 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     } catch (ExecutionException e) {
       throw new IOException("Failed to execute command " + request, e);
     } catch (InterruptedException e) {
-      LOG.error("Command execution was interrupted ", e);
       Thread.currentThread().interrupt();
-      return null;
+      throw (IOException) new InterruptedException(
+          "Command " + request + " was interrupted.")
+          .initCause(e);
     }
   }
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -53,6 +53,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.HashMap;
@@ -235,7 +236,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       throw new IOException("Failed to execute command " + request, e);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw (IOException) new InterruptedException(
+      throw (IOException) new InterruptedIOException(
           "Command " + request + " was interrupted.")
           .initCause(e);
     }
@@ -253,7 +254,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       throw new IOException("Failed to execute command " + request, e);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw (IOException) new InterruptedException(
+      throw (IOException) new InterruptedIOException(
           "Command " + request + " was interrupted.")
           .initCause(e);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Sonar: Interrupted current thread to handle InterruptedException

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2555

## How was this patch tested?
Local build was successful.
