### PR TITLE
HDDS-2678. Add thread name to log pattern

### DIFF
--- a/hadoop-ozone/dist/src/shell/conf/log4j.properties
+++ b/hadoop-ozone/dist/src/shell/conf/log4j.properties
@@ -42,9 +42,9 @@ log4j.appender.RFA.MaxBackupIndex=${hadoop.log.maxbackupindex}
 log4j.appender.RFA.layout=org.apache.log4j.PatternLayout
 
 # Pattern format: Date LogLevel LoggerName LogMessage
-log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
+log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} [%t] %p %c: %m%n
 # Debugging Pattern format
-#log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
+#log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M(%L)) - %m%n
 
 
 #
@@ -60,9 +60,9 @@ log4j.appender.DRFA.DatePattern=.yyyy-MM-dd
 log4j.appender.DRFA.layout=org.apache.log4j.PatternLayout
 
 # Pattern format: Date LogLevel LoggerName LogMessage
-log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
+log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} [%t] %p %c: %m%n
 # Debugging Pattern format
-#log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
+#log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M(%L)) - %m%n
 
 
 #
@@ -73,7 +73,7 @@ log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n
+log4j.appender.console.layout.ConversionPattern=%d{ISO8601} [%t] %p %c{2}: %m%n
 
 #
 # TaskLog Appender


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make sure thread name is included in log messages.

https://issues.apache.org/jira/browse/HDDS-2678

## How was this patch tested?

Example:

```
om_1        | 2019-12-05 18:37:44,710 [main] INFO om.OzoneManager: OzoneManager RPC server is listening at om/172.23.0.2:9862
...
om_1        | 2019-12-05 18:38:04,757 [IPC Server handler 4 on 9862] INFO volume.OMVolumeCreateRequest: created volume:vol-0-96689 for user:hadoop
```

https://github.com/adoroszlai/hadoop-ozone/runs/335406247