### PR TITLE
HDDS-1989. Fix ApplyTransaction error handling in OzoneManagerStateMachine.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -190,7 +190,8 @@ public final class OzoneManagerRatisServer {
         } else {
           // Current Ratis is setting cause, this is an safer side check.
           LOG.error("StateMachine exception cause is not set");
-          omResponse.setStatus(OzoneManagerProtocolProtos.Status.INTERNAL_ERROR);
+          omResponse.setStatus(
+              OzoneManagerProtocolProtos.Status.INTERNAL_ERROR);
         }
 
         if (LOG.isDebugEnabled()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -81,6 +81,7 @@ import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.SizeInBytes;
+import org.apache.ratis.util.StringUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -192,6 +193,8 @@ public final class OzoneManagerRatisServer {
           LOG.error("StateMachine exception cause is not set");
           omResponse.setStatus(
               OzoneManagerProtocolProtos.Status.INTERNAL_ERROR);
+          omResponse.setMessage(
+              StringUtils.stringifyException(stateMachineException));
         }
 
         if (LOG.isDebugEnabled()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;
 import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
 import org.apache.hadoop.ozone.om.ha.OMNodeDetails;
@@ -83,8 +84,6 @@ import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.hadoop.ozone.om.exceptions.OMException.STATUS_CODE;
 
 /**
  * Creates a Ratis server endpoint for OM.
@@ -185,8 +184,8 @@ public final class OzoneManagerRatisServer {
         omResponse.setCmdType(omRequest.getCmdType());
         omResponse.setSuccess(false);
         omResponse.setMessage(stateMachineException.getCause().getMessage());
-        omResponse.setStatus(parseErrorStatus(
-            stateMachineException.getCause().getMessage()));
+        omResponse.setStatus(
+            exceptionToResponseStatus(stateMachineException.getCause()));
         if (LOG.isDebugEnabled()) {
           LOG.debug("Error while executing ratis request. " +
               "stateMachineException: ", stateMachineException);
@@ -210,23 +209,24 @@ public final class OzoneManagerRatisServer {
   }
 
   /**
-   * Parse errorMessage received from the exception and convert to
-   * {@link OzoneManagerProtocolProtos.Status}.
-   * @param errorMessage
-   * @return OzoneManagerProtocolProtos.Status
+   * Convert exception to {@link OzoneManagerProtocolProtos.Status}.
+   * @param cause - Cause from stateMachine exception
+   * @return {@link OzoneManagerProtocolProtos.Status}
    */
-  private OzoneManagerProtocolProtos.Status parseErrorStatus(
-      String errorMessage) {
-    if (errorMessage.contains(STATUS_CODE)) {
-      String errorCode = errorMessage.substring(
-          errorMessage.indexOf(STATUS_CODE) + STATUS_CODE.length());
-      LOG.debug("Parsing error message for error code " +
-          errorCode);
-      return OzoneManagerProtocolProtos.Status.valueOf(errorCode.trim());
-    } else {
+  private OzoneManagerProtocolProtos.Status exceptionToResponseStatus(
+      Throwable cause) {
+    if (cause == null) {
+      // Current Ratis is setting cause, this is an safer side check.
+      LOG.error("StateMachine exception cause is not set");
       return OzoneManagerProtocolProtos.Status.INTERNAL_ERROR;
     }
-
+    if (cause instanceof OMException) {
+      return OzoneManagerProtocolProtos.Status.values()[
+          ((OMException) cause).getResult().ordinal()];
+    } else {
+      LOG.error("Unknown error occurs", cause);
+      return OzoneManagerProtocolProtos.Status.INTERNAL_ERROR;
+    }
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -55,9 +55,13 @@ import org.apache.ratis.statemachine.TransactionContext;
 import org.apache.ratis.statemachine.impl.BaseStateMachine;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.util.ExitUtils;
 import org.apache.ratis.util.LifeCycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.INTERNAL_ERROR;
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.METADATA_ERROR;
 
 /**
  * The OM StateMachine is the state machine for OM Ratis server. It is
@@ -221,14 +225,61 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
 
       // Add the term index and transaction log index to applyTransaction map
       // . This map will be used to update lastAppliedIndex.
+
+      CompletableFuture<Message> ratisFuture =
+          new CompletableFuture<>();
+
       applyTransactionMap.put(trxLogIndex, trx.getLogEntry().getTerm());
-      CompletableFuture<Message> future = CompletableFuture.supplyAsync(
-          () -> runCommand(request, trxLogIndex),
-          executorService);
-      return future;
-    } catch (IOException e) {
+      CompletableFuture<OMResponse> future = CompletableFuture.supplyAsync(
+          () -> runCommand(request, trxLogIndex), executorService);
+      future.thenApply(omResponse -> {
+        if(!omResponse.getSuccess()) {
+          // When INTERNAL_ERROR or METADATA_ERROR it is considered as
+          // critical error and terminate the OM. Considering INTERNAL_ERROR
+          // also for now because INTERNAL_ERROR is thrown for any error
+          // which is not type OMException.
+
+          // Not done future with completeExceptionally because if we do
+          // that OM will still continue applying transaction until next
+          // snapshot. So in OM case if a transaction failed with un
+          // recoverable error and if we wait till snapshot to terminate
+          // OM, then if some client requested the read transaction of the
+          // failed request, there is a chance we shall give wrong result.
+          // So, to avoid these kind of issue, we should terminate OM here.
+          if (omResponse.getStatus() == INTERNAL_ERROR) {
+            terminate(omResponse, OMException.ResultCodes.INTERNAL_ERROR);
+          } else if (omResponse.getStatus() == METADATA_ERROR) {
+            terminate(omResponse, OMException.ResultCodes.METADATA_ERROR);
+          } else {
+            // For all other errors which are not critical, we can complete
+            // future normally.
+            ratisFuture.complete(OMRatisHelper.convertResponseToMessage(
+                omResponse));
+          }
+        } else {
+          ratisFuture.complete(OMRatisHelper.convertResponseToMessage(
+              omResponse));
+        }
+        return ratisFuture;
+      });
+      return ratisFuture;
+    } catch (Exception e) {
       return completeExceptionally(e);
     }
+  }
+
+  /**
+   * Terminate OM.
+   * @param omResponse
+   * @param resultCode
+   */
+  private void terminate(OMResponse omResponse,
+      OMException.ResultCodes resultCode) {
+    OMException exception = new OMException(omResponse.getMessage(),
+        resultCode);
+    String errorMessage = "OM Response has received unrecoverable " +
+        "error, terminating OM. Error Response is" + omResponse;
+    ExitUtils.terminate(1, errorMessage, exception, LOG);
   }
 
   /**
@@ -351,10 +402,9 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
    * @return response from OM
    * @throws ServiceException
    */
-  private Message runCommand(OMRequest request, long trxLogIndex) {
-    OMResponse response = handler.handleWriteRequest(request,
+  private OMResponse runCommand(OMRequest request, long trxLogIndex) {
+    return handler.handleWriteRequest(request,
         trxLogIndex).getOMResponse();
-    return OMRatisHelper.convertResponseToMessage(response);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -403,8 +403,15 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
    * @throws ServiceException
    */
   private OMResponse runCommand(OMRequest request, long trxLogIndex) {
-    return handler.handleWriteRequest(request,
-        trxLogIndex).getOMResponse();
+    try {
+      return handler.handleWriteRequest(request,
+          trxLogIndex).getOMResponse();
+    } catch (Throwable e) {
+      // For any Runtime exceptions, terminate OM.
+      String errorMessage = "Request " + request + "failed with exception";
+      ExitUtils.terminate(1, errorMessage, e, LOG);
+    }
+    return null;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -250,16 +250,13 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
             terminate(omResponse, OMException.ResultCodes.INTERNAL_ERROR);
           } else if (omResponse.getStatus() == METADATA_ERROR) {
             terminate(omResponse, OMException.ResultCodes.METADATA_ERROR);
-          } else {
-            // For all other errors which are not critical, we can complete
-            // future normally.
-            ratisFuture.complete(OMRatisHelper.convertResponseToMessage(
-                omResponse));
           }
-        } else {
-          ratisFuture.complete(OMRatisHelper.convertResponseToMessage(
-              omResponse));
         }
+
+        // For successful response and for all other errors which are not
+        // critical, we can complete future normally.
+        ratisFuture.complete(OMRatisHelper.convertResponseToMessage(
+            omResponse));
         return ratisFuture;
       });
       return ratisFuture;
@@ -277,8 +274,9 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
       OMException.ResultCodes resultCode) {
     OMException exception = new OMException(omResponse.getMessage(),
         resultCode);
-    String errorMessage = "OM Response has received unrecoverable " +
-        "error, terminating OM. Error Response is" + omResponse;
+    String errorMessage = "OM Ratis Server has received unrecoverable " +
+        "error, to avoid further DB corruption, terminating OM. Error " +
+        "Response received is:" + omResponse;
     ExitUtils.terminate(1, errorMessage, exception, LOG);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -198,7 +198,7 @@ public final class OzoneManagerRatisUtils {
   public static Status exceptionToResponseStatus(IOException exception) {
     if (exception instanceof OMException) {
       return Status.values()[((OMException) exception).getResult().ordinal()];
-    } else if (exception instanceof IOException) {
+    } else {
       // Doing this here, because when DB error happens we need to return
       // correct error code, so that in applyTransaction we can
       // completeExceptionally for DB errors.
@@ -213,8 +213,6 @@ public final class OzoneManagerRatisUtils {
       } else {
         return Status.INTERNAL_ERROR;
       }
-    } else {
-      return Status.INTERNAL_ERROR;
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -62,6 +62,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMReque
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneObj.ObjectType;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
+import org.rocksdb.RocksDBException;
 
 import java.io.IOException;
 
@@ -197,6 +198,21 @@ public final class OzoneManagerRatisUtils {
   public static Status exceptionToResponseStatus(IOException exception) {
     if (exception instanceof OMException) {
       return Status.values()[((OMException) exception).getResult().ordinal()];
+    } else if (exception instanceof IOException) {
+      // Doing this here, because when DB error happens we need to return
+      // correct error code, so that in applyTransaction we can
+      // completeExceptionally for DB errors.
+
+      // Currently Table API's are in hdds-common, which are used by SCM, OM
+      // currently. So, they return IOException with setting cause to
+      // RocksDBException. So, here that is the reason for the instanceof
+      // check RocksDBException.
+      if (exception.getCause() != null
+          && exception.getCause() instanceof RocksDBException) {
+        return Status.METADATA_ERROR;
+      } else {
+        return Status.INTERNAL_ERROR;
+      }
     } else {
       return Status.INTERNAL_ERROR;
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.rocksdb.RocksDBException;
 
 import javax.annotation.Nonnull;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -46,7 +46,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.rocksdb.RocksDBException;
 
 import javax.annotation.Nonnull;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Terminate OM, after a critical error in apply transaction. Right now terminate for INTERNAL_ERROR and METADATA_ERROR.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-1989

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

We need to see if any test for this failure scenario can be added. Mostly will try to come up with UT once HDDS-2682 merges in. Since the code in applyTransaction is running in an executor thread, not able to come up with a test for this failure scenario.
