### PR TITLE
HDDS-2739. No need to try install awscli before each test

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
@@ -19,7 +19,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            commonawslib.robot
-Test Setup          Setup s3 tests
+Suite Setup         Setup s3 tests
 
 *** Keywords ***
 Create Random file

--- a/hadoop-ozone/dist/src/main/smoketest/s3/__init__.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/__init__.robot
@@ -18,4 +18,4 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            ./commonawslib.robot
-Test Setup          Setup s3 tests
+Suite Setup         Setup s3 tests

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
@@ -19,7 +19,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            commonawslib.robot
-Test Setup          Setup s3 tests
+Suite Setup         Setup s3 tests
 
 *** Variables ***
 ${ENDPOINT_URL}       http://s3g:9878

--- a/hadoop-ozone/dist/src/main/smoketest/s3/buckethead.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/buckethead.robot
@@ -19,7 +19,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            commonawslib.robot
-Test Setup          Setup s3 tests
+Suite Setup         Setup s3 tests
 
 *** Variables ***
 ${ENDPOINT_URL}       http://s3g:9878

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
@@ -19,7 +19,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            commonawslib.robot
-Test Setup          Setup s3 tests
+Suite Setup         Setup s3 tests
 
 *** Variables ***
 ${ENDPOINT_URL}       http://s3g:9878

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectcopy.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectcopy.robot
@@ -19,7 +19,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            commonawslib.robot
-Test Setup          Setup s3 tests
+Suite Setup         Setup s3 tests
 
 *** Variables ***
 ${ENDPOINT_URL}       http://s3g:9878

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectdelete.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectdelete.robot
@@ -19,7 +19,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            commonawslib.robot
-Test Setup          Setup s3 tests
+Suite Setup         Setup s3 tests
 
 *** Variables ***
 ${ENDPOINT_URL}       http://s3g:9878

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectmultidelete.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectmultidelete.robot
@@ -19,7 +19,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            commonawslib.robot
-Test Setup          Setup s3 tests
+Suite Setup         Setup s3 tests
 
 *** Variables ***
 ${ENDPOINT_URL}       http://s3g:9878

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectputget.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectputget.robot
@@ -19,7 +19,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            commonawslib.robot
-Test Setup          Setup s3 tests
+Suite Setup         Setup s3 tests
 
 *** Variables ***
 ${ENDPOINT_URL}       http://s3g:9878


### PR DESCRIPTION
## What changes were proposed in this pull request?

S3 acceptance test attempts to install `awscli` prior to each test case.  This change proposes to do so only before each suite (each `.robot` file).

https://issues.apache.org/jira/browse/HDDS-2739

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/348720715

Previously 3x40:

```
$ grep -c "Running command 'sudo yum install" acceptance/*s3*xml | grep -v ':0'
acceptance/robot-ozone-om-ha-s3-ozone-om-ha-s3-s3-scm.xml:40
acceptance/robot-ozone-ozone-s3-scm.xml:40
acceptance/robot-ozonesecure-ozonesecure-s3-s3g.xml:40
```

Now 3x11:

```
$ grep -c "Running command 'sudo yum install" acceptance/*s3*xml | grep -v ':0'
acceptance/robot-ozone-om-ha-s3-ozone-om-ha-s3-s3-scm.xml:11
acceptance/robot-ozone-ozone-s3-scm.xml:11
acceptance/robot-ozonesecure-ozonesecure-s3-s3g.xml:11
```