### PR TITLE
HDDS-2693. HddsVolume mixes ChunkLayOutVersion and DataNodeLayoutVersion

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hdfs.server.datanode.checker.VolumeCheckResult;
 import org.apache.hadoop.ozone.common.InconsistentStorageStateException;
 import org.apache.hadoop.ozone.container.common.DataNodeLayoutVersion;
 import org.apache.hadoop.ozone.container.common.helpers.DatanodeVersionFile;
-import org.apache.hadoop.ozone.container.common.impl.ChunkLayOutVersion;
 import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
 
 import org.apache.hadoop.util.DiskChecker;
@@ -265,7 +264,7 @@ public class HddsVolume
   private void createVersionFile() throws IOException {
     this.storageID = HddsVolumeUtil.generateUuid();
     this.cTime = Time.now();
-    this.layoutVersion = ChunkLayOutVersion.getLatestVersion().getVersion();
+    this.layoutVersion = DataNodeLayoutVersion.getLatestVersion().getVersion();
 
     if (this.clusterID == null || datanodeUuid == null) {
       // HddsDatanodeService does not have the cluster information yet. Wait


### PR DESCRIPTION
## What changes were proposed in this pull request?

`HddsVolume` [initializes `layoutVersion` using latest `ChunkLayOutVersion`](https://github.com/apache/hadoop-ozone/blob/1d56bc244995e857b842f62d3d1e544ee100bbc1/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java#L268).  But when writing the same info to file, it [verifies `layoutVersion` matches the latest `DataNodeLayoutVersion`](https://github.com/apache/hadoop-ozone/blob/1d56bc244995e857b842f62d3d1e544ee100bbc1/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java#L292-L293).  To satisfy the condition `ChunkLayOutVersion` and `DataNodeLayoutVersion` have to be in sync, which means only one of them is necessary.  I think the intention was to use `DataNodeLayoutVersion` in both cases, as `ChunkLayOutVersion` is for key-value container internal structure.

https://github.com/apache/hadoop-ozone/blob/1d56bc244995e857b842f62d3d1e544ee100bbc1/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java#L268

https://github.com/apache/hadoop-ozone/blob/1d56bc244995e857b842f62d3d1e544ee100bbc1/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java#L292-L293

https://issues.apache.org/jira/browse/HDDS-2693

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/340156676

Currently no test validates this change, since both `ChunkLayOutVersion` and `DataNodeLayoutVersion` are at version 1.