### PR TITLE
HDDS-2689. OMException NOT_A_FILE missing space in the exception mess…

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -208,7 +208,7 @@ public class OMFileCreateRequest extends OMKeyRequest {
         throw new OMException("Can not write to directory: " + keyName,
             OMException.ResultCodes.NOT_A_FILE);
       } else if (omDirectoryResult == FILE_EXISTS_IN_GIVENPATH) {
-        throw new OMException("Can not create file: " + keyName + "as there " +
+        throw new OMException("Can not create file: " + keyName + " as there " +
             "is already file in the given path",
             OMException.ResultCodes.NOT_A_FILE);
       }
@@ -243,8 +243,8 @@ public class OMFileCreateRequest extends OMKeyRequest {
           boolean canBeCreated = checkKeysUnderPath(omMetadataManager,
               volumeName, bucketName, keyName);
           if (!canBeCreated) {
-            throw new OMException("Can not create file: " + keyName + "as one" +
-                " of parent directory is not created",
+            throw new OMException("Can not create file: " + keyName +
+                " as one of parent directory is not created",
                 OMException.ResultCodes.NOT_A_FILE);
           }
         }


### PR DESCRIPTION
…age.

## What changes were proposed in this pull request?

`ayush@ayushpc:~/ozone/hadoop-ozone/hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/bin$ ./ozone fs -fs o3fs://bucket.hive -put -d ozone /dir/ozone/file
put: NOT_A_FILE: Can not create file: dir/ozone/fileas there is already file in the given path
`
"as" got attached to the name of the file.
OMFileCreateRequest L211 and L246 : Need to add space before "as"

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2689

## How was this patch tested?
Simple change. No testing needed.