### PR TITLE
HDDS-2607 DeadNodeHandler should not remove replica for a dead maintenance node

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorImpl.java
@@ -170,7 +170,6 @@ public class DatanodeAdminMonitorImpl implements DatanodeAdminMonitor {
         LOG.warn("Failed processing the cancel admin request for {}",
             dn.getDatanodeDetails(), e);
       }
-      // TODO - fire event to bring node back into service?
     }
   }
 
@@ -320,8 +319,6 @@ public class DatanodeAdminMonitorImpl implements DatanodeAdminMonitor {
       throws NodeNotFoundException {
     // The end state of Maintenance is to put the node back IN_SERVICE, whether
     // it is dead or not.
-    // TODO - if the node is dead do we trigger a dead node event here or leave
-    //        it to the heartbeat manager?
     LOG.info("Datanode {} has ended maintenance automatically",
         dn.getDatanodeDetails());
     putNodeBackInService(dn);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
@@ -74,12 +74,14 @@ public class DeadNodeHandler implements EventHandler<DatanodeDetails> {
        * To be on a safer side, we double check here and take appropriate
        * action.
        */
-
       destroyPipelines(datanodeDetails);
       closeContainers(datanodeDetails, publisher);
 
-      // Remove the container replicas associated with the dead node.
-      removeContainerReplicas(datanodeDetails);
+      // Remove the container replicas associated with the dead node unless it
+      // is IN_MAINTENANCE
+      if (!nodeManager.getNodeStatus(datanodeDetails).isInMaintenance()) {
+        removeContainerReplicas(datanodeDetails);
+      }
 
     } catch (NodeNotFoundException ex) {
       // This should not happen, we cannot get a dead node event for an

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
@@ -93,11 +93,6 @@ public class NodeStateManager implements Runnable, Closeable {
    */
   private final StateMachine<NodeState, NodeLifeCycleEvent> nodeHealthSM;
   /**
-   * StateMachine for node operational state.
-   */
-  private final StateMachine<HddsProtos.NodeOperationalState,
-      NodeOperationStateEvent> nodeOpStateSM;
-  /**
    * This is the map which maintains the current state of all datanodes.
    */
   private final NodeStateMap nodeStateMap;
@@ -112,7 +107,7 @@ public class NodeStateManager implements Runnable, Closeable {
   /**
    * Maps the event to be triggered when a node state us updated.
    */
-  private final Map<NodeStatus, Event<DatanodeDetails>> state2EventMap;
+  private final Map<NodeState, Event<DatanodeDetails>> state2EventMap;
   /**
    * ExecutorService used for scheduling heartbeat processing thread.
    */
@@ -162,10 +157,7 @@ public class NodeStateManager implements Runnable, Closeable {
     this.state2EventMap = new HashMap<>();
     initialiseState2EventMap();
     Set<NodeState> finalStates = new HashSet<>();
-    Set<HddsProtos.NodeOperationalState> opStateFinalStates = new HashSet<>();
     this.nodeHealthSM = new StateMachine<>(NodeState.HEALTHY, finalStates);
-    this.nodeOpStateSM = new StateMachine<>(
-        NodeOperationalState.IN_SERVICE, opStateFinalStates);
     initializeStateMachines();
     heartbeatCheckerIntervalMs = HddsServerUtil
         .getScmheartbeatCheckerInterval(conf);
@@ -190,12 +182,10 @@ public class NodeStateManager implements Runnable, Closeable {
    * Populates state2event map.
    */
   private void initialiseState2EventMap() {
-    state2EventMap.put(NodeStatus.inServiceStale(), SCMEvents.STALE_NODE);
-    state2EventMap.put(NodeStatus.inServiceDead(), SCMEvents.DEAD_NODE);
-    state2EventMap.put(NodeStatus.inServiceHealthy(),
+    state2EventMap.put(NodeState.STALE, SCMEvents.STALE_NODE);
+    state2EventMap.put(NodeState.DEAD, SCMEvents.DEAD_NODE);
+    state2EventMap.put(NodeState.HEALTHY,
         SCMEvents.NON_HEALTHY_TO_HEALTHY_NODE);
-    // TODO - add whatever events are needed for decomm / maint to stale, dead,
-    //        healthy
   }
 
   /*
@@ -238,36 +228,6 @@ public class NodeStateManager implements Runnable, Closeable {
         NodeState.STALE, NodeState.HEALTHY, NodeLifeCycleEvent.RESTORE);
     nodeHealthSM.addTransition(
         NodeState.DEAD, NodeState.HEALTHY, NodeLifeCycleEvent.RESURRECT);
-
-    nodeOpStateSM.addTransition(
-        NodeOperationalState.IN_SERVICE, NodeOperationalState.DECOMMISSIONING,
-        NodeOperationStateEvent.START_DECOMMISSION);
-    nodeOpStateSM.addTransition(
-        NodeOperationalState.DECOMMISSIONING, NodeOperationalState.IN_SERVICE,
-        NodeOperationStateEvent.RETURN_TO_SERVICE);
-    nodeOpStateSM.addTransition(
-        NodeOperationalState.DECOMMISSIONING,
-        NodeOperationalState.DECOMMISSIONED,
-        NodeOperationStateEvent.COMPLETE_DECOMMISSION);
-    nodeOpStateSM.addTransition(
-        NodeOperationalState.DECOMMISSIONED, NodeOperationalState.IN_SERVICE,
-        NodeOperationStateEvent.RETURN_TO_SERVICE);
-
-    nodeOpStateSM.addTransition(
-        NodeOperationalState.IN_SERVICE,
-        NodeOperationalState.ENTERING_MAINTENANCE,
-        NodeOperationStateEvent.START_MAINTENANCE);
-    nodeOpStateSM.addTransition(
-        NodeOperationalState.ENTERING_MAINTENANCE,
-        NodeOperationalState.IN_SERVICE,
-        NodeOperationStateEvent.RETURN_TO_SERVICE);
-    nodeOpStateSM.addTransition(
-        NodeOperationalState.ENTERING_MAINTENANCE,
-        NodeOperationalState.IN_MAINTENANCE,
-        NodeOperationStateEvent.ENTER_MAINTENANCE);
-    nodeOpStateSM.addTransition(
-        NodeOperationalState.IN_MAINTENANCE, NodeOperationalState.IN_SERVICE,
-        NodeOperationStateEvent.RETURN_TO_SERVICE);
   }
 
   /**
@@ -280,7 +240,7 @@ public class NodeStateManager implements Runnable, Closeable {
   public void addNode(DatanodeDetails datanodeDetails)
       throws NodeAlreadyExistsException {
     nodeStateMap.addNode(datanodeDetails, new NodeStatus(
-        nodeOpStateSM.getInitialState(), nodeHealthSM.getInitialState()));
+        NodeOperationalState.IN_SERVICE, nodeHealthSM.getInitialState()));
     eventPublisher.fireEvent(SCMEvents.NEW_NODE, datanodeDetails);
   }
 
@@ -404,8 +364,18 @@ public class NodeStateManager implements Runnable, Closeable {
   public void setNodeOperationalState(DatanodeDetails dn,
       NodeOperationalState newState)  throws NodeNotFoundException {
     DatanodeInfo dni = nodeStateMap.getNodeInfo(dn.getUuid());
-    if (dni.getNodeStatus().getOperationalState() != newState) {
+    NodeStatus oldStatus = dni.getNodeStatus();
+    if (oldStatus.getOperationalState() != newState) {
       nodeStateMap.updateNodeOperationalState(dn.getUuid(), newState);
+      // This will trigger an event based on the nodes health when the
+      // operational state changes. Eg a node that was IN_MAINTENANCE goes
+      // to IN_SERVICE + HEALTHY. This will trigger the HEALTHY node event to
+      // create new pipelines. OTH, if the nodes goes IN_MAINTENANCE to
+      // IN_SERVICE + DEAD, it will trigger the dead node handler to remove its
+      // container replicas. Sometimes the event will do nothing, but it will
+      // not do any harm either. Eg DECOMMISSIONING -> DECOMMISSIONED + HEALTHY
+      // but the pipeline creation logic will ignore decommissioning nodes.
+      fireHealthStateEvent(oldStatus.getHealth(), dn);
     }
   }
 
@@ -706,14 +676,20 @@ public class NodeStateManager implements Runnable, Closeable {
             getNextState(status.getHealth(), lifeCycleEvent);
         NodeStatus newStatus =
             nodeStateMap.updateNodeHealthState(node.getUuid(), newHealthState);
-        if (state2EventMap.containsKey(newStatus)) {
-          eventPublisher.fireEvent(state2EventMap.get(newStatus), node);
-        }
+        fireHealthStateEvent(newStatus.getHealth(), node);
       }
     } catch (InvalidStateTransitionException e) {
       LOG.warn("Invalid state transition of node {}." +
               " Current state: {}, life cycle event: {}",
           node, status.getHealth(), lifeCycleEvent);
+    }
+  }
+
+  private void fireHealthStateEvent(HddsProtos.NodeState health,
+      DatanodeDetails node) {
+    Event<DatanodeDetails> event = state2EventMap.get(health);
+    if (event != null) {
+      eventPublisher.fireEvent(event, node);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
@@ -80,11 +80,6 @@ public class NodeStateManager implements Runnable, Closeable {
     TIMEOUT, RESTORE, RESURRECT
   }
 
-  private enum NodeOperationStateEvent {
-    START_DECOMMISSION, COMPLETE_DECOMMISSION, START_MAINTENANCE,
-    ENTER_MAINTENANCE, RETURN_TO_SERVICE
-  }
-
   private static final Logger LOG = LoggerFactory
       .getLogger(NodeStateManager.class);
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -61,7 +61,6 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -112,7 +111,6 @@ public class TestDeadNodeHandler {
   }
 
   @Test
-  @Ignore("Tracked by HDDS-2508.")
   public void testOnMessage() throws IOException, NodeNotFoundException {
     //GIVEN
     DatanodeDetails datanode1 = TestUtils.randomDatanodeDetails();
@@ -174,22 +172,44 @@ public class TestDeadNodeHandler {
     TestUtils.closeContainer(containerManager, container2.containerID());
     TestUtils.quasiCloseContainer(containerManager, container3.containerID());
 
+    // First set the node to IN_MAINTENANCE and ensure the container replicas
+    // are not removed on the dead event
+    nodeManager.setNodeOperationalState(datanode1,
+        HddsProtos.NodeOperationalState.IN_MAINTENANCE);
     deadNodeHandler.onMessage(datanode1, publisher);
 
     Set<ContainerReplica> container1Replicas = containerManager
+        .getContainerReplicas(new ContainerID(container1.getContainerID()));
+    Assert.assertEquals(2, container1Replicas.size());
+
+    Set<ContainerReplica> container2Replicas = containerManager
+        .getContainerReplicas(new ContainerID(container2.getContainerID()));
+    Assert.assertEquals(2, container2Replicas.size());
+
+    Set<ContainerReplica> container3Replicas = containerManager
+            .getContainerReplicas(new ContainerID(container3.getContainerID()));
+    Assert.assertEquals(1, container3Replicas.size());
+
+    // Now set the node to anything other than IN_MAINTENANCE and the relevant
+    // replicas should be removed
+    nodeManager.setNodeOperationalState(datanode1,
+        HddsProtos.NodeOperationalState.IN_SERVICE);
+    deadNodeHandler.onMessage(datanode1, publisher);
+
+    container1Replicas = containerManager
         .getContainerReplicas(new ContainerID(container1.getContainerID()));
     Assert.assertEquals(1, container1Replicas.size());
     Assert.assertEquals(datanode2,
         container1Replicas.iterator().next().getDatanodeDetails());
 
-    Set<ContainerReplica> container2Replicas = containerManager
+    container2Replicas = containerManager
         .getContainerReplicas(new ContainerID(container2.getContainerID()));
     Assert.assertEquals(1, container2Replicas.size());
     Assert.assertEquals(datanode2,
         container2Replicas.iterator().next().getDatanodeDetails());
 
-    Set<ContainerReplica> container3Replicas = containerManager
-            .getContainerReplicas(new ContainerID(container3.getContainerID()));
+    container3Replicas = containerManager
+        .getContainerReplicas(new ContainerID(container3.getContainerID()));
     Assert.assertEquals(1, container3Replicas.size());
     Assert.assertEquals(datanode3,
         container3Replicas.iterator().next().getDatanodeDetails());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -58,10 +58,7 @@ import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.security.authentication.client
     .AuthenticationException;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.mockito.Mockito;
 
 /**
@@ -111,6 +108,7 @@ public class TestDeadNodeHandler {
   }
 
   @Test
+  @Ignore("Tracked by HDDS-2508.")
   public void testOnMessage() throws IOException, NodeNotFoundException {
     //GIVEN
     DatanodeDetails datanode1 = TestUtils.randomDatanodeDetails();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -58,7 +58,11 @@ import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.security.authentication.client
     .AuthenticationException;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.Assert;
+import org.junit.After;
 import org.mockito.Mockito;
 
 /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
 import org.apache.hadoop.hdds.scm.HddsServerUtil;
+import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.node.states.NodeAlreadyExistsException;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.server.events.Event;
@@ -145,7 +146,7 @@ public class TestNodeStateManager {
 
     DatanodeDetails dn = generateDatanode();
     nsm.addNode(dn);
-    assertEquals("New_Node", eventPublisher.getLastEvent().getName());
+    assertEquals(SCMEvents.NEW_NODE, eventPublisher.getLastEvent());
     DatanodeInfo dni = nsm.getNode(dn);
     dni.updateLastHeartbeatTime();
 
@@ -159,31 +160,31 @@ public class TestNodeStateManager {
     dni.updateLastHeartbeatTime(now - staleLimit);
     nsm.checkNodesHealth();
     assertEquals(NodeState.STALE, nsm.getNodeStatus(dn).getHealth());
-    assertEquals("Stale_Node", eventPublisher.getLastEvent().getName());
+    assertEquals(SCMEvents.STALE_NODE, eventPublisher.getLastEvent());
 
     // Now make it dead
     dni.updateLastHeartbeatTime(now - deadLimit);
     nsm.checkNodesHealth();
     assertEquals(NodeState.DEAD, nsm.getNodeStatus(dn).getHealth());
-    assertEquals("Dead_Node", eventPublisher.getLastEvent().getName());
+    assertEquals(SCMEvents.DEAD_NODE, eventPublisher.getLastEvent());
 
     // Transition back to healthy from dead
     dni.updateLastHeartbeatTime();
     nsm.checkNodesHealth();
     assertEquals(NodeState.HEALTHY, nsm.getNodeStatus(dn).getHealth());
-    assertEquals("NON_HEALTHY_TO_HEALTHY_NODE",
-        eventPublisher.getLastEvent().getName());
+    assertEquals(SCMEvents.NON_HEALTHY_TO_HEALTHY_NODE,
+        eventPublisher.getLastEvent());
 
     // Make the node stale again, and transition to healthy.
     dni.updateLastHeartbeatTime(now - staleLimit);
     nsm.checkNodesHealth();
     assertEquals(NodeState.STALE, nsm.getNodeStatus(dn).getHealth());
-    assertEquals("Stale_Node", eventPublisher.getLastEvent().getName());
+    assertEquals(SCMEvents.STALE_NODE, eventPublisher.getLastEvent());
     dni.updateLastHeartbeatTime();
     nsm.checkNodesHealth();
     assertEquals(NodeState.HEALTHY, nsm.getNodeStatus(dn).getHealth());
-    assertEquals("NON_HEALTHY_TO_HEALTHY_NODE",
-        eventPublisher.getLastEvent().getName());
+    assertEquals(SCMEvents.NON_HEALTHY_TO_HEALTHY_NODE,
+        eventPublisher.getLastEvent());
   }
 
   @Test
@@ -216,8 +217,8 @@ public class TestNodeStateManager {
         HddsProtos.NodeOperationalState.values()) {
       eventPublisher.clearEvents();
       nsm.setNodeOperationalState(dn, s);
-      assertEquals("NON_HEALTHY_TO_HEALTHY_NODE",
-          eventPublisher.getLastEvent().getName());
+      assertEquals(SCMEvents.NON_HEALTHY_TO_HEALTHY_NODE,
+          eventPublisher.getLastEvent());
     }
 
     // Now make the node stale and run through all states again ensuring the
@@ -235,8 +236,7 @@ public class TestNodeStateManager {
         HddsProtos.NodeOperationalState.values()) {
       eventPublisher.clearEvents();
       nsm.setNodeOperationalState(dn, s);
-      assertEquals("Stale_Node",
-          eventPublisher.getLastEvent().getName());
+      assertEquals(SCMEvents.STALE_NODE, eventPublisher.getLastEvent());
     }
 
     // Finally make the node dead and run through all the op states again
@@ -249,8 +249,7 @@ public class TestNodeStateManager {
         HddsProtos.NodeOperationalState.values()) {
       eventPublisher.clearEvents();
       nsm.setNodeOperationalState(dn, s);
-      assertEquals("Dead_Node",
-          eventPublisher.getLastEvent().getName());
+      assertEquals(SCMEvents.DEAD_NODE, eventPublisher.getLastEvent());
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Normally, when a node goes dead, the DeadNodeHandler removes all the containers and replica associated with the node from the ContainerManager.

If a node is IN_MAINTENANCE and goes dead, then we do not want to remove its replica. They should remain present in the system to prevent the container being marked as under-replicated.

We also need to consider the case where the node is dead, and then maintenance expires automatically. In that case, the replica associated with the node must be removed and the affected containers will become under-replicated.

This PR resolves this issue, by ensuring stale, dead and healthy node events are fired as normal by the NodeStateManager when the node health state changes. This is works as before, prior to any decommission related changes.

To ensure the the container replicas are not removed for a node IN_MAINTENANCE, the DeadNodeHandler has been modified to check the node state and skip removing the replicas if the node is IN_MAINTENANE. For all other states, the dead node handling is unchanged.

Then, for any changes in the node operational state, the same health events are fired when the operational state is changed. This means that a DECOMMISSIONED or IN_MAINTENANCE node that is heartbeating and healthy will fire the HEALTHY node event when it is moved to IN_SERVICE, which triggers pipeline creation.

Similarly, if a node was IN_MAINTENANCE and is DEAD, when it transitions to IN_SERVICE, the dead node event will be trigger, causing the container replicas to be removed. Some of these events will have no effect, but the volume of changes to the node operational state will be minimal, as it will only be changed by the decommission monitor or someone triggering or cancelling decommission and maintenance.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2607

## How was this patch tested?

Additional and modified unit tests
