### PR TITLE
HDDS-2683. Ratis MaxBuffer should be the same size as the segment size.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -168,14 +168,12 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     final RpcType rpc = setRpcType(properties);
 
     // set raft segment size
-    setRaftSegmentSize(properties);
+    setRaftSegmentAndWriteBufferSize(properties);
 
     // set raft segment pre-allocated size
     final int raftSegmentPreallocatedSize =
         setRaftSegmentPreallocatedSize(properties);
 
-    // Set max write buffer size, which is the scm chunk size
-    final int maxChunkSize = setMaxWriteBuffer(properties);
     TimeUnit timeUnit;
     long duration;
 
@@ -215,7 +213,8 @@ public final class XceiverServerRatis implements XceiverServerSpi {
 
     // For grpc set the maximum message size
     GrpcConfigKeys.setMessageSizeMax(properties,
-        SizeInBytes.valueOf(maxChunkSize + raftSegmentPreallocatedSize));
+        SizeInBytes.valueOf(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE
+                + raftSegmentPreallocatedSize));
 
     // Set the ratis port number
     if (rpc == SupportedRpcType.GRPC) {
@@ -346,13 +345,6 @@ public final class XceiverServerRatis implements XceiverServerSpi {
         .setRequestTimeout(properties, serverRequestTimeout);
   }
 
-  private int setMaxWriteBuffer(RaftProperties properties) {
-    final int maxChunkSize = OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE;
-    RaftServerConfigKeys.Log.setWriteBufferSize(properties,
-        SizeInBytes.valueOf(maxChunkSize));
-    return maxChunkSize;
-  }
-
   private int setRaftSegmentPreallocatedSize(RaftProperties properties) {
     final int raftSegmentPreallocatedSize = (int) conf.getStorageSize(
         OzoneConfigKeys.DFS_CONTAINER_RATIS_SEGMENT_PREALLOCATED_SIZE_KEY,
@@ -376,13 +368,15 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     return raftSegmentPreallocatedSize;
   }
 
-  private void setRaftSegmentSize(RaftProperties properties) {
+  private void setRaftSegmentAndWriteBufferSize(RaftProperties properties) {
     final int raftSegmentSize = (int)conf.getStorageSize(
         OzoneConfigKeys.DFS_CONTAINER_RATIS_SEGMENT_SIZE_KEY,
         OzoneConfigKeys.DFS_CONTAINER_RATIS_SEGMENT_SIZE_DEFAULT,
         StorageUnit.BYTES);
     RaftServerConfigKeys.Log.setSegmentSizeMax(properties,
         SizeInBytes.valueOf(raftSegmentSize));
+    RaftServerConfigKeys.Log.setWriteBufferSize(properties,
+            SizeInBytes.valueOf(raftSegmentSize));
   }
 
   private RpcType setRpcType(RaftProperties properties) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

As noticed with RATIS-767, the write buffer is allocated with 32MB size whereas the raft log segment is 1MB. The rest of the buffer will not be used and the memory is wasted allocation.

This jira sets the max buffer size same as segment size.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2683

## How was this patch tested?
Ran MiniOzoneChaosCluster with the new config to ensure data read/write are working fine.
