### PR TITLE
HDDS-2722. Let ChunkManager read/write ChunkBuffer instead of ByteBuffer

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ByteStringConversion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ByteStringConversion.java
@@ -41,7 +41,7 @@ public final class ByteStringConversion {
    * @param config the Ozone configuration
    * @return the conversion function defined by
    *          {@link OzoneConfigKeys#OZONE_UNSAFEBYTEOPERATIONS_ENABLED}
-   * @see <pre>ByteBuffer</pre>
+   * @see ByteBuffer
    */
   public static Function<ByteBuffer, ByteString> createByteBufferConversion(
       Configuration config){
@@ -50,13 +50,15 @@ public final class ByteStringConversion {
             OzoneConfigKeys.OZONE_UNSAFEBYTEOPERATIONS_ENABLED,
             OzoneConfigKeys.OZONE_UNSAFEBYTEOPERATIONS_ENABLED_DEFAULT);
     if (unsafeEnabled) {
-      return buffer -> UnsafeByteOperations.unsafeWrap(buffer);
+      return UnsafeByteOperations::unsafeWrap;
     } else {
-      return buffer -> {
-        ByteString retval = ByteString.copyFrom(buffer);
-        buffer.flip();
-        return retval;
-      };
+      return ByteStringConversion::safeWrap;
     }
+  }
+
+  public static ByteString safeWrap(ByteBuffer buffer) {
+    ByteString retval = ByteString.copyFrom(buffer);
+    buffer.flip();
+    return retval;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBuffer.java
@@ -19,7 +19,9 @@ package org.apache.hadoop.ozone.common;
 
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.GatheringByteChannel;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.function.Function;
@@ -43,6 +45,17 @@ final class ChunkBufferImplWithByteBuffer implements ChunkBuffer {
   }
 
   @Override
+  public int limit() {
+    return buffer.limit();
+  }
+
+  @Override
+  public ChunkBuffer rewind() {
+    buffer.rewind();
+    return this;
+  }
+
+  @Override
   public Iterable<ByteBuffer> iterate(int bufferSize) {
     return () -> new Iterator<ByteBuffer>() {
       @Override
@@ -63,6 +76,11 @@ final class ChunkBufferImplWithByteBuffer implements ChunkBuffer {
   }
 
   @Override
+  public long writeTo(GatheringByteChannel channel) throws IOException {
+    return channel.write(buffer);
+  }
+
+  @Override
   public ChunkBuffer duplicate(int newPosition, int newLimit) {
     final ByteBuffer duplicated = buffer.duplicate();
     duplicated.position(newPosition).limit(newLimit);
@@ -70,13 +88,15 @@ final class ChunkBufferImplWithByteBuffer implements ChunkBuffer {
   }
 
   @Override
-  public void put(ByteBuffer b) {
+  public ChunkBuffer put(ByteBuffer b) {
     buffer.put(b);
+    return this;
   }
 
   @Override
-  public void clear() {
+  public ChunkBuffer clear() {
     buffer.clear();
+    return this;
   }
 
   @Override

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/MockGatheringChannel.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/MockGatheringChannel.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.utils;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+import static com.google.common.base.Preconditions.checkElementIndex;
+
+/**
+ * {@link GatheringByteChannel} implementation for testing.  Delegates
+ * to a {@link WritableByteChannel}.
+ *
+ * @see java.nio.channels.Channels#newChannel(java.io.OutputStream)
+ */
+public class MockGatheringChannel implements GatheringByteChannel {
+
+  private final WritableByteChannel delegate;
+
+  public MockGatheringChannel(WritableByteChannel delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public long write(ByteBuffer[] srcs, int offset, int length)
+      throws IOException {
+
+    checkElementIndex(offset, srcs.length, "offset");
+    checkElementIndex(offset+length-1, srcs.length, "offset+length");
+
+    long bytes = 0;
+    for (ByteBuffer b : srcs) {
+      bytes += write(b);
+    }
+    return bytes;
+  }
+
+  @Override
+  public long write(ByteBuffer[] srcs) throws IOException {
+    return write(srcs, 0, srcs.length);
+  }
+
+  @Override
+  public int write(ByteBuffer src) throws IOException {
+    return delegate.write(src);
+  }
+
+  @Override
+  public boolean isOpen() {
+    return delegate.isOpen();
+  }
+
+  @Override
+  public void close() throws IOException {
+    delegate.close();
+  }
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChunkBuffer.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChunkBuffer.java
@@ -17,11 +17,15 @@
  */
 package org.apache.hadoop.ozone.common;
 
+import org.apache.hadoop.hdds.utils.MockGatheringChannel;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
 import java.util.Iterator;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -73,10 +77,12 @@ public class TestChunkBuffer {
     // check position, remaining
     Assert.assertEquals(0, impl.position());
     Assert.assertEquals(n, impl.remaining());
+    Assert.assertEquals(n, impl.limit());
 
-    impl.put(expected, 0, expected.length);
+    impl.put(expected);
     Assert.assertEquals(n, impl.position());
     Assert.assertEquals(0, impl.remaining());
+    Assert.assertEquals(n, impl.limit());
 
     // duplicate
     assertDuplicate(expected, impl);
@@ -96,6 +102,8 @@ public class TestChunkBuffer {
         assertIterate(expected, impl, bytesPerChecksum);
       }
     }
+
+    assertWrite(expected, impl);
   }
 
   private static void assertDuplicate(byte[] expected, ChunkBuffer impl) {
@@ -148,5 +156,20 @@ public class TestChunkBuffer {
     Assert.assertEquals(length, duplicated.remaining());
     Assert.assertEquals("offset=" + offset + ", length=" + length,
         ByteString.copyFrom(expected, offset, length), computed);
+  }
+
+  private static void assertWrite(byte[] expected, ChunkBuffer impl) {
+    impl.rewind();
+    Assert.assertEquals(0, impl.position());
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream(expected.length);
+
+    try {
+      impl.writeTo(new MockGatheringChannel(Channels.newChannel(output)));
+    } catch (IOException e) {
+      Assert.fail("Unexpected error: " + e);
+    }
+
+    Assert.assertArrayEquals(expected, output.toByteArray());
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -48,12 +48,14 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.KeyValue;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
     .PutSmallFileRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.WriteChunkRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.ByteStringConversion;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.common.helpers
     .StorageContainerException;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerMetrics;
@@ -567,7 +569,7 @@ public class KeyValueHandler extends Handler {
       return ContainerUtils.logAndReturnError(LOG, sce, request);
     }
 
-    ByteBuffer data;
+    ChunkBuffer data;
     try {
       BlockID blockID = BlockID.getFromProtobuf(
           request.getReadChunk().getBlockID());
@@ -592,7 +594,8 @@ public class KeyValueHandler extends Handler {
 
     Preconditions.checkNotNull(data, "Chunk data is null");
 
-    return getReadChunkResponse(request, byteBufferToByteString.apply(data));
+    ByteString byteString = data.toByteString(byteBufferToByteString);
+    return getReadChunkResponse(request, byteString);
   }
 
   /**
@@ -678,21 +681,20 @@ public class KeyValueHandler extends Handler {
     try {
       checkContainerOpen(kvContainer);
 
-      BlockID blockID = BlockID.getFromProtobuf(
-          request.getWriteChunk().getBlockID());
-      ContainerProtos.ChunkInfo chunkInfoProto =
-          request.getWriteChunk().getChunkData();
+      WriteChunkRequestProto writeChunk = request.getWriteChunk();
+      BlockID blockID = BlockID.getFromProtobuf(writeChunk.getBlockID());
+      ContainerProtos.ChunkInfo chunkInfoProto = writeChunk.getChunkData();
       ChunkInfo chunkInfo = ChunkInfo.getFromProtoBuf(chunkInfoProto);
       Preconditions.checkNotNull(chunkInfo);
 
-      ByteBuffer data = null;
+      ChunkBuffer data = null;
       if (dispatcherContext == null) {
         dispatcherContext = new DispatcherContext.Builder().build();
       }
       WriteChunkStage stage = dispatcherContext.getStage();
       if (stage == WriteChunkStage.WRITE_DATA ||
           stage == WriteChunkStage.COMBINED) {
-        data = request.getWriteChunk().getData().asReadOnlyByteBuffer();
+        data = ChunkBuffer.wrap(writeChunk.getData().asReadOnlyByteBuffer());
       }
 
       chunkManager
@@ -701,7 +703,7 @@ public class KeyValueHandler extends Handler {
       // We should increment stats after writeChunk
       if (stage == WriteChunkStage.WRITE_DATA||
           stage == WriteChunkStage.COMBINED) {
-        metrics.incContainerBytesStats(Type.WriteChunk, request.getWriteChunk()
+        metrics.incContainerBytesStats(Type.WriteChunk, writeChunk
             .getChunkData().getLen());
       }
     } catch (StorageContainerException ex) {
@@ -745,7 +747,8 @@ public class KeyValueHandler extends Handler {
       ChunkInfo chunkInfo = ChunkInfo.getFromProtoBuf(chunkInfoProto);
       Preconditions.checkNotNull(chunkInfo);
 
-      ByteBuffer data = putSmallFileReq.getData().asReadOnlyByteBuffer();
+      ChunkBuffer data = ChunkBuffer.wrap(
+          putSmallFileReq.getData().asReadOnlyByteBuffer());
       if (dispatcherContext == null) {
         dispatcherContext = new DispatcherContext.Builder().build();
       }
@@ -765,7 +768,7 @@ public class KeyValueHandler extends Handler {
       blockManager.putBlock(kvContainer, blockData);
 
       blockDataProto = blockData.getProtoBufMessage();
-      metrics.incContainerBytesStats(Type.PutSmallFile, data.capacity());
+      metrics.incContainerBytesStats(Type.PutSmallFile, chunkInfo.getLen());
     } catch (StorageContainerException ex) {
       return ContainerUtils.logAndReturnError(LOG, ex, request);
     } catch (IOException ex) {
@@ -815,9 +818,9 @@ public class KeyValueHandler extends Handler {
       for (ContainerProtos.ChunkInfo chunk : responseData.getChunks()) {
         // if the block is committed, all chunks must have been committed.
         // Tmp chunk files won't exist here.
-        ByteBuffer data = chunkManager.readChunk(kvContainer, blockID,
+        ChunkBuffer data = chunkManager.readChunk(kvContainer, blockID,
             ChunkInfo.getFromProtoBuf(chunk), dispatcherContext);
-        ByteString current = byteBufferToByteString.apply(data);
+        ByteString current = data.toByteString(byteBufferToByteString);
         dataBuf = dataBuf.concat(current);
         chunkInfo = chunk;
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDummyImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDummyImpl.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.container.keyvalue.impl;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
+import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
@@ -62,7 +63,7 @@ public class ChunkManagerDummyImpl extends ChunkManagerImpl {
    */
   @Override
   public void writeChunk(Container container, BlockID blockID, ChunkInfo info,
-      ByteBuffer data, DispatcherContext dispatcherContext)
+      ChunkBuffer data, DispatcherContext dispatcherContext)
       throws StorageContainerException {
     long writeTimeStart = Time.monotonicNow();
 
@@ -112,7 +113,7 @@ public class ChunkManagerDummyImpl extends ChunkManagerImpl {
    * TODO: Explore if we need to do that for ozone.
    */
   @Override
-  public ByteBuffer readChunk(Container container, BlockID blockID,
+  public ChunkBuffer readChunk(Container container, BlockID blockID,
       ChunkInfo info, DispatcherContext dispatcherContext) {
 
     long readStartTime = Time.monotonicNow();
@@ -130,7 +131,7 @@ public class ChunkManagerDummyImpl extends ChunkManagerImpl {
     volumeIOStats.incReadOpCount();
     volumeIOStats.incReadBytes(info.getLen());
 
-    return data;
+    return ChunkBuffer.wrap(data);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerImpl.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
@@ -79,7 +80,7 @@ public class ChunkManagerImpl implements ChunkManager {
    * @throws StorageContainerException
    */
   public void writeChunk(Container container, BlockID blockID, ChunkInfo info,
-      ByteBuffer data, DispatcherContext dispatcherContext)
+      ChunkBuffer data, DispatcherContext dispatcherContext)
       throws StorageContainerException {
     Preconditions.checkNotNull(dispatcherContext);
     DispatcherContext.WriteChunkStage stage = dispatcherContext.getStage();
@@ -203,7 +204,7 @@ public class ChunkManagerImpl implements ChunkManager {
    * TODO: Right now we do not support partial reads and writes of chunks.
    * TODO: Explore if we need to do that for ozone.
    */
-  public ByteBuffer readChunk(Container container, BlockID blockID,
+  public ChunkBuffer readChunk(Container container, BlockID blockID,
       ChunkInfo info, DispatcherContext dispatcherContext)
       throws StorageContainerException {
     KeyValueContainerData containerData = (KeyValueContainerData) container
@@ -234,7 +235,7 @@ public class ChunkManagerImpl implements ChunkManager {
           containerData.incrReadCount();
           long length = info.getLen();
           containerData.incrReadBytes(length);
-          return data;
+          return ChunkBuffer.wrap(data);
         } catch (StorageContainerException ex) {
           //UNABLE TO FIND chunk is not a problem as we will try with the
           //next possible location

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/ChunkManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/ChunkManager.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.container.keyvalue.interfaces;
 
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
+import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
@@ -39,12 +40,20 @@ public interface ChunkManager {
    * @param container - Container for the chunk
    * @param blockID - ID of the block.
    * @param info - ChunkInfo.
+   * @param data
    * @param dispatcherContext - dispatcher context info.
    * @throws StorageContainerException
    */
   void writeChunk(Container container, BlockID blockID, ChunkInfo info,
-      ByteBuffer data, DispatcherContext dispatcherContext)
+      ChunkBuffer data, DispatcherContext dispatcherContext)
       throws StorageContainerException;
+
+  default void writeChunk(Container container, BlockID blockID, ChunkInfo info,
+      ByteBuffer data, DispatcherContext dispatcherContext)
+      throws StorageContainerException {
+    ChunkBuffer wrapper = ChunkBuffer.wrap(data);
+    writeChunk(container, blockID, info, wrapper, dispatcherContext);
+  }
 
   /**
    * reads the data defined by a chunk.
@@ -59,7 +68,7 @@ public interface ChunkManager {
    * TODO: Right now we do not support partial reads and writes of chunks.
    * TODO: Explore if we need to do that for ozone.
    */
-  ByteBuffer readChunk(Container container, BlockID blockID, ChunkInfo info,
+  ChunkBuffer readChunk(Container container, BlockID blockID, ChunkInfo info,
       DispatcherContext dispatcherContext) throws StorageContainerException;
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ContainerTestHelper.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ContainerTestHelper.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.common.Checksum;
+import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.common.OzoneChecksumException;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
@@ -59,7 +60,6 @@ import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.server.impl.RaftServerImpl;
 import org.apache.ratis.server.impl.RaftServerProxy;
 import org.apache.ratis.statemachine.StateMachine;
-import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -161,10 +161,10 @@ public final class ContainerTestHelper {
    * @param len - Number of bytes.
    * @return byte array with valid data.
    */
-  public static ByteBuffer getData(int len) {
+  public static ChunkBuffer getData(int len) {
     byte[] data = new byte[len];
     r.nextBytes(data);
-    return ByteBuffer.wrap(data);
+    return ChunkBuffer.wrap(ByteBuffer.wrap(data));
   }
 
   /**
@@ -173,10 +173,11 @@ public final class ContainerTestHelper {
    * @param info - chunk info.
    * @param data - data array
    */
-  public static void setDataChecksum(ChunkInfo info, ByteBuffer data)
+  public static void setDataChecksum(ChunkInfo info, ChunkBuffer data)
       throws OzoneChecksumException {
     Checksum checksum = new Checksum();
     info.setChecksumData(checksum.computeChecksum(data));
+    data.rewind();
   }
 
   /**
@@ -216,12 +217,12 @@ public final class ContainerTestHelper {
 
     writeRequest.setBlockID(blockID.getDatanodeBlockIDProtobuf());
 
-    ByteBuffer data = getData(datalen);
+    ChunkBuffer data = getData(datalen);
     ChunkInfo info = getChunk(blockID.getLocalID(), seq, 0, datalen);
     setDataChecksum(info, data);
 
     writeRequest.setChunkData(info.getProtoBufMessage());
-    writeRequest.setData(ByteString.copyFrom(data));
+    writeRequest.setData(data.toByteString());
 
     Builder request =
         ContainerCommandRequestProto.newBuilder();
@@ -249,7 +250,7 @@ public final class ContainerTestHelper {
       throws Exception {
     ContainerProtos.PutSmallFileRequestProto.Builder smallFileRequest =
         ContainerProtos.PutSmallFileRequestProto.newBuilder();
-    ByteBuffer data = getData(dataLen);
+    ChunkBuffer data = getData(dataLen);
     ChunkInfo info = getChunk(blockID.getLocalID(), 0, 0, dataLen);
     setDataChecksum(info, data);
 
@@ -264,7 +265,7 @@ public final class ContainerTestHelper {
     putRequest.setBlockData(blockData.getProtoBufMessage());
 
     smallFileRequest.setChunkInfo(info.getProtoBufMessage());
-    smallFileRequest.setData(ByteString.copyFrom(data));
+    smallFileRequest.setData(data.toByteString());
     smallFileRequest.setBlock(putRequest);
 
     Builder request =

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
+import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.volume.VolumeIOStats;
 import org.apache.hadoop.test.GenericTestUtils;
@@ -63,11 +64,11 @@ public class TestChunkUtils {
   public void concurrentReadOfSameFile() throws Exception {
     String s = "Hello World";
     byte[] array = s.getBytes();
-    ByteBuffer data = ByteBuffer.wrap(array);
+    ChunkBuffer data = ChunkBuffer.wrap(ByteBuffer.wrap(array));
     Path tempFile = Files.createTempFile(PREFIX, "concurrent");
     try {
       ChunkInfo chunkInfo = new ChunkInfo(tempFile.toString(),
-          0, data.capacity());
+          0, data.limit());
       File file = tempFile.toFile();
       VolumeIOStats stats = new VolumeIOStats();
       ChunkUtils.writeData(file, chunkInfo, data, stats, true);
@@ -149,11 +150,11 @@ public class TestChunkUtils {
   public void serialRead() throws Exception {
     String s = "Hello World";
     byte[] array = s.getBytes();
-    ByteBuffer data = ByteBuffer.wrap(array);
+    ChunkBuffer data = ChunkBuffer.wrap(ByteBuffer.wrap(array));
     Path tempFile = Files.createTempFile(PREFIX, "serial");
     try {
       ChunkInfo chunkInfo = new ChunkInfo(tempFile.toString(),
-          0, data.capacity());
+          0, data.limit());
       File file = tempFile.toFile();
       VolumeIOStats stats = new VolumeIOStats();
       ChunkUtils.writeData(file, chunkInfo, data, stats, true);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change `ChunkManager` read/write methods to accept/return `ChunkBuffer` instead of `ByteBuffer`.  This allows seamlessly passing multiple buffers without further interface change.

https://issues.apache.org/jira/browse/HDDS-2722

## How was this patch tested?

Added unit test for new functionality in `ChunkBuffer`.  The rest is covered by existing tests.

https://github.com/adoroszlai/hadoop-ozone/runs/346822935