### PR TITLE
HDDS-2750. OzoneFSInputStream to support StreamCapabilities

### DIFF
--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.ozone;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.EnumSet;
@@ -215,8 +216,12 @@ public class BasicOzoneFileSystem extends FileSystem {
     statistics.incrementReadOps(1);
     LOG.trace("open() path:{}", f);
     final String key = pathToKey(f);
-    return new FSDataInputStream(
-        new OzoneFSInputStream(adapter.readFile(key), statistics));
+    InputStream inputStream = adapter.readFile(key);
+    return new FSDataInputStream(createFSInputStream(inputStream));
+  }
+
+  protected InputStream createFSInputStream(InputStream inputStream) {
+    return new OzoneFSInputStream(inputStream, statistics);
   }
 
   protected void incrementCounter(Statistic statistic) {

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/CapableOzoneFSInputStream.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/CapableOzoneFSInputStream.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.fs.FileSystem.Statistics;
+import org.apache.hadoop.fs.StreamCapabilities;
+import org.apache.hadoop.util.StringUtils;
+
+import java.io.InputStream;
+
+final class CapableOzoneFSInputStream extends OzoneFSInputStream
+    implements StreamCapabilities {
+
+  CapableOzoneFSInputStream(InputStream inputStream, Statistics statistics) {
+    super(inputStream, statistics);
+  }
+
+  @Override
+  public boolean hasCapability(String capability) {
+    switch (StringUtils.toLowerCase(capability)) {
+    case OzoneStreamCapabilities.READBYTEBUFFER:
+      return true;
+    default:
+      return false;
+    }
+  }
+}

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFSInputStream.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFSInputStream.java
@@ -38,7 +38,7 @@ import org.apache.hadoop.fs.Seekable;
  */
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
-public final class OzoneFSInputStream extends FSInputStream
+public class OzoneFSInputStream extends FSInputStream
     implements ByteBufferReadable {
 
   private final InputStream inputStream;

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.fs.ozone;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -102,5 +103,10 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
       return new OzoneClientAdapterImpl(omHost, omPort, conf,
           volumeStr, bucketStr, storageStatistics);
     }
+  }
+
+  @Override
+  protected InputStream createFSInputStream(InputStream inputStream) {
+    return new CapableOzoneFSInputStream(inputStream, statistics);
   }
 }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneStreamCapabilities.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneStreamCapabilities.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Utility class to query streams for supported capabilities of Ozone.
+ * Capability strings must be in lower case.
+ */
+final class OzoneStreamCapabilities {
+
+  private OzoneStreamCapabilities() {
+  }
+
+  /**
+   * Stream read(ByteBuffer) capability implemented by
+   * {@link OzoneFSInputStream#read(ByteBuffer)}.
+   *
+   * TODO: If Hadoop dependency is upgraded, this string can be removed.
+   */
+  static final String READBYTEBUFFER = "in:readbytebuffer";
+}

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
@@ -32,6 +32,7 @@ import java.util.function.IntFunction;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link OzoneFSInputStream}.
@@ -111,6 +112,17 @@ public class TestOzoneFSInputStream {
       assertEquals(-1, bytesRead);
       assertEquals(0, buf.position());
     }
+  }
+
+  @Test
+  public void testStreamCapability() {
+    final OzoneFSInputStream subject = createTestSubject(emptyStream());
+    final CapableOzoneFSInputStream capableOzoneFSInputStream =
+        new CapableOzoneFSInputStream(subject,
+            new FileSystem.Statistics("test"));
+
+    assertTrue(capableOzoneFSInputStream.
+        hasCapability(OzoneStreamCapabilities.READBYTEBUFFER));
   }
 
   private static OzoneFSInputStream createTestSubject(InputStream input) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR was created to let client probe for `read(ByteBuffer)` ability. 
(Cause the interface `StreamCapabilities` doesn't has constant string `READBYTEBUFFER` for Hadoop 3.2.0, I use `in:readbytebuffer` and this case will be updated after the new version of Hadoop is applied.)

#### Proposed fix.
We couldn't implement `StreamCapabilities` from `OzoneFSInputStream` directly cause the older version Hadoop can't find the class.

So we added `CapableOzoneFSInputStream` that extends `OzoneFSInputStream` and implements `StreamCapabilities`.

Then we maked
`BasicOzoneFileSystem#createFSInputStream(InputStream)` return `OzoneFSInputStream` and 
`OzoneFileSystem#createFSInputStream(InputStream)` return `CapableOzoneFSInputStream` that implements `StreamCapabilities`.

With these fixes, the older version Hadoop couldn't report `NoClassDefFoundError`.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2750

## How was this patch tested?
UT is updated, and [Github Actions](https://github.com/apache/hadoop-ozone/runs/388775928).