### PR TITLE
HDDS-2704. Source tar file is not created during the relase build

### DIFF
--- a/hadoop-ozone/dist/dev-support/bin/dist-tar-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-tar-stitching
@@ -38,8 +38,8 @@ function run()
   fi
 }
 
-run tar -c -f "hadoop-ozone-${VERSION}.tar" "ozone-${VERSION}"
-run gzip -f "hadoop-ozone-${VERSION}.tar"
+run tar -c -f "hadoop-ozone-${VERSION}-bin.tar" "ozone-${VERSION}"
+run gzip -f "hadoop-ozone-${VERSION}-bin.tar"
 echo
-echo "Ozone dist tar available at: ${BASEDIR}/hadoop-ozone-${VERSION}.tar.gz"
+echo "Ozone dist tar available at: ${BASEDIR}/hadoop-ozone-bin${VERSION}.tar.gz"
 echo

--- a/hadoop-ozone/dist/dev-support/bin/dist-tar-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-tar-stitching
@@ -41,5 +41,5 @@ function run()
 run tar -c -f "hadoop-ozone-${VERSION}-bin.tar" "ozone-${VERSION}"
 run gzip -f "hadoop-ozone-${VERSION}-bin.tar"
 echo
-echo "Ozone dist tar available at: ${BASEDIR}/hadoop-ozone-bin${VERSION}.tar.gz"
+echo "Ozone dist tar available at: ${BASEDIR}/hadoop-ozone-${VERSION}-bin.tar.gz"
 echo

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -413,11 +413,11 @@
                   <attach>false</attach>
                   <finalName>hadoop-ozone-${project.version}-src</finalName>
                   <outputDirectory>target</outputDirectory>
-                  <basedir>../..</basedir>
+                  <basedir>${project.basedir}/../..</basedir>
                   <!-- Not using descriptorRef and hadoop-assembly dependency -->
                   <!-- to avoid making hadoop-main to depend on a module      -->
                   <descriptors>
-                    <descriptor>src/main/assemblies/ozone-src.xml</descriptor>
+                    <descriptor>${project.basedir}/src/main/assemblies/ozone-src.xml</descriptor>
                   </descriptors>
                 </configuration>
               </execution>

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -388,6 +388,45 @@
       </dependencies>
 
     </profile>
+
+    <profile>
+      <id>src</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <inherited>false</inherited>
+            <executions>
+              <execution>
+                <id>src-dist</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>single</goal>
+                </goals>
+                <configuration>
+                  <archiveBaseDirectory>../..</archiveBaseDirectory>
+                  <appendAssemblyId>false</appendAssemblyId>
+                  <attach>false</attach>
+                  <finalName>hadoop-ozone-${project.version}-src</finalName>
+                  <outputDirectory>target</outputDirectory>
+                  <basedir>../..</basedir>
+                  <!-- Not using descriptorRef and hadoop-assembly dependency -->
+                  <!-- to avoid making hadoop-main to depend on a module      -->
+                  <descriptors>
+                    <descriptor>src/main/assemblies/ozone-src.xml</descriptor>
+                  </descriptors>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>docker-build</id>
       <build>

--- a/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
+++ b/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
@@ -25,11 +25,11 @@
   <includeBaseDirectory>true</includeBaseDirectory>
   <files>
     <file>
-      <source>hadoop-ozone/dist/src/main/license/src/LICENSE.txt</source>
+      <source>LICENSE.txt</source>
       <outputDirectory>/</outputDirectory>
     </file>
     <file>
-      <source>hadoop-ozone/dist/src/main/license/src/NOTICE.txt</source>
+      <source>NOTICE.txt</source>
       <outputDirectory>/</outputDirectory>
     </file>
     <file>

--- a/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
+++ b/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
@@ -25,11 +25,11 @@
   <includeBaseDirectory>true</includeBaseDirectory>
   <files>
     <file>
-      <source>LICENSE.txt</source>
+      <source>hadoop-ozone/dist/src/main/license/src/LICENSE.txt</source>
       <outputDirectory>/</outputDirectory>
     </file>
     <file>
-      <source>NOTICE.txt</source>
+      <source>hadoop-ozone/dist/src/main/license/src/NOTICE.txt</source>
       <outputDirectory>/</outputDirectory>
     </file>
     <file>

--- a/pom.xml
+++ b/pom.xml
@@ -1903,62 +1903,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         </plugins>
       </build>
     </profile>
-    <profile>
-      <id>src</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-assembly-plugin</artifactId>
-            <inherited>false</inherited>
-            <executions>
-              <execution>
-                <id>src-dist</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>single</goal>
-                </goals>
-                <configuration>
-                  <appendAssemblyId>false</appendAssemblyId>
-                  <attach>false</attach>
-                  <finalName>hadoop-ozone-${project.version}-src</finalName>
-                  <outputDirectory>hadoop-ozone/dist/target</outputDirectory>
-                  <!-- Not using descriptorRef and hadoop-assembly dependency -->
-                  <!-- to avoid making hadoop-main to depend on a module      -->
-                  <descriptors>
-                    <descriptor>hadoop-ozone/dist/src/main/assemblies/ozone-src.xml</descriptor>
-                  </descriptors>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <inherited>false</inherited>
-            <executions>
-              <execution>
-                <id>src-dist-msg</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <configuration>
-                  <target>
-                    <echo/>
-                    <echo>Hadoop Ozone source tar available at: ${basedir}/hadoop-ozone/dist/target/hadoop-ozone-${project.version}-src.tar.gz</echo>
-                    <echo/>
-                  </target>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
+
 
     <profile>
       <id>sign</id>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Thanks to @dineshchitlangia who reported this problem.

With a release build:

```
mvn clean install -Dmaven.javadoc.skip=true -DskipTests -Psign,dist,src -Dtar -Dgpg.keyname=$CODESIGNINGKEY 
```

The source package (__the__ release) is not created.

In fact it's created, but the problem with the order of clean and install:

* clean is executed in the root project
* install is executed in the root project (creates hadoop-ozone/dist/target/..src.tar.gx
*  .....
* clean is executed in the hadoop-ozone/dist project (here the src package is deleted)
* install is executed in the hadoop-ozone/dist project

One possible fix is to move the creation of the src package to the hadoop-ozone/dist project (but do it from the project root)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2704

## How was this patch tested?

```
mvn clean install -Dmaven.javadoc.skip=true -DskipTests -Psign,dist,src -Dtar -Dgpg.keyname=$CODESIGNINGKEY 
```
