### PR TITLE
HDDS-2755. Compare transactionID and updateID of Volume operations to avoid replaying transactions

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
@@ -221,6 +221,8 @@ public class OMException extends IOException {
 
     SCM_GET_PIPELINE_EXCEPTION,
 
-    INVALID_BUCKET_NAME
+    INVALID_BUCKET_NAME,
+
+    REPLAY // When ratis logs are replayed.
   }
 }

--- a/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
+++ b/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
@@ -311,6 +311,9 @@ enum Status {
     INVALID_PART_ORDER = 56;
     SCM_GET_PIPELINE_EXCEPTION = 57;
     INVALID_BUCKET_NAME = 58;
+
+    // When transactions are replayed
+    REPLAY = 100;
 }
 
 /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -136,7 +136,7 @@ public class OzoneManagerDoubleBuffer {
 
             readyBuffer.iterator().forEachRemaining((entry) -> {
               try {
-                entry.getResponse().addToDBBatch(omMetadataManager,
+                entry.getResponse().checkAndUpdateDB(omMetadataManager,
                     batchOperation);
               } catch (IOException ex) {
                 // During Adding to RocksDB batch entry got an exception.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -252,8 +252,8 @@ public abstract class OMClientRequest implements RequestAuditor {
    * @return true if transactionID is less than or equal to updateID, false
    * otherwise.
    */
-  public boolean isReplay(long updateID, long transactionID) {
-    return transactionID <= updateID;
+  public boolean isReplay(OzoneManager om, long updateID, long transactionID) {
+    return om.isRatisEnabled() && transactionID <= updateID;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -205,6 +205,7 @@ public abstract class OMClientRequest implements RequestAuditor {
     return omResponse.build();
   }
 
+
   private String exceptionErrorMessage(IOException ex) {
     if (ex instanceof OMException) {
       return ex.getMessage();
@@ -242,5 +243,27 @@ public abstract class OMClientRequest implements RequestAuditor {
     Map<String, String> auditMap = new LinkedHashMap<>();
     auditMap.put(OzoneConsts.VOLUME, volume);
     return auditMap;
+  }
+
+  /**
+   * Check if the transaction is a replay.
+   * @param updateID last updateID of the entity in the DB
+   * @param transactionID the current transaction ID
+   * @return true if transactionID is less than or equal to updateID, false
+   * otherwise.
+   */
+  public boolean isReplay(long updateID, long transactionID) {
+    return transactionID <= updateID;
+  }
+
+  /**
+   * Return a dummy OMClientResponse for when the transactions are replayed.
+   */
+  protected OMResponse createReplayOMResponse(
+      @Nonnull OMResponse.Builder omResponse) {
+
+    omResponse.setSuccess(false);
+    omResponse.setStatus(OzoneManagerProtocolProtos.Status.REPLAY);
+    return omResponse.build();
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/bucket/S3BucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/bucket/S3BucketCreateRequest.java
@@ -173,9 +173,13 @@ public class S3BucketCreateRequest extends OMVolumeRequest {
         // ozone volume.
         String volumeKey = omMetadataManager.getVolumeKey(volumeName);
         if (!omMetadataManager.getVolumeTable().isExist(volumeKey)) {
+          // A replay transaction for S3BucketCreate can reach here only if the
+          // volume has been deleted in later transactions. Hence, we can
+          // continue with this request irrespective of whether it is a
+          // replay or not.
           OmVolumeArgs omVolumeArgs = createOmVolumeArgs(volumeName, userName,
-              s3CreateBucketRequest.getS3CreateVolumeInfo()
-                  .getCreationTime());
+              s3CreateBucketRequest.getS3CreateVolumeInfo().getCreationTime(),
+              transactionLogIndex);
           UserVolumeInfo volumeList = omMetadataManager.getUserTable().get(
               omMetadataManager.getUserKey(userName));
           volumeList = addVolumeToOwnerList(volumeList,
@@ -327,12 +331,14 @@ public class S3BucketCreateRequest extends OMVolumeRequest {
    * @return {@link OmVolumeArgs}
    */
   private OmVolumeArgs createOmVolumeArgs(String volumeName, String userName,
-      long creationTime) throws IOException {
+      long creationTime, long transactionLogIndex) throws IOException {
     OmVolumeArgs.Builder builder = OmVolumeArgs.newBuilder()
         .setAdminName(S3_ADMIN_NAME).setVolume(volumeName)
         .setQuotaInBytes(OzoneConsts.MAX_QUOTA_IN_BYTES)
         .setOwnerName(userName)
-        .setCreationTime(creationTime);
+        .setCreationTime(creationTime)
+        .setObjectID(transactionLogIndex)
+        .setUpdateID(transactionLogIndex);
 
     // Set default acls.
     for (OzoneAcl acl : getDefaultAcls(userName)) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/bucket/S3BucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/bucket/S3BucketCreateRequest.java
@@ -188,8 +188,8 @@ public class S3BucketCreateRequest extends OMVolumeRequest {
           createVolume(omMetadataManager, omVolumeArgs, volumeList, volumeKey,
               omMetadataManager.getUserKey(userName), transactionLogIndex);
           volumeCreated = true;
-          omVolumeCreateResponse = new OMVolumeCreateResponse(omVolumeArgs,
-              volumeList, omResponse.build());
+          omVolumeCreateResponse = new OMVolumeCreateResponse(
+              omResponse.build(), omVolumeArgs, volumeList);
         }
       } finally {
         if (acquiredUserLock) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
@@ -132,7 +132,10 @@ public class OMVolumeCreateRequest extends OMVolumeRequest {
         }
       }
 
-      UserVolumeInfo volumeList = null;
+      // A replay transaction for CreateVolume can reach here only if the
+      // volume has been deleted in later transactions. Hence, we can
+      // continue with this request irrespective of whether it is a replay or
+      // not.
 
       // acquire lock.
       acquiredVolumeLock = omMetadataManager.getLock().acquireWriteLock(
@@ -146,6 +149,7 @@ public class OMVolumeCreateRequest extends OMVolumeRequest {
       OmVolumeArgs dbVolumeArgs =
           omMetadataManager.getVolumeTable().get(dbVolumeKey);
 
+      UserVolumeInfo volumeList = null;
       if (dbVolumeArgs == null) {
         String dbUserKey = omMetadataManager.getUserKey(owner);
         volumeList = omMetadataManager.getUserTable().get(dbUserKey);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeDeleteRequest.java
@@ -103,7 +103,8 @@ public class OMVolumeDeleteRequest extends OMVolumeRequest {
       // If this is a replay, then the response has already been returned to
       // the client. So take no further action and return a dummy
       // OMClientResponse.
-      if (isReplay(omVolumeArgs.getUpdateID(), transactionLogIndex)) {
+      if (isReplay(ozoneManager, omVolumeArgs.getUpdateID(),
+          transactionLogIndex)) {
         LOG.debug("Replayed Transaction {} ignored. Request: {}",
             transactionLogIndex, deleteVolumeRequest);
         return new OMVolumeDeleteResponse(createReplayOMResponse(omResponse));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeDeleteRequest.java
@@ -104,6 +104,8 @@ public class OMVolumeDeleteRequest extends OMVolumeRequest {
       // the client. So take no further action and return a dummy
       // OMClientResponse.
       if (isReplay(omVolumeArgs.getUpdateID(), transactionLogIndex)) {
+        LOG.debug("Replayed Transaction {} ignored. Request: {}",
+            transactionLogIndex, deleteVolumeRequest);
         return new OMVolumeDeleteResponse(createReplayOMResponse(omResponse));
       }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeDeleteRequest.java
@@ -94,12 +94,20 @@ public class OMVolumeDeleteRequest extends OMVolumeRequest {
             null, null);
       }
 
-      OmVolumeArgs omVolumeArgs = null;
-      OzoneManagerProtocolProtos.UserVolumeInfo newVolumeList = null;
-
       acquiredVolumeLock = omMetadataManager.getLock().acquireWriteLock(
           VOLUME_LOCK, volume);
-      owner = getVolumeInfo(omMetadataManager, volume).getOwnerName();
+
+      OmVolumeArgs omVolumeArgs = getVolumeInfo(omMetadataManager, volume);
+
+      // Check if this transaction is a replay of ratis logs.
+      // If this is a replay, then the response has already been returned to
+      // the client. So take no further action and return a dummy
+      // OMClientResponse.
+      if (isReplay(omVolumeArgs.getUpdateID(), transactionLogIndex)) {
+        return new OMVolumeDeleteResponse(createReplayOMResponse(omResponse));
+      }
+
+      owner = omVolumeArgs.getOwnerName();
       acquiredUserLock = omMetadataManager.getLock().acquireWriteLock(USER_LOCK,
           owner);
 
@@ -111,7 +119,8 @@ public class OMVolumeDeleteRequest extends OMVolumeRequest {
         throw new OMException(OMException.ResultCodes.VOLUME_NOT_EMPTY);
       }
 
-      newVolumeList = omMetadataManager.getUserTable().get(owner);
+      OzoneManagerProtocolProtos.UserVolumeInfo newVolumeList =
+          omMetadataManager.getUserTable().get(owner);
 
       // delete the volume from the owner list
       // as well as delete the volume entry
@@ -127,12 +136,12 @@ public class OMVolumeDeleteRequest extends OMVolumeRequest {
 
       omResponse.setDeleteVolumeResponse(
           DeleteVolumeResponse.newBuilder().build());
-      omClientResponse = new OMVolumeDeleteResponse(volume, owner,
-          newVolumeList, omResponse.build());
+      omClientResponse = new OMVolumeDeleteResponse(omResponse.build(),
+          volume, owner, newVolumeList);
 
     } catch (IOException ex) {
       exception = ex;
-      omClientResponse = new OMVolumeDeleteResponse(null, null, null,
+      omClientResponse = new OMVolumeDeleteResponse(
           createErrorOMResponse(omResponse, exception));
     } finally {
       if (omClientResponse != null) {
@@ -163,29 +172,6 @@ public class OMVolumeDeleteRequest extends OMVolumeRequest {
       omMetrics.incNumVolumeDeleteFails();
     }
     return omClientResponse;
-
-  }
-
-  /**
-   * Return volume info for the specified volume. This method should be
-   * called after acquiring volume lock.
-   * @param omMetadataManager
-   * @param volume
-   * @return OmVolumeArgs
-   * @throws IOException
-   */
-  private OmVolumeArgs getVolumeInfo(OMMetadataManager omMetadataManager,
-      String volume) throws IOException {
-
-    String dbVolumeKey = omMetadataManager.getVolumeKey(volume);
-    OmVolumeArgs volumeArgs =
-        omMetadataManager.getVolumeTable().get(dbVolumeKey);
-    if (volumeArgs == null) {
-      throw new OMException("Volume " + volume + " is not found",
-          OMException.ResultCodes.VOLUME_NOT_FOUND);
-    }
-    return volumeArgs;
-
   }
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeRequest.java
@@ -140,4 +140,24 @@ public abstract class OMVolumeRequest extends OMClientRequest {
         new CacheValue<>(Optional.of(omVolumeArgs), transactionLogIndex));
   }
 
+  /**
+   * Return volume info for the specified volume. This method should be
+   * called after acquiring volume lock.
+   * @param omMetadataManager
+   * @param volume
+   * @return OmVolumeArgs
+   * @throws IOException
+   */
+  protected OmVolumeArgs getVolumeInfo(OMMetadataManager omMetadataManager,
+      String volume) throws IOException {
+
+    String dbVolumeKey = omMetadataManager.getVolumeKey(volume);
+    OmVolumeArgs volumeArgs =
+        omMetadataManager.getVolumeTable().get(dbVolumeKey);
+    if (volumeArgs == null) {
+      throw new OMException("Volume " + volume + " is not found",
+          OMException.ResultCodes.VOLUME_NOT_FOUND);
+    }
+    return volumeArgs;
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetOwnerRequest.java
@@ -135,7 +135,8 @@ public class OMVolumeSetOwnerRequest extends OMVolumeRequest {
       // If this is a replay, then the response has already been returned to
       // the client. So take no further action and return a dummy
       // OMClientResponse.
-      if (isReplay(omVolumeArgs.getUpdateID(), transactionLogIndex)) {
+      if (isReplay(ozoneManager, omVolumeArgs.getUpdateID(),
+          transactionLogIndex)) {
         LOG.debug("Replayed Transaction {} ignored. Request: {}",
             transactionLogIndex, setVolumePropertyRequest);
         return new OMVolumeSetOwnerResponse(createReplayOMResponse(omResponse));
@@ -176,9 +177,8 @@ public class OMVolumeSetOwnerRequest extends OMVolumeRequest {
 
       omResponse.setSetVolumePropertyResponse(
           SetVolumePropertyResponse.newBuilder().build());
-      omClientResponse = new OMVolumeSetOwnerResponse(oldOwner,
-          oldOwnerVolumeList, newOwnerVolumeList, omVolumeArgs,
-          omResponse.build());
+      omClientResponse = new OMVolumeSetOwnerResponse(omResponse.build(),
+          oldOwner, oldOwnerVolumeList, newOwnerVolumeList, omVolumeArgs);
 
     } catch (IOException ex) {
       exception = ex;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetOwnerRequest.java
@@ -136,6 +136,8 @@ public class OMVolumeSetOwnerRequest extends OMVolumeRequest {
       // the client. So take no further action and return a dummy
       // OMClientResponse.
       if (isReplay(omVolumeArgs.getUpdateID(), transactionLogIndex)) {
+        LOG.debug("Replayed Transaction {} ignored. Request: {}",
+            transactionLogIndex, setVolumePropertyRequest);
         return new OMVolumeSetOwnerResponse(createReplayOMResponse(omResponse));
       }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetQuotaRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetQuotaRequest.java
@@ -125,6 +125,8 @@ public class OMVolumeSetQuotaRequest extends OMVolumeRequest {
       // the client. So take no further action and return a dummy
       // OMClientResponse.
       if (isReplay(omVolumeArgs.getUpdateID(), transactionLogIndex)) {
+        LOG.debug("Replayed Transaction {} ignored. Request: {}",
+            transactionLogIndex, setVolumePropertyRequest);
         return new OMVolumeSetQuotaResponse(createReplayOMResponse(omResponse));
       }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetQuotaRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetQuotaRequest.java
@@ -53,7 +53,6 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_LOCK;
 
-
 /**
  * Handles set Quota request for volume.
  */
@@ -79,15 +78,12 @@ public class OMVolumeSetQuotaRequest extends OMVolumeRequest {
         OzoneManagerProtocolProtos.Type.SetVolumeProperty).setStatus(
         OzoneManagerProtocolProtos.Status.OK).setSuccess(true);
 
-
-
     // In production this will never happen, this request will be called only
     // when we have quota in bytes is set in setVolumePropertyRequest.
     if (!setVolumePropertyRequest.hasQuotaInBytes()) {
       omResponse.setStatus(OzoneManagerProtocolProtos.Status.INVALID_REQUEST)
           .setSuccess(false);
-      return new OMVolumeSetQuotaResponse(null,
-          omResponse.build());
+      return new OMVolumeSetQuotaResponse(omResponse.build());
     }
 
     String volume = setVolumePropertyRequest.getVolumeName();
@@ -124,6 +120,14 @@ public class OMVolumeSetQuotaRequest extends OMVolumeRequest {
         throw new OMException(OMException.ResultCodes.VOLUME_NOT_FOUND);
       }
 
+      // Check if this transaction is a replay of ratis logs.
+      // If this is a replay, then the response has already been returned to
+      // the client. So take no further action and return a dummy
+      // OMClientResponse.
+      if (isReplay(omVolumeArgs.getUpdateID(), transactionLogIndex)) {
+        return new OMVolumeSetQuotaResponse(createReplayOMResponse(omResponse));
+      }
+
       omVolumeArgs.setQuotaInBytes(setVolumePropertyRequest.getQuotaInBytes());
 
       // update cache.
@@ -133,11 +137,11 @@ public class OMVolumeSetQuotaRequest extends OMVolumeRequest {
 
       omResponse.setSetVolumePropertyResponse(
           SetVolumePropertyResponse.newBuilder().build());
-      omClientResponse = new OMVolumeSetQuotaResponse(omVolumeArgs,
-        omResponse.build());
+      omClientResponse = new OMVolumeSetQuotaResponse(omResponse.build(),
+          omVolumeArgs);
     } catch (IOException ex) {
       exception = ex;
-      omClientResponse = new OMVolumeSetQuotaResponse(null,
+      omClientResponse = new OMVolumeSetQuotaResponse(
           createErrorOMResponse(omResponse, exception));
     } finally {
       if (omClientResponse != null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetQuotaRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetQuotaRequest.java
@@ -124,7 +124,8 @@ public class OMVolumeSetQuotaRequest extends OMVolumeRequest {
       // If this is a replay, then the response has already been returned to
       // the client. So take no further action and return a dummy
       // OMClientResponse.
-      if (isReplay(omVolumeArgs.getUpdateID(), transactionLogIndex)) {
+      if (isReplay(ozoneManager, omVolumeArgs.getUpdateID(),
+          transactionLogIndex)) {
         LOG.debug("Replayed Transaction {} ignored. Request: {}",
             transactionLogIndex, setVolumePropertyRequest);
         return new OMVolumeSetQuotaResponse(createReplayOMResponse(omResponse));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetQuotaRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetQuotaRequest.java
@@ -132,6 +132,7 @@ public class OMVolumeSetQuotaRequest extends OMVolumeRequest {
       }
 
       omVolumeArgs.setQuotaInBytes(setVolumePropertyRequest.getQuotaInBytes());
+      omVolumeArgs.setUpdateID(transactionLogIndex);
 
       // update cache.
       omMetadataManager.getVolumeTable().addCacheEntry(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/OMClientResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/OMClientResponse.java
@@ -42,6 +42,14 @@ public abstract class OMClientResponse {
   }
 
   /**
+   * For error or replay cases, check that the status of omResponse is not OK.
+   */
+  public void checkStatusNotOK() {
+    Preconditions.checkArgument(!omResponse.getStatus().equals(
+        OzoneManagerProtocolProtos.Status.OK));
+  }
+
+  /**
    * Check if omResponse status is OK. If yes, add to DB.
    * For OmResponse with failure, this should do nothing. This method is not
    * called in failure scenario in OM code.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/OMClientResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/OMClientResponse.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletableFuture;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
@@ -38,6 +39,21 @@ public abstract class OMClientResponse {
   public OMClientResponse(OMResponse omResponse) {
     Preconditions.checkNotNull(omResponse);
     this.omResponse = omResponse;
+  }
+
+  /**
+   * Check if omResponse status is OK. If yes, add to DB.
+   * For OmResponse with failure, this should do nothing. This method is not
+   * called in failure scenario in OM code.
+   * @param omMetadataManager
+   * @param batchOperation
+   * @throws IOException
+   */
+  public void checkAndUpdateDB(OMMetadataManager omMetadataManager,
+      BatchOperation batchOperation) throws IOException {
+    if (omResponse.getStatus() == OzoneManagerProtocolProtos.Status.OK) {
+      addToDBBatch(omMetadataManager, batchOperation);
+    }
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/OMClientResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/OMClientResponse.java
@@ -65,12 +65,13 @@ public abstract class OMClientResponse {
   }
 
   /**
-   * Implement logic to add the response to batch.
+   * Implement logic to add the response to batch. This function should be
+   * called from checkAndUpdateDB only.
    * @param omMetadataManager
    * @param batchOperation
    * @throws IOException
    */
-  public abstract void addToDBBatch(OMMetadataManager omMetadataManager,
+  protected abstract void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException;
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponse.java
@@ -50,19 +50,18 @@ public class OMDirectoryCreateResponse extends OMClientResponse {
   @Override
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
-    if (getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK) {
-      if (dirKeyInfo != null) {
-        String dirKey =
-            omMetadataManager.getOzoneKey(dirKeyInfo.getVolumeName(),
-                dirKeyInfo.getBucketName(), dirKeyInfo.getKeyName());
-        omMetadataManager.getKeyTable().putWithBatch(batchOperation, dirKey,
-            dirKeyInfo);
-      } else {
-        // When directory already exists, we don't add it to cache. And it is
-        // not an error, in this case dirKeyInfo will be null.
-        LOG.debug("Response Status is OK, dirKeyInfo is null in " +
-            "OMDirectoryCreateResponse");
-      }
+
+    if (dirKeyInfo != null) {
+      String dirKey =
+          omMetadataManager.getOzoneKey(dirKeyInfo.getVolumeName(),
+              dirKeyInfo.getBucketName(), dirKeyInfo.getKeyName());
+      omMetadataManager.getKeyTable().putWithBatch(batchOperation, dirKey,
+          dirKeyInfo);
+    } else {
+      // When directory already exists, we don't add it to cache. And it is
+      // not an error, in this case dirKeyInfo will be null.
+      LOG.debug("Response Status is OK, dirKeyInfo is null in " +
+          "OMDirectoryCreateResponse");
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponse.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om.response.file;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
@@ -48,7 +47,7 @@ public class OMDirectoryCreateResponse extends OMClientResponse {
   }
 
   @Override
-  public void addToDBBatch(OMMetadataManager omMetadataManager,
+  protected void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
     if (dirKeyInfo != null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/bucket/S3BucketCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/bucket/S3BucketCreateResponse.java
@@ -61,11 +61,13 @@ public class S3BucketCreateResponse extends OMClientResponse {
 
     if (getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK) {
       if (omVolumeCreateResponse != null) {
-        omVolumeCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
+        omVolumeCreateResponse.checkAndUpdateDB(omMetadataManager,
+            batchOperation);
       }
 
       Preconditions.checkState(omBucketCreateResponse != null);
-      omBucketCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
+      omBucketCreateResponse.checkAndUpdateDB(omMetadataManager,
+          batchOperation);
 
       omMetadataManager.getS3Table().putWithBatch(batchOperation, s3Bucket,
           s3Mapping);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeAclOpResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeAclOpResponse.java
@@ -45,8 +45,6 @@ public class OMVolumeAclOpResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    // For OmResponse with failure, this should do nothing. This method is
-    // not called in failure scenario in OM code.
     if (getOMResponse().getSuccess()) {
       if ((getOMResponse().hasAddAclResponse() &&
           getOMResponse().getAddAclResponse().getResponse()) ||

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeCreateResponse.java
@@ -24,7 +24,6 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.UserVolumeInfo;
@@ -32,7 +31,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.UserVol
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
 import javax.annotation.Nonnull;
-import org.apache.ratis.util.Preconditions;
 
 /**
  * Response for CreateBucket request.
@@ -42,8 +40,9 @@ public class OMVolumeCreateResponse extends OMClientResponse {
   private UserVolumeInfo userVolumeInfo;
   private OmVolumeArgs omVolumeArgs;
 
-  public OMVolumeCreateResponse(OmVolumeArgs omVolumeArgs,
-      UserVolumeInfo userVolumeInfo, @Nonnull OMResponse omResponse) {
+  public OMVolumeCreateResponse(@Nonnull OMResponse omResponse,
+      @Nonnull OmVolumeArgs omVolumeArgs,
+      @Nonnull UserVolumeInfo userVolumeInfo) {
     super(omResponse);
     this.omVolumeArgs = omVolumeArgs;
     this.userVolumeInfo = userVolumeInfo;
@@ -55,8 +54,7 @@ public class OMVolumeCreateResponse extends OMClientResponse {
    */
   public OMVolumeCreateResponse(@Nonnull OMResponse omResponse) {
     super(omResponse);
-    Preconditions.assertTrue(!omResponse.getStatus().equals(
-        OzoneManagerProtocolProtos.Status.OK));
+    checkStatusNotOK();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeCreateResponse.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.UserVol
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
 import javax.annotation.Nonnull;
+import org.apache.ratis.util.Preconditions;
 
 /**
  * Response for CreateBucket request.
@@ -47,6 +48,17 @@ public class OMVolumeCreateResponse extends OMClientResponse {
     this.omVolumeArgs = omVolumeArgs;
     this.userVolumeInfo = userVolumeInfo;
   }
+
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
+  public OMVolumeCreateResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+    Preconditions.assertTrue(!omResponse.getStatus().equals(
+        OzoneManagerProtocolProtos.Status.OK));
+  }
+
   @Override
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeCreateResponse.java
@@ -51,19 +51,15 @@ public class OMVolumeCreateResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    // For OmResponse with failure, this should do nothing. This method is
-    // not called in failure scenario in OM code.
-    if (getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK) {
-      String dbVolumeKey =
-          omMetadataManager.getVolumeKey(omVolumeArgs.getVolume());
-      String dbUserKey =
-          omMetadataManager.getUserKey(omVolumeArgs.getOwnerName());
+    String dbVolumeKey =
+        omMetadataManager.getVolumeKey(omVolumeArgs.getVolume());
+    String dbUserKey =
+        omMetadataManager.getUserKey(omVolumeArgs.getOwnerName());
 
-      omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
-          dbVolumeKey, omVolumeArgs);
-      omMetadataManager.getUserTable().putWithBatch(batchOperation, dbUserKey,
-          userVolumeInfo);
-    }
+    omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
+        dbVolumeKey, omVolumeArgs);
+    omMetadataManager.getUserTable().putWithBatch(batchOperation, dbUserKey,
+        userVolumeInfo);
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeCreateResponse.java
@@ -58,7 +58,7 @@ public class OMVolumeCreateResponse extends OMClientResponse {
   }
 
   @Override
-  public void addToDBBatch(OMMetadataManager omMetadataManager,
+  protected void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
     String dbVolumeKey =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeDeleteResponse.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -30,7 +29,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
 import javax.annotation.Nonnull;
-import org.apache.ratis.util.Preconditions;
 
 /**
  * Response for CreateVolume request.
@@ -41,7 +39,8 @@ public class OMVolumeDeleteResponse extends OMClientResponse {
   private UserVolumeInfo updatedVolumeList;
 
   public OMVolumeDeleteResponse(@Nonnull OMResponse omResponse,
-      String volume, String owner, UserVolumeInfo updatedVolumeList) {
+      @Nonnull String volume, @Nonnull String owner,
+      @Nonnull UserVolumeInfo updatedVolumeList) {
     super(omResponse);
     this.volume = volume;
     this.owner = owner;
@@ -54,8 +53,7 @@ public class OMVolumeDeleteResponse extends OMClientResponse {
    */
   public OMVolumeDeleteResponse(@Nonnull OMResponse omResponse) {
     super(omResponse);
-    Preconditions.assertTrue(!omResponse.getStatus().equals(
-        OzoneManagerProtocolProtos.Status.OK));
+    checkStatusNotOK();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeDeleteResponse.java
@@ -51,22 +51,17 @@ public class OMVolumeDeleteResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    // For OmResponse with failure, this should do nothing. This method is
-    // not called in failure scenario in OM code.
-    if (getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK) {
-      String dbUserKey = omMetadataManager.getUserKey(owner);
-      UserVolumeInfo volumeList = updatedVolumeList;
-      if (updatedVolumeList.getVolumeNamesList().size() == 0) {
-        omMetadataManager.getUserTable().deleteWithBatch(batchOperation,
-            dbUserKey);
-      } else {
-        omMetadataManager.getUserTable().putWithBatch(batchOperation, dbUserKey,
-            volumeList);
-      }
-      omMetadataManager.getVolumeTable().deleteWithBatch(batchOperation,
-          omMetadataManager.getVolumeKey(volume));
+    String dbUserKey = omMetadataManager.getUserKey(owner);
+    UserVolumeInfo volumeList = updatedVolumeList;
+    if (updatedVolumeList.getVolumeNamesList().size() == 0) {
+      omMetadataManager.getUserTable().deleteWithBatch(batchOperation,
+          dbUserKey);
+    } else {
+      omMetadataManager.getUserTable().putWithBatch(batchOperation, dbUserKey,
+          volumeList);
     }
+    omMetadataManager.getVolumeTable().deleteWithBatch(batchOperation,
+        omMetadataManager.getVolumeKey(volume));
   }
-
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeDeleteResponse.java
@@ -39,12 +39,16 @@ public class OMVolumeDeleteResponse extends OMClientResponse {
   private String owner;
   private UserVolumeInfo updatedVolumeList;
 
-  public OMVolumeDeleteResponse(String volume, String owner,
-      UserVolumeInfo updatedVolumeList, @Nonnull OMResponse omResponse) {
+  public OMVolumeDeleteResponse(@Nonnull OMResponse omResponse,
+      String volume, String owner, UserVolumeInfo updatedVolumeList) {
     super(omResponse);
     this.volume = volume;
     this.owner = owner;
     this.updatedVolumeList = updatedVolumeList;
+  }
+
+  public OMVolumeDeleteResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeDeleteResponse.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
 import javax.annotation.Nonnull;
+import org.apache.ratis.util.Preconditions;
 
 /**
  * Response for CreateVolume request.
@@ -47,8 +48,14 @@ public class OMVolumeDeleteResponse extends OMClientResponse {
     this.updatedVolumeList = updatedVolumeList;
   }
 
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
   public OMVolumeDeleteResponse(@Nonnull OMResponse omResponse) {
     super(omResponse);
+    Preconditions.assertTrue(!omResponse.getStatus().equals(
+        OzoneManagerProtocolProtos.Status.OK));
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeDeleteResponse.java
@@ -57,7 +57,7 @@ public class OMVolumeDeleteResponse extends OMClientResponse {
   }
 
   @Override
-  public void addToDBBatch(OMMetadataManager omMetadataManager,
+  protected void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
     String dbUserKey = omMetadataManager.getUserKey(owner);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetOwnerResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetOwnerResponse.java
@@ -53,6 +53,10 @@ public class OMVolumeSetOwnerResponse extends OMClientResponse {
     this.newOwnerVolumeArgs = newOwnerVolumeArgs;
   }
 
+  public OMVolumeSetOwnerResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+  }
+
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetOwnerResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetOwnerResponse.java
@@ -56,26 +56,22 @@ public class OMVolumeSetOwnerResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    // For OmResponse with failure, this should do nothing. This method is
-    // not called in failure scenario in OM code.
-    if (getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK) {
-      String oldOwnerKey = omMetadataManager.getUserKey(oldOwner);
-      String newOwnerKey =
-          omMetadataManager.getUserKey(newOwnerVolumeArgs.getOwnerName());
-      if (oldOwnerVolumeList.getVolumeNamesList().size() == 0) {
-        omMetadataManager.getUserTable().deleteWithBatch(batchOperation,
-            oldOwnerKey);
-      } else {
-        omMetadataManager.getUserTable().putWithBatch(batchOperation,
-            oldOwnerKey, oldOwnerVolumeList);
-      }
-      omMetadataManager.getUserTable().putWithBatch(batchOperation, newOwnerKey,
-          newOwnerVolumeList);
-
-      String dbVolumeKey =
-          omMetadataManager.getVolumeKey(newOwnerVolumeArgs.getVolume());
-      omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
-          dbVolumeKey, newOwnerVolumeArgs);
+    String oldOwnerKey = omMetadataManager.getUserKey(oldOwner);
+    String newOwnerKey =
+        omMetadataManager.getUserKey(newOwnerVolumeArgs.getOwnerName());
+    if (oldOwnerVolumeList.getVolumeNamesList().size() == 0) {
+      omMetadataManager.getUserTable().deleteWithBatch(batchOperation,
+          oldOwnerKey);
+    } else {
+      omMetadataManager.getUserTable().putWithBatch(batchOperation,
+          oldOwnerKey, oldOwnerVolumeList);
     }
+    omMetadataManager.getUserTable().putWithBatch(batchOperation, newOwnerKey,
+        newOwnerVolumeList);
+
+    String dbVolumeKey =
+        omMetadataManager.getVolumeKey(newOwnerVolumeArgs.getVolume());
+    omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
+        dbVolumeKey, newOwnerVolumeArgs);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetOwnerResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetOwnerResponse.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .UserVolumeInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -32,7 +31,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
 import javax.annotation.Nonnull;
-import org.apache.ratis.util.Preconditions;
 
 /**
  * Response for set owner request.
@@ -44,9 +42,10 @@ public class OMVolumeSetOwnerResponse extends OMClientResponse {
   private UserVolumeInfo newOwnerVolumeList;
   private OmVolumeArgs newOwnerVolumeArgs;
 
-  public OMVolumeSetOwnerResponse(String oldOwner,
-      UserVolumeInfo oldOwnerVolumeList, UserVolumeInfo newOwnerVolumeList,
-      OmVolumeArgs newOwnerVolumeArgs, @Nonnull OMResponse omResponse) {
+  public OMVolumeSetOwnerResponse(@Nonnull OMResponse omResponse,
+      @Nonnull String oldOwner, @Nonnull UserVolumeInfo oldOwnerVolumeList,
+      @Nonnull UserVolumeInfo newOwnerVolumeList,
+      @Nonnull OmVolumeArgs newOwnerVolumeArgs) {
     super(omResponse);
     this.oldOwner = oldOwner;
     this.oldOwnerVolumeList = oldOwnerVolumeList;
@@ -60,8 +59,7 @@ public class OMVolumeSetOwnerResponse extends OMClientResponse {
    */
   public OMVolumeSetOwnerResponse(@Nonnull OMResponse omResponse) {
     super(omResponse);
-    Preconditions.assertTrue(!omResponse.getStatus().equals(
-        OzoneManagerProtocolProtos.Status.OK));
+    checkStatusNotOK();
   }
 
   public void addToDBBatch(OMMetadataManager omMetadataManager,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetOwnerResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetOwnerResponse.java
@@ -62,7 +62,8 @@ public class OMVolumeSetOwnerResponse extends OMClientResponse {
     checkStatusNotOK();
   }
 
-  public void addToDBBatch(OMMetadataManager omMetadataManager,
+  @Override
+  protected void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
     String oldOwnerKey = omMetadataManager.getUserKey(oldOwner);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetOwnerResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetOwnerResponse.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
 import javax.annotation.Nonnull;
+import org.apache.ratis.util.Preconditions;
 
 /**
  * Response for set owner request.
@@ -53,8 +54,14 @@ public class OMVolumeSetOwnerResponse extends OMClientResponse {
     this.newOwnerVolumeArgs = newOwnerVolumeArgs;
   }
 
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
   public OMVolumeSetOwnerResponse(@Nonnull OMResponse omResponse) {
     super(omResponse);
+    Preconditions.assertTrue(!omResponse.getStatus().equals(
+        OzoneManagerProtocolProtos.Status.OK));
   }
 
   public void addToDBBatch(OMMetadataManager omMetadataManager,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetQuotaResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetQuotaResponse.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om.response.volume;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
@@ -29,7 +28,6 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import java.io.IOException;
 
 import javax.annotation.Nonnull;
-import org.apache.ratis.util.Preconditions;
 
 /**
  * Response for set quota request.
@@ -38,7 +36,7 @@ public class OMVolumeSetQuotaResponse extends OMClientResponse {
   private OmVolumeArgs omVolumeArgs;
 
   public OMVolumeSetQuotaResponse(@Nonnull OMResponse omResponse,
-      OmVolumeArgs omVolumeArgs) {
+      @Nonnull OmVolumeArgs omVolumeArgs) {
     super(omResponse);
     this.omVolumeArgs = omVolumeArgs;
   }
@@ -49,8 +47,7 @@ public class OMVolumeSetQuotaResponse extends OMClientResponse {
    */
   public OMVolumeSetQuotaResponse(@Nonnull OMResponse omResponse) {
     super(omResponse);
-    Preconditions.assertTrue(!omResponse.getStatus().equals(
-        OzoneManagerProtocolProtos.Status.OK));
+    checkStatusNotOK();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetQuotaResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetQuotaResponse.java
@@ -51,7 +51,7 @@ public class OMVolumeSetQuotaResponse extends OMClientResponse {
   }
 
   @Override
-  public void addToDBBatch(OMMetadataManager omMetadataManager,
+  protected void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
     omMetadataManager.getVolumeTable().putWithBatch(batchOperation,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetQuotaResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetQuotaResponse.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import java.io.IOException;
 
 import javax.annotation.Nonnull;
+import org.apache.ratis.util.Preconditions;
 
 /**
  * Response for set quota request.
@@ -42,8 +43,14 @@ public class OMVolumeSetQuotaResponse extends OMClientResponse {
     this.omVolumeArgs = omVolumeArgs;
   }
 
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
   public OMVolumeSetQuotaResponse(@Nonnull OMResponse omResponse) {
     super(omResponse);
+    Preconditions.assertTrue(!omResponse.getStatus().equals(
+        OzoneManagerProtocolProtos.Status.OK));
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetQuotaResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetQuotaResponse.java
@@ -36,10 +36,14 @@ import javax.annotation.Nonnull;
 public class OMVolumeSetQuotaResponse extends OMClientResponse {
   private OmVolumeArgs omVolumeArgs;
 
-  public OMVolumeSetQuotaResponse(OmVolumeArgs omVolumeArgs,
-      @Nonnull OMResponse omResponse) {
+  public OMVolumeSetQuotaResponse(@Nonnull OMResponse omResponse,
+      OmVolumeArgs omVolumeArgs) {
     super(omResponse);
     this.omVolumeArgs = omVolumeArgs;
+  }
+
+  public OMVolumeSetQuotaResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetQuotaResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetQuotaResponse.java
@@ -46,12 +46,8 @@ public class OMVolumeSetQuotaResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    // For OmResponse with failure, this should do nothing. This method is
-    // not called in failure scenario in OM code.
-    if (getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK) {
-      omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
-          omMetadataManager.getVolumeKey(omVolumeArgs.getVolume()),
-          omVolumeArgs);
-    }
+    omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
+        omMetadataManager.getVolumeKey(omVolumeArgs.getVolume()),
+        omVolumeArgs);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
@@ -30,8 +30,6 @@ import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .CreateVolumeRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .VolumeInfo;
@@ -44,7 +42,6 @@ import static org.mockito.Mockito.when;
 
 public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
 
-
   @Test
   public void testPreExecute() throws Exception {
     String volumeName = UUID.randomUUID().toString();
@@ -52,7 +49,6 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
     String ownerName = UUID.randomUUID().toString();
     doPreExecute(volumeName, adminName, ownerName);
   }
-
 
   @Test
   public void testValidateAndUpdateCacheWithZeroMaxUserVolumeCount()
@@ -83,7 +79,6 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
       GenericTestUtils.assertExceptionContains("should be greater than zero",
           ex);
     }
-
   }
 
   @Test
@@ -163,10 +158,7 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
 
     Assert.assertTrue(omMetadataManager
         .getUserTable().get(ownerKey).getVolumeNamesList().size() == 2);
-
-
   }
-
 
   @Test
   public void testValidateAndUpdateCacheWithVolumeAlreadyExists()
@@ -200,9 +192,7 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
     // Check really if we have a volume with the specified volume name.
     Assert.assertNotNull(omMetadataManager.getVolumeTable().get(
         omMetadataManager.getVolumeKey(volumeName)));
-
   }
-
 
   private void doPreExecute(String volumeName,
       String adminName, String ownerName) throws Exception {
@@ -237,22 +227,29 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
         updated.getCreationTime());
   }
 
-  /**
-   * Create OMRequest for create volume.
-   * @param volumeName
-   * @param adminName
-   * @param ownerName
-   * @return OMRequest
-   */
-  private OMRequest createVolumeRequest(String volumeName, String adminName,
-      String ownerName) {
-    VolumeInfo volumeInfo = VolumeInfo.newBuilder().setVolume(volumeName)
-        .setAdminName(adminName).setOwnerName(ownerName).build();
-    CreateVolumeRequest createVolumeRequest =
-        CreateVolumeRequest.newBuilder().setVolumeInfo(volumeInfo).build();
+  @Test
+  public void testReplayRequest() throws Exception {
 
-    return OMRequest.newBuilder().setClientId(UUID.randomUUID().toString())
-        .setCmdType(OzoneManagerProtocolProtos.Type.CreateVolume)
-        .setCreateVolumeRequest(createVolumeRequest).build();
+    String volumeName = UUID.randomUUID().toString();
+    String adminName = "user1";
+    String ownerName = "user1";
+    OMRequest originalRequest = createVolumeRequest(volumeName,adminName,
+        ownerName);
+    OMVolumeCreateRequest omVolumeCreateRequest =
+        new OMVolumeCreateRequest(originalRequest);
+
+    // Execute the original request
+    omVolumeCreateRequest.preExecute(ozoneManager);
+    omVolumeCreateRequest.validateAndUpdateCache(ozoneManager, 1,
+        ozoneManagerDoubleBufferHelper);
+
+    // Replay the transaction - Execute the same request again
+    OMClientResponse omClientResponse =
+        omVolumeCreateRequest.validateAndUpdateCache(ozoneManager, 1,
+            ozoneManagerDoubleBufferHelper);
+
+    // Replay should result in Replay response
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.REPLAY,
+        omClientResponse.getOMResponse().getStatus());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
@@ -233,7 +233,7 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
     String volumeName = UUID.randomUUID().toString();
     String adminName = "user1";
     String ownerName = "user1";
-    OMRequest originalRequest = createVolumeRequest(volumeName,adminName,
+    OMRequest originalRequest = createVolumeRequest(volumeName, adminName,
         ownerName);
     OMVolumeCreateRequest omVolumeCreateRequest =
         new OMVolumeCreateRequest(originalRequest);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeRequest.java
@@ -19,6 +19,7 @@
 
 package org.apache.hadoop.ozone.om.request.volume;
 
+import java.util.UUID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.AuditMessage;
@@ -28,6 +29,14 @@ import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+    .CreateVolumeRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+    .OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+    .VolumeInfo;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -67,6 +76,7 @@ public class TestOMVolumeRequest {
     when(ozoneManager.getMetrics()).thenReturn(omMetrics);
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
     when(ozoneManager.getMaxUserVolumeCount()).thenReturn(10L);
+    when(ozoneManager.isRatisEnabled()).thenReturn(true);
     auditLogger = Mockito.mock(AuditLogger.class);
     when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
     Mockito.doNothing().when(auditLogger).logWrite(any(AuditMessage.class));
@@ -76,5 +86,25 @@ public class TestOMVolumeRequest {
   public void stop() {
     omMetrics.unRegister();
     Mockito.framework().clearInlineMocks();
+  }
+
+  /**
+   * Create OMRequest for create volume.
+   * @param volumeName
+   * @param adminName
+   * @param ownerName
+   * @return OMRequest
+   */
+  static OMRequest createVolumeRequest(String volumeName,
+      String adminName,
+      String ownerName) {
+    VolumeInfo volumeInfo = VolumeInfo.newBuilder().setVolume(volumeName)
+        .setAdminName(adminName).setOwnerName(ownerName).build();
+    CreateVolumeRequest createVolumeRequest =
+        CreateVolumeRequest.newBuilder().setVolumeInfo(volumeInfo).build();
+
+    return OMRequest.newBuilder().setClientId(UUID.randomUUID().toString())
+        .setCmdType(OzoneManagerProtocolProtos.Type.CreateVolume)
+        .setCreateVolumeRequest(createVolumeRequest).build();
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetOwnerRequest.java
@@ -158,4 +158,35 @@ public class TestOMVolumeSetOwnerRequest extends TestOMVolumeRequest {
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.INVALID_REQUEST,
         omResponse.getStatus());
   }
+
+  @Test
+  public void testReplayRequest() throws Exception {
+    // create volume
+    String volumeName = UUID.randomUUID().toString();
+    String ownerName = "user1";
+    TestOMRequestUtils.addUserToDB(volumeName, ownerName, omMetadataManager);
+    TestOMRequestUtils.addVolumeToDB(volumeName, ownerName, omMetadataManager);
+
+    // create request to set new owner
+    String newOwnerName = "user2";
+    OMRequest originalRequest =
+        TestOMRequestUtils.createSetVolumePropertyRequest(volumeName,
+            newOwnerName);
+    OMVolumeSetOwnerRequest omVolumeSetOwnerRequest =
+        new OMVolumeSetOwnerRequest(originalRequest);
+
+    // Execute the original request
+    omVolumeSetOwnerRequest.preExecute(ozoneManager);
+    omVolumeSetOwnerRequest.validateAndUpdateCache(ozoneManager, 1,
+        ozoneManagerDoubleBufferHelper);
+
+    // Replay the transaction - Execute the same request again
+    OMClientResponse omClientResponse =
+        omVolumeSetOwnerRequest.validateAndUpdateCache(ozoneManager, 1,
+            ozoneManagerDoubleBufferHelper);
+
+    // Replay should result in Replay response
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.REPLAY,
+        omClientResponse.getOMResponse().getStatus());
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestOMResponseUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestOMResponseUtils.java
@@ -67,7 +67,7 @@ public final class TestOMResponseUtils {
         .setVolume(volumeName).setCreationTime(Time.now()).build();
 
     OMVolumeCreateResponse omVolumeCreateResponse =
-        new OMVolumeCreateResponse(omVolumeArgs, userVolumeInfo, omResponse);
+        new OMVolumeCreateResponse(omResponse, omVolumeArgs, userVolumeInfo);
 
 
     OmBucketInfo omBucketInfo = TestOMResponseUtils.createBucket(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeCreateResponse.java
@@ -115,7 +115,8 @@ public class TestOMVolumeCreateResponse {
         new OMVolumeCreateResponse(omResponse);
 
     try {
-      omVolumeCreateResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+      omVolumeCreateResponse.checkAndUpdateDB(omMetadataManager,
+          batchOperation);
       Assert.assertTrue(omMetadataManager.countRowsInTable(
           omMetadataManager.getVolumeTable()) == 0);
     } catch (IOException ex) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeCreateResponse.java
@@ -115,7 +115,7 @@ public class TestOMVolumeCreateResponse {
         new OMVolumeCreateResponse(omResponse);
 
     try {
-      omVolumeCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
+      omVolumeCreateResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
       Assert.assertTrue(omMetadataManager.countRowsInTable(
           omMetadataManager.getVolumeTable()) == 0);
     } catch (IOException ex) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeCreateResponse.java
@@ -83,7 +83,7 @@ public class TestOMVolumeCreateResponse {
         .setOwnerName(userName).setAdminName(userName)
         .setVolume(volumeName).setCreationTime(Time.now()).build();
     OMVolumeCreateResponse omVolumeCreateResponse =
-        new OMVolumeCreateResponse(omVolumeArgs, volumeList, omResponse);
+        new OMVolumeCreateResponse(omResponse, omVolumeArgs, volumeList);
 
     omVolumeCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
 
@@ -112,7 +112,7 @@ public class TestOMVolumeCreateResponse {
         .build();
 
     OMVolumeCreateResponse omVolumeCreateResponse =
-        new OMVolumeCreateResponse(null, null, omResponse);
+        new OMVolumeCreateResponse(omResponse);
 
     try {
       omVolumeCreateResponse.addToDBBatch(omMetadataManager, batchOperation);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeDeleteResponse.java
@@ -90,8 +90,8 @@ public class TestOMVolumeDeleteResponse {
     UserVolumeInfo updatedVolumeList = UserVolumeInfo.newBuilder()
         .setObjectID(1).setUpdateID(1).build();
     OMVolumeDeleteResponse omVolumeDeleteResponse =
-        new OMVolumeDeleteResponse(volumeName, userName, updatedVolumeList,
-            omResponse);
+        new OMVolumeDeleteResponse(omResponse, volumeName, userName,
+            updatedVolumeList);
 
     omVolumeCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
     omVolumeDeleteResponse.addToDBBatch(omMetadataManager, batchOperation);
@@ -118,8 +118,8 @@ public class TestOMVolumeDeleteResponse {
         .setCreateVolumeResponse(CreateVolumeResponse.getDefaultInstance())
         .build();
 
-    OMVolumeDeleteResponse omVolumeDeleteResponse =
-        new OMVolumeDeleteResponse(null, null, null, omResponse);
+    OMVolumeDeleteResponse omVolumeDeleteResponse = new OMVolumeDeleteResponse(
+        omResponse);
 
     try {
       omVolumeDeleteResponse.addToDBBatch(omMetadataManager, batchOperation);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeDeleteResponse.java
@@ -84,7 +84,7 @@ public class TestOMVolumeDeleteResponse {
         .setOwnerName(userName).setAdminName(userName)
         .setVolume(volumeName).setCreationTime(Time.now()).build();
     OMVolumeCreateResponse omVolumeCreateResponse =
-        new OMVolumeCreateResponse(omVolumeArgs, volumeList, omResponse);
+        new OMVolumeCreateResponse(omResponse, omVolumeArgs, volumeList);
 
     // As we are deleting updated volume list should be empty.
     UserVolumeInfo updatedVolumeList = UserVolumeInfo.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeDeleteResponse.java
@@ -122,7 +122,7 @@ public class TestOMVolumeDeleteResponse {
         omResponse);
 
     try {
-      omVolumeDeleteResponse.addToDBBatch(omMetadataManager, batchOperation);
+      omVolumeDeleteResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
     } catch (IOException ex) {
       fail("testAddToDBBatchFailure failed");
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeDeleteResponse.java
@@ -122,7 +122,8 @@ public class TestOMVolumeDeleteResponse {
         omResponse);
 
     try {
-      omVolumeDeleteResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+      omVolumeDeleteResponse.checkAndUpdateDB(omMetadataManager,
+          batchOperation);
     } catch (IOException ex) {
       fail("testAddToDBBatchFailure failed");
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetOwnerResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetOwnerResponse.java
@@ -140,7 +140,7 @@ public class TestOMVolumeSetOwnerResponse {
         .build();
 
     OMVolumeSetOwnerResponse omVolumeSetOwnerResponse =
-        new OMVolumeSetOwnerResponse(null, null, null, null, omResponse);
+        new OMVolumeSetOwnerResponse(omResponse);
 
     try {
       omVolumeSetOwnerResponse.addToDBBatch(omMetadataManager, batchOperation);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetOwnerResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetOwnerResponse.java
@@ -143,7 +143,7 @@ public class TestOMVolumeSetOwnerResponse {
         new OMVolumeSetOwnerResponse(omResponse);
 
     try {
-      omVolumeSetOwnerResponse.addToDBBatch(omMetadataManager, batchOperation);
+      omVolumeSetOwnerResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
       Assert.assertTrue(omMetadataManager.countRowsInTable(
           omMetadataManager.getVolumeTable()) == 0);
     } catch (IOException ex) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetOwnerResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetOwnerResponse.java
@@ -143,7 +143,8 @@ public class TestOMVolumeSetOwnerResponse {
         new OMVolumeSetOwnerResponse(omResponse);
 
     try {
-      omVolumeSetOwnerResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+      omVolumeSetOwnerResponse.checkAndUpdateDB(omMetadataManager,
+          batchOperation);
       Assert.assertTrue(omMetadataManager.countRowsInTable(
           omMetadataManager.getVolumeTable()) == 0);
     } catch (IOException ex) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetOwnerResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetOwnerResponse.java
@@ -85,7 +85,7 @@ public class TestOMVolumeSetOwnerResponse {
         .setOwnerName(oldOwner).setAdminName(oldOwner)
         .setVolume(volumeName).setCreationTime(Time.now()).build();
     OMVolumeCreateResponse omVolumeCreateResponse =
-        new OMVolumeCreateResponse(omVolumeArgs, volumeList, omResponse);
+        new OMVolumeCreateResponse(omResponse, omVolumeArgs, volumeList);
 
 
 
@@ -104,8 +104,8 @@ public class TestOMVolumeSetOwnerResponse {
         .build();
 
     OMVolumeSetOwnerResponse omVolumeSetOwnerResponse =
-        new OMVolumeSetOwnerResponse(oldOwner,  oldOwnerVolumeList,
-            newOwnerVolumeList, newOwnerVolumeArgs, omResponse);
+        new OMVolumeSetOwnerResponse(omResponse, oldOwner,  oldOwnerVolumeList,
+            newOwnerVolumeList, newOwnerVolumeArgs);
 
     omVolumeCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
     omVolumeSetOwnerResponse.addToDBBatch(omMetadataManager, batchOperation);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetQuotaResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetQuotaResponse.java
@@ -79,7 +79,7 @@ public class TestOMVolumeSetQuotaResponse {
         .setOwnerName(userName).setAdminName(userName)
         .setVolume(volumeName).setCreationTime(Time.now()).build();
     OMVolumeSetQuotaResponse omVolumeSetQuotaResponse =
-        new OMVolumeSetQuotaResponse(omVolumeArgs, omResponse);
+        new OMVolumeSetQuotaResponse(omResponse, omVolumeArgs);
 
     omVolumeSetQuotaResponse.addToDBBatch(omMetadataManager, batchOperation);
 
@@ -109,7 +109,7 @@ public class TestOMVolumeSetQuotaResponse {
         .build();
 
     OMVolumeSetQuotaResponse omVolumeSetQuotaResponse =
-        new OMVolumeSetQuotaResponse(null, omResponse);
+        new OMVolumeSetQuotaResponse(omResponse);
 
     try {
       omVolumeSetQuotaResponse.addToDBBatch(omMetadataManager, batchOperation);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetQuotaResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/volume/TestOMVolumeSetQuotaResponse.java
@@ -112,7 +112,8 @@ public class TestOMVolumeSetQuotaResponse {
         new OMVolumeSetQuotaResponse(omResponse);
 
     try {
-      omVolumeSetQuotaResponse.addToDBBatch(omMetadataManager, batchOperation);
+      omVolumeSetQuotaResponse.checkAndUpdateDB(omMetadataManager,
+          batchOperation);
       Assert.assertTrue(omMetadataManager.countRowsInTable(
           omMetadataManager.getVolumeTable()) == 0);
     } catch (IOException ex) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

To ensure that volume operations are idempotent, we should first compare the transactionID with the objectID and updateID to make sure that the transaction is not a replay. If the transactionID <= updateID, then it implies that the transaction is a replay and hence it should be skipped.

After this patch, the replay behavior for volume operations will be as follows:
Lets say we have the following transactions:
Tx 10 - CreateVolume (Vol1, objectID = 10, updateID = 10, owner = o1, quota = 100)
Tx 12 - SetOwner (Vol1, objectID = 10, updateID = 12, owner = o2, quota = 100)
Tx 20 - SetQuota (Vol1, objectID = 10, updateID = 20, owner = o2, quota = 200)
Tx 28 - DeleteVolume (Vol1)
Tx 40 - CreateVolume (Vol1, objectID = 40, updateID = 40, owner = o1, quota = 100)
Tx 50 - SetOwner (Vol1, objectID = 40, updateID = 50, owner = o3, quota = 100)

On replaying these transactions:
Replay Tx 10 - Vol1 already exists => Tx will throw VOLUME_ALREADY_EXISTS when trying to createVolume
Replay Tx 12 - UpdateID (50) is more than equal to TxID (12) => Tx will not update DB (return ReplayResponse in validateAndUpdateCache)
Replay Tx 20 - UpdateID (50) is more than equal to TxID (20) => Tx will not update DB (return ReplayResponse in validateAndUpdateCache)
Replay Tx 28 - UpdateID (50) is more than equal to TxID (28) => Tx will not update DB (return ReplayResponse in validateAndUpdateCache)
Replay Tx 40 - Vol1 already exists => Tx will throw VOLUME_ALREADY_EXISTS when trying to createVolume
Replay Tx 50 - UpdateID (50) is more than equal to TxID (28) => Tx will not update DB (return ReplayResponse in validateAndUpdateCache)

So none of the transactions will effect any change in the DB.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2755

## How was this patch tested?

Will add unit test in next commit
