### PR TITLE
HDDS-2692. Seek to file end throws EOF Exception.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyInputStream.java
@@ -207,7 +207,7 @@ public class KeyInputStream extends InputStream implements Seekable {
   @Override
   public synchronized void seek(long pos) throws IOException {
     checkOpen();
-    if (pos < 0 || pos >= length) {
+    if (pos < 0 || pos > length) {
       if (pos == 0) {
         // It is possible for length and pos to be zero in which case
         // seek should return instead of throwing exception

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -263,6 +264,17 @@ public class TestOzoneFileSystem {
         fileStatus1.equals(dir12.toString()));
     assertTrue(fileStatus2.equals(dir11.toString()) ||
         fileStatus2.equals(dir12.toString()));
+  }
+
+  @Test
+  public void testSeekOnFileLength() throws IOException {
+    Path file = new Path("/file");
+    ContractTestUtils.createFile(fs, file, true, "a".getBytes());
+    try (FSDataInputStream stream = fs.open(file)) {
+      long fileLength = fs.getFileStatus(file).getLen();
+      stream.seek(fileLength);
+      assertEquals(-1, stream.read());
+    }
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Seek to file end shouldn't throw EOF Exception.

In DFSInputStream too, it throws above filelength :
```
  public synchronized void seek(long targetPos) throws IOException {
    if (targetPos > getFileLength()) {
      throw new EOFException("Cannot seek after EOF");
    }
```
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2692

## How was this patch tested?

Added a Unit Test 