### PR TITLE
HDDS-2671 Have NodeManager.getNodeStatus throw NodeNotFoundException

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -576,7 +576,7 @@ public class ReplicationManager implements MetricsSource {
         LOG.warn("Cannot replicate container {}, no healthy replica found.",
             container.containerID());
       }
-    } catch (IOException | RuntimeException ex) {
+    } catch (IOException | IllegalStateException ex) {
       LOG.warn("Exception while replicating container {}.",
           container.getContainerID(), ex);
     }
@@ -789,7 +789,7 @@ public class ReplicationManager implements MetricsSource {
 
   /**
    * Wrap the call to nodeManager.getNodeStatus, catching any
-   * NodeNotFoundException and instead throwing a RuntimeException.
+   * NodeNotFoundException and instead throwing an IllegalStateException.
    * @param dn The datanodeDetails to obtain the NodeStatus for
    * @return NodeStatus corresponding to the given Datanode.
    */
@@ -797,7 +797,7 @@ public class ReplicationManager implements MetricsSource {
     try {
       return nodeManager.getNodeStatus(dn);
     } catch (NodeNotFoundException e) {
-      throw new RuntimeException("Unable to find NodeStatus for "+dn, e);
+      throw new IllegalStateException("Unable to find NodeStatus for "+dn, e);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -42,6 +42,8 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementPolicy;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsInfo;
@@ -544,7 +546,7 @@ public class ReplicationManager implements MetricsSource {
           // maintenance nodes, as the replicas will remain present in the
           // container manager, even when they go dead.
           .filter(r ->
-              nodeManager.getNodeStatus(r.getDatanodeDetails()).isHealthy())
+              getNodeStatus(r.getDatanodeDetails()).isHealthy())
           .filter(r -> !deletionInFlight.contains(r.getDatanodeDetails()))
           .sorted((r1, r2) -> r2.getSequenceId().compareTo(r1.getSequenceId()))
           .map(ContainerReplica::getDatanodeDetails)
@@ -574,7 +576,7 @@ public class ReplicationManager implements MetricsSource {
         LOG.warn("Cannot replicate container {}, no healthy replica found.",
             container.containerID());
       }
-    } catch (IOException ex) {
+    } catch (IOException | RuntimeException ex) {
       LOG.warn("Exception while replicating container {}.",
           container.getContainerID(), ex);
     }
@@ -783,6 +785,20 @@ public class ReplicationManager implements MetricsSource {
         new CommandForDatanode<>(datanode.getUuid(), command);
     eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND, datanodeCommand);
     tracker.accept(new InflightAction(datanode, Time.monotonicNow()));
+  }
+
+  /**
+   * Wrap the call to nodeManager.getNodeStatus, catching any
+   * NodeNotFoundException and instead throwing a RuntimeException.
+   * @param dn The datanodeDetails to obtain the NodeStatus for
+   * @return NodeStatus corresponding to the given Datanode.
+   */
+  private NodeStatus getNodeStatus(DatanodeDetails dn) {
+    try {
+      return nodeManager.getNodeStatus(dn);
+    } catch (NodeNotFoundException e) {
+      throw new RuntimeException("Unable to find NodeStatus for "+dn, e);
+    }
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitor.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 public interface DatanodeAdminMonitor extends Runnable {
 
   void startMonitoring(DatanodeDetails dn, int endInHours);
-
   void stopMonitoring(DatanodeDetails dn);
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorImpl.java
@@ -363,16 +363,9 @@ public class DatanodeAdminMonitorImpl implements DatanodeAdminMonitor {
     nodeManager.setNodeOperationalState(dn.getDatanodeDetails(), state);
   }
 
-  // TODO - The nodeManager.getNodeStatus call should really throw
-  //        NodeNotFoundException rather than having to handle it here as all
-  //        registered nodes must have a status.
   private NodeStatus getNodeStatus(DatanodeDetails dnd)
       throws NodeNotFoundException {
-    NodeStatus nodeStatus = nodeManager.getNodeStatus(dnd);
-    if (nodeStatus == null) {
-      throw new NodeNotFoundException("Unable to retrieve the nodeStatus");
-    }
-    return nodeStatus;
+    return nodeManager.getNodeStatus(dnd);
   }
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -331,11 +331,7 @@ public class NodeDecommissionManager {
 
   private NodeStatus getNodeStatus(DatanodeDetails dn)
       throws NodeNotFoundException {
-    NodeStatus nodeStatus = nodeManager.getNodeStatus(dn);
-    if (nodeStatus == null) {
-      throw new NodeNotFoundException();
-    }
-    return nodeStatus;
+    return nodeManager.getNodeStatus(dn);
   }
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -128,8 +128,10 @@ public interface NodeManager extends StorageContainerNodeProtocol,
    * Returns the node status of a specific node.
    * @param datanodeDetails DatanodeDetails
    * @return NodeStatus for the node
+   * @throws NodeNotFoundException if the node does not exist
    */
-  NodeStatus getNodeStatus(DatanodeDetails datanodeDetails);
+  NodeStatus getNodeStatus(DatanodeDetails datanodeDetails)
+      throws NodeNotFoundException;
 
   /**
    * Set the operation state of a node.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -218,13 +218,9 @@ public class SCMNodeManager implements NodeManager {
    * @return NodeStatus for the node
    */
   @Override
-  public NodeStatus getNodeStatus(DatanodeDetails datanodeDetails) {
-    try {
-      return nodeStateManager.getNodeStatus(datanodeDetails);
-    } catch (NodeNotFoundException e) {
-      // TODO: should we throw NodeNotFoundException?
-      return null;
-    }
+  public NodeStatus getNodeStatus(DatanodeDetails datanodeDetails)
+      throws NodeNotFoundException {
+    return nodeStateManager.getNodeStatus(datanodeDetails);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -263,7 +263,8 @@ public class MockNodeManager implements NodeManager {
    * @return Healthy/Stale/Dead.
    */
   @Override
-  public NodeStatus getNodeStatus(DatanodeDetails dd) {
+  public NodeStatus getNodeStatus(DatanodeDetails dd)
+      throws NodeNotFoundException {
     return null;
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -87,7 +87,8 @@ public class SimpleMockNodeManager implements NodeManager {
    *         Inservice and Healthy NodeStatus.
    */
   @Override
-  public NodeStatus getNodeStatus(DatanodeDetails datanodeDetails) {
+  public NodeStatus getNodeStatus(DatanodeDetails datanodeDetails)
+      throws NodeNotFoundException {
     DatanodeInfo dni = nodeMap.get(datanodeDetails.getUuid());
     if (dni != null) {
       return dni.getNodeStatus();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
@@ -98,7 +98,8 @@ public class TestDatanodeAdminMonitor {
    * must wait until the pipelines have closed before completing the flow.
    */
   @Test
-  public void testClosePipelinesEventFiredWhenAdminStarted() {
+  public void testClosePipelinesEventFiredWhenAdminStarted()
+      throws NodeNotFoundException{
     DatanodeDetails dn1 = TestUtils.randomDatanodeDetails();
     nodeManager.register(dn1,
         new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
@@ -136,7 +137,8 @@ public class TestDatanodeAdminMonitor {
    * state.
    */
   @Test
-  public void testDecommissionNodeTransitionsToCompleteWhenNoContainers() {
+  public void testDecommissionNodeTransitionsToCompleteWhenNoContainers()
+      throws NodeNotFoundException {
     DatanodeDetails dn1 = TestUtils.randomDatanodeDetails();
     nodeManager.register(dn1,
         new NodeStatus(HddsProtos.NodeOperationalState.DECOMMISSIONING,
@@ -280,7 +282,8 @@ public class TestDatanodeAdminMonitor {
   }
 
   @Test
-  public void testMaintenanceWaitsForMaintenanceToComplete() {
+  public void testMaintenanceWaitsForMaintenanceToComplete()
+      throws NodeNotFoundException {
     DatanodeDetails dn1 = TestUtils.randomDatanodeDetails();
     nodeManager.register(dn1,
         new NodeStatus(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
@@ -310,7 +313,8 @@ public class TestDatanodeAdminMonitor {
   }
 
   @Test
-  public void testMaintenanceEndsClosingPipelines() {
+  public void testMaintenanceEndsClosingPipelines()
+      throws NodeNotFoundException {
     DatanodeDetails dn1 = TestUtils.randomDatanodeDetails();
     nodeManager.register(dn1,
         new NodeStatus(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
@@ -366,7 +370,8 @@ public class TestDatanodeAdminMonitor {
   }
 
   @Test
-  public void testDeadMaintenanceNodeDoesNotAbortWorkflow() {
+  public void testDeadMaintenanceNodeDoesNotAbortWorkflow()
+      throws NodeNotFoundException {
     DatanodeDetails dn1 = TestUtils.randomDatanodeDetails();
     nodeManager.register(dn1,
         new NodeStatus(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
@@ -393,7 +398,8 @@ public class TestDatanodeAdminMonitor {
   }
 
   @Test
-  public void testCancelledNodesMovedToInService() {
+  public void testCancelledNodesMovedToInService()
+      throws NodeNotFoundException {
     DatanodeDetails dn1 = TestUtils.randomDatanodeDetails();
     nodeManager.register(dn1,
         new NodeStatus(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.TestUtils;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.hadoop.test.GenericTestUtils;
@@ -134,7 +135,7 @@ public class TestNodeDecommissionManager {
 
   @Test
   public void testNodesCanBeDecommissionedAndRecommissioned()
-      throws InvalidHostStringException {
+      throws InvalidHostStringException, NodeNotFoundException {
     List<DatanodeDetails> dns = generateDatanodes();
 
     // Decommission 2 valid nodes
@@ -173,7 +174,7 @@ public class TestNodeDecommissionManager {
 
   @Test
   public void testNodesCanBePutIntoMaintenanceAndRecommissioned()
-      throws InvalidHostStringException {
+      throws InvalidHostStringException, NodeNotFoundException {
     List<DatanodeDetails> dns = generateDatanodes();
 
     // Put 2 valid nodes into maintenance


### PR DESCRIPTION
## Requires HDDS-2593 to be committed before this one.

## What changes were proposed in this pull request?

Currently, the SCM node manager method getNodeStatus catches any NodeNotFoundException and returns null.

```
  /**
   * Returns the node status of a specific node.
   *
   * @param datanodeDetails Datanode Details
   * @return NodeStatus for the node
   */
  @Override
  public NodeStatus getNodeStatus(DatanodeDetails datanodeDetails) {
    try {
      return nodeStateManager.getNodeStatus(datanodeDetails);
    } catch (NodeNotFoundException e) {
      // TODO: should we throw NodeNotFoundException?
      return null;
    }
  }
```

This should throw the exception to ensure downstream code does not need to perform a null check each time it is called.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2671

## How was this patch tested?

Tested by existing unit tests which make calls to this API.
