### PR TITLE
HDDS-2679. Ratis ring creation might be failed with async pipeline creation.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
@@ -158,6 +159,18 @@ public interface RatisHelper {
         OzoneConfigKeys.DFS_RATIS_CLIENT_REQUEST_TIMEOUT_DURATION_DEFAULT
             .getDuration(), timeUnit);
     return TimeDuration.valueOf(duration, timeUnit);
+  }
+
+  static RpcType getRpcType(Configuration conf) {
+    return SupportedRpcType.valueOfIgnoreCase(conf.get(
+        ScmConfigKeys.DFS_CONTAINER_RATIS_RPC_TYPE_KEY,
+        ScmConfigKeys.DFS_CONTAINER_RATIS_RPC_TYPE_DEFAULT));
+  }
+
+  static RaftClient newRaftClient(RaftPeer leader, Configuration conf) {
+    return newRaftClient(getRpcType(conf), leader, RetryPolicies.noRetry(),
+        GrpcConfigKeys.OutputStream.OUTSTANDING_APPENDS_MAX_DEFAULT,
+        getClientRequestTimeout(conf));
   }
 
   static RaftClient newRaftClient(RpcType rpcType, RaftPeer leader,

--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -42,6 +42,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-server-framework</artifactId>
     </dependency>
+      <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdds-client</artifactId>
+      </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
@@ -62,6 +66,18 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs</artifactId>
       <scope>provided</scope>
+    </dependency>
+      <dependency>
+          <groupId>org.powermock</groupId>
+          <artifactId>powermock-module-junit4</artifactId>
+          <version>2.0.4</version>
+          <scope>test</scope>
+      </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>2.0.4</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -137,7 +137,7 @@ public class DatanodeStateMachine implements Closeable {
         .addHandler(new DeleteContainerCommandHandler(
             dnConf.getContainerDeleteThreads()))
         .addHandler(new ClosePipelineCommandHandler())
-        .addHandler(new CreatePipelineCommandHandler())
+        .addHandler(new CreatePipelineCommandHandler(conf))
         .setConnectionManager(connectionManager)
         .setContainer(container)
         .setContext(context)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CreatePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CreatePipelineCommandHandler.java
@@ -113,13 +113,13 @@ public class CreatePipelineCommandHandler implements CommandHandler {
         createCommand.getDatanodeList().stream().filter(
             d -> !d.getUuid().equals(dn.getUuidString()))
             .forEach(d -> {
-              final RaftPeer p = RatisHelper.toRaftPeer(
+              final RaftPeer peer = RatisHelper.toRaftPeer(
                   DatanodeDetails.getFromProtoBuf(d));
               try (RaftClient client = RatisHelper
                   .newRaftClient(SupportedRpcType.valueOfIgnoreCase(rpcType),
-                      p, retryPolicy, maxOutstandingRequest,
+                      peer, retryPolicy, maxOutstandingRequest,
                       requestTimeout)) {
-                client.groupAdd(group, p.getId());
+                client.groupAdd(group, peer.getId());
               } catch (IOException ioe) {
                 LOG.warn("Add group failed for {}", d, ioe);
               }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -734,6 +734,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
 
   void notifyGroupAdd(RaftGroupId gid) {
     raftGids.add(gid);
+    sendPipelineReport();
   }
 
   void handleLeaderChangedNotification(RaftGroupMemberId groupMemberId,
@@ -745,9 +746,13 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     groupLeaderMap.put(groupMemberId.getGroupId(), leaderForGroup);
     if (context != null && leaderForGroup) {
       // Publish new report from leader
-      context.addReport(context.getParent().getContainer().getPipelineReport());
-      // Trigger HB immediately
-      context.getParent().triggerHeartbeat();
+     sendPipelineReport();
     }
+  }
+
+  private void sendPipelineReport() {
+    // TODO: Send IncrementalPipelineReport instead of full PipelineReport
+    context.addReport(context.getParent().getContainer().getPipelineReport());
+    context.getParent().triggerHeartbeat();
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -746,7 +746,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     groupLeaderMap.put(groupMemberId.getGroupId(), leaderForGroup);
     if (context != null && leaderForGroup) {
       // Publish new report from leader
-     sendPipelineReport();
+      sendPipelineReport();
     }
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCreatePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCreatePipelineCommandHandler.java
@@ -51,6 +51,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Test cases to verify CreatePipelineCommandHandler.
+ */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(RaftClient.class)
 public class TestCreatePipelineCommandHandler {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCreatePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCreatePipelineCommandHandler.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.statemachine.commandhandler;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto
+    .StorageContainerDatanodeProtocolProtos.CreatePipelineCommandProto;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine
+    .SCMConnectionManager;
+import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
+import org.apache.hadoop.ozone.container.common.transport.server
+    .XceiverServerSpi;
+import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
+import org.apache.hadoop.ozone.protocol.commands.CreatePipelineCommand;
+import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.retry.RetryPolicy;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(RaftClient.class)
+public class TestCreatePipelineCommandHandler {
+
+  private OzoneContainer ozoneContainer;
+  private StateContext stateContext;
+  private SCMConnectionManager connectionManager;
+  private RaftClient raftClient;
+
+  @Before
+  public void setup() throws Exception {
+    ozoneContainer = Mockito.mock(OzoneContainer.class);
+    stateContext = Mockito.mock(StateContext.class);
+    connectionManager = Mockito.mock(SCMConnectionManager.class);
+    raftClient = Mockito.mock(RaftClient.class);
+    final RaftClient.Builder builder = mockRaftClientBuilder();
+    Mockito.when(builder.build()).thenReturn(raftClient);
+    PowerMockito.mockStatic(RaftClient.class);
+    PowerMockito.when(RaftClient.newBuilder()).thenReturn(builder);
+  }
+
+  private RaftClient.Builder mockRaftClientBuilder() {
+    final RaftClient.Builder builder = Mockito.mock(RaftClient.Builder.class);
+    Mockito.when(builder.setClientId(Mockito.any(ClientId.class)))
+        .thenReturn(builder);
+    Mockito.when(builder.setRaftGroup(Mockito.any(RaftGroup.class)))
+        .thenReturn(builder);
+    Mockito.when(builder.setLeaderId(Mockito.any(RaftPeerId.class)))
+        .thenReturn(builder);
+    Mockito.when(builder.setProperties(Mockito.any(RaftProperties.class)))
+        .thenReturn(builder);
+    Mockito.when(builder.setRetryPolicy(Mockito.any(RetryPolicy.class)))
+        .thenReturn(builder);
+    return builder;
+  }
+
+  @Test
+  public void testPipelineCreation() throws IOException {
+
+    final List<DatanodeDetails> datanodes = getDatanodes();
+    final PipelineID pipelineID = PipelineID.randomId();
+    final SCMCommand<CreatePipelineCommandProto> command =
+        new CreatePipelineCommand(pipelineID, HddsProtos.ReplicationType.RATIS,
+            HddsProtos.ReplicationFactor.THREE, datanodes);
+
+    final XceiverServerSpi writeChanel = Mockito.mock(XceiverServerSpi.class);
+    final DatanodeStateMachine dnsm = Mockito.mock(DatanodeStateMachine.class);
+
+    Mockito.when(stateContext.getParent()).thenReturn(dnsm);
+    Mockito.when(dnsm.getDatanodeDetails()).thenReturn(datanodes.get(0));
+    Mockito.when(ozoneContainer.getWriteChannel()).thenReturn(writeChanel);
+    Mockito.when(writeChanel.isExist(pipelineID.getProtobuf()))
+        .thenReturn(false);
+
+    final CreatePipelineCommandHandler commandHandler =
+        new CreatePipelineCommandHandler(new OzoneConfiguration());
+    commandHandler.handle(command, ozoneContainer, stateContext,
+        connectionManager);
+
+    Mockito.verify(writeChanel, Mockito.times(1))
+        .addGroup(pipelineID.getProtobuf(), datanodes);
+
+    Mockito.verify(raftClient, Mockito.times(2))
+        .groupAdd(Mockito.any(RaftGroup.class), Mockito.any(RaftPeerId.class));
+  }
+
+  @Test
+  public void testCommandIdempotency() throws IOException {
+    final List<DatanodeDetails> datanodes = getDatanodes();
+    final PipelineID pipelineID = PipelineID.randomId();
+    final SCMCommand<CreatePipelineCommandProto> command =
+        new CreatePipelineCommand(pipelineID, HddsProtos.ReplicationType.RATIS,
+            HddsProtos.ReplicationFactor.THREE, datanodes);
+
+    final XceiverServerSpi writeChanel = Mockito.mock(XceiverServerSpi.class);
+    final DatanodeStateMachine dnsm = Mockito.mock(DatanodeStateMachine.class);
+
+    Mockito.when(stateContext.getParent()).thenReturn(dnsm);
+    Mockito.when(dnsm.getDatanodeDetails()).thenReturn(datanodes.get(0));
+    Mockito.when(ozoneContainer.getWriteChannel()).thenReturn(writeChanel);
+    Mockito.when(writeChanel.isExist(pipelineID.getProtobuf()))
+        .thenReturn(true);
+
+    final CreatePipelineCommandHandler commandHandler =
+        new CreatePipelineCommandHandler(new OzoneConfiguration());
+    commandHandler.handle(command, ozoneContainer, stateContext,
+        connectionManager);
+
+    Mockito.verify(writeChanel, Mockito.times(0))
+        .addGroup(pipelineID.getProtobuf(), datanodes);
+
+    Mockito.verify(raftClient, Mockito.times(0))
+        .groupAdd(Mockito.any(RaftGroup.class), Mockito.any(RaftPeerId.class));
+  }
+
+  private List<DatanodeDetails> getDatanodes() {
+    final DatanodeDetails dnOne = MockDatanodeDetails.randomDatanodeDetails();
+    final DatanodeDetails dnTwo = MockDatanodeDetails.randomDatanodeDetails();
+    final DatanodeDetails dnThree = MockDatanodeDetails.randomDatanodeDetails();
+    return Arrays.asList(dnOne, dnTwo, dnThree);
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -158,8 +158,8 @@ public class RatisPipelineProvider implements PipelineProvider {
             factor, dns);
 
     dns.forEach(node -> {
-      LOG.info("Send pipeline:{} create command to datanode {}",
-          pipeline.getId(), node);
+      LOG.info("Sending CreatePipelineCommand for pipeline:{} to datanode:{}",
+          pipeline.getId(), node.getUuidString());
       eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND,
           new CommandForDatanode<>(node.getUuid(), createCommand));
     });

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -157,12 +157,11 @@ public class RatisPipelineProvider implements PipelineProvider {
         new CreatePipelineCommand(pipeline.getId(), pipeline.getType(),
             factor, dns);
 
-    dns.stream().forEach(node -> {
-      final CommandForDatanode datanodeCommand =
-          new CommandForDatanode<>(node.getUuid(), createCommand);
+    dns.forEach(node -> {
       LOG.info("Send pipeline:{} create command to datanode {}",
-          pipeline.getId(), datanodeCommand.getDatanodeId());
-      eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND, datanodeCommand);
+          pipeline.getId(), node);
+      eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND,
+          new CommandForDatanode<>(node.getUuid(), createCommand));
     });
 
     return pipeline;

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>0.5.0-ce699ba3-SNAPSHOT</ratis.version>
+    <ratis.version>0.5.0-1c07496-SNAPSHOT</ratis.version>
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>
     <distMgmtSnapshotsUrl>https://repository.apache.org/content/repositories/snapshots</distMgmtSnapshotsUrl>


### PR DESCRIPTION
## What changes were proposed in this pull request?

`CreatePipelineCommandHandler` in the datanode will now send addGroup calls to the peers in the pipeline. This way, the datanode which received the CreatePipeline command will act as a proxy and relay the command to other datanodes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2679


## How was this patch tested?

Unit-test added.
