### PR TITLE
HDDS-2279. Ozone S3 CLI commands not working on HA cluster

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/GetS3SecretHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/GetS3SecretHandler.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.web.ozShell.Handler;
 import org.apache.hadoop.ozone.web.ozShell.OzoneAddress;
 import org.apache.hadoop.security.UserGroupInformation;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
@@ -35,6 +36,12 @@ public class GetS3SecretHandler extends Handler {
 
   public static final String OZONE_GETS3SECRET_ERROR = "This command is not" +
       " supported in unsecure clusters.";
+
+  @CommandLine.Option(names = {"--om-service-id"},
+      required = false,
+      description = "OM Service ID is required to be specified for OM HA" +
+          " cluster")
+  private String omServiceID;
   /**
    * Executes getS3Secret.
    */
@@ -42,7 +49,8 @@ public class GetS3SecretHandler extends Handler {
   public Void call() throws Exception {
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
     try (OzoneClient client =
-        new OzoneAddress().createClient(ozoneConfiguration)) {
+        new OzoneAddress().createClientForS3Commands(ozoneConfiguration,
+            omServiceID)) {
 
       // getS3Secret works only with secured clusters
       if (ozoneConfiguration.getBoolean(OZONE_SECURITY_ENABLED_KEY, false)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make Ozone S3 commands work on OM HA cluster

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2279


## How was this patch tested?

Without this patch used to get an error **Service ID or host name must not be omitted when ozone.om.service.ids is defined.**

With this patch on non-secure OM HA cluster
**bash-4.2$ ozone s3 getsecret --om-service-id id1
This command is not supported in unsecure clusters.** 
From this message, we can confirm the client is able to create.

As we don't have any secure om ha docker-compose cluster, not added any new test in this PR. Opened a new Jira HDDS-2700 to have a secure OM HA cluster where this can be tested end to end.