### PR TITLE
HDDS-2623. Expose SCMDatanodeProtocolServer RPC endpoint through Recon.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.recon;
+
+/**
+ * This class contains constants for Recon related configuration keys used in
+ * SCM & Datanode.
+ */
+public final class ReconConfigKeys {
+
+  /**
+   * Never constructed.
+   */
+  private ReconConfigKeys() {
+  }
+
+  public static final String OZONE_RECON_DATANODE_ADDRESS_KEY =
+      "ozone.recon.datanode.address";
+  public static final String OZONE_RECON_DATANODE_BIND_HOST_KEY =
+      "ozone.recon.datanode.bind.host";
+  public static final String OZONE_RECON_DATANODE_BIND_HOST_DEFAULT =
+      "0.0.0.0";
+  public static final int OZONE_RECON_DATANODE_PORT_DEFAULT = 9865;
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/package-info.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.recon;
+
+/**
+ * This package contains classes related to Recon.
+ */

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/hdds/scm/HddsServerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/hdds/scm/HddsServerUtil.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm;
 
 import com.google.common.base.Strings;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.recon.ReconConfigKeys;
 import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
@@ -183,6 +184,27 @@ public final class HddsServerUtil {
             port.orElse(ScmConfigKeys.OZONE_SCM_DATANODE_PORT_DEFAULT));
   }
 
+
+  /**
+   * Retrieve the socket address that should be used by DataNodes to connect
+   * to Recon.
+   *
+   * @param conf
+   * @return Target {@code InetSocketAddress} for the SCM service endpoint.
+   */
+  public static InetSocketAddress getReconDataNodeBindAddress(
+      Configuration conf) {
+    final Optional<String> host = getHostNameFromConfigKeys(conf,
+        ReconConfigKeys.OZONE_RECON_DATANODE_BIND_HOST_KEY);
+
+    final OptionalInt port = getPortNumberFromConfigKeys(conf,
+        ReconConfigKeys.OZONE_RECON_DATANODE_ADDRESS_KEY);
+
+    return NetUtils.createSocketAddr(
+        host.orElse(
+            ReconConfigKeys.OZONE_RECON_DATANODE_BIND_HOST_DEFAULT) + ":" +
+            port.orElse(ReconConfigKeys.OZONE_RECON_DATANODE_PORT_DEFAULT));
+  }
 
   /**
    * Returns the interval in which the heartbeat processor thread runs.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/OzoneStorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/OzoneStorageContainerManager.java
@@ -19,16 +19,24 @@
 package org.apache.hadoop.hdds.scm.server;
 
 import org.apache.hadoop.hdds.scm.block.BlockManager;
+import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.container.ReplicationManager;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 
 /**
  * Interface for the SCM Facade class that can be used by a passive SCM like
  * Recon to tweak implementation.
  */
