### PR TITLE
HDDS-2751. Wrong number of placeholders in log message

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
@@ -240,7 +240,7 @@ public class DefaultCAServer implements CertificateServer {
         return null; // cannot happen, keeping checkstyle happy.
       }
     } catch (CertificateException | IOException | OperatorCreationException e) {
-      LOG.error("Unable to issue a certificate. {}", e);
+      LOG.error("Unable to issue a certificate.", e);
       xcertHolder.completeExceptionally(new SCMSecurityException(e));
     }
     return xcertHolder;
@@ -279,7 +279,7 @@ public class DefaultCAServer implements CertificateServer {
     try {
       store.revokeCertificate(certificate.getSerialNumber());
     } catch (IOException ex) {
-      LOG.error("Revoking the certificate failed. {}", ex.getCause());
+      LOG.error("Revoking the certificate failed.", ex.getCause());
       throw new SCMSecurityException(ex);
     }
     return revoked;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -742,7 +742,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
         publicKey = pubKey;
       } else {
         getLogger().error("Can't recover public key " +
-            "corresponding to private key.", BOOTSTRAP_ERROR);
+            "corresponding to private key.");
         return false;
       }
     } catch (IOException e) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/RocksDBStoreMBean.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/RocksDBStoreMBean.java
@@ -199,7 +199,7 @@ public class RocksDBStoreMBean implements DynamicMBean, MetricsSource {
                   histogramAttribute.toUpperCase(), "RocksDBStat"),
               metricValue);
         } catch (Exception e) {
-          LOG.error("Error reading histogram data {} ", e);
+          LOG.error("Error reading histogram data", e);
         }
       }
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
@@ -208,7 +208,7 @@ public class EndpointStateMachine
               this.getMissedCount() * getScmHeartbeatInterval(this.conf)), ex);
     }
     if (LOG.isTraceEnabled()) {
-      LOG.trace("Incrementing the Missed count. Ex : {}", ex);
+      LOG.trace("Incrementing the Missed count.", ex);
     }
     this.incMissed();
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandDispatcher.java
@@ -70,7 +70,7 @@ public final class CommandDispatcher {
     for (CommandHandler h : handlers) {
       if(handlerMap.containsKey(h.getCommandType())){
         LOG.error("Duplicate handler for the same command. Exiting. Handle " +
-            "key : { }", h.getCommandType().getDescriptorForType().getName());
+            "key : {}", h.getCommandType().getDescriptorForType().getName());
         throw new IllegalArgumentException("Duplicate handler for the same " +
             "command.");
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolumeChecker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolumeChecker.java
@@ -217,7 +217,7 @@ public class HddsVolumeChecker {
     // Wait until our timeout elapses, after which we give up on
     // the remaining volumes.
     if (!latch.await(maxAllowedTimeForCheckMs, TimeUnit.MILLISECONDS)) {
-      LOG.warn("checkAllVolumes timed out after {} ms" +
+      LOG.warn("checkAllVolumes timed out after {} ms",
           maxAllowedTimeForCheckMs);
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerImpl.java
@@ -164,16 +164,16 @@ public class ChunkManagerImpl implements ChunkManager {
     } catch (StorageContainerException ex) {
       throw ex;
     } catch (NoSuchAlgorithmException ex) {
-      LOG.error("write data failed. error: {}", ex);
+      LOG.error("write data failed.", ex);
       throw new StorageContainerException("Internal error: ", ex,
           NO_SUCH_ALGORITHM);
     } catch (ExecutionException  | IOException ex) {
-      LOG.error("write data failed. error: {}", ex);
+      LOG.error("write data failed.", ex);
       throw new StorageContainerException("Internal error: ", ex,
           CONTAINER_INTERNAL_ERROR);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      LOG.error("write data failed. error: {}", e);
+      LOG.error("write data failed.", e);
       throw new StorageContainerException("Internal error: ", e,
           CONTAINER_INTERNAL_ERROR);
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
@@ -316,7 +316,7 @@ public class ContainerStateMap {
         // Just flush both old and new data sets from the result cache.
         flushCache(currentInfo);
       } catch (SCMException ex) {
-        LOG.error("Unable to update the container state. {}", ex);
+        LOG.error("Unable to update the container state.", ex);
         // we need to revert the change in this attribute since we are not
         // able to update the hash table.
         LOG.info("Reverting the update to lifecycle state. Moving back to " +

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreator.java
@@ -119,7 +119,7 @@ class BackgroundPipelineCreator {
         } catch (IOException ioe) {
           break;
         } catch (Throwable t) {
-          LOG.error("Error while creating pipelines {}", t);
+          LOG.error("Error while creating pipelines", t);
           break;
         }
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineActionHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineActionHandler.java
@@ -67,7 +67,7 @@ public class PipelineActionHandler
               action, pipelineID, ioe);
         }
       } else {
-        LOG.error("unknown pipeline action:{}" + action.getAction());
+        LOG.error("unknown pipeline action:{}", action.getAction());
       }
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -160,7 +160,7 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol {
    */
   @Override
   public String getCertificate(String certSerialId) throws IOException {
-    LOGGER.debug("Getting certificate with certificate serial id",
+    LOGGER.debug("Getting certificate with certificate serial id {}",
         certSerialId);
     try {
       X509Certificate certificate =

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/OS3Exception.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/OS3Exception.java
@@ -142,7 +142,7 @@ public class OS3Exception extends  Exception {
           + val;
       return xmlLine;
     } catch (Exception ex) {
-      LOG.error("Exception occurred {}", ex);
+      LOG.error("Exception occurred", ex);
     }
 
     //When we get exception log it, and return exception as xml from actual

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/header/AuthorizationHeaderV4.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/header/AuthorizationHeaderV4.java
@@ -128,7 +128,7 @@ public class AuthorizationHeaderV4 {
     if (signature.startsWith(SIGNATURE)) {
       signature = signature.substring(SIGNATURE.length());
       if (!isNoneEmpty(signature)) {
-        LOG.error("Signature can't be empty.", signature);
+        LOG.error("Signature can't be empty: {}", signature);
         throw S3ErrorTable.newError(MALFORMED_HEADER, authHeader);
       }
       try {
@@ -139,7 +139,7 @@ public class AuthorizationHeaderV4 {
         throw S3ErrorTable.newError(MALFORMED_HEADER, authHeader);
       }
     } else {
-      LOG.error("Signature can't be empty.", signature);
+      LOG.error("No signature found: {}", signature);
       throw S3ErrorTable.newError(MALFORMED_HEADER, authHeader);
     }
   }
@@ -170,7 +170,7 @@ public class AuthorizationHeaderV4 {
       throw S3ErrorTable.newError(MALFORMED_HEADER, authHeader);
     }
     if (credentialObj.getAwsService().isEmpty()) {
-      LOG.error("AWS service:{} shouldn't be empty. credential:{}",
+      LOG.error("AWS service shouldn't be empty. credential:{}",
           credential);
       throw S3ErrorTable.newError(MALFORMED_HEADER, authHeader);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix log messages where number of placeholders does not match the number of parameters provided.  Except one being fixed in HDDS-2669.

https://issues.apache.org/jira/browse/HDDS-2751

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/349273449