### PR TITLE
HDDS-2729. Enable multilingual Hugo features in ozone docs

### DIFF
--- a/hadoop-hdds/docs/config.yaml
+++ b/hadoop-hdds/docs/config.yaml
@@ -21,7 +21,7 @@ languages:
     languageName: English
     weight: 1
   zh:
-    languageName: Mandarin
+    languageName: 中文
     weight: 2
 title: "Ozone"
 theme: "ozonedoc"

--- a/hadoop-hdds/docs/config.yaml
+++ b/hadoop-hdds/docs/config.yaml
@@ -16,6 +16,13 @@
 
 languageCode: "en-us"
 DefaultContentLanguage: "en"
+languages:
+  en:
+    languageName: English
+    weight: 1
+  zh:
+    languageName: Mandarin
+    weight: 2
 title: "Ozone"
 theme: "ozonedoc"
 pygmentsCodeFences: true

--- a/hadoop-hdds/docs/content/_index.md
+++ b/hadoop-hdds/docs/content/_index.md
@@ -29,10 +29,7 @@ Apart from scaling to billions of objects of varying sizes,
 Ozone can function effectively in containerized environments
 like Kubernetes._* <p>
 
-Applications like Apache Spark, Hive and YARN, work without any modifications when using Ozone. Ozone comes with a [Java client library]({{<
-ref "JavaApi.md"
->}}), [S3 protocol support] ({{< ref "S3.md" >}}), and a [command line interface]
-({{< ref "shell/_index.md" >}})  which makes it easy to use Ozone.
+Applications like Apache Spark, Hive and YARN, work without any modifications when using Ozone. Ozone comes with a [Java client library]({{<ref "JavaApi.md">}}), [S3 protocol support]({{< ref "S3.md" >}}), and a [command line interface]({{< ref "shell/_index.md" >}})  which makes it easy to use Ozone.
 
 Ozone consists of volumes, buckets, and keys:
 
@@ -40,6 +37,3 @@ Ozone consists of volumes, buckets, and keys:
 * Buckets are similar to directories. A bucket can contain any number of keys, but buckets cannot contain other buckets.
 * Keys are similar to files.
 
- <a href="{{< ref "start/_index.md" >}}"> <button type="button"
- class="btn  btn-success btn-lg">Next >></button>
-</div>

--- a/hadoop-hdds/docs/content/_index.zh.md
+++ b/hadoop-hdds/docs/content/_index.zh.md
@@ -1,3 +1,8 @@
+---
+title: Overview
+menu: main
+weight: -10
+---
 <!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -14,24 +19,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-{{ partial "header.html" . }}
 
-  <body>
 
-{{ partial "navbar.html" . }}
-
-    <div class="container-fluid">
-      <div class="row">
-        {{ partial "sidebar.html" . }}
-        <div class="col-sm-10 col-sm-offset-2 col-md-10 col-md-offset-2 main">
-            {{ partial "languages.html" .}}
-
-            {{ .Content }}
-        </div>
-      </div>
-    </div>
-
-{{ partial "footer.html" . }}
-
-  </body>
-</html>
+Ozone page translation.

--- a/hadoop-hdds/docs/content/concept/Datanodes.zh.md
+++ b/hadoop-hdds/docs/content/concept/Datanodes.zh.md
@@ -1,3 +1,9 @@
+---
+title: "Datanodes"
+date: "2017-09-14"
+weight: 4
+summary: TODO translated summary
+---
 <!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -14,24 +20,5 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-{{ partial "header.html" . }}
 
-  <body>
-
-{{ partial "navbar.html" . }}
-
-    <div class="container-fluid">
-      <div class="row">
-        {{ partial "sidebar.html" . }}
-        <div class="col-sm-10 col-sm-offset-2 col-md-10 col-md-offset-2 main">
-            {{ partial "languages.html" .}}
-
-            {{ .Content }}
-        </div>
-      </div>
-    </div>
-
-{{ partial "footer.html" . }}
-
-  </body>
-</html>
+TODO: content translations

--- a/hadoop-hdds/docs/content/concept/_index.zh.md
+++ b/hadoop-hdds/docs/content/concept/_index.zh.md
@@ -1,3 +1,11 @@
+---
+title: Concepts
+date: "2017-10-10"
+menu: main
+weight: 6
+
+---
+
 <!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -14,24 +22,5 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-{{ partial "header.html" . }}
 
-  <body>
-
-{{ partial "navbar.html" . }}
-
-    <div class="container-fluid">
-      <div class="row">
-        {{ partial "sidebar.html" . }}
-        <div class="col-sm-10 col-sm-offset-2 col-md-10 col-md-offset-2 main">
-            {{ partial "languages.html" .}}
-
-            {{ .Content }}
-        </div>
-      </div>
-    </div>
-
-{{ partial "footer.html" . }}
-
-  </body>
-</html>
+TODO translate section

--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/_default/section.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/_default/section.html
@@ -25,8 +25,12 @@
         {{ partial "sidebar.html" . }}
         <div class="col-sm-10 col-sm-offset-2 col-md-10 col-md-offset-2 main">
             <div class="col-md-9">
+
+                {{ partial "languages.html" .}}
+
                 <h1>{{ .Title }}</h1>
             </div>
+
             <div class="col-md-9">
                 {{ .Content }}
                 {{.Params.card}}

--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/_default/single.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/_default/single.html
@@ -36,15 +36,19 @@
                 </ol>
               </nav>
 
+          {{ partial "languages.html" .}}
+
+
           <div class="col-md-9">
             <h1>{{.Title}}</h1>
-          </div>
 
-          {{ .Content }}
+            {{ .Content }}
 
           {{ with .PrevInSection }}
           <a class="btn  btn-success btn-lg" href="{{ .Permalink }}">Next >></a>
           {{ end }}
+          </div>
+
         </div>
       </div>
     </div>

--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/languages.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/languages.html
@@ -14,24 +14,11 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-{{ partial "header.html" . }}
 
-  <body>
-
-{{ partial "navbar.html" . }}
-
-    <div class="container-fluid">
-      <div class="row">
-        {{ partial "sidebar.html" . }}
-        <div class="col-sm-10 col-sm-offset-2 col-md-10 col-md-offset-2 main">
-            {{ partial "languages.html" .}}
-
-            {{ .Content }}
-        </div>
-      </div>
-    </div>
-
-{{ partial "footer.html" . }}
-
-  </body>
-</html>
+<div class="pull-right">
+    {{ range .AllTranslations }}
+    {{ if ne $.Language .Language}}
+    <a href="{{.Permalink}}"><span class="label label-success">{{ .Language.LanguageName }}</span></a>
+    {{end}}
+    {{ end }}
+</div>


### PR DESCRIPTION
## What changes were proposed in this pull request?

We need to reconfigure hugo to support multilingual site (to support other languages)

https://gohugo.io/content-management/multilingual/

I added three type of fake translations to test the templates of the Hugo.
 
 * translation of the main page
 * translation of a section (concept)
 * translation of a page (concept / datanode) 

The fake translation pages can be removed later or replaced during the translation process.

The name "Mandarin" can be replaced with the proper Chinese characters in the follow-up patches (`config.yaml` in the `hadoop-hdds/docs` folder)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2729

## How was this patch tested?

```
cd hadoop-hdds/docs
hugo serve
firefox localhost:1313
```

You should see a "mandarin" text on the top right corner which points to the translated page