### PR TITLE
HDDS-2685. Fix Rename API in BasicOzoneFileSystem

### DIFF
--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -377,7 +377,8 @@ public class BasicOzoneFileSystem extends FileSystem {
     }
 
     if (srcStatus.isDirectory()) {
-      if (dstPath.toString().startsWith(srcPath.toString() + OZONE_URI_DELIMITER)) {
+      if (dstPath.toString()
+          .startsWith(srcPath.toString() + OZONE_URI_DELIMITER)) {
         LOG.trace("Cannot rename a directory to a subdirectory of self");
         return false;
       }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -295,7 +295,12 @@ public class BasicOzoneFileSystem extends FileSystem {
   public boolean rename(Path src, Path dst) throws IOException {
     incrementCounter(Statistic.INVOCATION_RENAME);
     statistics.incrementWriteOps(1);
-    if (src.equals(dst)) {
+    super.checkPath(src);
+    super.checkPath(dst);
+
+    String srcPath = src.toUri().getPath();
+    String dstPath = dst.toUri().getPath();
+    if (srcPath.equals(dstPath)) {
       return true;
     }
 
@@ -306,13 +311,6 @@ public class BasicOzoneFileSystem extends FileSystem {
       return false;
     }
 
-    // Cannot rename a directory to its own subdirectory
-    Path dstParent = dst.getParent();
-    while (dstParent != null && !src.equals(dstParent)) {
-      dstParent = dstParent.getParent();
-    }
-    Preconditions.checkArgument(dstParent == null,
-        "Cannot rename a directory to its own subdirectory");
     // Check if the source exists
     FileStatus srcStatus;
     try {
@@ -322,6 +320,15 @@ public class BasicOzoneFileSystem extends FileSystem {
       return false;
     }
 
+    // Cannot rename a directory to its own subdirectory
+    if (srcStatus.isDirectory()) {
+      Path dstParent = dst.getParent();
+      while (dstParent != null && !src.equals(dstParent)) {
+        dstParent = dstParent.getParent();
+      }
+      Preconditions.checkArgument(dstParent == null,
+          "Cannot rename a directory to its own subdirectory");
+    }
     // Check if the destination exists
     FileStatus dstStatus;
     try {
@@ -348,6 +355,7 @@ public class BasicOzoneFileSystem extends FileSystem {
         // If dst is a directory, rename source as subpath of it.
         // for example rename /source to /dst will lead to /dst/source
         dst = new Path(dst, src.getName());
+        dstPath = dst.toUri().getPath();
         FileStatus[] statuses;
         try {
           statuses = listStatus(dst);
@@ -369,7 +377,7 @@ public class BasicOzoneFileSystem extends FileSystem {
     }
 
     if (srcStatus.isDirectory()) {
-      if (dst.toString().startsWith(src.toString() + OZONE_URI_DELIMITER)) {
+      if (dstPath.toString().startsWith(srcPath.toString() + OZONE_URI_DELIMITER)) {
         LOG.trace("Cannot rename a directory to a subdirectory of self");
         return false;
       }
@@ -635,7 +643,7 @@ public class BasicOzoneFileSystem extends FileSystem {
    * @return the key of the object that represents the file.
    */
   public String pathToKey(Path path) {
-    Objects.requireNonNull(path, "Path canf not be null!");
+    Objects.requireNonNull(path, "Path can not be null!");
     if (!path.isAbsolute()) {
       path = new Path(workingDir, path);
     }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -474,7 +474,7 @@ public class BasicOzoneFileSystem extends FileSystem {
 
     if (result) {
       // If this delete operation removes all files/directories from the
-      // parent direcotry, then an empty parent directory must be created.
+      // parent directory, then an empty parent directory must be created.
       createFakeParentDirectory(f);
     }
 

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsRenameDir.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsRenameDir.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.fs.ozone;
 
-import java.io.IOException;
 
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileSystem;

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsRenameDir.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsRenameDir.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
-
+import org.apache.hadoop.test.LambdaTestUtils;
 import org.junit.After;
 import static org.junit.Assert.assertTrue;
 import org.junit.Before;
@@ -81,9 +81,10 @@ public class TestOzoneFsRenameDir {
 
   /**
    * Tests directory rename opertion through OzoneFS.
+   * @throws Exception
    */
   @Test(timeout=300_000)
-  public void testRenameDir() throws IOException {
+  public void testRenameDir() throws Exception {
     final String dir = "/root_dir/dir1";
     final Path source = new Path(fs.getUri().toString() + dir);
     final Path dest = new Path(source.toString() + ".renamed");
@@ -98,5 +99,13 @@ public class TestOzoneFsRenameDir {
     // sub-directories of the renamed directory have also been renamed.
     assertTrue("Keys under the renamed direcotry not renamed",
         fs.exists(new Path(dest, "sub_dir1")));
+
+    // Test if one path belongs to other FileSystem.
+    LambdaTestUtils.intercept(IllegalArgumentException.class, "Wrong FS",
+        () -> fs.rename(new Path(fs.getUri().toString() + "fake" + dir), dest));
+
+    // Renaming to same path when src is specified with scheme.
+    assertTrue("Renaming to same path should be success.",
+        fs.rename(source, new Path(dir)));
   }
 }

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsRenameDir.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsRenameDir.java
@@ -96,7 +96,7 @@ public class TestOzoneFsRenameDir {
     assertTrue("Directory rename failed", fs.exists(dest));
     // Verify that the subdir is also renamed i.e. keys corresponding to the
     // sub-directories of the renamed directory have also been renamed.
-    assertTrue("Keys under the renamed direcotry not renamed",
+    assertTrue("Keys under the renamed directory not renamed",
         fs.exists(new Path(dest, "sub_dir1")));
 
     // Test if one path belongs to other FileSystem.


### PR DESCRIPTION
## What changes were proposed in this pull request?



In the Rename API :
1. This doesn't work if one of the path contains URI and other doesn't.

    if (src.equals(dst)) {
      return true;
    }

2. This check is suppose to be done only for directories, but is done for Files too, it can be moved after getting the FileStatus and checking the type.

    // Cannot rename a directory to its own subdirectory
    Path dstParent = dst.getParent();
    while (dstParent != null && !src.equals(dstParent)) {
      dstParent = dstParent.getParent();
    }
    Preconditions.checkArgument(dstParent == null,
        "Cannot rename a directory to its own subdirectory");

3. This too doesn't work (similar to 1.)

    if (srcStatus.isDirectory()) {
      if (dst.toString().startsWith(src.toString() + OZONE_URI_DELIMITER)) {
        LOG.trace("Cannot rename a directory to a subdirectory of self");
        return false;
      }

4. Rename is even success if the URI provided is of different FileSystem.
In general HDFS/Other FS shall throw IllegalArgumentException if the path doesn't belong to the same FS.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2685

## How was this patch tested?

Added UT.