### PR TITLE
HDDS-2735. Let GitHub Actions run acceptance check in parallel

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -99,12 +99,6 @@ jobs:
   acceptance:
     name: acceptance
     runs-on: ubuntu-18.04
-    needs:
-       - build
-       - rat
-       - checkstyle
-       - unit
-       - findbugs
     steps:
         - uses: actions/checkout@master
         - uses: ./.github/buildenv

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,12 +92,6 @@ jobs:
   acceptance:
     name: acceptance
     runs-on: ubuntu-18.04
-    needs:
-       - build
-       - rat
-       - checkstyle
-       - unit
-       - findbugs
     steps:
         - uses: actions/checkout@master
         - uses: ./.github/buildenv


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently GitHub Actions workflows are configured to run all checks in parallel, except acceptance test.  The rationale is that acceptance test takes the most time, and there is no reason to run it if a cheaper check catches some problem.

This change proposes to let GitHub Actions run acceptance test in parallel to other checks, to address the following concerns:

1. Although acceptance test is the slowest (~60 minutes), unit test also takes quite some time (~20-25 minutes).  Serializing these two checks increases the time to get feedback on PRs and commits by ~33-40%.
2. For PRs and post-commit builds in forks, running all checks regardless of the result of independent checks allows authors to reduce the number of rounds they need to address any problems.
3. For post-commit builds in Apache master, we expect all checks to pass.  However, checks sometime fail eg. due to transient network errors.  Skipping acceptance test due to such a problem in another check provides no benefit.

https://issues.apache.org/jira/browse/HDDS-2735

## How was this patch tested?

Post-commit workflow: https://github.com/adoroszlai/hadoop-ozone/runs/348489099

PR workflow is being tested with this PR.