### PR TITLE
HDDS-2680. Fix updating lastAppliedIndex in OzoneManagerStateMachine.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -187,7 +187,7 @@ public class OzoneManagerDoubleBuffer {
           //  transactions are serialized this should be fine.
           // update the last updated index in OzoneManagerStateMachine.
           ozoneManagerRatisSnapShot.updateLastAppliedIndex(
-              lastRatisTransactionIndex);
+              flushedEpochs);
 
           // set metrics.
           updateMetrics(flushedTransactionsSize);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -182,9 +182,6 @@ public class OzoneManagerDoubleBuffer {
 
           readyBuffer.clear();
 
-          // TODO: Need to revisit this logic, once we have multiple
-          //  executors for volume/bucket request handling. As for now
-          //  transactions are serialized this should be fine.
           // update the last updated index in OzoneManagerStateMachine.
           ozoneManagerRatisSnapShot.updateLastAppliedIndex(
               flushedEpochs);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisSnapshot.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisSnapshot.java
@@ -17,6 +17,8 @@
 
 package org.apache.hadoop.ozone.om.ratis;
 
+import java.util.List;
+
 /**
  * Functional interface for OM RatisSnapshot.
  */
@@ -24,9 +26,9 @@ package org.apache.hadoop.ozone.om.ratis;
 public interface OzoneManagerRatisSnapshot {
 
   /**
-   * Update lastAppliedIndex with the specified value in OzoneManager
-   * StateMachine.
-   * @param lastAppliedIndex
+   * Update lastAppliedIndex in OzoneManager StateMachine.
+   * @param flushedEpochs - list of ratis transaction indexes which are
+   * flushed to DB.
    */
-  void updateLastAppliedIndex(long lastAppliedIndex);
+  void updateLastAppliedIndex(List<Long> flushedEpochs);
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -446,4 +446,9 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
     HadoopExecutors.shutdown(executorService, LOG, 5, TimeUnit.SECONDS);
     HadoopExecutors.shutdown(installSnapshotExecutor, LOG, 5, TimeUnit.SECONDS);
   }
+
+  @VisibleForTesting
+  void addApplyTransactionTermIndex(long term, long index) {
+    applyTransactionMap.put(index, term);
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -23,6 +23,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.ServiceException;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
@@ -77,7 +78,14 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
   private final ExecutorService executorService;
   private final ExecutorService installSnapshotExecutor;
 
+  // Map which contains index and term for the ratis transactions which are
+  // stateMachine entries which are recived through applyTransaction.
   private ConcurrentMap<Long, Long> applyTransactionMap =
+      new ConcurrentSkipListMap<>();
+
+  // Map which contains index and term for the ratis transactions which are
+  // conf/metadata entries which are received through notifyIndexUpdate.
+  private ConcurrentMap<Long, Long> ratisTransactionMap =
       new ConcurrentSkipListMap<>();
 
 
@@ -134,13 +142,13 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
     // SnapshotInfo represents the snapshotIndex i.e. the index of the last
     // transaction included in the snapshot. Hence, snaphsotInfo#index is not
     // updated here.
-    applyTransactionMap.put(index, currentTerm);
+
     // We need to call updateLastApplied here because now in ratis when a
     // node becomes leader, it is checking stateMachineIndex >=
     // placeHolderIndex (when a node becomes leader, it writes a conf entry
     // with some information like its peers and termIndex). So, calling
     // updateLastApplied updates lastAppliedTermIndex.
-    updateLastAppliedIndex(index);
+    updateLastAppliedIndex(index, currentTerm, null, false);
     snapshotInfo.updateTerm(currentTerm);
   }
 
@@ -349,22 +357,51 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
   /**
    * Update lastAppliedIndex term and it's corresponding term in the
    * stateMachine.
-   * @param lastFlushedIndex
+   * @param flushedEpochs
    */
-  public synchronized void updateLastAppliedIndex(long lastFlushedIndex) {
-    Long appliedTerm = null;
-    long appliedIndex = -1;
-    for(long i = getLastAppliedTermIndex().getIndex() + 1;
-        i <= lastFlushedIndex; i++) {
-      final Long removed = applyTransactionMap.remove(i);
-      if (removed == null) {
-        break;
+  public void updateLastAppliedIndex(List<Long> flushedEpochs) {
+    Preconditions.checkArgument(flushedEpochs.size() > 0);
+    updateLastAppliedIndex(flushedEpochs.get(flushedEpochs.size() -1),
+        -1L, flushedEpochs, true);
+  }
+
+  /**
+   * Update State machine lastAppliedTermIndex.
+   * @param lastFlushedIndex
+   * @param currentTerm
+   * @param flushedEpochs - list of ratis transactions flushed to DB. If it
+   * is just one index and term, this can be set to null.
+   * @param checkMap - if true check applyTransactionMap, ratisTransaction
+   * Map and update lastAppliedTermIndex accordingly, else check
+   * lastAppliedTermIndex and update it.
+   */
+  private synchronized void updateLastAppliedIndex(long lastFlushedIndex,
+      long currentTerm, List<Long> flushedEpochs, boolean checkMap) {
+    if (checkMap) {
+      Long appliedTerm = null;
+      long appliedIndex = -1;
+      for (long i = getLastAppliedTermIndex().getIndex() + 1; ; i++) {
+        if (flushedEpochs.contains(i)) {
+          appliedIndex = i;
+          final Long removed = applyTransactionMap.remove(i);
+          appliedTerm = removed;
+        } else if (ratisTransactionMap.containsKey(i)) {
+          final Long removed = ratisTransactionMap.remove(i);
+          appliedTerm = removed;
+          appliedIndex = i;
+        } else {
+          break;
+        }
       }
-      appliedTerm = removed;
-      appliedIndex = i;
-    }
-    if (appliedTerm != null) {
-      updateLastAppliedTermIndex(appliedTerm, appliedIndex);
+      if (appliedTerm != null) {
+        updateLastAppliedTermIndex(appliedTerm, appliedIndex);
+      }
+    } else {
+      if (getLastAppliedTermIndex().getIndex() + 1 == lastFlushedIndex) {
+        updateLastAppliedTermIndex(currentTerm, lastFlushedIndex);
+      } else {
+        ratisTransactionMap.put(lastFlushedIndex, currentTerm);
+      }
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
@@ -69,7 +69,7 @@ public class TestOzoneManagerDoubleBufferWithDummyResponse {
     omMetadataManager =
         new OmMetadataManagerImpl(configuration);
     OzoneManagerRatisSnapshot ozoneManagerRatisSnapshot = index -> {
-      lastAppliedIndex = index;
+      lastAppliedIndex = index.get(index.size() - 1);
     };
     doubleBuffer = new OzoneManagerDoubleBuffer(omMetadataManager,
         ozoneManagerRatisSnapshot);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
@@ -103,7 +103,7 @@ public class TestOzoneManagerDoubleBufferWithOMResponse {
     when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
     Mockito.doNothing().when(auditLogger).logWrite(any(AuditMessage.class));
     ozoneManagerRatisSnapshot = index -> {
-      lastAppliedIndex = index;
+      lastAppliedIndex = index.get(index.size() - 1);
     };
     doubleBuffer = new OzoneManagerDoubleBuffer(omMetadataManager,
         ozoneManagerRatisSnapshot);
@@ -124,7 +124,6 @@ public class TestOzoneManagerDoubleBufferWithOMResponse {
    * @throws Exception
    */
   @Test(timeout = 500_000)
-  @Ignore("see HDDS-2535")
   public void testDoubleBuffer() throws Exception {
     // This test checks whether count in tables are correct or not.
     testDoubleBuffer(1, 10);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
@@ -4,11 +4,9 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
@@ -130,8 +128,71 @@ public class TestOzoneManagerStateMachine {
 
     Assert.assertEquals(0L,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
-    Assert.assertEquals(1L,
+    Assert.assertEquals(5L,
         ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
 
+  }
+
+
+  @Test
+  public void testLastAppliedIndexWithMultipleExecutors() {
+
+    // first flush batch
+    ozoneManagerStateMachine.addApplyTransactionTermIndex(0L, 1L);
+    ozoneManagerStateMachine.addApplyTransactionTermIndex(0L, 2L);
+    ozoneManagerStateMachine.addApplyTransactionTermIndex(0L, 4L);
+
+    List<Long> flushedEpochs = new ArrayList<>();
+
+
+    flushedEpochs.add(1L);
+    flushedEpochs.add(2L);
+    flushedEpochs.add(4L);
+
+    ozoneManagerStateMachine.updateLastAppliedIndex(flushedEpochs);
+
+    Assert.assertEquals(0L,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
+    Assert.assertEquals(2L,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
+
+
+
+
+    // 2nd flush batch
+    ozoneManagerStateMachine.addApplyTransactionTermIndex(0L, 3L);
+    ozoneManagerStateMachine.addApplyTransactionTermIndex(0L, 5L);
+    ozoneManagerStateMachine.addApplyTransactionTermIndex(0L, 6L);
+
+    flushedEpochs.clear();
+    flushedEpochs.add(3L);
+    flushedEpochs.add(5L);
+    flushedEpochs.add(6L);
+
+    ozoneManagerStateMachine.updateLastAppliedIndex(flushedEpochs);
+
+    Assert.assertEquals(0L,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
+    Assert.assertEquals(6L,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
+
+    // 3rd flush batch
+    ozoneManagerStateMachine.addApplyTransactionTermIndex(0L, 7L);
+    ozoneManagerStateMachine.addApplyTransactionTermIndex(0L, 8L);
+    ozoneManagerStateMachine.addApplyTransactionTermIndex(0L, 9L);
+    ozoneManagerStateMachine.addApplyTransactionTermIndex(0L, 10L);
+
+    flushedEpochs.clear();
+    flushedEpochs.add(7L);
+    flushedEpochs.add(8L);
+    flushedEpochs.add(9L);
+    flushedEpochs.add(10L);
+
+    ozoneManagerStateMachine.updateLastAppliedIndex(flushedEpochs);
+
+    Assert.assertEquals(0L,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
+    Assert.assertEquals(10L,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
@@ -1,0 +1,137 @@
+package org.apache.hadoop.ozone.om.ratis;
+
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * Class to test OzoneManagerStateMachine.
+ */
+public class TestOzoneManagerStateMachine {
+
+  private OzoneManagerStateMachine ozoneManagerStateMachine;
+  @Before
+  public void setup() {
+    OzoneManagerRatisServer ozoneManagerRatisServer =
+        Mockito.mock(OzoneManagerRatisServer.class);
+    OzoneManager ozoneManager = Mockito.mock(OzoneManager.class);
+
+    when(ozoneManagerRatisServer.getOzoneManager()).thenReturn(ozoneManager);
+    when(ozoneManager.getSnapshotInfo()).thenReturn(Mockito.mock(OMRatisSnapshotInfo.class));
+    ozoneManagerStateMachine =
+        new OzoneManagerStateMachine(ozoneManagerRatisServer);
+  }
+
+  @Test
+  public void testLastAppliedIndex() {
+
+    // Happy scenario.
+
+    // Conf/metadata transaction.
+    ozoneManagerStateMachine.notifyIndexUpdate(0, 1);
+    Assert.assertEquals(0,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
+    Assert.assertEquals(1,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
+
+    List<Long> flushedEpochs = new ArrayList<>();
+
+    // Add some apply transactions.
+    ozoneManagerStateMachine.addApplyTransactionTermIndex(0, 2);
+    ozoneManagerStateMachine.addApplyTransactionTermIndex(0, 3);
+
+    flushedEpochs.add(2L);
+    flushedEpochs.add(3L);
+
+    // call update last applied index
+    ozoneManagerStateMachine.updateLastAppliedIndex(flushedEpochs);
+
+    Assert.assertEquals(0,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
+    Assert.assertEquals(3,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
+
+    // Conf/metadata transaction.
+    ozoneManagerStateMachine.notifyIndexUpdate(0L, 4L);
+
+    Assert.assertEquals(0L,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
+    Assert.assertEquals(4L,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
+
+    // Add some apply transactions.
+    ozoneManagerStateMachine.addApplyTransactionTermIndex(0L, 5L);
+    ozoneManagerStateMachine.addApplyTransactionTermIndex(0L, 6L);
+
+    flushedEpochs.clear();
+    flushedEpochs.add(5L);
+    flushedEpochs.add(6L);
+    ozoneManagerStateMachine.updateLastAppliedIndex(flushedEpochs);
+
+    Assert.assertEquals(0L,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
+    Assert.assertEquals(6L,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
+
+
+  }
+
+
+  @Test
+  public void testApplyTransactionsUpdateLastAppliedIndexCalledLate() {
+    // Now try a scenario where 1,2,3 transactions are in applyTransactionMap
+    // and updateLastAppliedIndex is not called for them, and before that
+    // notifyIndexUpdate is called with transaction 4. And see now at the end
+    // when updateLastAppliedIndex is called with epochs we have
+    // lastAppliedIndex as 4 or not.
+
+    // Conf/metadata transaction.
+    ozoneManagerStateMachine.notifyIndexUpdate(0, 1);
+    Assert.assertEquals(0,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
+    Assert.assertEquals(1,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
+
+
+
+    ozoneManagerStateMachine.addApplyTransactionTermIndex(0L, 2L);
+    ozoneManagerStateMachine.addApplyTransactionTermIndex(0L, 3L);
+    ozoneManagerStateMachine.addApplyTransactionTermIndex(0L, 4L);
+
+
+
+    // Conf/metadata transaction.
+    ozoneManagerStateMachine.notifyIndexUpdate(0L, 5L);
+
+  // Still it should be zero, as for 2,3,4 updateLastAppliedIndex is not yet
+    // called so the lastAppliedIndex will be at older value.
+    Assert.assertEquals(0L,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
+    Assert.assertEquals(1L,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
+
+    List<Long> flushedEpochs = new ArrayList<>();
+
+
+    flushedEpochs.add(2L);
+    flushedEpochs.add(3L);
+    flushedEpochs.add(4L);
+
+    ozoneManagerStateMachine.updateLastAppliedIndex(flushedEpochs);
+
+    Assert.assertEquals(0L,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getTerm());
+    Assert.assertEquals(1L,
+        ozoneManagerStateMachine.getLastAppliedTermIndex().getIndex());
+
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.hadoop.ozone.om.ratis;
 
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -24,7 +40,8 @@ public class TestOzoneManagerStateMachine {
     OzoneManager ozoneManager = Mockito.mock(OzoneManager.class);
 
     when(ozoneManagerRatisServer.getOzoneManager()).thenReturn(ozoneManager);
-    when(ozoneManager.getSnapshotInfo()).thenReturn(Mockito.mock(OMRatisSnapshotInfo.class));
+    when(ozoneManager.getSnapshotInfo()).thenReturn(
+        Mockito.mock(OMRatisSnapshotInfo.class));
     ozoneManagerStateMachine =
         new OzoneManagerStateMachine(ozoneManagerRatisServer);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This Jira is to fix a bug that has been caused by HDDS-2637.

Now we have applyTransactionMap where we put all entries of ratisTransactionIndex before complete.

And when updating lastAppliedIndex, now there is a chance that we updateLastAppliedIndex before DoubleBuffer flush has committed transactions to DB.


Let's take 1-10 are apply transaction entries which are not flushed, 11th is indexUpdate a metadata/conf entry transaction, now when notifyIndexUpdate is called with 11, we updateLastAppliedIndex to 11. (Which we should not do) This Jira is to fix this issue.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2680

## How was this patch tested?

Trying to add some UT's to test this.
