### PR TITLE
HDDS-2752. Unnecessary calls to isNoneEmpty and isAllEmpty

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/header/AuthorizationHeaderV4.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/header/AuthorizationHeaderV4.java
@@ -31,8 +31,8 @@ import java.time.LocalDate;
 import java.util.Collection;
 
 import static java.time.temporal.ChronoUnit.DAYS;
-import static org.apache.commons.lang3.StringUtils.isAllEmpty;
-import static org.apache.commons.lang3.StringUtils.isNoneEmpty;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.MALFORMED_HEADER;
 import static org.apache.hadoop.ozone.s3.AWSV4AuthParser.AWS4_SIGNING_ALGORITHM;
 import static org.apache.hadoop.ozone.s3.AWSV4AuthParser.DATE_FORMATTER;
@@ -107,7 +107,7 @@ public class AuthorizationHeaderV4 {
    * Validate Signed headers.
    * */
   private void validateSignedHeaders() throws OS3Exception {
-    if (isNoneEmpty(signedHeadersStr)
+    if (isNotEmpty(signedHeadersStr)
         && signedHeadersStr.startsWith(SIGNEDHEADERS)) {
       signedHeadersStr = signedHeadersStr.substring(SIGNEDHEADERS.length());
       signedHeaders = StringUtils.getStringCollection(signedHeadersStr, ";");
@@ -127,7 +127,7 @@ public class AuthorizationHeaderV4 {
   private void validateSignature() throws OS3Exception {
     if (signature.startsWith(SIGNATURE)) {
       signature = signature.substring(SIGNATURE.length());
-      if (!isNoneEmpty(signature)) {
+      if (isEmpty(signature)) {
         LOG.error("Signature can't be empty: {}", signature);
         throw S3ErrorTable.newError(MALFORMED_HEADER, authHeader);
       }
@@ -148,7 +148,7 @@ public class AuthorizationHeaderV4 {
    * Validate credentials.
    * */
   private void validateCredentials() throws OS3Exception {
-    if (isNoneEmpty(credential) && credential.startsWith(CREDENTIAL)) {
+    if (isNotEmpty(credential) && credential.startsWith(CREDENTIAL)) {
       credential = credential.substring(CREDENTIAL.length());
       // Parse credential. Other parts of header are not validated yet. When
       // security comes, it needs to be completed.
@@ -197,7 +197,7 @@ public class AuthorizationHeaderV4 {
    * Validate if algorithm is in expected format.
    * */
   private void validateAlgorithm() throws OS3Exception {
-    if (isAllEmpty(algorithm) || !algorithm.equals(AWS4_SIGNING_ALGORITHM)) {
+    if (isEmpty(algorithm) || !algorithm.equals(AWS4_SIGNING_ALGORITHM)) {
       LOG.error("Unexpected hash algorithm. Algo:{}", algorithm);
       throw S3ErrorTable.newError(MALFORMED_HEADER, authHeader);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace `isNoneEmpty` and `isAllEmpty` with `isNotEmpty` and `isEmpty` for single string invocations to avoid varargs.

https://issues.apache.org/jira/browse/HDDS-2752

## How was this patch tested?

`TestAuthorizationHeaderV4` unit test.

https://github.com/adoroszlai/hadoop-ozone/runs/350168306