### PR TITLE
HDDS-2423. Add the recover-trash command client side code

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -336,6 +336,19 @@ public interface ClientProtocol {
       throws IOException;
 
   /**
+   * Recover trash allows the user to recover keys that were marked as deleted,
+   * but not actually deleted by Ozone Manager.
+   * @param volumeName - The volume name.
+   * @param bucketName - The bucket name.
+   * @param keyName - The key user want to recover.
+   * @param destinationBucket - The bucket user want to recover to.
+   * @return The recoverTrash
+   * @throws IOException
+   */
+  boolean recoverTrash(String volumeName, String bucketName, String keyName,
+      String destinationBucket) throws IOException;
+
+  /**
    * Get OzoneKey.
    * @param volumeName Name of the Volume
    * @param bucketName Name of the Bucket

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -721,6 +721,14 @@ public class RpcClient implements ClientProtocol {
   }
 
   @Override
+  public boolean recoverTrash(String volumeName, String bucketName,
+      String keyName, String destinationName) throws IOException {
+
+    return ozoneManagerClient.recoverTrash(volumeName, bucketName, keyName,
+        destinationName);
+  }
+
+  @Override
   public OzoneKeyDetails getKeyDetails(
       String volumeName, String bucketName, String keyName)
       throws IOException {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -722,10 +722,10 @@ public class RpcClient implements ClientProtocol {
 
   @Override
   public boolean recoverTrash(String volumeName, String bucketName,
-      String keyName, String destinationName) throws IOException {
+      String keyName, String destinationBucket) throws IOException {
 
     return ozoneManagerClient.recoverTrash(volumeName, bucketName, keyName,
-        destinationName);
+        destinationBucket);
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -205,6 +205,7 @@ public final class OmUtils {
     case LookupKey:
     case ListKeys:
     case ListTrash:
+    case RecoverTrash:
     case InfoS3Bucket:
     case ListS3Buckets:
     case ServiceList:

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -546,4 +546,17 @@ public interface OzoneManagerProtocol
   List<RepeatedOmKeyInfo> listTrash(String volumeName, String bucketName,
       String startKeyName, String keyPrefix, int maxKeys) throws IOException;
 
+  /**
+   * Recover trash allows the user to recover keys that were marked as deleted,
+   * but not actually deleted by Ozone Manager.
+   * @param volumeName - The volume name.
+   * @param bucketName - The bucket name.
+   * @param keyName - The key user want to recover.
+   * @param destinationBucket - The bucket user want to recover to.
+   * @return The recoverTrash
+   * @throws IOException
+   */
+  boolean recoverTrash(String volumeName, String bucketName, String keyName,
+      String destinationBucket) throws IOException;
+
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -108,6 +108,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListBuc
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListKeysRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListKeysResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListTrashResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RecoverTrashRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RecoverTrashResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListTrashRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListVolumeRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ListVolumeResponse;
@@ -1662,5 +1664,42 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
             .collect(Collectors.toList()));
 
     return deletedKeyList;
+  }
+
+  @Override
+  public boolean recoverTrash(String volumeName, String bucketName,
+      String keyName, String destinationBucket) throws IOException {
+
+    Preconditions.checkArgument(Strings.isNullOrEmpty(volumeName),
+        "The volume name cannot be null or empty. " +
+        "Please enter a valid volume name.");
+
+    Preconditions.checkArgument(Strings.isNullOrEmpty(bucketName),
+        "The bucket name cannot be null or empty. " +
+        "Please enter a valid bucket name.");
+
+    Preconditions.checkArgument(Strings.isNullOrEmpty(keyName),
+        "The key name cannot be null or empty. " +
+        "Please enter a valid key name.");
+
+    Preconditions.checkArgument(Strings.isNullOrEmpty(destinationBucket),
+        "The destination bucket name cannot be null or empty. " +
+        "Please enter a valid destination bucket name.");
+
+    RecoverTrashRequest recoverRequest = RecoverTrashRequest.newBuilder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setDestinationBucket(destinationBucket)
+        .build();
+
+    OMRequest omRequest = createOMRequest(Type.RecoverTrash)
+        .setRecoverTrashRequest(recoverRequest)
+        .build();
+
+    RecoverTrashResponse recoverResponse =
+        handleError(submitRequest(omRequest)).getRecoverTrashResponse();
+
+    return recoverResponse.getResponse();
   }
 }

--- a/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
+++ b/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
@@ -94,6 +94,7 @@ enum Type {
   ListMultipartUploads = 82;
 
   ListTrash = 91;
+  RecoverTrash = 92;
 }
 
 message OMRequest {
@@ -165,6 +166,7 @@ message OMRequest {
   optional ListMultipartUploadsRequest      listMultipartUploadsRequest    = 83;
 
   optional ListTrashRequest                 listTrashRequest               = 91;
+  optional RecoverTrashRequest              RecoverTrashRequest            = 92;
 }
 
 message OMResponse {
@@ -236,6 +238,7 @@ message OMResponse {
   optional ListMultipartUploadsResponse listMultipartUploadsResponse = 82;
 
   optional ListTrashResponse                  listTrashResponse            = 91;
+  optional RecoverTrashResponse               RecoverTrashResponse         = 92;
 }
 
 enum Status {
@@ -324,6 +327,22 @@ message ListTrashRequest {
 
 message ListTrashResponse {
   repeated RepeatedKeyInfo deletedKeys = 1;
+}
+
+/**
+    This command acts as a recover command for deleted keys that are still
+    in deleted table on Ozone Manager.
+*/
+
+message RecoverTrashRequest {
+    required string volumeName = 1;
+    required string bucketName = 2;
+    required string keyName = 3;
+    required string destinationBucket = 4;
+}
+
+message RecoverTrashResponse {
+    required bool response = 1;
 }
 
 message VolumeInfo {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2238,6 +2238,15 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     }
   }
 
+  // TODO: HDDS-2424. recover-trash command server side handling.
+  @Override
+  public boolean recoverTrash(String volumeName, String bucketName,
+      String keyName, String destinationBucket) throws IOException {
+
+    boolean recoverOperation = true;
+    return recoverOperation;
+  }
+
   /**
    * Sets bucket property from args.
    *

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestTrashService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestTrashService.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.hadoop.ozone.om;
+
+
+/**
+ * Test Key Trash Service.
+ * <p>
+ * This test does the things including:
+ * 1. UTs for list trash.
+ * 2. UTs for recover trash.
+ * 3. UTs for empty trash.
+ * <p>
+ */
+public class TestTrashService {
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR adds the client side of ```recover-trash ```.

Fix 1. Add the new fields on protobuf.
Fix 2. Add the corresponding method on ```RpcClient```.
Fix 3. Add the corresponding method on ```OzoneManager``` and the method would be completed on following PR.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2423

## How was this patch tested?
Build, compile and checkstyle simply.
UTs would be updated on following JIRA.