### PR TITLE
HDDS-2709. Maven property skipShade should not skip ozonefs compilation

### DIFF
--- a/hadoop-ozone/dev-support/checks/unit.sh
+++ b/hadoop-ozone/dev-support/checks/unit.sh
@@ -17,7 +17,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
 export MAVEN_OPTS="-Xmx4096m"
-mvn -B -DskipShade -Dskip.yarn -fn test -pl \!:hadoop-ozone-integration-test,\!:hadoop-ozone-tools "$@"
+mvn -B -DskipShade -Dskip.yarn -fn test -pl \!:hadoop-ozone-integration-test,\!:hadoop-ozone-filesystem,\!:hadoop-ozone-tools "$@"
 
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/unit"}
 mkdir -p "$REPORT_DIR"

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -33,6 +33,7 @@
     <module>ozone-manager</module>
     <module>tools</module>
     <module>integration-test</module>
+    <module>ozonefs</module>
     <module>datanode</module>
     <module>s3gateway</module>
     <module>dist</module>
@@ -358,7 +359,6 @@
         </property>
       </activation>
       <modules>
-        <module>ozonefs</module>
         <module>ozonefs-lib-current</module>
         <module>ozonefs-lib-legacy</module>
       </modules>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Maven skipShade profile should not skip ozonefs compilation.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2709

## How was this patch tested?

Test manually that with the `pom.xml` change, code change under `./hadoop-ozone/ozonefs/` is compiled and reflected in `dist`.