### PR TITLE
HDDS-2630. NullPointerException in S3g.

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/header/AuthenticationHeaderParser.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/header/AuthenticationHeaderParser.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.s3.header;
 
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
+import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +38,9 @@ public class AuthenticationHeaderParser {
   private String accessKeyID;
 
   public void parse() throws OS3Exception {
+    if (authHeader == null) {
+      throw S3ErrorTable.MALFORMED_HEADER;
+    }
     if (authHeader.startsWith("AWS4")) {
       LOG.debug("V4 Header {}", authHeader);
       AuthorizationHeaderV4 authorizationHeader = new AuthorizationHeaderV4(

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketPut.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.hadoop.ozone.s3.endpoint;
+
+import javax.ws.rs.core.Response;
+
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.client.OzoneClientStub;
+
+import org.apache.hadoop.ozone.s3.exception.OS3Exception;
+import org.apache.hadoop.ozone.s3.header.AuthenticationHeaderParser;
+
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static org.apache.hadoop.ozone.s3.AWSV4AuthParser.DATE_FORMATTER;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.MALFORMED_HEADER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDate;
+
+/**
+ * This class test Create Bucket functionality.
+ */
+public class TestBucketPut {
+
+  private String bucketName = OzoneConsts.BUCKET;
+  private OzoneClientStub clientStub;
+  private BucketEndpoint bucketEndpoint;
+
+  @Before
+  public void setup() throws Exception {
+
+    //Create client stub and object store stub.
+    clientStub = new OzoneClientStub();
+
+    // Create HeadBucket and setClient to OzoneClientStub
+    bucketEndpoint = new BucketEndpoint();
+    bucketEndpoint.setClient(clientStub);
+  }
+
+  @Test
+  public void testBucketFailWithAuthHeaderMissing() throws Exception {
+
+    bucketEndpoint.setAuthenticationHeaderParser(
+        new AuthenticationHeaderParser());
+    bucketEndpoint.getAuthenticationHeaderParser().setAuthHeader(null);
+    try {
+      bucketEndpoint.put(bucketName, null);
+    } catch (OS3Exception ex) {
+      Assert.assertEquals(HTTP_NOT_FOUND, ex.getHttpCode());
+      Assert.assertEquals(MALFORMED_HEADER.getCode(), ex.getCode());
+    }
+  }
+
+  @Test
+  public void testBucketPut() throws Exception {
+    String auth = generateAuthHeader();
+    bucketEndpoint.setAuthenticationHeaderParser(
+        new AuthenticationHeaderParser());
+    bucketEndpoint.getAuthenticationHeaderParser().setAuthHeader(auth);
+    Response response = bucketEndpoint.put(bucketName, null);
+    assertEquals(200, response.getStatus());
+    assertNotNull(response.getLocation());
+  }
+
+  @Test
+  public void testBucketFailWithInvalidHeader() throws Exception {
+    bucketEndpoint.setAuthenticationHeaderParser(
+        new AuthenticationHeaderParser());
+    bucketEndpoint.getAuthenticationHeaderParser().setAuthHeader("auth");
+    try {
+      bucketEndpoint.put(bucketName, null);
+    } catch (OS3Exception ex) {
+      Assert.assertEquals(HTTP_NOT_FOUND, ex.getHttpCode());
+      Assert.assertEquals(MALFORMED_HEADER.getCode(), ex.getCode());
+    }
+  }
+
+  /**
+   * Generate dummy auth header.
+   * @return
+   */
+  private String generateAuthHeader() {
+    LocalDate now = LocalDate.now();
+    String curDate = DATE_FORMATTER.format(now);
+    return  "AWS4-HMAC-SHA256 " +
+        "Credential=ozone/" + curDate + "/us-east-1/s3/aws4_request, " +
+        "SignedHeaders=host;range;x-amz-date, " +
+        "Signature=fe5f80f77d5fa3beca038a248ff027";
+  }
+
+}

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketPut.java
@@ -100,7 +100,7 @@ public class TestBucketPut {
 
   /**
    * Generate dummy auth header.
-   * @return
+   * @return auth header.
    */
   private String generateAuthHeader() {
     LocalDate now = LocalDate.now();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix null pointer exception when creating a bucket

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2630


## How was this patch tested?

Tested in docker-compose ozones3 cluster with out credentials.
bash-4.2$ aws s3api --endpoint http://s3g:9878 create-bucket --bucket b12345
Unable to locate credentials. You can configure credentials by running "aws configure".

This is the same behavior when running against AWS S3. Used the same error code for S3Gateway also.

> **<?xml version="1.0" encoding="UTF-8"?>
> <Error>
>     <Code>AuthorizationHeaderMalformed</Code>
>     <Message>The authorization header is malformed; a non-empty Access Key (AKID) must be provided in the credential.</Message>
>     <RequestId>5E763C5A06D2B716</RequestId>
>     <HostId>MY4ON8DQYtZnCj2kQn7OZVQ4bvzeHalbwmZt4Ysq87y63DbBxpaTDTLTuYNFFZ8Ol314nMUTcOI=</HostId>
> </Error>**
