### PR TITLE
HDDS-2035 Implement datanode level CLI to reveal pipeline relation.

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SCMCLI.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/SCMCLI.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.cli.container.ContainerCommands;
+import org.apache.hadoop.hdds.scm.cli.datanode.DatanodeCommands;
 import org.apache.hadoop.hdds.scm.cli.pipeline.PipelineCommands;
 import org.apache.hadoop.hdds.scm.client.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
@@ -59,6 +60,7 @@ import picocli.CommandLine.Option;
         SafeModeCommands.class,
         ContainerCommands.class,
         PipelineCommands.class,
+        DatanodeCommands.class,
         TopologySubcommand.class,
         ReplicationManagerCommands.class
     },

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DatanodeCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DatanodeCommands.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.cli.datanode;
+
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.cli.MissingSubcommandException;
+import org.apache.hadoop.hdds.scm.cli.SCMCLI;
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Subcommand for datanode related operations.
+ */
+@CommandLine.Command(
+    name = "datanode",
+    description = "Datanode specific operations",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class,
+    subcommands = {
+        ListInfoSubcommand.class
+    })
+public class DatanodeCommands implements Callable<Void> {
+
+  @CommandLine.ParentCommand
+  private SCMCLI parent;
+
+  public SCMCLI getParent() {
+    return parent;
+  }
+
+  @Override
+  public Void call() throws Exception {
+    throw new MissingSubcommandException(
+        this.parent.getCmd().getSubcommands().get("datanode"));
+  }
+}

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.cli.datanode;
+
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.client.ScmClient;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+/**
+ * Handler of list datanodes info command.
+ */
+@CommandLine.Command(
+    name = "list",
+    description = "List info of datanodes",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class)
+public class ListInfoSubcommand implements Callable<Void> {
+
+  @CommandLine.ParentCommand
+  private DatanodeCommands parent;
+
+  @CommandLine.Option(names = {"-ip", "--byIp"},
+      description = "Show info by ip address.",
+      defaultValue = "",
+      required = false)
+  private String ipaddress;
+
+  @CommandLine.Option(names = {"-id", "--byUuid"},
+      description = "Show info by datanode UUID.",
+      defaultValue = "",
+      required = false)
+  private String uuid;
+
+  private List<Pipeline> pipelines;
+
+
+  @Override
+  public Void call() throws Exception {
+    try (ScmClient scmClient = parent.getParent().createScmClient()) {
+      pipelines = scmClient.listPipelines();
+      if (isNullOrEmpty(ipaddress) && isNullOrEmpty(uuid)) {
+        getAllNodes(scmClient).stream().forEach(p -> printDatanodeInfo(p));
+      } else {
+        getAllNodes(scmClient).stream().filter(
+            p -> ((isNullOrEmpty(ipaddress) ||
+            (p.getIpAddress().compareToIgnoreCase(ipaddress) == 0))
+            && (isNullOrEmpty(uuid) ||
+            (p.getUuid().equals(uuid)))))
+            .forEach(p -> printDatanodeInfo(p));
+      }
+      return null;
+    }
+  }
+
+  private List<DatanodeDetails> getAllNodes(ScmClient scmClient)
+      throws IOException {
+    List<HddsProtos.Node> nodes = scmClient.queryNode(
+        HddsProtos.NodeState.HEALTHY, HddsProtos.QueryScope.CLUSTER, "");
+    List<DatanodeDetails> datanodes = new ArrayList<>(nodes.size());
+    nodes.stream().forEach(
+        p -> datanodes.add(DatanodeDetails.getFromProtoBuf(p.getNodeID())));
+    return datanodes;
+  }
+
+  private void printDatanodeInfo(DatanodeDetails datanode) {
+    if (pipelines.isEmpty()) {
+      System.out.println("Datanode: " + datanode.getUuid().toString() +
+          " (" + datanode.getIpAddress() + "/"
+          + datanode.getHostName() + "). \n No pipeline created.");
+      return;
+    }
+    List<Pipeline> relatedPipelines = pipelines.stream().filter(
+        p -> p.getNodes().contains(datanode)).collect(Collectors.toList());
+    StringBuilder pipelineList = new StringBuilder()
+        .append("Related pipelines:\n");
+    relatedPipelines.stream().forEach(
+        p -> pipelineList.append(p.getId().getId().toString())
+            .append("/").append(p.getFactor().toString()).append("/")
+            .append(p.getType().toString()).append("/")
+            .append(p.getPipelineState().toString()).append("/")
+            .append(datanode.getUuid().equals(p.getLeaderId()) ?
+                "Leader" : "Follower")
+            .append(System.getProperty("line.separator")));
+    System.out.println("Datanode: " + datanode.getUuid().toString() +
+        " (" + datanode.getIpAddress() + "/"
+        + datanode.getHostName() + "/" + relatedPipelines.size() +
+        " pipelines). \n" + pipelineList);
+  }
+
+  protected static boolean isNullOrEmpty(String str) {
+    return ((str == null) || str.trim().isEmpty());
+  }
+}

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/package-info.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains all of the datanode related scm commands.
+ */
+package org.apache.hadoop.hdds.scm.cli.datanode;


### PR DESCRIPTION
## What changes were proposed in this pull request?

#HDDS-2035 Implement datanode level CLI to reveal pipeline info

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2035

(Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HDDS-XXXX. Fix a typo in YYY.)

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

bash-4.2$ ozone scmcli datanode list
Datanode: 7a68a668-3dbe-4366-9fed-271f221c1db0 (172.20.0.2/ozone_datanode_1.ozone_default).
Related pipelines:
cd060313-b724-46cf-a83a-8764ba066ae2/ONE/RATIS/OPEN

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
