### PR TITLE
HDDS-2774. Hadoop 3.1 acceptance test fails with apk command not found

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/test.sh
@@ -24,7 +24,7 @@ source "$COMPOSE_DIR/../../testlib.sh"
 start_docker_env
 
 #rm is the container name (resource manager) and not the rm command
-execute_command_in_container rm bash -c "if test -e /sbin/apk; then sudo apk add --update py-pip; sudo pip install robotframework; else sudo alternatives --set python /usr/bin/python3; fi"
+execute_command_in_container rm bash -c "if test -e /sbin/apk; then sudo apk add --update py-pip; sudo pip install robotframework; fi"
 
 execute_robot_test scm createmrenv.robot
 

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/test.sh
@@ -23,12 +23,10 @@ source "$COMPOSE_DIR/../../testlib.sh"
 
 start_docker_env
 
-execute_robot_test scm createmrenv.robot
-
-
 #rm is the container name (resource manager) and not the rm command
-execute_command_in_container rm sudo apk add --update py-pip
-execute_command_in_container rm sudo pip install robotframework
+execute_command_in_container rm bash -c "if test -e /sbin/apk; then sudo apk add --update py-pip; sudo pip install robotframework; else sudo alternatives --set python /usr/bin/python3; fi"
+
+execute_robot_test scm createmrenv.robot
 
 # reinitialize the directories to use
 export OZONE_DIR=/opt/ozone

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -117,7 +117,7 @@ execute_robot_test(){
 execute_command_in_container(){
   set -e
   # shellcheck disable=SC2068
-  docker-compose -f "$COMPOSE_FILE" exec -T $@
+  docker-compose -f "$COMPOSE_FILE" exec -T "$@"
   set +e
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update `ozone-mr/hadoop31` test with recent changes made in `hadoop:3.1.2` image:

 * It is based on CentOS, not Alpine, so `apk` doesn't work.
 * `pip` and `robotframework` are both pre-installed.
 * But `python` needs to point to `python3`.

Also check if `apk` is present, in case the new image is reverted or otherwise updated to be Alpine-based again.

https://issues.apache.org/jira/browse/HDDS-2774

## How was this patch tested?

Tested `ozone-mr/hadoop31` locally with both old and new image.

Successful run in fork: https://github.com/adoroszlai/hadoop-ozone/runs/354300796