### PR TITLE
HDDS-2650 Fix createPipeline and make createPipeline CLI message based.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.PipelineResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ActivatePipelineRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ActivatePipelineResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ClosePipelineRequestProto;
@@ -69,6 +70,9 @@ import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.PipelineResponseProto.Error.errorPipelineAlreadyExists;
+import static org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.PipelineResponseProto.Error.success;
 
 /**
  * This class is the server-side translator that forwards requests received on
@@ -157,6 +161,12 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setStatus(Status.OK)
             .setScmCloseContainerResponse(closeContainer(
                 request.getScmCloseContainerRequest()))
+            .build();
+      case AllocatePipeline:
+        return ScmContainerLocationResponse.newBuilder()
+            .setCmdType(request.getCmdType())
+            .setStatus(Status.OK)
+            .setPipelineResponse(allocatePipeline(request.getPipelineRequest()))
             .build();
       case ListPipelines:
         return ScmContainerLocationResponse.newBuilder()
@@ -316,6 +326,22 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
       throws IOException {
     impl.closeContainer(request.getContainerID());
     return SCMCloseContainerResponseProto.newBuilder().build();
+  }
+
+  public PipelineResponseProto allocatePipeline(
+      StorageContainerLocationProtocolProtos.PipelineRequestProto request)
+      throws IOException {
+    Pipeline pipeline = impl.createReplicationPipeline(
+        request.getReplicationType(), request.getReplicationFactor(),
+        HddsProtos.NodePool.getDefaultInstance());
+    if (pipeline == null) {
+      return PipelineResponseProto.newBuilder()
+          .setErrorCode(errorPipelineAlreadyExists).build();
+    }
+    PipelineResponseProto response = PipelineResponseProto.newBuilder()
+        .setErrorCode(success)
+        .setPipeline(pipeline.getProtobufMessage()).build();
+    return response;
   }
 
   public ListPipelineResponseProto listPipelines(

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/CreatePipelineSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/CreatePipelineSubcommand.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.scm.cli.pipeline;
 
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.scm.cli.SCMCLI;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import picocli.CommandLine;
 
@@ -30,13 +29,13 @@ import java.util.concurrent.Callable;
  * Handler of createPipeline command.
  */
 @CommandLine.Command(
-    name = "createPipeline",
+    name = "create",
     description = "create pipeline",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
 public class CreatePipelineSubcommand implements Callable<Void> {
   @CommandLine.ParentCommand
-  private SCMCLI parent;
+  private PipelineCommands parent;
 
   @CommandLine.Option(
       names = {"-t", "--replicationType"},
@@ -60,7 +59,7 @@ public class CreatePipelineSubcommand implements Callable<Void> {
       throw new IllegalArgumentException(type.name()
           + " is not supported yet.");
     }
-    try (ScmClient scmClient = parent.createScmClient()) {
+    try (ScmClient scmClient = parent.getParent().createScmClient()) {
       scmClient.createReplicationPipeline(
           type,
           factor,


### PR DESCRIPTION
## What changes were proposed in this pull request?
#HDDS-2650 Make createPipeline CLI message based to fix after merge with master.

(Please fill in changes proposed in this fix)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2650

(Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HDDS-XXXX. Fix a typo in YYY.)

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?
bash-4.2$ ozone scmcli pipeline list
Pipeline[ Id: 2aa5b959-8e9d-4c72-a6ef-ec30f00f1dca, Nodes: 53ab812b-6ec4-468b-861c-64d2a1445deb{ip: 192.168.32.2, host: ozone_datanode_1.ozone_default, networkLocation: /default-rack, certSerialId: null}, Type:RATIS, Factor:ONE, State:ALLOCATED, leaderId:null, CreationTimestamp1576579695167]
bash-4.2$ ozone scmcli pipeline create
bash-4.2$ ozone scmcli pipeline list
Pipeline[ Id: 2aa5b959-8e9d-4c72-a6ef-ec30f00f1dca, Nodes: 53ab812b-6ec4-468b-861c-64d2a1445deb{ip: 192.168.32.2, host: ozone_datanode_1.ozone_default, networkLocation: /default-rack, certSerialId: null}, Type:RATIS, Factor:ONE, State:OPEN, leaderId:53ab812b-6ec4-468b-861c-64d2a1445deb, CreationTimestamp1576579705686]
Pipeline[ Id: c34c276f-f187-4048-9e20-81188c24fe79, Nodes: 53ab812b-6ec4-468b-861c-64d2a1445deb{ip: 192.168.32.2, host: ozone_datanode_1.ozone_default, networkLocation: /default-rack, certSerialId: null}, Type:STAND_ALONE, Factor:ONE, State:OPEN, leaderId:null, CreationTimestamp1576579705686]

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
