### PR TITLE
HDDS-2773. Configure Goldmark renderer

### DIFF
--- a/hadoop-hdds/docs/config.yaml
+++ b/hadoop-hdds/docs/config.yaml
@@ -31,3 +31,7 @@ relativeURLs: true
 disableKinds:
 - taxonomy
 - taxonomyTerm
+markup:
+  goldmark:
+    renderer:
+      unsafe: true

--- a/hadoop-hdds/docs/content/beyond/Containers.md
+++ b/hadoop-hdds/docs/content/beyond/Containers.md
@@ -174,8 +174,8 @@ adjust base image, umask, security settings, user settings according to your own
 
 You can use the source of our development images as an example:
 
- * [Base image] (https://github.com/apache/hadoop/blob/docker-hadoop-runner-jdk11/Dockerfile)
- * [Docker image] (https://github.com/apache/hadoop/blob/trunk/hadoop-ozone/dist/src/main/docker/Dockerfile)
+ * [Base image](https://github.com/apache/hadoop/blob/docker-hadoop-runner-jdk11/Dockerfile)
+ * [Docker image](https://github.com/apache/hadoop/blob/trunk/hadoop-ozone/dist/src/main/docker/Dockerfile)
 
  Most of the elements are optional and just helper function but to use the provided example
  kubernetes resources you may need the scripts from

--- a/hadoop-hdds/docs/content/concept/Overview.md
+++ b/hadoop-hdds/docs/content/concept/Overview.md
@@ -29,7 +29,7 @@ scale to billions of objects.
 Ozone separates namespace management and block space management; this helps
 ozone to scale much better. The namespace is managed by a daemon called
 [Ozone Manager ]({{< ref "OzoneManager.md" >}}) (OM),  and block space is
-managed by [Storage Container Manager] ({{< ref "Hdds.md" >}}) (SCM).
+managed by [Storage Container Manager]({{< ref "Hdds.md" >}}) (SCM).
 
 
 Ozone consists of volumes, buckets, and keys.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable `unsafe` option for the new [Goldmark renderer](https://gohugo.io/getting-started/configuration-markup/#goldmark) introduced in Hugo 0.60.

> **unsafe**
> By default, Goldmark does not render raw HTMLs and potentially dangerous links. If you have lots of inline HTML and/or JavaScript, you may need to turn this on.

Also fix couple of incorrectly formatted links (no space allowed between `]` and `(`).

https://issues.apache.org/jira/browse/HDDS-2773

## How was this patch tested?

Built docs locally with Hugo 0.61.0.