-public interface StorageContainerManagerInterface {
+public interface OzoneStorageContainerManager {
 
   NodeManager getScmNodeManager();
 
   BlockManager getScmBlockManager();
 
+  PipelineManager getPipelineManager();
+
+  ContainerManager getContainerManager();
+
+  ReplicationManager getReplicationManager();
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -152,8 +152,7 @@ public class SCMDatanodeProtocolServer implements
                 new StorageContainerDatanodeProtocolServerSideTranslatorPB(
                     this, protocolMessageMetrics));
 
-    InetSocketAddress datanodeRpcAddr =
-        HddsServerUtil.getScmDataNodeBindAddress(conf);
+    InetSocketAddress datanodeRpcAddr = getDataNodeBindAddress(conf);
 
     datanodeRpcServer =
         startRpcServer(
@@ -406,6 +405,10 @@ public class SCMDatanodeProtocolServer implements
         .replaceAll(System.lineSeparator(), " ")
         .trim()
         .replaceAll(" +", " ");
+  }
+
+  protected InetSocketAddress getDataNodeBindAddress(OzoneConfiguration conf) {
+    return HddsServerUtil.getScmDataNodeBindAddress(conf);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -115,14 +115,15 @@ public class SCMDatanodeProtocolServer implements
    */
   private final RPC.Server datanodeRpcServer;
 
-  private final StorageContainerManager scm;
+  private final StorageContainerManagerInterface scm;
   private final InetSocketAddress datanodeRpcAddress;
   private final SCMDatanodeHeartbeatDispatcher heartbeatDispatcher;
   private final EventPublisher eventPublisher;
   private final ProtocolMessageMetrics protocolMessageMetrics;
 
   public SCMDatanodeProtocolServer(final OzoneConfiguration conf,
-      StorageContainerManager scm, EventPublisher eventPublisher)
+                                   StorageContainerManagerInterface scm,
+                                   EventPublisher eventPublisher)
       throws IOException {
 
     Preconditions.checkNotNull(scm, "SCM cannot be null");

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -115,14 +115,14 @@ public class SCMDatanodeProtocolServer implements
    */
   private final RPC.Server datanodeRpcServer;
 
-  private final StorageContainerManagerInterface scm;
+  private final OzoneStorageContainerManager scm;
   private final InetSocketAddress datanodeRpcAddress;
   private final SCMDatanodeHeartbeatDispatcher heartbeatDispatcher;
   private final EventPublisher eventPublisher;
   private final ProtocolMessageMetrics protocolMessageMetrics;
 
   public SCMDatanodeProtocolServer(final OzoneConfiguration conf,
-                                   StorageContainerManagerInterface scm,
+                                   OzoneStorageContainerManager scm,
                                    EventPublisher eventPublisher)
       throws IOException {
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -131,7 +131,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_SCM_WATCHER_TIMEOUT_
  */
 @InterfaceAudience.LimitedPrivate({"HDFS", "CBLOCK", "OZONE", "HBASE"})
 public final class StorageContainerManager extends ServiceRuntimeInfoImpl
-    implements SCMMXBean {
+    implements SCMMXBean, StorageContainerManagerInterface {
 
   private static final Logger LOG = LoggerFactory
       .getLogger(StorageContainerManager.class);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -131,7 +131,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_SCM_WATCHER_TIMEOUT_
  */
 @InterfaceAudience.LimitedPrivate({"HDFS", "CBLOCK", "OZONE", "HBASE"})
 public final class StorageContainerManager extends ServiceRuntimeInfoImpl
-    implements SCMMXBean, StorageContainerManagerInterface {
+    implements SCMMXBean, OzoneStorageContainerManager {
 
   private static final Logger LOG = LoggerFactory
       .getLogger(StorageContainerManager.class);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerInterface.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerInterface.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.server;
+
+import org.apache.hadoop.hdds.scm.block.BlockManager;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+
+/**
+ * Interface for the SCM Facade class that can be used by a passive SCM like
+ * Recon to tweak implementation.
+ */
+public interface StorageContainerManagerInterface {
+
+  NodeManager getScmNodeManager();
+
+  BlockManager getScmBlockManager();
+
+}

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -196,6 +196,10 @@
       <artifactId>hadoop-ozone-ozone-manager</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-server-scm</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
       <version>${guice.version}</version>

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconControllerModule.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconControllerModule.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.ozone.recon.persistence.DataSourceConfiguration;
 import org.apache.hadoop.ozone.recon.persistence.JooqPersistenceModule;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.recovery.ReconOmMetadataManagerImpl;
+import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManager;
 import org.apache.hadoop.ozone.recon.spi.ContainerDBServiceProvider;
 import org.apache.hadoop.ozone.recon.spi.OzoneManagerServiceProvider;
 import org.apache.hadoop.ozone.recon.spi.impl.ReconContainerDBProvider;
@@ -85,6 +86,7 @@ public class ReconControllerModule extends AbstractModule {
 
     bind(ReconTaskController.class)
         .to(ReconTaskControllerImpl.class).in(Singleton.class);
+    bind(ReconStorageContainerManager.class);
   }
 
   @Provides

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -104,11 +104,11 @@ public class ReconServer extends GenericCli {
     ozoneManagerServiceProvider.stop();
   }
 
-  OzoneManagerServiceProvider getOzoneManagerServiceProvider() {
+  private OzoneManagerServiceProvider getOzoneManagerServiceProvider() {
     return injector.getInstance(OzoneManagerServiceProvider.class);
   }
 
-  ReconStorageContainerManager getReconStorageContainerManager() {
+  private ReconStorageContainerManager getReconStorageContainerManager() {
     return injector.getInstance(ReconStorageContainerManager.class);
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.recon;
 
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManager;
 import org.apache.hadoop.ozone.recon.spi.OzoneManagerServiceProvider;
 import org.hadoop.ozone.recon.codegen.ReconSchemaGenerationModule;
 import org.slf4j.Logger;
@@ -77,10 +78,9 @@ public class ReconServer extends GenericCli {
       LOG.info("Starting Recon server");
       httpServer.start();
 
-      //Start Ozone Manager Service that pulls data from OM.
-      OzoneManagerServiceProvider ozoneManagerServiceProvider = injector
-          .getInstance(OzoneManagerServiceProvider.class);
-      ozoneManagerServiceProvider.start();
+      getOzoneManagerServiceProvider().start();
+      getReconStorageContainerManager().start();
+
     } catch (Exception e) {
       LOG.error("Error during initializing Recon server.", e);
       stop();
@@ -103,4 +103,13 @@ public class ReconServer extends GenericCli {
         .getInstance(OzoneManagerServiceProvider.class);
     ozoneManagerServiceProvider.stop();
   }
+
+  OzoneManagerServiceProvider getOzoneManagerServiceProvider() {
+    return injector.getInstance(OzoneManagerServiceProvider.class);
+  }
+
+  ReconStorageContainerManager getReconStorageContainerManager() {
+    return injector.getInstance(ReconStorageContainerManager.class);
+  }
+
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconDatanodeProtocolServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconDatanodeProtocolServer.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMVersionRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMVersionResponseProto;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer;
-import org.apache.hadoop.hdds.scm.server.StorageContainerManagerInterface;
+import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 
 /**
@@ -40,7 +40,7 @@ import org.apache.hadoop.hdds.server.events.EventPublisher;
 public class ReconDatanodeProtocolServer extends SCMDatanodeProtocolServer {
 
   public ReconDatanodeProtocolServer(OzoneConfiguration conf,
-                                     StorageContainerManagerInterface scm,
+                                     OzoneStorageContainerManager scm,
                                      EventPublisher eventPublisher)
       throws IOException {
     super(conf, scm, eventPublisher);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconDatanodeProtocolServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconDatanodeProtocolServer.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.recon.scm;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
@@ -30,6 +31,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMRegisteredResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMVersionRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMVersionResponseProto;
+import org.apache.hadoop.hdds.scm.HddsServerUtil;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
@@ -65,5 +67,10 @@ public class ReconDatanodeProtocolServer extends SCMDatanodeProtocolServer {
       ContainerReportsProto containerReportsRequestProto,
       PipelineReportsProto pipelineReports) throws IOException {
     return null;
+  }
+
+  @Override
+  public InetSocketAddress getDataNodeBindAddress(OzoneConfiguration conf) {
+    return HddsServerUtil.getReconDataNodeBindAddress(conf);
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconDatanodeProtocolServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconDatanodeProtocolServer.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.scm;
+
+import java.io.IOException;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReportsProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMHeartbeatRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMHeartbeatResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMRegisteredResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMVersionRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMVersionResponseProto;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManagerInterface;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
+
+/**
+ * Recon's Datanode protocol server extended from SCM.
+ */
+public class ReconDatanodeProtocolServer extends SCMDatanodeProtocolServer {
+
+  public ReconDatanodeProtocolServer(OzoneConfiguration conf,
+                                     StorageContainerManagerInterface scm,
+                                     EventPublisher eventPublisher)
+      throws IOException {
+    super(conf, scm, eventPublisher);
+  }
+
+  @Override
+  public SCMVersionResponseProto getVersion(
+      SCMVersionRequestProto versionRequest) throws IOException {
+    return null;
+  }
+
+  @Override
+  public SCMHeartbeatResponseProto sendHeartbeat(
+      SCMHeartbeatRequestProto heartbeat) throws IOException {
+    return null;
+  }
+
+  @Override
+  public SCMRegisteredResponseProto register(
+      DatanodeDetailsProto datanodeDetails,
+      NodeReportProto nodeReport,
+      ContainerReportsProto containerReportsRequestProto,
+      PipelineReportsProto pipelineReports) throws IOException {
+    return null;
+  }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.ozone.recon.scm;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
@@ -1,0 +1,21 @@
+package org.apache.hadoop.ozone.recon.scm;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.net.NetworkTopology;
+import org.apache.hadoop.hdds.scm.node.SCMNodeManager;
+import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
+
+/**
+ * Recon's version of SCM Node Manager.
+ * TODO This is just an initial implementation. Will be revisited in future.
+ */
+public class ReconNodeManager extends SCMNodeManager {
+
+  public ReconNodeManager(OzoneConfiguration conf,
+                          SCMStorageConfig scmStorageConfig,
+                          EventPublisher eventPublisher,
+                          NetworkTopology networkTopology) {
+    super(conf, scmStorageConfig, eventPublisher, networkTopology);
+  }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManager.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.scm;
+
+import static org.apache.hadoop.hdds.scm.server.StorageContainerManager.buildRpcServerStartMessage;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.block.BlockManager;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManagerInterface;
+import org.apache.hadoop.hdds.server.events.EventQueue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Recon's 'lite' version of SCM.
+ */
+public class ReconStorageContainerManager
+    implements StorageContainerManagerInterface {
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(ReconStorageContainerManager.class);
+
+  private final OzoneConfiguration ozoneConfiguration;
+  private final ReconDatanodeProtocolServer datanodeProtocolServer;
+  private final EventQueue eventQueue;
+  private final SCMStorageConfig scmStorageConfig;
+  private static final String RECON_SCM_CONFIG_PREFIX = "recon.";
+
+  @Inject
+  public ReconStorageContainerManager(OzoneConfiguration conf)
+      throws IOException {
+    this.eventQueue = new EventQueue();
+    this.ozoneConfiguration = getReconScmConfiguration(conf);
+    this.scmStorageConfig = new SCMStorageConfig(conf);
+    this.datanodeProtocolServer = new ReconDatanodeProtocolServer(
+        conf, this, eventQueue);
+  }
+
+  private OzoneConfiguration getReconScmConfiguration(
+      OzoneConfiguration configuration) {
+    Map<String, String> reconScmConfigs =
+        configuration.getPropsWithPrefix(RECON_SCM_CONFIG_PREFIX);
+    for (Map.Entry<String, String> entry : reconScmConfigs.entrySet()) {
+      configuration.set(entry.getKey(), entry.getValue());
+    }
+    return configuration;
+  }
+
+  /**
+   * Start the Recon SCM subsystems.
+   */
+  public void start() {
+    if (LOG.isInfoEnabled()) {
+      LOG.info(buildRpcServerStartMessage(
+          "Recon ScmDatanodeProtocol RPC server",
+          getDatanodeProtocolServer().getDatanodeRpcAddress()));
+    }
+    getDatanodeProtocolServer().start();
+  }
+
+  /**
+   * Stop the Recon SCM subsystems.
+   */
+  public void stop() {
+    getDatanodeProtocolServer().stop();
+  }
+
+  public ReconDatanodeProtocolServer getDatanodeProtocolServer() {
+    return datanodeProtocolServer;
+  }
+
+  @Override
+  public NodeManager getScmNodeManager() {
+    return new ReconNodeManager(ozoneConfiguration, scmStorageConfig,
+        eventQueue, null);
+  }
+
+  @Override
+  public BlockManager getScmBlockManager() {
+    return null;
+  }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManager.java
@@ -27,9 +27,12 @@ import javax.inject.Inject;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.block.BlockManager;
+import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.container.ReplicationManager;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
-import org.apache.hadoop.hdds.scm.server.StorageContainerManagerInterface;
+import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * Recon's 'lite' version of SCM.
  */
 public class ReconStorageContainerManager
-    implements StorageContainerManagerInterface {
+    implements OzoneStorageContainerManager {
 
   private static final Logger LOG = LoggerFactory
       .getLogger(ReconStorageContainerManager.class);
@@ -109,6 +112,21 @@ public class ReconStorageContainerManager
 
   @Override
   public BlockManager getScmBlockManager() {
+    return null;
+  }
+
+  @Override
+  public PipelineManager getPipelineManager() {
+    return null;
+  }
+
+  @Override
+  public ContainerManager getContainerManager() {
+    return null;
+  }
+
+  @Override
+  public ReplicationManager getReplicationManager() {
     return null;
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManager.java
@@ -59,6 +59,15 @@ public class ReconStorageContainerManager
         conf, this, eventQueue);
   }
 
+  /**
+   *  For every config key which is prefixed by 'recon.scm', create a new
+   *  config key without the prefix keeping the same value.
+   *  For example, if recon.scm.a.b. = xyz, we add a new config like
+   *  a.b.c = xyz. This is done to override Recon's passive SCM configs if
+   *  needed.
+   * @param configuration configuration object.
+   * @return same configuration object with possible added elements.
+   */
   private OzoneConfiguration getReconScmConfiguration(
       OzoneConfiguration configuration) {
     Map<String, String> reconScmConfigs =

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManager.java
@@ -73,12 +73,14 @@ public class ReconStorageContainerManager
    */
   private OzoneConfiguration getReconScmConfiguration(
       OzoneConfiguration configuration) {
+    OzoneConfiguration reconScmConfiguration =
+        new OzoneConfiguration(configuration);
     Map<String, String> reconScmConfigs =
         configuration.getPropsWithPrefix(RECON_SCM_CONFIG_PREFIX);
     for (Map.Entry<String, String> entry : reconScmConfigs.entrySet()) {
-      configuration.set(entry.getKey(), entry.getValue());
+      reconScmConfiguration.set(entry.getKey(), entry.getValue());
     }
-    return configuration;
+    return reconScmConfiguration;
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/package-info.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The classes in this package handle OM snapshot recovery and checkpoints.
+ */
+package org.apache.hadoop.ozone.recon.scm;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Recon should expose the 'SCMDatanodeProtocol' RPC protocol server as an endpoint. This is the first step in sending DN reports to Recon. The goal is to reuse SCM's code as much as possible.

**NOTE** : This patch has intentionally left the various subsystems (Node, Pipeline, Container) of the SCM server in Recon incomplete. Those will be completed one by one.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2623

## How was this patch tested?
Started ozone/recon docker and verified that the RPC server starts up.

```
2019-12-13 00:02:18,906 [main] INFO org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManager: Recon ScmDatanodeProtocol RPC server
 is listening at localhost/127.0.0.1:9961
2019-12-13 00:02:18,906 [main] INFO org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer: RPC server for DataNodes is listening a
t localhost/127.0.0.1:9961
2019-12-13 00:02:18,907 [IPC Server listener on 9961] INFO org.apache.hadoop.ipc.Server: IPC Server listener on 9961: starting
2019-12-13 00:02:18,907 [IPC Server Responder] INFO org.apache.hadoop.ipc.Server: IPC Server Responder: starting
```