### PR TITLE
[WIP] HDDS-2665. Implement new Ozone Filesystem scheme ofs://

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -84,6 +84,7 @@ public final class OzoneConsts {
 
   // Ozone File System scheme
   public static final String OZONE_URI_SCHEME = "o3fs";
+  public static final String OZONE_OFS_URI_SCHEME = "ofs";
 
   public static final String OZONE_RPC_SCHEME = "o3";
   public static final String OZONE_HTTP_SCHEME = "http";

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -390,6 +390,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
           .setTraceID(TracingUtil.exportCurrentSpan())
           .build();
 
+      // TODO: For debugging. Remove this.
+      FAILOVER_PROXY_PROVIDER_LOG.warn("OMRequest payload = \n" + payload);
       OMResponse omResponse =
           rpcProxy.submitRequest(NULL_RPC_CONTROLLER, payload);
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -390,8 +390,6 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
           .setTraceID(TracingUtil.exportCurrentSpan())
           .build();
 
-      // TODO: For debugging. Remove this.
-      FAILOVER_PROXY_PROVIDER_LOG.warn("OMRequest payload = \n" + payload);
       OMResponse omResponse =
           rpcProxy.submitRequest(NULL_RPC_CONTROLLER, payload);
 

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-config
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+CORE-SITE.XML_fs.ofs.impl=org.apache.hadoop.fs.ozone.OFileSystem
+CORE-SITE.XML_fs.o3fs.impl=org.apache.hadoop.fs.ozone.OzoneFileSystem
 OZONE-SITE.XML_ozone.om.address=om
 OZONE-SITE.XML_ozone.om.http-address=om:9874
 OZONE-SITE.XML_ozone.scm.names=scm

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOFileSystem.java
@@ -215,7 +215,7 @@ public class BasicOFileSystem extends FileSystem {
   }
 
   protected void incrementCounter(Statistic statistic) {
-    //don't do anyting in this default implementation.
+    //don't do anything in this default implementation.
   }
 
   @Override

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOFileSystem.java
@@ -49,8 +49,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.StringTokenizer;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.fs.ozone.Constants.LISTING_PAGE_SIZE;

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOFileSystem.java
@@ -87,9 +87,10 @@ public class BasicOFileSystem extends FileSystem {
   private String adapterPath;
 
   private static final String URI_EXCEPTION_TEXT =
-      "Ozone file system URL should be one of the following formats: " +
-      "ofs://om-host.example.com/volume/bucket/[key]  OR " +
-      "ofs://om-host.example.com:5678/volume/bucket/[key]";
+      "URL should be one of the following formats: " +
+      "ofs://om-service-id/  OR " +
+      "ofs://om-host.example.com/  OR " +
+      "ofs://om-host.example.com:5678/";
 
   @Override
   public void initialize(URI name, Configuration conf) throws IOException {

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOFileSystem.java
@@ -63,7 +63,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
  * This is a basic version which doesn't extend
  * KeyProviderTokenIssuer and doesn't include statistics. It can be used
  * from older hadoop version. For newer hadoop version use the full featured
- * OzoneFileSystem.
+ * OFileSystem.
  */
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
@@ -670,7 +670,7 @@ public class BasicOFileSystem extends FileSystem {
 
   @Override
   public String toString() {
-    return "OzoneFileSystem{URI=" + uri + ", "
+    return "OFileSystem{URI=" + uri + ", "
         + "workingDir=" + workingDir + ", "
         + "userName=" + userName + ", "
         + "statistics=" + statistics

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOFileSystem.java
@@ -150,7 +150,6 @@ public class BasicOFileSystem extends FileSystem {
       } catch (IOException e) {
         this.userName = OZONE_DEFAULT_USER;
       }
-      // TODO: Might need to change.
       this.workingDir = new Path(OZONE_USER_DIR, this.userName)
           .makeQualified(this.uri, this.workingDir);
     } catch (URISyntaxException ue) {
@@ -285,9 +284,6 @@ public class BasicOFileSystem extends FileSystem {
     @Override
     boolean processKey(String key) throws IOException {
       String newKeyName = dstKey.concat(key.substring(srcKey.length()));
-      // TODO: Double check.
-      assert(adapter != null);
-      assert(adapterPath != null);
       adapter.renameKey(key, newKeyName);
       return true;
     }
@@ -674,12 +670,13 @@ public class BasicOFileSystem extends FileSystem {
     }
     // removing leading '/' char
     String key = path.toUri().getPath().substring(1);
-    // TODO: Clean up code.
-    key = new OFSPath(key).getKeyName();
+    OFSPath ofsPath = new OFSPath(key);
+    key = ofsPath.getKeyName();
     LOG.trace("path for key:{} is:{}", key, path);
     return key;
   }
 
+  // TODO: Consider renaming and moving this class to a new file.
   static class OFSPath {
     // Note: static class variables are defaulted to null / 0.
     private String volumeName;

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOFileSystem.java
@@ -56,7 +56,7 @@ import static org.apache.hadoop.fs.ozone.Constants.LISTING_PAGE_SIZE;
 import static org.apache.hadoop.fs.ozone.Constants.OZONE_DEFAULT_USER;
 import static org.apache.hadoop.fs.ozone.Constants.OZONE_USER_DIR;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_SCHEME;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OFS_URI_SCHEME;
 
 /**
  * The minimal Ozone Filesystem implementation.
@@ -134,7 +134,7 @@ public class BasicOFileSystem extends FileSystem {
     }
 
     try {
-      uri = new URIBuilder().setScheme(OZONE_URI_SCHEME)
+      uri = new URIBuilder().setScheme(OZONE_OFS_URI_SCHEME)
           .setHost(authority)
           .build();
       LOG.trace("Ozone URI for ozfs initialization is " + uri);
@@ -202,7 +202,7 @@ public class BasicOFileSystem extends FileSystem {
 
   @Override
   public String getScheme() {
-    return OZONE_URI_SCHEME;
+    return OZONE_OFS_URI_SCHEME;
   }
 
   @Override

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOFileSystem.java
@@ -1,0 +1,786 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.ozone;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CreateFlag;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.util.Progressable;
+import org.apache.http.client.utils.URIBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.apache.hadoop.fs.ozone.Constants.LISTING_PAGE_SIZE;
+import static org.apache.hadoop.fs.ozone.Constants.OZONE_DEFAULT_USER;
+import static org.apache.hadoop.fs.ozone.Constants.OZONE_USER_DIR;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_SCHEME;
+
+/**
+ * The minimal Ozone Filesystem implementation.
+ * <p>
+ * This is a basic version which doesn't extend
+ * KeyProviderTokenIssuer and doesn't include statistics. It can be used
+ * from older hadoop version. For newer hadoop version use the full featured
+ * OzoneFileSystem.
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Evolving
+public class BasicOFileSystem extends FileSystem {
+  static final Logger LOG =
+      LoggerFactory.getLogger(BasicOFileSystem.class);
+
+  /**
+   * The Ozone client for connecting to Ozone server.
+   */
+
+  private URI uri;
+  private String userName;
+  private Path workingDir;
+
+  private OzoneClientAdapter adapter;
+
+  private static final Pattern URL_SCHEMA_PATTERN =
+      Pattern.compile("([^\\.]+)\\.([^\\.]+)\\.{0,1}(.*)");
+
+  private static final String URI_EXCEPTION_TEXT = "Ozone file system URL " +
+      "should be one of the following formats: " +
+      "o3fs://bucket.volume/key  OR " +
+      "o3fs://bucket.volume.om-host.example.com/key  OR " +
+      "o3fs://bucket.volume.om-host.example.com:5678/key";
+
+  @Override
+  public void initialize(URI name, Configuration conf) throws IOException {
+    super.initialize(name, conf);
+    setConf(conf);
+    Objects.requireNonNull(name.getScheme(), "No scheme provided in " + name);
+    Preconditions.checkArgument(getScheme().equals(name.getScheme()),
+        "Invalid scheme provided in " + name);
+
+    String authority = name.getAuthority();
+    if (authority == null) {
+      // authority is null when fs.defaultFS is not a qualified o3fs URI and
+      // o3fs:/// is passed to the client. matcher will NPE if authority is null
+      throw new IllegalArgumentException(URI_EXCEPTION_TEXT);
+    }
+
+    Matcher matcher = URL_SCHEMA_PATTERN.matcher(authority);
+
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException(URI_EXCEPTION_TEXT);
+    }
+    String bucketStr = matcher.group(1);
+    String volumeStr = matcher.group(2);
+    String remaining = matcher.groupCount() == 3 ? matcher.group(3) : null;
+
+    String omHost = null;
+    int omPort = -1;
+    if (!isEmpty(remaining)) {
+      String[] parts = remaining.split(":");
+      // Array length should be either 1(hostname or service id) or 2(host:port)
+      if (parts.length > 2) {
+        throw new IllegalArgumentException(URI_EXCEPTION_TEXT);
+      }
+      omHost = parts[0];
+      if (parts.length == 2) {
+        try {
+          omPort = Integer.parseInt(parts[1]);
+        } catch (NumberFormatException e) {
+          throw new IllegalArgumentException(URI_EXCEPTION_TEXT);
+        }
+      }
+    }
+
+    try {
+      uri = new URIBuilder().setScheme(OZONE_URI_SCHEME)
+          .setHost(authority)
+          .build();
+      LOG.trace("Ozone URI for ozfs initialization is " + uri);
+
+      //isolated is the default for ozonefs-lib-legacy which includes the
+      // /ozonefs.txt, otherwise the default is false. It could be overridden.
+      boolean defaultValue =
+          BasicOFileSystem.class.getClassLoader()
+              .getResource("ozonefs.txt")
+              != null;
+
+      //Use string here instead of the constant as constant may not be available
+      //on the classpath of a hadoop 2.7
+      boolean isolatedClassloader =
+          conf.getBoolean("ozone.fs.isolated-classloader", defaultValue);
+
+      this.adapter = createAdapter(conf, bucketStr, volumeStr, omHost, omPort,
+          isolatedClassloader);
+
+      try {
+        this.userName =
+            UserGroupInformation.getCurrentUser().getShortUserName();
+      } catch (IOException e) {
+        this.userName = OZONE_DEFAULT_USER;
+      }
+      this.workingDir = new Path(OZONE_USER_DIR, this.userName)
+          .makeQualified(this.uri, this.workingDir);
+    } catch (URISyntaxException ue) {
+      final String msg = "Invalid Ozone endpoint " + name;
+      LOG.error(msg, ue);
+      throw new IOException(msg, ue);
+    }
+  }
+
+  protected OzoneClientAdapter createAdapter(Configuration conf,
+      String bucketStr,
+      String volumeStr, String omHost, int omPort,
+      boolean isolatedClassloader) throws IOException {
+
+    if (isolatedClassloader) {
+
+      return OzoneClientAdapterFactory
+          .createAdapter(volumeStr, bucketStr);
+
+    } else {
+
+      return new BasicOzoneClientAdapterImpl(omHost, omPort, conf,
+          volumeStr, bucketStr);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      adapter.close();
+    } finally {
+      super.close();
+    }
+  }
+
+  @Override
+  public URI getUri() {
+    return uri;
+  }
+
+  @Override
+  public String getScheme() {
+    return OZONE_URI_SCHEME;
+  }
+
+  @Override
+  public FSDataInputStream open(Path f, int bufferSize) throws IOException {
+    incrementCounter(Statistic.INVOCATION_OPEN);
+    statistics.incrementWriteOps(1);
+    LOG.trace("open() path:{}", f);
+    final String key = pathToKey(f);
+    return new FSDataInputStream(new OzoneFSInputStream(adapter.readFile(key)));
+  }
+
+  protected void incrementCounter(Statistic statistic) {
+    //don't do anyting in this default implementation.
+  }
+
+  @Override
+  public FSDataOutputStream create(Path f, FsPermission permission,
+      boolean overwrite, int bufferSize,
+      short replication, long blockSize,
+      Progressable progress) throws IOException {
+    LOG.trace("create() path:{}", f);
+    incrementCounter(Statistic.INVOCATION_CREATE);
+    statistics.incrementWriteOps(1);
+    final String key = pathToKey(f);
+    return createOutputStream(key, overwrite, true);
+  }
+
+  @Override
+  public FSDataOutputStream createNonRecursive(Path path,
+      FsPermission permission,
+      EnumSet<CreateFlag> flags,
+      int bufferSize,
+      short replication,
+      long blockSize,
+      Progressable progress) throws IOException {
+    incrementCounter(Statistic.INVOCATION_CREATE_NON_RECURSIVE);
+    statistics.incrementWriteOps(1);
+    final String key = pathToKey(path);
+    return createOutputStream(key, flags.contains(CreateFlag.OVERWRITE), false);
+  }
+
+  private FSDataOutputStream createOutputStream(String key, boolean overwrite,
+      boolean recursive) throws IOException {
+    return new FSDataOutputStream(adapter.createFile(key, overwrite, recursive),
+        statistics);
+  }
+
+  @Override
+  public FSDataOutputStream append(Path f, int bufferSize,
+      Progressable progress) throws IOException {
+    throw new UnsupportedOperationException("append() Not implemented by the "
+        + getClass().getSimpleName() + " FileSystem implementation");
+  }
+
+  private class RenameIterator extends OzoneListingIterator {
+    private final String srcKey;
+    private final String dstKey;
+
+    RenameIterator(Path srcPath, Path dstPath)
+        throws IOException {
+      super(srcPath);
+      srcKey = pathToKey(srcPath);
+      dstKey = pathToKey(dstPath);
+      LOG.trace("rename from:{} to:{}", srcKey, dstKey);
+    }
+
+    @Override
+    boolean processKey(String key) throws IOException {
+      String newKeyName = dstKey.concat(key.substring(srcKey.length()));
+      adapter.renameKey(key, newKeyName);
+      return true;
+    }
+  }
+
+  /**
+   * Check whether the source and destination path are valid and then perform
+   * rename from source path to destination path.
+   * <p>
+   * The rename operation is performed by renaming the keys with src as prefix.
+   * For such keys the prefix is changed from src to dst.
+   *
+   * @param src source path for rename
+   * @param dst destination path for rename
+   * @return true if rename operation succeeded or
+   * if the src and dst have the same path and are of the same type
+   * @throws IOException on I/O errors or if the src/dst paths are invalid.
+   */
+  @Override
+  public boolean rename(Path src, Path dst) throws IOException {
+    incrementCounter(Statistic.INVOCATION_RENAME);
+    statistics.incrementWriteOps(1);
+    if (src.equals(dst)) {
+      return true;
+    }
+
+    LOG.trace("rename() from:{} to:{}", src, dst);
+    if (src.isRoot()) {
+      // Cannot rename root of file system
+      LOG.trace("Cannot rename the root of a filesystem");
+      return false;
+    }
+
+    // Cannot rename a directory to its own subdirectory
+    Path dstParent = dst.getParent();
+    while (dstParent != null && !src.equals(dstParent)) {
+      dstParent = dstParent.getParent();
+    }
+    Preconditions.checkArgument(dstParent == null,
+        "Cannot rename a directory to its own subdirectory");
+    // Check if the source exists
+    FileStatus srcStatus;
+    try {
+      srcStatus = getFileStatus(src);
+    } catch (FileNotFoundException fnfe) {
+      // source doesn't exist, return
+      return false;
+    }
+
+    // Check if the destination exists
+    FileStatus dstStatus;
+    try {
+      dstStatus = getFileStatus(dst);
+    } catch (FileNotFoundException fnde) {
+      dstStatus = null;
+    }
+
+    if (dstStatus == null) {
+      // If dst doesn't exist, check whether dst parent dir exists or not
+      // if the parent exists, the source can still be renamed to dst path
+      dstStatus = getFileStatus(dst.getParent());
+      if (!dstStatus.isDirectory()) {
+        throw new IOException(String.format(
+            "Failed to rename %s to %s, %s is a file", src, dst,
+            dst.getParent()));
+      }
+    } else {
+      // if dst exists and source and destination are same,
+      // check both the src and dst are of same type
+      if (srcStatus.getPath().equals(dstStatus.getPath())) {
+        return !srcStatus.isDirectory();
+      } else if (dstStatus.isDirectory()) {
+        // If dst is a directory, rename source as subpath of it.
+        // for example rename /source to /dst will lead to /dst/source
+        dst = new Path(dst, src.getName());
+        FileStatus[] statuses;
+        try {
+          statuses = listStatus(dst);
+        } catch (FileNotFoundException fnde) {
+          statuses = null;
+        }
+
+        if (statuses != null && statuses.length > 0) {
+          // If dst exists and not a directory not empty
+          throw new FileAlreadyExistsException(String.format(
+              "Failed to rename %s to %s, file already exists or not empty!",
+              src, dst));
+        }
+      } else {
+        // If dst is not a directory
+        throw new FileAlreadyExistsException(String.format(
+            "Failed to rename %s to %s, file already exists!", src, dst));
+      }
+    }
+
+    if (srcStatus.isDirectory()) {
+      if (dst.toString().startsWith(src.toString() + OZONE_URI_DELIMITER)) {
+        LOG.trace("Cannot rename a directory to a subdirectory of self");
+        return false;
+      }
+    }
+    RenameIterator iterator = new RenameIterator(src, dst);
+    boolean result = iterator.iterate();
+    if (result) {
+      createFakeParentDirectory(src);
+    }
+    return result;
+  }
+
+  private class DeleteIterator extends OzoneListingIterator {
+    private boolean recursive;
+
+    DeleteIterator(Path f, boolean recursive)
+        throws IOException {
+      super(f);
+      this.recursive = recursive;
+      if (getStatus().isDirectory()
+          && !this.recursive
+          && listStatus(f).length != 0) {
+        throw new PathIsNotEmptyDirectoryException(f.toString());
+      }
+    }
+
+    @Override
+    boolean processKey(String key) throws IOException {
+      if (key.equals("")) {
+        LOG.trace("Skipping deleting root directory");
+        return true;
+      } else {
+        LOG.trace("deleting key:" + key);
+        boolean succeed = adapter.deleteObject(key);
+        // if recursive delete is requested ignore the return value of
+        // deleteObject and issue deletes for other keys.
+        return recursive || succeed;
+      }
+    }
+  }
+
+  /**
+   * Deletes the children of the input dir path by iterating though the
+   * DeleteIterator.
+   *
+   * @param f directory path to be deleted
+   * @return true if successfully deletes all required keys, false otherwise
+   * @throws IOException
+   */
+  private boolean innerDelete(Path f, boolean recursive) throws IOException {
+    LOG.trace("delete() path:{} recursive:{}", f, recursive);
+    try {
+      DeleteIterator iterator = new DeleteIterator(f, recursive);
+      return iterator.iterate();
+    } catch (FileNotFoundException e) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Couldn't delete {} - does not exist", f);
+      }
+      return false;
+    }
+  }
+
+  @Override
+  public boolean delete(Path f, boolean recursive) throws IOException {
+    incrementCounter(Statistic.INVOCATION_DELETE);
+    statistics.incrementWriteOps(1);
+    LOG.debug("Delete path {} - recursive {}", f, recursive);
+    FileStatus status;
+    try {
+      status = getFileStatus(f);
+    } catch (FileNotFoundException ex) {
+      LOG.warn("delete: Path does not exist: {}", f);
+      return false;
+    }
+
+    String key = pathToKey(f);
+    boolean result;
+
+    if (status.isDirectory()) {
+      LOG.debug("delete: Path is a directory: {}", f);
+      key = addTrailingSlashIfNeeded(key);
+
+      if (key.equals("/")) {
+        LOG.warn("Cannot delete root directory.");
+        return false;
+      }
+
+      result = innerDelete(f, recursive);
+    } else {
+      LOG.debug("delete: Path is a file: {}", f);
+      result = adapter.deleteObject(key);
+    }
+
+    if (result) {
+      // If this delete operation removes all files/directories from the
+      // parent direcotry, then an empty parent directory must be created.
+      createFakeParentDirectory(f);
+    }
+
+    return result;
+  }
+
+  /**
+   * Create a fake parent directory key if it does not already exist and no
+   * other child of this parent directory exists.
+   *
+   * @param f path to the fake parent directory
+   * @throws IOException
+   */
+  private void createFakeParentDirectory(Path f) throws IOException {
+    Path parent = f.getParent();
+    if (parent != null && !parent.isRoot()) {
+      createFakeDirectoryIfNecessary(parent);
+    }
+  }
+
+  /**
+   * Create a fake directory key if it does not already exist.
+   *
+   * @param f path to the fake directory
+   * @throws IOException
+   */
+  private void createFakeDirectoryIfNecessary(Path f) throws IOException {
+    String key = pathToKey(f);
+    if (!key.isEmpty() && !o3Exists(f)) {
+      LOG.debug("Creating new fake directory at {}", f);
+      String dirKey = addTrailingSlashIfNeeded(key);
+      adapter.createDirectory(dirKey);
+    }
+  }
+
+  /**
+   * Check if a file or directory exists corresponding to given path.
+   *
+   * @param f path to file/directory.
+   * @return true if it exists, false otherwise.
+   * @throws IOException
+   */
+  private boolean o3Exists(final Path f) throws IOException {
+    Path path = makeQualified(f);
+    try {
+      getFileStatus(path);
+      return true;
+    } catch (FileNotFoundException ex) {
+      return false;
+    }
+  }
+
+  @Override
+  public FileStatus[] listStatus(Path f) throws IOException {
+    incrementCounter(Statistic.INVOCATION_LIST_STATUS);
+    statistics.incrementReadOps(1);
+    LOG.trace("listStatus() path:{}", f);
+    int numEntries = LISTING_PAGE_SIZE;
+    LinkedList<FileStatus> statuses = new LinkedList<>();
+    List<FileStatus> tmpStatusList;
+    String startKey = "";
+
+    do {
+      tmpStatusList =
+          adapter.listStatus(pathToKey(f), false, startKey, numEntries, uri,
+              workingDir, getUsername())
+              .stream()
+              .map(this::convertFileStatus)
+              .collect(Collectors.toList());
+
+      if (!tmpStatusList.isEmpty()) {
+        if (startKey.isEmpty()) {
+          statuses.addAll(tmpStatusList);
+        } else {
+          statuses.addAll(tmpStatusList.subList(1, tmpStatusList.size()));
+        }
+        startKey = pathToKey(statuses.getLast().getPath());
+      }
+      // listStatus returns entries numEntries in size if available.
+      // Any lesser number of entries indicate that the required entries have
+      // exhausted.
+    } while (tmpStatusList.size() == numEntries);
+
+
+    return statuses.toArray(new FileStatus[0]);
+  }
+
+  @Override
+  public void setWorkingDirectory(Path newDir) {
+    workingDir = newDir;
+  }
+
+  @Override
+  public Path getWorkingDirectory() {
+    return workingDir;
+  }
+
+  @Override
+  public Token<?> getDelegationToken(String renewer) throws IOException {
+    return adapter.getDelegationToken(renewer);
+  }
+
+  /**
+   * Get a canonical service name for this file system. If the URI is logical,
+   * the hostname part of the URI will be returned.
+   *
+   * @return a service string that uniquely identifies this file system.
+   */
+  @Override
+  public String getCanonicalServiceName() {
+    return adapter.getCanonicalServiceName();
+  }
+
+  /**
+   * Get the username of the FS.
+   *
+   * @return the short name of the user who instantiated the FS
+   */
+  public String getUsername() {
+    return userName;
+  }
+
+  /**
+   * Creates a directory. Directory is represented using a key with no value.
+   *
+   * @param path directory path to be created
+   * @return true if directory exists or created successfully.
+   * @throws IOException
+   */
+  private boolean mkdir(Path path) throws IOException {
+    return adapter.createDirectory(pathToKey(path));
+  }
+
+  @Override
+  public boolean mkdirs(Path f, FsPermission permission) throws IOException {
+    LOG.trace("mkdir() path:{} ", f);
+    String key = pathToKey(f);
+    if (isEmpty(key)) {
+      return false;
+    }
+    return mkdir(f);
+  }
+
+  @Override
+  public FileStatus getFileStatus(Path f) throws IOException {
+    incrementCounter(Statistic.INVOCATION_GET_FILE_STATUS);
+    statistics.incrementReadOps(1);
+    LOG.trace("getFileStatus() path:{}", f);
+    Path qualifiedPath = f.makeQualified(uri, workingDir);
+    String key = pathToKey(qualifiedPath);
+    FileStatus fileStatus = null;
+    try {
+      fileStatus = convertFileStatus(
+          adapter.getFileStatus(key, uri, qualifiedPath, getUsername()));
+    } catch (OMException ex) {
+      if (ex.getResult().equals(OMException.ResultCodes.KEY_NOT_FOUND)) {
+        throw new FileNotFoundException("File not found. path:" + f);
+      }
+    }
+    return fileStatus;
+  }
+
+  /**
+   * Turn a path (relative or otherwise) into an Ozone key.
+   *
+   * @param path the path of the file.
+   * @return the key of the object that represents the file.
+   */
+  public String pathToKey(Path path) {
+    Objects.requireNonNull(path, "Path canf not be null!");
+    if (!path.isAbsolute()) {
+      path = new Path(workingDir, path);
+    }
+    // removing leading '/' char
+    String key = path.toUri().getPath().substring(1);
+    LOG.trace("path for key:{} is:{}", key, path);
+    return key;
+  }
+
+  /**
+   * Add trailing delimiter to path if it is already not present.
+   *
+   * @param key the ozone Key which needs to be appended
+   * @return delimiter appended key
+   */
+  private String addTrailingSlashIfNeeded(String key) {
+    if (!isEmpty(key) && !key.endsWith(OZONE_URI_DELIMITER)) {
+      return key + OZONE_URI_DELIMITER;
+    } else {
+      return key;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "OzoneFileSystem{URI=" + uri + ", "
+        + "workingDir=" + workingDir + ", "
+        + "userName=" + userName + ", "
+        + "statistics=" + statistics
+        + "}";
+  }
+
+  /**
+   * This class provides an interface to iterate through all the keys in the
+   * bucket prefixed with the input path key and process them.
+   * <p>
+   * Each implementing class should define how the keys should be processed
+   * through the processKey() function.
+   */
+  private abstract class OzoneListingIterator {
+    private final Path path;
+    private final FileStatus status;
+    private String pathKey;
+    private Iterator<BasicKeyInfo> keyIterator;
+
+    OzoneListingIterator(Path path)
+        throws IOException {
+      this.path = path;
+      this.status = getFileStatus(path);
+      this.pathKey = pathToKey(path);
+      if (status.isDirectory()) {
+        this.pathKey = addTrailingSlashIfNeeded(pathKey);
+      }
+      keyIterator = adapter.listKeys(pathKey);
+    }
+
+    /**
+     * The output of processKey determines if further iteration through the
+     * keys should be done or not.
+     *
+     * @return true if we should continue iteration of keys, false otherwise.
+     * @throws IOException
+     */
+    abstract boolean processKey(String key) throws IOException;
+
+    /**
+     * Iterates thorugh all the keys prefixed with the input path's key and
+     * processes the key though processKey().
+     * If for any key, the processKey() returns false, then the iteration is
+     * stopped and returned with false indicating that all the keys could not
+     * be processed successfully.
+     *
+     * @return true if all keys are processed successfully, false otherwise.
+     * @throws IOException
+     */
+    boolean iterate() throws IOException {
+      LOG.trace("Iterating path {}", path);
+      if (status.isDirectory()) {
+        LOG.trace("Iterating directory:{}", pathKey);
+        while (keyIterator.hasNext()) {
+          BasicKeyInfo key = keyIterator.next();
+          LOG.trace("iterating key:{}", key.getName());
+          if (!processKey(key.getName())) {
+            return false;
+          }
+        }
+        return true;
+      } else {
+        LOG.trace("iterating file:{}", path);
+        return processKey(pathKey);
+      }
+    }
+
+    String getPathKey() {
+      return pathKey;
+    }
+
+    boolean pathIsDirectory() {
+      return status.isDirectory();
+    }
+
+    FileStatus getStatus() {
+      return status;
+    }
+  }
+
+  public OzoneClientAdapter getAdapter() {
+    return adapter;
+  }
+
+  public boolean isEmpty(CharSequence cs) {
+    return cs == null || cs.length() == 0;
+  }
+
+  public boolean isNumber(String number) {
+    try {
+      Integer.parseInt(number);
+    } catch (NumberFormatException ex) {
+      return false;
+    }
+    return true;
+  }
+
+  private FileStatus convertFileStatus(
+      FileStatusAdapter fileStatusAdapter) {
+
+    Path symLink = null;
+    try {
+      fileStatusAdapter.getSymlink();
+    } catch (Exception ex) {
+      //NOOP: If not symlink symlink remains null.
+    }
+
+    return new FileStatus(
+        fileStatusAdapter.getLength(),
+        fileStatusAdapter.isDir(),
+        fileStatusAdapter.getBlockReplication(),
+        fileStatusAdapter.getBlocksize(),
+        fileStatusAdapter.getModificationTime(),
+        fileStatusAdapter.getAccessTime(),
+        new FsPermission(fileStatusAdapter.getPermission()),
+        fileStatusAdapter.getOwner(),
+        fileStatusAdapter.getGroup(),
+        symLink,
+        fileStatusAdapter.getPath()
+    );
+
+  }
+}

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOFileSystem.java
@@ -182,7 +182,9 @@ public class BasicOFileSystem extends FileSystem {
   @Override
   public void close() throws IOException {
     try {
-      adapter.close();
+      if (adapter != null) {
+        adapter.close();
+      }
     } finally {
       super.close();
     }
@@ -203,6 +205,9 @@ public class BasicOFileSystem extends FileSystem {
     incrementCounter(Statistic.INVOCATION_OPEN);
     statistics.incrementWriteOps(1);
     LOG.trace("open() path:{}", f);
+    if (this.adapter != null) {
+      this.adapter.close();
+    }
     this.adapter = createAdapter(new OFSPath(f.toUri().getPath()));
     final String key = pathToKey(f);
     return new FSDataInputStream(new OzoneFSInputStream(adapter.readFile(key)));
@@ -218,6 +223,9 @@ public class BasicOFileSystem extends FileSystem {
       short replication, long blockSize,
       Progressable progress) throws IOException {
     LOG.trace("create() path:{}", f);
+    if (this.adapter != null) {
+      this.adapter.close();
+    }
     this.adapter = createAdapter(new OFSPath(f.toUri().getPath()));
     incrementCounter(Statistic.INVOCATION_CREATE);
     statistics.incrementWriteOps(1);
@@ -433,6 +441,9 @@ public class BasicOFileSystem extends FileSystem {
     incrementCounter(Statistic.INVOCATION_DELETE);
     statistics.incrementWriteOps(1);
     LOG.debug("Delete path {} - recursive {}", f, recursive);
+    if (this.adapter != null) {
+      this.adapter.close();
+    }
     this.adapter = createAdapter(new OFSPath(f.toUri().getPath()));
     FileStatus status;
     try {
@@ -520,6 +531,9 @@ public class BasicOFileSystem extends FileSystem {
     incrementCounter(Statistic.INVOCATION_LIST_STATUS);
     statistics.incrementReadOps(1);
     LOG.trace("listStatus() path:{}", f);
+    if (this.adapter != null) {
+      this.adapter.close();
+    }
     this.adapter = createAdapter(new OFSPath(f.toUri().getPath()));
     int numEntries = LISTING_PAGE_SIZE;
     LinkedList<FileStatus> statuses = new LinkedList<>();
@@ -600,6 +614,9 @@ public class BasicOFileSystem extends FileSystem {
   @Override
   public boolean mkdirs(Path f, FsPermission permission) throws IOException {
     LOG.trace("mkdir() path:{} ", f);
+    if (this.adapter != null) {
+      this.adapter.close();
+    }
     this.adapter = createAdapter(new OFSPath(f.toUri().getPath()));
     String key = pathToKey(f);
     if (isEmpty(key)) {
@@ -613,6 +630,9 @@ public class BasicOFileSystem extends FileSystem {
     incrementCounter(Statistic.INVOCATION_GET_FILE_STATUS);
     statistics.incrementReadOps(1);
     LOG.trace("getFileStatus() path:{}", f);
+    if (this.adapter != null) {
+      this.adapter.close();
+    }
     this.adapter = createAdapter(new OFSPath(f.toUri().getPath()));
     Path qualifiedPath = f.makeQualified(uri, workingDir);
     String key = pathToKey(qualifiedPath);

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFileSystem.java
@@ -41,7 +41,7 @@ import java.net.URI;
  */
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
-public class OFileSystem extends BasicOzoneFileSystem
+public class OFileSystem extends BasicOFileSystem
     implements KeyProviderTokenIssuer {
 
   private OzoneFSStorageStatistics storageStatistics;

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFileSystem.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.crypto.key.KeyProvider;
+import org.apache.hadoop.crypto.key.KeyProviderTokenIssuer;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.GlobalStorageStatistics;
+import org.apache.hadoop.fs.StorageStatistics;
+import org.apache.hadoop.security.token.DelegationTokenIssuer;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * The Ozone Filesystem implementation.
+ * <p>
+ * This subclass is marked as private as code should not be creating it
+ * directly; use {@link FileSystem#get(Configuration)} and variants to create
+ * one. If cast to {@link OFileSystem}, extra methods and features may be
+ * accessed. Consider those private and unstable.
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Evolving
+public class OFileSystem extends BasicOzoneFileSystem
+    implements KeyProviderTokenIssuer {
+
+  private OzoneFSStorageStatistics storageStatistics;
+
+  @Override
+  public KeyProvider getKeyProvider() throws IOException {
+    return getAdapter().getKeyProvider();
+  }
+
+  @Override
+  public URI getKeyProviderUri() throws IOException {
+    return getAdapter().getKeyProviderUri();
+  }
+
+  @Override
+  public DelegationTokenIssuer[] getAdditionalTokenIssuers()
+      throws IOException {
+    KeyProvider keyProvider;
+    try {
+      keyProvider = getKeyProvider();
+    } catch (IOException ioe) {
+      LOG.debug("Error retrieving KeyProvider.", ioe);
+      return null;
+    }
+    if (keyProvider instanceof DelegationTokenIssuer) {
+      return new DelegationTokenIssuer[]{(DelegationTokenIssuer)keyProvider};
+    }
+    return null;
+  }
+
+  StorageStatistics getOzoneFSOpsCountStatistics() {
+    return storageStatistics;
+  }
+
+  @Override
+  protected void incrementCounter(Statistic statistic) {
+    if (storageStatistics != null) {
+      storageStatistics.incrementCounter(statistic, 1);
+    }
+  }
+
+  @Override
+  protected OzoneClientAdapter createAdapter(Configuration conf,
+      String bucketStr,
+      String volumeStr, String omHost, int omPort,
+      boolean isolatedClassloader) throws IOException {
+
+    this.storageStatistics =
+        (OzoneFSStorageStatistics) GlobalStorageStatistics.INSTANCE
+            .put(OzoneFSStorageStatistics.NAME,
+                OzoneFSStorageStatistics::new);
+
+    if (isolatedClassloader) {
+      return OzoneClientAdapterFactory.createAdapter(volumeStr, bucketStr,
+          storageStatistics);
+
+    } else {
+      return new OzoneClientAdapterImpl(omHost, omPort, conf,
+          volumeStr, bucketStr, storageStatistics);
+    }
+  }
+}

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFileSystem.java
@@ -77,15 +77,10 @@ public class TestOFileSystem {
     OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
     volumeName = bucket.getVolumeName();
     bucketName = bucket.getName();
-//    volumeName = "vol1";
-//    bucketName = "buc1";
 
     // For now:
     rootPath = String.format("%s://%s/", OzoneConsts.OZONE_OFS_URI_SCHEME,
         conf.get("ozone.om.address"));  // TODO: OZONE_OM_ADDRESS_KEY
-//    rootPath = String.format("%s://%s/%s/%s/", OzoneConsts.OZONE_OFS_URI_SCHEME,
-//        conf.get("ozone.om.address"),  // TODO: OZONE_OM_ADDRESS_KEY
-//        volumeName, bucketName);
 
     // Set the fs.defaultFS and start the filesystem
     conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
@@ -117,7 +112,8 @@ public class TestOFileSystem {
   @Test
   public void testCreateDoesNotAddParentDirKeys() throws Exception {
     Path rootBucket = new Path("/" + volumeName + "/" + bucketName);
-    Path grandparent = new Path(rootBucket, "testCreateDoesNotAddParentDirKeys");
+    Path grandparent = new Path(rootBucket,
+        "testCreateDoesNotAddParentDirKeys");
     Path parent = new Path(grandparent, "parent");
     Path child = new Path(parent, "child");
     ContractTestUtils.touch(fs, child);

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFileSystem.java
@@ -170,7 +170,7 @@ public class TestOFileSystem {
 
     FileStatus[] fileStatuses = ofs.listStatus(rootBucket);
     assertEquals("Should be empty", 0, fileStatuses.length);
-    /*
+
     ContractTestUtils.touch(fs, file1);
     ContractTestUtils.touch(fs, file2);
 
@@ -188,7 +188,6 @@ public class TestOFileSystem {
     fileStatuses = ofs.listStatus(parent);
     assertEquals("FileStatus did not return all children of the directory",
         3, fileStatuses.length);
-     */
   }
 
   /**

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFileSystem.java
@@ -1,0 +1,305 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClientException;
+import org.apache.hadoop.ozone.client.OzoneKeyDetails;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Ozone file system tests that are not covered by contract tests.
+ */
+public class TestOFileSystem {
+
+  @Rule
+  public Timeout globalTimeout = new Timeout(300_000);
+
+  private static MiniOzoneCluster cluster = null;
+
+  private static FileSystem fs;
+  private static OzoneFileSystem o3fs;
+
+  private String volumeName;
+  private String bucketName;
+
+  private String rootPath;
+
+  @Before
+  public void init() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(3)
+        .build();
+    cluster.waitForClusterToBeReady();
+
+    // create a volume and a bucket to be used by OzoneFileSystem
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
+    volumeName = bucket.getVolumeName();
+    bucketName = bucket.getName();
+
+    rootPath = String.format("%s://%s.%s/",
+        OzoneConsts.OZONE_URI_SCHEME, bucket.getName(), bucket.getVolumeName());
+
+    // Set the fs.defaultFS and start the filesystem
+    conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+    fs = FileSystem.get(conf);
+    o3fs = (OzoneFileSystem) fs;
+  }
+
+  @After
+  public void teardown() throws IOException {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+    IOUtils.closeQuietly(fs);
+  }
+
+  @Test
+  public void testOzoneFsServiceLoader() throws IOException {
+    assertEquals(
+        FileSystem.getFileSystemClass(OzoneConsts.OZONE_URI_SCHEME, null),
+        OzoneFileSystem.class);
+  }
+
+  @Test
+  public void testCreateDoesNotAddParentDirKeys() throws Exception {
+    Path grandparent = new Path("/testCreateDoesNotAddParentDirKeys");
+    Path parent = new Path(grandparent, "parent");
+    Path child = new Path(parent, "child");
+    ContractTestUtils.touch(fs, child);
+
+    OzoneKeyDetails key = getKey(child, false);
+    assertEquals(key.getName(), o3fs.pathToKey(child));
+
+    // Creating a child should not add parent keys to the bucket
+    try {
+      getKey(parent, true);
+    } catch (IOException ex) {
+      assertKeyNotFoundException(ex);
+    }
+
+    // List status on the parent should show the child file
+    assertEquals("List status of parent should include the 1 child file", 1L,
+        (long)fs.listStatus(parent).length);
+    assertTrue("Parent directory does not appear to be a directory",
+        fs.getFileStatus(parent).isDirectory());
+  }
+
+  @Test
+  public void testDeleteCreatesFakeParentDir() throws Exception {
+    Path grandparent = new Path("/testDeleteCreatesFakeParentDir");
+    Path parent = new Path(grandparent, "parent");
+    Path child = new Path(parent, "child");
+    ContractTestUtils.touch(fs, child);
+
+    // Verify that parent dir key does not exist
+    // Creating a child should not add parent keys to the bucket
+    try {
+      getKey(parent, true);
+    } catch (IOException ex) {
+      assertKeyNotFoundException(ex);
+    }
+
+    // Delete the child key
+    fs.delete(child, false);
+
+    // Deleting the only child should create the parent dir key if it does
+    // not exist
+    String parentKey = o3fs.pathToKey(parent) + "/";
+    OzoneKeyDetails parentKeyInfo = getKey(parent, true);
+    assertEquals(parentKey, parentKeyInfo.getName());
+  }
+
+  @Test
+  public void testListStatus() throws Exception {
+    Path parent = new Path("/testListStatus");
+    Path file1 = new Path(parent, "key1");
+    Path file2 = new Path(parent, "key2");
+    ContractTestUtils.touch(fs, file1);
+    ContractTestUtils.touch(fs, file2);
+
+
+    // ListStatus on a directory should return all subdirs along with
+    // files, even if there exists a file and sub-dir with the same name.
+    FileStatus[] fileStatuses = o3fs.listStatus(parent);
+    assertEquals("FileStatus did not return all children of the directory",
+        2, fileStatuses.length);
+
+    // ListStatus should return only the immediate children of a directory.
+    Path file3 = new Path(parent, "dir1/key3");
+    Path file4 = new Path(parent, "dir1/key4");
+    ContractTestUtils.touch(fs, file3);
+    ContractTestUtils.touch(fs, file4);
+    fileStatuses = o3fs.listStatus(parent);
+    assertEquals("FileStatus did not return all children of the directory",
+        3, fileStatuses.length);
+  }
+
+  /**
+   * Tests listStatus operation on root directory.
+   */
+  @Test
+  public void testListStatusOnRoot() throws Exception {
+    Path root = new Path("/");
+    Path dir1 = new Path(root, "dir1");
+    Path dir12 = new Path(dir1, "dir12");
+    Path dir2 = new Path(root, "dir2");
+    fs.mkdirs(dir12);
+    fs.mkdirs(dir2);
+
+    // ListStatus on root should return dir1 (even though /dir1 key does not
+    // exist) and dir2 only. dir12 is not an immediate child of root and
+    // hence should not be listed.
+    FileStatus[] fileStatuses = o3fs.listStatus(root);
+    assertEquals("FileStatus should return only the immediate children", 2,
+        fileStatuses.length);
+
+    // Verify that dir12 is not included in the result of the listStatus on root
+    String fileStatus1 = fileStatuses[0].getPath().toUri().getPath();
+    String fileStatus2 = fileStatuses[1].getPath().toUri().getPath();
+    assertFalse(fileStatus1.equals(dir12.toString()));
+    assertFalse(fileStatus2.equals(dir12.toString()));
+  }
+
+  /**
+   * Tests listStatus operation on root directory.
+   */
+  @Test
+  public void testListStatusOnLargeDirectory() throws Exception {
+    Path root = new Path("/");
+    Set<String> paths = new TreeSet<>();
+    int numDirs = 5111;
+    for(int i = 0; i < numDirs; i++) {
+      Path p = new Path(root, String.valueOf(i));
+      fs.mkdirs(p);
+      paths.add(p.getName());
+    }
+
+    FileStatus[] fileStatuses = o3fs.listStatus(root);
+    assertEquals(
+        "Total directories listed do not match the existing directories",
+        numDirs, fileStatuses.length);
+
+    for (int i=0; i < numDirs; i++) {
+      assertTrue(paths.contains(fileStatuses[i].getPath().getName()));
+    }
+  }
+
+  /**
+   * Tests listStatus on a path with subdirs.
+   */
+  @Test
+  public void testListStatusOnSubDirs() throws Exception {
+    // Create the following key structure
+    //      /dir1/dir11/dir111
+    //      /dir1/dir12
+    //      /dir1/dir12/file121
+    //      /dir2
+    // ListStatus on /dir1 should return all its immediated subdirs only
+    // which are /dir1/dir11 and /dir1/dir12. Super child files/dirs
+    // (/dir1/dir12/file121 and /dir1/dir11/dir111) should not be returned by
+    // listStatus.
+    Path dir1 = new Path("/dir1");
+    Path dir11 = new Path(dir1, "dir11");
+    Path dir111 = new Path(dir11, "dir111");
+    Path dir12 = new Path(dir1, "dir12");
+    Path file121 = new Path(dir12, "file121");
+    Path dir2 = new Path("/dir2");
+    fs.mkdirs(dir111);
+    fs.mkdirs(dir12);
+    ContractTestUtils.touch(fs, file121);
+    fs.mkdirs(dir2);
+
+    FileStatus[] fileStatuses = o3fs.listStatus(dir1);
+    assertEquals("FileStatus should return only the immediate children", 2,
+        fileStatuses.length);
+
+    // Verify that the two children of /dir1 returned by listStatus operation
+    // are /dir1/dir11 and /dir1/dir12.
+    String fileStatus1 = fileStatuses[0].getPath().toUri().getPath();
+    String fileStatus2 = fileStatuses[1].getPath().toUri().getPath();
+    assertTrue(fileStatus1.equals(dir11.toString()) ||
+        fileStatus1.equals(dir12.toString()));
+    assertTrue(fileStatus2.equals(dir11.toString()) ||
+        fileStatus2.equals(dir12.toString()));
+  }
+
+  @Test
+  public void testNonExplicitlyCreatedPathExistsAfterItsLeafsWereRemoved()
+      throws Exception {
+    Path source = new Path("/source");
+    Path interimPath = new Path(source, "interimPath");
+    Path leafInsideInterimPath = new Path(interimPath, "leaf");
+    Path target = new Path("/target");
+    Path leafInTarget = new Path(target, "leaf");
+
+    fs.mkdirs(source);
+    fs.mkdirs(target);
+    fs.mkdirs(leafInsideInterimPath);
+    assertTrue(fs.rename(leafInsideInterimPath, leafInTarget));
+
+    // after rename listStatus for interimPath should succeed and
+    // interimPath should have no children
+    FileStatus[] statuses = fs.listStatus(interimPath);
+    assertNotNull("liststatus returns a null array", statuses);
+    assertEquals("Statuses array is not empty", 0, statuses.length);
+    FileStatus fileStatus = fs.getFileStatus(interimPath);
+    assertEquals("FileStatus does not point to interimPath",
+        interimPath.getName(), fileStatus.getPath().getName());
+  }
+
+  private OzoneKeyDetails getKey(Path keyPath, boolean isDirectory)
+      throws IOException, OzoneClientException {
+    String key = o3fs.pathToKey(keyPath);
+    if (isDirectory) {
+      key = key + "/";
+    }
+    return cluster.getClient().getObjectStore().getVolume(volumeName)
+        .getBucket(bucketName).getKey(key);
+  }
+
+  private void assertKeyNotFoundException(IOException ex) {
+    GenericTestUtils.assertExceptionContains("KEY_NOT_FOUND", ex);
+  }
+}

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFileSystem.java
@@ -117,8 +117,7 @@ public class TestOFileSystem {
   @Test
   public void testCreateDoesNotAddParentDirKeys() throws Exception {
     Path rootBucket = new Path("/" + volumeName + "/" + bucketName);
-    Path grandparent = new Path(rootBucket,
-        "/testCreateDoesNotAddParentDirKeys");
+    Path grandparent = new Path(rootBucket, "testCreateDoesNotAddParentDirKeys");
     Path parent = new Path(grandparent, "parent");
     Path child = new Path(parent, "child");
     ContractTestUtils.touch(fs, child);
@@ -143,8 +142,7 @@ public class TestOFileSystem {
   @Test
   public void testDeleteCreatesFakeParentDir() throws Exception {
     Path rootBucket = new Path("/" + volumeName + "/" + bucketName);
-    Path grandparent = new Path(rootBucket,
-        "/testDeleteCreatesFakeParentDir");
+    Path grandparent = new Path(rootBucket, "testDeleteCreatesFakeParentDir");
     Path parent = new Path(grandparent, "parent");
     Path child = new Path(parent, "child");
     ContractTestUtils.touch(fs, child);
@@ -261,12 +259,12 @@ public class TestOFileSystem {
     // (/dir1/dir12/file121 and /dir1/dir11/dir111) should not be returned by
     // listStatus.
     Path rootBucket = new Path("/" + volumeName + "/" + bucketName);
-    Path dir1 = new Path(rootBucket, "/dir1");
+    Path dir1 = new Path(rootBucket, "dir1");
     Path dir11 = new Path(dir1, "dir11");
     Path dir111 = new Path(dir11, "dir111");
     Path dir12 = new Path(dir1, "dir12");
     Path file121 = new Path(dir12, "file121");
-    Path dir2 = new Path(rootBucket, "/dir2");
+    Path dir2 = new Path(rootBucket, "dir2");
     fs.mkdirs(dir111);
     fs.mkdirs(dir12);
     ContractTestUtils.touch(fs, file121);
@@ -290,10 +288,10 @@ public class TestOFileSystem {
   public void testNonExplicitlyCreatedPathExistsAfterItsLeafsWereRemoved()
       throws Exception {
     Path rootBucket = new Path("/" + volumeName + "/" + bucketName);
-    Path source = new Path(rootBucket, "/source");
+    Path source = new Path(rootBucket, "source");
     Path interimPath = new Path(source, "interimPath");
     Path leafInsideInterimPath = new Path(interimPath, "leaf");
-    Path target = new Path(rootBucket, "/target");
+    Path target = new Path(rootBucket, "target");
     Path leafInTarget = new Path(target, "leaf");
 
     fs.mkdirs(source);

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFileSystem.java
@@ -81,11 +81,11 @@ public class TestOFileSystem {
 //    bucketName = "buc1";
 
     // For now:
-//    rootPath = String.format("%s://%s/", OzoneConsts.OZONE_OFS_URI_SCHEME,
-//        conf.get("ozone.om.http-address"));
-    rootPath = String.format("%s://%s/%s/%s/", OzoneConsts.OZONE_OFS_URI_SCHEME,
-        conf.get("ozone.om.http-address"),  // TODO: OZONE_OM_HTTP_ADDRESS_KEY
-        volumeName, bucketName);
+    rootPath = String.format("%s://%s/", OzoneConsts.OZONE_OFS_URI_SCHEME,
+        conf.get("ozone.om.address"));  // TODO: OZONE_OM_ADDRESS_KEY
+//    rootPath = String.format("%s://%s/%s/%s/", OzoneConsts.OZONE_OFS_URI_SCHEME,
+//        conf.get("ozone.om.address"),  // TODO: OZONE_OM_ADDRESS_KEY
+//        volumeName, bucketName);
 
     // Set the fs.defaultFS and start the filesystem
     conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
@@ -163,16 +163,20 @@ public class TestOFileSystem {
 
   @Test
   public void testListStatus() throws Exception {
-    Path parent = new Path("/testListStatus");
+    Path rootBucket = new Path("/" + volumeName + "/" + bucketName);
+    Path parent = new Path(rootBucket, "testListStatus");
     Path file1 = new Path(parent, "key1");
     Path file2 = new Path(parent, "key2");
+
+    FileStatus[] fileStatuses = ofs.listStatus(rootBucket);
+    assertEquals("Should be empty", 0, fileStatuses.length);
+    /*
     ContractTestUtils.touch(fs, file1);
     ContractTestUtils.touch(fs, file2);
 
-
     // ListStatus on a directory should return all subdirs along with
     // files, even if there exists a file and sub-dir with the same name.
-    FileStatus[] fileStatuses = ofs.listStatus(parent);
+    fileStatuses = ofs.listStatus(parent);
     assertEquals("FileStatus did not return all children of the directory",
         2, fileStatuses.length);
 
@@ -184,6 +188,7 @@ public class TestOFileSystem {
     fileStatuses = ofs.listStatus(parent);
     assertEquals("FileStatus did not return all children of the directory",
         3, fileStatuses.length);
+     */
   }
 
   /**

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFileSystem.java
@@ -107,14 +107,18 @@ public class TestOFileSystem {
 
   @Test
   public void testOzoneFsServiceLoader() throws IOException {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set("fs.ofs.impl", "org.apache.hadoop.fs.ozone.OFileSystem"); // TODO
     assertEquals(
         FileSystem.getFileSystemClass(OzoneConsts.OZONE_OFS_URI_SCHEME,
-            null), OFileSystem.class);
+            conf), OFileSystem.class);
   }
 
   @Test
   public void testCreateDoesNotAddParentDirKeys() throws Exception {
-    Path grandparent = new Path("/testCreateDoesNotAddParentDirKeys");
+    Path rootBucket = new Path("/" + volumeName + "/" + bucketName);
+    Path grandparent = new Path(rootBucket,
+        "/testCreateDoesNotAddParentDirKeys");
     Path parent = new Path(grandparent, "parent");
     Path child = new Path(parent, "child");
     ContractTestUtils.touch(fs, child);
@@ -138,7 +142,9 @@ public class TestOFileSystem {
 
   @Test
   public void testDeleteCreatesFakeParentDir() throws Exception {
-    Path grandparent = new Path("/testDeleteCreatesFakeParentDir");
+    Path rootBucket = new Path("/" + volumeName + "/" + bucketName);
+    Path grandparent = new Path(rootBucket,
+        "/testDeleteCreatesFakeParentDir");
     Path parent = new Path(grandparent, "parent");
     Path child = new Path(parent, "child");
     ContractTestUtils.touch(fs, child);
@@ -195,7 +201,7 @@ public class TestOFileSystem {
    */
   @Test
   public void testListStatusOnRoot() throws Exception {
-    Path root = new Path("/");
+    Path root = new Path("/" + volumeName + "/" + bucketName);
     Path dir1 = new Path(root, "dir1");
     Path dir12 = new Path(dir1, "dir12");
     Path dir2 = new Path(root, "dir2");
@@ -221,7 +227,7 @@ public class TestOFileSystem {
    */
   @Test
   public void testListStatusOnLargeDirectory() throws Exception {
-    Path root = new Path("/");
+    Path root = new Path("/" + volumeName + "/" + bucketName);
     Set<String> paths = new TreeSet<>();
     int numDirs = 5111;
     for(int i = 0; i < numDirs; i++) {
@@ -254,12 +260,13 @@ public class TestOFileSystem {
     // which are /dir1/dir11 and /dir1/dir12. Super child files/dirs
     // (/dir1/dir12/file121 and /dir1/dir11/dir111) should not be returned by
     // listStatus.
-    Path dir1 = new Path("/dir1");
+    Path rootBucket = new Path("/" + volumeName + "/" + bucketName);
+    Path dir1 = new Path(rootBucket, "/dir1");
     Path dir11 = new Path(dir1, "dir11");
     Path dir111 = new Path(dir11, "dir111");
     Path dir12 = new Path(dir1, "dir12");
     Path file121 = new Path(dir12, "file121");
-    Path dir2 = new Path("/dir2");
+    Path dir2 = new Path(rootBucket, "/dir2");
     fs.mkdirs(dir111);
     fs.mkdirs(dir12);
     ContractTestUtils.touch(fs, file121);
@@ -282,10 +289,11 @@ public class TestOFileSystem {
   @Test
   public void testNonExplicitlyCreatedPathExistsAfterItsLeafsWereRemoved()
       throws Exception {
-    Path source = new Path("/source");
+    Path rootBucket = new Path("/" + volumeName + "/" + bucketName);
+    Path source = new Path(rootBucket, "/source");
     Path interimPath = new Path(source, "interimPath");
     Path leafInsideInterimPath = new Path(interimPath, "leaf");
-    Path target = new Path("/target");
+    Path target = new Path(rootBucket, "/target");
     Path leafInTarget = new Path(target, "leaf");
 
     fs.mkdirs(source);

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFileSystemWithMocks.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFileSystemWithMocks.java
@@ -1,0 +1,148 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Ozone File system tests that are light weight and use mocks.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ OzoneClientFactory.class, UserGroupInformation.class })
+public class TestOFileSystemWithMocks {
+
+  @Test
+  public void testFSUriWithHostPortOverrides() throws Exception {
+    Configuration conf = new OzoneConfiguration();
+    OzoneClient ozoneClient = mock(OzoneClient.class);
+    ObjectStore objectStore = mock(ObjectStore.class);
+    OzoneVolume volume = mock(OzoneVolume.class);
+    OzoneBucket bucket = mock(OzoneBucket.class);
+
+    when(ozoneClient.getObjectStore()).thenReturn(objectStore);
+    when(objectStore.getVolume(eq("volume1"))).thenReturn(volume);
+    when(volume.getBucket("bucket1")).thenReturn(bucket);
+
+    PowerMockito.mockStatic(OzoneClientFactory.class);
+    PowerMockito.when(OzoneClientFactory.getRpcClient(eq("local.host"),
+        eq(5899), eq(conf))).thenReturn(ozoneClient);
+
+    UserGroupInformation ugi = mock(UserGroupInformation.class);
+    PowerMockito.mockStatic(UserGroupInformation.class);
+    PowerMockito.when(UserGroupInformation.getCurrentUser()).thenReturn(ugi);
+    when(ugi.getShortUserName()).thenReturn("user1");
+
+    URI uri = new URI("o3fs://bucket1.volume1.local.host:5899");
+
+    FileSystem fileSystem = FileSystem.get(uri, conf);
+    OzoneFileSystem ozfs = (OzoneFileSystem) fileSystem;
+
+    assertEquals(ozfs.getUri().getAuthority(),
+        "bucket1.volume1.local.host:5899");
+    PowerMockito.verifyStatic();
+    OzoneClientFactory.getRpcClient("local.host", 5899, conf);
+  }
+
+  @Test
+  public void testFSUriWithHostPortUnspecified() throws Exception {
+    Configuration conf = new OzoneConfiguration();
+    final int omPort = OmUtils.getOmRpcPort(conf);
+
+    OzoneClient ozoneClient = mock(OzoneClient.class);
+    ObjectStore objectStore = mock(ObjectStore.class);
+    OzoneVolume volume = mock(OzoneVolume.class);
+    OzoneBucket bucket = mock(OzoneBucket.class);
+
+    when(ozoneClient.getObjectStore()).thenReturn(objectStore);
+    when(objectStore.getVolume(eq("volume1"))).thenReturn(volume);
+    when(volume.getBucket("bucket1")).thenReturn(bucket);
+
+    PowerMockito.mockStatic(OzoneClientFactory.class);
+    PowerMockito.when(OzoneClientFactory.getRpcClient(eq("local.host"),
+        eq(omPort), eq(conf))).thenReturn(ozoneClient);
+
+    UserGroupInformation ugi = mock(UserGroupInformation.class);
+    PowerMockito.mockStatic(UserGroupInformation.class);
+    PowerMockito.when(UserGroupInformation.getCurrentUser()).thenReturn(ugi);
+    when(ugi.getShortUserName()).thenReturn("user1");
+
+    URI uri = new URI("o3fs://bucket1.volume1.local.host");
+
+    FileSystem fileSystem = FileSystem.get(uri, conf);
+    OzoneFileSystem ozfs = (OzoneFileSystem) fileSystem;
+
+    assertEquals(ozfs.getUri().getHost(), "bucket1.volume1.local.host");
+    // The URI doesn't contain a port number, expect -1 from getPort()
+    assertEquals(ozfs.getUri().getPort(), -1);
+    PowerMockito.verifyStatic();
+    // Check the actual port number in use
+    OzoneClientFactory.getRpcClient("local.host", omPort, conf);
+  }
+
+  @Test
+  public void testFSUriHostVersionDefault() throws Exception {
+    Configuration conf = new OzoneConfiguration();
+    OzoneClient ozoneClient = mock(OzoneClient.class);
+    ObjectStore objectStore = mock(ObjectStore.class);
+    OzoneVolume volume = mock(OzoneVolume.class);
+    OzoneBucket bucket = mock(OzoneBucket.class);
+
+    when(ozoneClient.getObjectStore()).thenReturn(objectStore);
+    when(objectStore.getVolume(eq("volume1"))).thenReturn(volume);
+    when(volume.getBucket("bucket1")).thenReturn(bucket);
+
+    PowerMockito.mockStatic(OzoneClientFactory.class);
+    PowerMockito.when(OzoneClientFactory.getRpcClient(eq(conf)))
+        .thenReturn(ozoneClient);
+
+    UserGroupInformation ugi = mock(UserGroupInformation.class);
+    PowerMockito.mockStatic(UserGroupInformation.class);
+    PowerMockito.when(UserGroupInformation.getCurrentUser()).thenReturn(ugi);
+    when(ugi.getShortUserName()).thenReturn("user1");
+
+    URI uri = new URI("o3fs://bucket1.volume1/key");
+
+    FileSystem fileSystem = FileSystem.get(uri, conf);
+    OzoneFileSystem ozfs = (OzoneFileSystem) fileSystem;
+
+    assertEquals(ozfs.getUri().getAuthority(), "bucket1.volume1");
+    PowerMockito.verifyStatic();
+    OzoneClientFactory.getRpcClient(conf);
+  }
+}

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFileSystemWithMocks.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFileSystemWithMocks.java
@@ -74,13 +74,13 @@ public class TestOFileSystemWithMocks {
     //  hence the workaround.
     conf.set("fs.ofs.impl", "org.apache.hadoop.fs.ozone.OFileSystem");
 
-    URI uri = new URI("ofs://bucket1.volume1.local.host:5899");
+//    URI uri = new URI("ofs://bucket1.volume1.local.host:5899");
+    URI uri = new URI("ofs://local.host:5899/volume1/bucket1");
 
     FileSystem fileSystem = FileSystem.get(uri, conf);
     OFileSystem ofs = (OFileSystem) fileSystem;
 
-    assertEquals(ofs.getUri().getAuthority(),
-        "bucket1.volume1.local.host:5899");
+    assertEquals(ofs.getUri().getAuthority(), "local.host:5899");
     PowerMockito.verifyStatic();
     OzoneClientFactory.getRpcClient("local.host", 5899, conf);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implement a new scheme for Ozone Filesystem where all volumes (and buckets) can be access from a single root.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2665

## How was this patch tested?

This is work-in-progress. Hasn't been completely tested yet. Still writing new test cases.

## Notes
1. So far the new FS class is named as `OFileSystem` (will later change into `OzoneRootedFileSystem` or something else);
2. A bunch of TODOs are noted in commit messages and within code.