### PR TITLE
HDDS-2781. Add ObjectID and updateID to BucketInfo to avoid replaying transactions

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -40,7 +40,7 @@ import com.google.common.base.Preconditions;
 /**
  * A class that encapsulates Bucket Info.
  */
-public final class OmBucketInfo extends WithMetadata implements Auditable{
+public final class OmBucketInfo extends WithMetadata implements Auditable {
   /**
    * Name of the volume in which the bucket belongs to.
    */
@@ -220,7 +220,7 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
 
   /**
    * Set the Object ID. If this value is already set then this function throws.
-   * There is a reason why we cannot use the final here. The OmVolumeArgs is
+   * There is a reason why we cannot use the final here. The OMBucketInfo is
    * deserialized from the protobuf in many places in code. We need to set
    * this object ID, after it is deserialized.
    *

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -266,8 +266,6 @@ public final class OmBucketInfo extends WithMetadata implements Auditable {
     auditMap.put(OzoneConsts.STORAGE_TYPE,
         (this.storageType != null) ? this.storageType.name() : null);
     auditMap.put(OzoneConsts.CREATION_TIME, String.valueOf(this.creationTime));
-    auditMap.put(OzoneConsts.OBJECT_ID, String.valueOf(this.getObjectID()));
-    auditMap.put(OzoneConsts.UPDATE_ID, String.valueOf(this.getUpdateID()));
     return auditMap;
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketInfo.java
@@ -66,6 +66,16 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
    * Creation time of bucket.
    */
   private final long creationTime;
+  /**
+   * ObjectIDs are unique and immutable identifier for each object in the
+   * System.
+   */
+  private long objectID;
+  /**
+   * UpdateIDs are monotonically increasing values which are updated
+   * each time there is an update.
+   */
+  private long updateID;
 
   /**
    * Bucket encryption key info if encryption is enabled.
@@ -90,6 +100,8 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
                        boolean isVersionEnabled,
                        StorageType storageType,
                        long creationTime,
+                       long objectID,
+                       long updateID,
                        Map<String, String> metadata,
                        BucketEncryptionKeyInfo bekInfo) {
     this.volumeName = volumeName;
@@ -98,6 +110,8 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
     this.isVersionEnabled = isVersionEnabled;
     this.storageType = storageType;
     this.creationTime = creationTime;
+    this.objectID = objectID;
+    this.updateID = updateID;
     this.metadata = metadata;
     this.bekInfo = bekInfo;
   }
@@ -181,6 +195,22 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
   }
 
   /**
+   * Returns objectID.
+   * @return long
+   */
+  public long getObjectID() {
+    return objectID;
+  }
+
+  /**
+   * Returns updateID.
+   * @return long
+   */
+  public long getUpdateID() {
+    return updateID;
+  }
+
+  /**
    * Returns bucket encryption key info.
    * @return bucket encryption key info
    */
@@ -188,6 +218,30 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
     return bekInfo;
   }
 
+  /**
+   * Set the Object ID. If this value is already set then this function throws.
+   * There is a reason why we cannot use the final here. The OmVolumeArgs is
+   * deserialized from the protobuf in many places in code. We need to set
+   * this object ID, after it is deserialized.
+   *
+   * @param obId - long
+   */
+  public void setObjectID(long obId) {
+    if(this.objectID != 0) {
+      throw new UnsupportedOperationException("Attempt to modify object ID " +
+          "which is not zero. Current Object ID is " + this.objectID);
+    }
+    this.objectID = obId;
+  }
+
+  /**
+   * Sets the update ID. For each modification of this object, we will set
+   * this to a value greater than the current value.
+   * @param updateID  long
+   */
+  public void setUpdateID(long updateID) {
+    this.updateID = updateID;
+  }
 
   /**
    * Returns new builder class that builds a OmBucketInfo.
@@ -212,6 +266,8 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
     auditMap.put(OzoneConsts.STORAGE_TYPE,
         (this.storageType != null) ? this.storageType.name() : null);
     auditMap.put(OzoneConsts.CREATION_TIME, String.valueOf(this.creationTime));
+    auditMap.put(OzoneConsts.OBJECT_ID, String.valueOf(this.getObjectID()));
+    auditMap.put(OzoneConsts.UPDATE_ID, String.valueOf(this.getUpdateID()));
     return auditMap;
   }
 
@@ -225,6 +281,8 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
         .setStorageType(storageType)
         .setIsVersionEnabled(isVersionEnabled)
         .setCreationTime(creationTime)
+        .setObjectID(objectID)
+        .setUpdateID(updateID)
         .setBucketEncryptionKey(bekInfo != null ?
             new BucketEncryptionKeyInfo(bekInfo.getVersion(),
                 bekInfo.getSuite(), bekInfo.getKeyName()) : null);
@@ -250,6 +308,8 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
     private Boolean isVersionEnabled;
     private StorageType storageType;
     private long creationTime;
+    private long objectID;
+    private long updateID;
     private Map<String, String> metadata;
     private BucketEncryptionKeyInfo bekInfo;
 
@@ -300,6 +360,16 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
       return this;
     }
 
+    public Builder setObjectID(long obId) {
+      this.objectID = obId;
+      return this;
+    }
+
+    public Builder setUpdateID(long id) {
+      this.updateID = id;
+      return this;
+    }
+
     public Builder addMetadata(String key, String value) {
       metadata.put(key, value);
       return this;
@@ -329,8 +399,8 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
       Preconditions.checkNotNull(isVersionEnabled);
       Preconditions.checkNotNull(storageType);
 
-      return new OmBucketInfo(volumeName, bucketName, acls,
-          isVersionEnabled, storageType, creationTime, metadata, bekInfo);
+      return new OmBucketInfo(volumeName, bucketName, acls, isVersionEnabled,
+          storageType, creationTime, objectID, updateID, metadata, bekInfo);
     }
   }
 
@@ -345,6 +415,8 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
         .setIsVersionEnabled(isVersionEnabled)
         .setStorageType(storageType.toProto())
         .setCreationTime(creationTime)
+        .setObjectID(objectID)
+        .setUpdateID(updateID)
         .addAllMetadata(KeyValueUtil.toProtobuf(metadata));
     if (bekInfo != null && bekInfo.getKeyName() != null) {
       bib.setBeinfo(OMPBHelper.convert(bekInfo));
@@ -366,6 +438,12 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
         .setIsVersionEnabled(bucketInfo.getIsVersionEnabled())
         .setStorageType(StorageType.valueOf(bucketInfo.getStorageType()))
         .setCreationTime(bucketInfo.getCreationTime());
+    if (bucketInfo.hasObjectID()) {
+      obib.setObjectID(bucketInfo.getObjectID());
+    }
+    if (bucketInfo.hasUpdateID()) {
+      obib.setUpdateID(bucketInfo.getUpdateID());
+    }
     if (bucketInfo.getMetadataList() != null) {
       obib.addAllMetadata(KeyValueUtil
           .getFromProtobuf(bucketInfo.getMetadataList()));
@@ -391,6 +469,8 @@ public final class OmBucketInfo extends WithMetadata implements Auditable{
         Objects.equals(acls, that.acls) &&
         Objects.equals(isVersionEnabled, that.isVersionEnabled) &&
         storageType == that.storageType &&
+        objectID == that.objectID &&
+        updateID == that.updateID &&
         Objects.equals(metadata, that.metadata) &&
         Objects.equals(bekInfo, that.bekInfo);
   }

--- a/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
+++ b/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
@@ -487,6 +487,8 @@ message BucketInfo {
     optional uint64 creationTime = 6;
     repeated hadoop.hdds.KeyValue metadata = 7;
     optional BucketEncryptionInfoProto beinfo = 8;
+    optional uint64 objectID = 9;
+    optional uint64 updateID = 10;
 }
 
 enum StorageTypeProto {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -120,7 +120,9 @@ public class OMBucketCreateRequest extends OMClientRequest {
 
     OMMetadataManager metadataManager = ozoneManager.getMetadataManager();
 
-    BucketInfo bucketInfo = getBucketInfoFromRequest();
+    CreateBucketRequest createBucketRequest = getOmRequest()
+        .getCreateBucketRequest();
+    BucketInfo bucketInfo = createBucketRequest.getBucketInfo();
 
     String volumeName = bucketInfo.getVolumeName();
     String bucketName = bucketInfo.getBucketName();
@@ -163,14 +165,32 @@ public class OMBucketCreateRequest extends OMClientRequest {
       }
 
       //Check if bucket already exists
-      if (metadataManager.getBucketTable().get(bucketKey) != null) {
-        LOG.debug("bucket: {} already exists ", bucketName);
-        throw new OMException("Bucket already exist",
-            OMException.ResultCodes.BUCKET_ALREADY_EXISTS);
+      OmBucketInfo dbBucketInfo = metadataManager.getBucketTable()
+          .get(bucketKey);
+      if (dbBucketInfo != null) {
+        // Check if this transaction is a replay of ratis logs.
+        if (isReplay(ozoneManager, dbBucketInfo.getUpdateID(),
+            transactionLogIndex)) {
+          // Replay implies the response has already been returned to
+          // the client. So take no further action and return a dummy
+          // OMClientResponse.
+          LOG.debug("Replayed Transaction {} ignored. Request: {}",
+              transactionLogIndex, createBucketRequest);
+          return new OMBucketCreateResponse(createReplayOMResponse(omResponse));
+        } else {
+          LOG.debug("bucket: {} already exists ", bucketName);
+          throw new OMException("Bucket already exist",
+              OMException.ResultCodes.BUCKET_ALREADY_EXISTS);
+        }
       }
+
+      // Add objectID and updateID
+      omBucketInfo.setObjectID(transactionLogIndex);
+      omBucketInfo.setUpdateID(transactionLogIndex);
 
       // Add default acls from volume.
       addDefaultAcls(omBucketInfo, omVolumeArgs);
+
 
       // Update table cache.
       metadataManager.getBucketTable().addCacheEntry(new CacheKey<>(bucketKey),
@@ -178,12 +198,12 @@ public class OMBucketCreateRequest extends OMClientRequest {
 
       omResponse.setCreateBucketResponse(
           CreateBucketResponse.newBuilder().build());
-      omClientResponse = new OMBucketCreateResponse(omBucketInfo,
-          omResponse.build());
+      omClientResponse = new OMBucketCreateResponse(omResponse.build(),
+          omBucketInfo);
     } catch (IOException ex) {
       exception = ex;
-      omClientResponse = new OMBucketCreateResponse(omBucketInfo,
-          createErrorOMResponse(omResponse, exception));
+      omClientResponse = new OMBucketCreateResponse(
+          createErrorOMResponse(omResponse, exception), omBucketInfo);
     } finally {
       if (omClientResponse != null) {
         omClientResponse.setFlushFuture(
@@ -237,13 +257,6 @@ public class OMBucketCreateRequest extends OMClientRequest {
 
     OzoneAclUtil.inheritDefaultAcls(acls, defaultVolumeAclList);
     omBucketInfo.setAcls(acls);
-  }
-
-
-  private BucketInfo getBucketInfoFromRequest() {
-    CreateBucketRequest createBucketRequest =
-        getOmRequest().getCreateBucketRequest();
-    return createBucketRequest.getBucketInfo();
   }
 
   private BucketEncryptionInfoProto getBeinfo(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
@@ -153,8 +153,8 @@ public class OMBucketDeleteRequest extends OMClientRequest {
       // Add to double buffer.
       omClientResponse = new OMBucketDeleteResponse(omResponse.build(),
           volumeName, bucketName);
-    } catch (IOException ex) {
-      exception = ex;
+    } catch (IOException e) {
+      exception = e;
       omClientResponse = new OMBucketDeleteResponse(
           createErrorOMResponse(omResponse, exception), volumeName, bucketName);
     } finally {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
@@ -153,11 +153,7 @@ public class OMBucketDeleteRequest extends OMClientRequest {
       // Add to double buffer.
       omClientResponse = new OMBucketDeleteResponse(omResponse.build(),
           volumeName, bucketName);
-      LOG.debug("Deleted bucket:{} in volume:{}", bucketName, volumeName);
     } catch (IOException ex) {
-      omMetrics.incNumBucketDeleteFails();
-      LOG.error("Delete bucket failed for bucket:{} in volume:{}", bucketName,
-          volumeName, exception);
       exception = ex;
       omClientResponse = new OMBucketDeleteResponse(
           createErrorOMResponse(omResponse, exception), volumeName, bucketName);
@@ -180,6 +176,15 @@ public class OMBucketDeleteRequest extends OMClientRequest {
     auditLog(auditLogger, buildAuditMessage(OMAction.DELETE_BUCKET,
         auditMap, exception, userInfo));
 
-    return omClientResponse;
+    // return response.
+    if (exception == null) {
+      LOG.debug("Deleted bucket:{} in volume:{}", bucketName, volumeName);
+      return omClientResponse;
+    } else {
+      omMetrics.incNumBucketDeleteFails();
+      LOG.error("Delete bucket failed for bucket:{} in volume:{}", bucketName,
+          volumeName, exception);
+      return omClientResponse;
+    }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
@@ -41,6 +41,8 @@ import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+    .DeleteBucketRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .DeleteBucketResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMRequest;
@@ -72,8 +74,10 @@ public class OMBucketDeleteRequest extends OMClientRequest {
     OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
 
     OMRequest omRequest = getOmRequest();
-    String volumeName = omRequest.getDeleteBucketRequest().getVolumeName();
-    String bucketName = omRequest.getDeleteBucketRequest().getBucketName();
+    DeleteBucketRequest deleteBucketRequest =
+        omRequest.getDeleteBucketRequest();
+    String volumeName = deleteBucketRequest.getVolumeName();
+    String bucketName = deleteBucketRequest.getBucketName();
 
     // Generate end user response
     OMResponse.Builder omResponse = OMResponse.newBuilder()
@@ -111,13 +115,25 @@ public class OMBucketDeleteRequest extends OMClientRequest {
       // with out volume creation.
       //Check if bucket exists
       String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
-      OmBucketInfo omBucketInfo =
-          omMetadataManager.getBucketTable().get(bucketKey);
+      OmBucketInfo omBucketInfo = omMetadataManager.getBucketTable()
+          .get(bucketKey);
       if (omBucketInfo == null) {
         LOG.debug("bucket: {} not found ", bucketName);
         throw new OMException("Bucket doesn't exist",
             OMException.ResultCodes.BUCKET_NOT_FOUND);
       }
+
+      // Check if this transaction is a replay of ratis logs.
+      // If this is a replay, then the response has already been returned to
+      // the client. So take no further action and return a dummy
+      // OMClientResponse.
+      if (isReplay(ozoneManager, omBucketInfo.getUpdateID(),
+          transactionLogIndex)) {
+        LOG.debug("Replayed Transaction {} ignored. Request: {}",
+            transactionLogIndex, deleteBucketRequest);
+        return new OMBucketDeleteResponse(createReplayOMResponse(omResponse));
+      }
+
       //Check if bucket is empty
       if (!omMetadataManager.isBucketEmpty(volumeName, bucketName)) {
         LOG.debug("bucket: {} is not empty ", bucketName);
@@ -135,12 +151,12 @@ public class OMBucketDeleteRequest extends OMClientRequest {
           DeleteBucketResponse.newBuilder().build());
 
       // Add to double buffer.
-      omClientResponse = new OMBucketDeleteResponse(volumeName, bucketName,
-          omResponse.build());
+      omClientResponse = new OMBucketDeleteResponse(omResponse.build(),
+          volumeName, bucketName);
     } catch (IOException ex) {
       exception = ex;
-      omClientResponse = new OMBucketDeleteResponse(volumeName, bucketName,
-          createErrorOMResponse(omResponse, exception));
+      omClientResponse = new OMBucketDeleteResponse(
+          createErrorOMResponse(omResponse, exception), volumeName, bucketName);
     } finally {
       if (omClientResponse != null) {
         omClientResponse.setFlushFuture(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
@@ -92,8 +92,8 @@ public class OMBucketDeleteRequest extends OMClientRequest {
     OzoneManagerProtocolProtos.UserInfo userInfo = getOmRequest().getUserInfo();
     IOException exception = null;
 
-    boolean acquiredBucketLock = false;
-    boolean acquiredVolumeLock = false;
+    boolean acquiredBucketLock = false, acquiredVolumeLock = false;
+    boolean success = true;
     OMClientResponse omClientResponse = null;
     try {
       // check Acl
@@ -153,8 +153,9 @@ public class OMBucketDeleteRequest extends OMClientRequest {
       // Add to double buffer.
       omClientResponse = new OMBucketDeleteResponse(omResponse.build(),
           volumeName, bucketName);
-    } catch (IOException e) {
-      exception = e;
+    } catch (IOException ex) {
+      success = false;
+      exception = ex;
       omClientResponse = new OMBucketDeleteResponse(
           createErrorOMResponse(omResponse, exception), volumeName, bucketName);
     } finally {
@@ -177,7 +178,7 @@ public class OMBucketDeleteRequest extends OMClientRequest {
         auditMap, exception, userInfo));
 
     // return response.
-    if (exception == null) {
+    if (success) {
       LOG.debug("Deleted bucket:{} in volume:{}", bucketName, volumeName);
       return omClientResponse;
     } else {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
@@ -153,7 +153,11 @@ public class OMBucketDeleteRequest extends OMClientRequest {
       // Add to double buffer.
       omClientResponse = new OMBucketDeleteResponse(omResponse.build(),
           volumeName, bucketName);
+      LOG.debug("Deleted bucket:{} in volume:{}", bucketName, volumeName);
     } catch (IOException ex) {
+      omMetrics.incNumBucketDeleteFails();
+      LOG.error("Delete bucket failed for bucket:{} in volume:{}", bucketName,
+          volumeName, exception);
       exception = ex;
       omClientResponse = new OMBucketDeleteResponse(
           createErrorOMResponse(omResponse, exception), volumeName, bucketName);
@@ -176,15 +180,6 @@ public class OMBucketDeleteRequest extends OMClientRequest {
     auditLog(auditLogger, buildAuditMessage(OMAction.DELETE_BUCKET,
         auditMap, exception, userInfo));
 
-    // return response.
-    if (exception == null) {
-      LOG.debug("Deleted bucket:{} in volume:{}", bucketName, volumeName);
-      return omClientResponse;
-    } else {
-      omMetrics.incNumBucketDeleteFails();
-      LOG.error("Delete bucket failed for bucket:{} in volume:{}", bucketName,
-          volumeName, exception);
-      return omClientResponse;
-    }
+    return omClientResponse;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -134,7 +134,8 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
           transactionLogIndex)) {
         LOG.debug("Replayed Transaction {} ignored. Request: {}",
             transactionLogIndex, setBucketPropertyRequest);
-        return new OMBucketSetPropertyResponse(createReplayOMResponse(omResponse));
+        return new OMBucketSetPropertyResponse(
+            createReplayOMResponse(omResponse));
       }
 
       OmBucketInfo.Builder bucketInfoBuilder = OmBucketInfo.newBuilder();
@@ -192,7 +193,12 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
           SetBucketPropertyResponse.newBuilder().build());
       omClientResponse = new OMBucketSetPropertyResponse(
           omResponse.build(), omBucketInfo);
+      LOG.debug("Setting bucket property for bucket:{} in volume:{}",
+          bucketName, volumeName);
     } catch (IOException ex) {
+      LOG.error("Setting bucket property failed for bucket:{} in volume:{}",
+          bucketName, volumeName, exception);
+      omMetrics.incNumBucketUpdateFails();
       exception = ex;
       omClientResponse = new OMBucketSetPropertyResponse(
           createErrorOMResponse(omResponse, exception), omBucketInfo);
@@ -213,15 +219,6 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
         omBucketArgs.toAuditMap(), exception, userInfo));
 
     // return response.
-    if (exception == null) {
-      LOG.debug("Setting bucket property for bucket:{} in volume:{}",
-          bucketName, volumeName);
-      return omClientResponse;
-    } else {
-      LOG.error("Setting bucket property failed for bucket:{} in volume:{}",
-          bucketName, volumeName, exception);
-      omMetrics.incNumBucketUpdateFails();
-      return omClientResponse;
-    }
+    return omClientResponse;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -97,7 +97,7 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
     AuditLogger auditLogger = ozoneManager.getAuditLogger();
     OzoneManagerProtocolProtos.UserInfo userInfo = getOmRequest().getUserInfo();
     IOException exception = null;
-    boolean acquiredBucketLock = false;
+    boolean acquiredBucketLock = false, success = true;
     OMClientResponse omClientResponse = null;
     try {
       // check Acl
@@ -187,8 +187,9 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
           SetBucketPropertyResponse.newBuilder().build());
       omClientResponse = new OMBucketSetPropertyResponse(
           omResponse.build(), omBucketInfo);
-    } catch (IOException e) {
-      exception = e;
+    } catch (IOException ex) {
+      success = false;
+      exception = ex;
       omClientResponse = new OMBucketSetPropertyResponse(
           createErrorOMResponse(omResponse, exception), omBucketInfo);
     } finally {
@@ -207,7 +208,7 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
         omBucketArgs.toAuditMap(), exception, userInfo));
 
     // return response.
-    if (exception == null) {
+    if (success) {
       LOG.debug("Setting bucket property for bucket:{} in volume:{}",
           bucketName, volumeName);
       return omClientResponse;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -193,12 +193,7 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
           SetBucketPropertyResponse.newBuilder().build());
       omClientResponse = new OMBucketSetPropertyResponse(
           omResponse.build(), omBucketInfo);
-      LOG.debug("Setting bucket property for bucket:{} in volume:{}",
-          bucketName, volumeName);
     } catch (IOException ex) {
-      LOG.error("Setting bucket property failed for bucket:{} in volume:{}",
-          bucketName, volumeName, exception);
-      omMetrics.incNumBucketUpdateFails();
       exception = ex;
       omClientResponse = new OMBucketSetPropertyResponse(
           createErrorOMResponse(omResponse, exception), omBucketInfo);
@@ -219,6 +214,15 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
         omBucketArgs.toAuditMap(), exception, userInfo));
 
     // return response.
-    return omClientResponse;
+    if (exception == null) {
+      LOG.debug("Setting bucket property for bucket:{} in volume:{}",
+          bucketName, volumeName);
+      return omClientResponse;
+    } else {
+      LOG.error("Setting bucket property failed for bucket:{} in volume:{}",
+          bucketName, volumeName, exception);
+      omMetrics.incNumBucketUpdateFails();
+      return omClientResponse;
+    }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -117,17 +117,31 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
           BUCKET_LOCK, volumeName, bucketName);
 
       String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
-      OmBucketInfo oldBucketInfo =
+      OmBucketInfo dbBucketInfo =
           omMetadataManager.getBucketTable().get(bucketKey);
       //Check if bucket exist
-      if (oldBucketInfo == null) {
+      if (dbBucketInfo == null) {
         LOG.debug("bucket: {} not found ", bucketName);
         throw new OMException("Bucket doesn't exist",
             OMException.ResultCodes.BUCKET_NOT_FOUND);
       }
+
+      // Check if this transaction is a replay of ratis logs.
+      // If this is a replay, then the response has already been returned to
+      // the client. So take no further action and return a dummy
+      // OMClientResponse.
+      if (isReplay(ozoneManager, dbBucketInfo.getUpdateID(),
+          transactionLogIndex)) {
+        LOG.debug("Replayed Transaction {} ignored. Request: {}",
+            transactionLogIndex, setBucketPropertyRequest);
+        return new OMBucketSetPropertyResponse(createReplayOMResponse(omResponse));
+      }
+
       OmBucketInfo.Builder bucketInfoBuilder = OmBucketInfo.newBuilder();
-      bucketInfoBuilder.setVolumeName(oldBucketInfo.getVolumeName())
-          .setBucketName(oldBucketInfo.getBucketName());
+      bucketInfoBuilder.setVolumeName(dbBucketInfo.getVolumeName())
+          .setBucketName(dbBucketInfo.getBucketName())
+          .setObjectID(dbBucketInfo.getObjectID())
+          .setUpdateID(transactionLogIndex);
       bucketInfoBuilder.addAllMetadata(KeyValueUtil
           .getFromProtobuf(bucketArgs.getMetadataList()));
 
@@ -138,7 +152,7 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
         LOG.debug("Updating bucket storage type for bucket: {} in volume: {}",
             bucketName, volumeName);
       } else {
-        bucketInfoBuilder.setStorageType(oldBucketInfo.getStorageType());
+        bucketInfoBuilder.setStorageType(dbBucketInfo.getStorageType());
       }
 
       //Check Versioning to update
@@ -149,15 +163,23 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
             bucketName, volumeName);
       } else {
         bucketInfoBuilder
-            .setIsVersionEnabled(oldBucketInfo.getIsVersionEnabled());
+            .setIsVersionEnabled(dbBucketInfo.getIsVersionEnabled());
       }
 
-      bucketInfoBuilder.setCreationTime(oldBucketInfo.getCreationTime());
+      bucketInfoBuilder.setCreationTime(dbBucketInfo.getCreationTime());
 
-      // Set acls from oldBucketInfo if it has any.
-      if (oldBucketInfo.getAcls() != null) {
-        bucketInfoBuilder.setAcls(oldBucketInfo.getAcls());
+      // Set acls from dbBucketInfo if it has any.
+      if (dbBucketInfo.getAcls() != null) {
+        bucketInfoBuilder.setAcls(dbBucketInfo.getAcls());
       }
+
+      // Set the objectID to dbBucketInfo objectID, if present
+      if (dbBucketInfo.getObjectID() != 0) {
+        bucketInfoBuilder.setObjectID(dbBucketInfo.getObjectID());
+      }
+
+      // Set the updateID to current transaction log index
+      bucketInfoBuilder.setUpdateID(transactionLogIndex);
 
       omBucketInfo = bucketInfoBuilder.build();
 
@@ -168,12 +190,12 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
 
       omResponse.setSetBucketPropertyResponse(
           SetBucketPropertyResponse.newBuilder().build());
-      omClientResponse =
-          new OMBucketSetPropertyResponse(omBucketInfo, omResponse.build());
+      omClientResponse = new OMBucketSetPropertyResponse(
+          omResponse.build(), omBucketInfo);
     } catch (IOException ex) {
       exception = ex;
-      omClientResponse = new OMBucketSetPropertyResponse(omBucketInfo,
-          createErrorOMResponse(omResponse, exception));
+      omClientResponse = new OMBucketSetPropertyResponse(
+          createErrorOMResponse(omResponse, exception), omBucketInfo);
     } finally {
       if (omClientResponse != null) {
         omClientResponse.setFlushFuture(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
+import org.apache.hadoop.ozone.om.response.bucket.acl.OMBucketAclResponse;
 import org.apache.hadoop.ozone.util.BooleanBiFunction;
 import org.apache.hadoop.ozone.om.request.util.ObjectParser;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -40,6 +41,8 @@ import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 
@@ -47,6 +50,9 @@ import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_L
  * Base class for Bucket acl request.
  */
 public abstract class OMBucketAclRequest extends OMClientRequest {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OMBucketAclRequest.class);
 
   private BooleanBiFunction<List<OzoneAcl>, OmBucketInfo> omBucketAclOp;
 
@@ -100,7 +106,19 @@ public abstract class OMBucketAclRequest extends OMClientRequest {
         throw new OMException(OMException.ResultCodes.BUCKET_NOT_FOUND);
       }
 
+      // Check if this transaction is a replay of ratis logs.
+      // If this is a replay, then the response has already been returned to
+      // the client. So take no further action and return a dummy
+      // OMClientResponse.
+      if (isReplay(ozoneManager, omBucketInfo.getUpdateID(),
+          transactionLogIndex)) {
+        LOG.debug("Replayed Transaction {} ignored. Request: {}",
+            transactionLogIndex, getOmRequest());
+        return new OMBucketAclResponse(createReplayOMResponse(omResponse));
+      }
+
       operationResult = omBucketAclOp.apply(ozoneAcls, omBucketInfo);
+      omBucketInfo.setUpdateID(transactionLogIndex);
 
       if (operationResult) {
         // update cache.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAddAclRequest.java
@@ -90,14 +90,13 @@ public class OMBucketAddAclRequest extends OMBucketAclRequest {
     omResponse.setSuccess(operationResult);
     omResponse.setAddAclResponse(AddAclResponse.newBuilder()
          .setResponse(operationResult));
-    return new OMBucketAclResponse(omBucketInfo,
-        omResponse.build());
+    return new OMBucketAclResponse(omResponse.build(), omBucketInfo);
   }
 
   @Override
   OMClientResponse onFailure(OMResponse.Builder omResponse,
       IOException exception) {
-    return new OMBucketAclResponse(null,
+    return new OMBucketAclResponse(
         createErrorOMResponse(omResponse, exception));
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketRemoveAclRequest.java
@@ -87,14 +87,13 @@ public class OMBucketRemoveAclRequest extends OMBucketAclRequest {
     omResponse.setSuccess(operationResult);
     omResponse.setRemoveAclResponse(RemoveAclResponse.newBuilder()
         .setResponse(operationResult));
-    return new OMBucketAclResponse(omBucketInfo,
-        omResponse.build());
+    return new OMBucketAclResponse(omResponse.build(), omBucketInfo);
   }
 
   @Override
   OMClientResponse onFailure(OMResponse.Builder omResponse,
       IOException exception) {
-    return new OMBucketAclResponse(null,
+    return new OMBucketAclResponse(
         createErrorOMResponse(omResponse, exception));
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketSetAclRequest.java
@@ -88,14 +88,13 @@ public class OMBucketSetAclRequest extends OMBucketAclRequest {
     omResponse.setSuccess(operationResult);
     omResponse.setSetAclResponse(SetAclResponse.newBuilder()
         .setResponse(operationResult));
-    return new OMBucketAclResponse(omBucketInfo,
-        omResponse.build());
+    return new OMBucketAclResponse(omResponse.build(), omBucketInfo);
   }
 
   @Override
   OMClientResponse onFailure(OMResponse.Builder omResponse,
       IOException exception) {
-    return new OMBucketAclResponse(null,
+    return new OMBucketAclResponse(
         createErrorOMResponse(omResponse, exception));
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/bucket/S3BucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/bucket/S3BucketCreateRequest.java
@@ -214,7 +214,7 @@ public class S3BucketCreateRequest extends OMVolumeRequest {
               transactionLogIndex));
 
       OMBucketCreateResponse omBucketCreateResponse =
-          new OMBucketCreateResponse(omBucketInfo, omResponse.build());
+          new OMBucketCreateResponse(omResponse.build(), omBucketInfo);
 
       omClientResponse = new S3BucketCreateResponse(omVolumeCreateResponse,
           omBucketCreateResponse, s3BucketName,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/bucket/S3BucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/bucket/S3BucketCreateRequest.java
@@ -231,8 +231,8 @@ public class S3BucketCreateRequest extends OMVolumeRequest {
               S3CreateBucketResponse.newBuilder()).build(),
           omVolumeCreateResponse, omBucketCreateResponse, s3BucketName,
           formatS3MappingName(volumeName, s3BucketName));
-    } catch (IOException ex) {
-      exception = ex;
+    } catch (IOException e) {
+      exception = e;
       omClientResponse = new S3BucketCreateResponse(
           createErrorOMResponse(omResponse, exception));
     } finally {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/bucket/S3BucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/bucket/S3BucketDeleteRequest.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import com.google.common.base.Optional;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
-import org.apache.hadoop.ozone.om.response.bucket.OMBucketDeleteResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -126,26 +125,34 @@ public class S3BucketDeleteRequest extends OMVolumeRequest {
         String bucketKey = omMetadataManager.getBucketKey(volumeName,
             s3BucketName);
 
-        // Check if this transaction is a replay of ratis logs.
-        // If this is a replay, then the response has already been returned to
-        // the client. So take no further action and return a dummy
-        // OMClientResponse.
+        // Check if Bucket exists in DB.
         OmBucketInfo dbBucketInfo =
             omMetadataManager.getBucketTable().get(bucketKey);
-        if (isReplay(ozoneManager, dbBucketInfo.getUpdateID(),
-            transactionLogIndex)) {
-          LOG.debug("Replayed Transaction {} ignored. Request: {}",
-              transactionLogIndex, s3DeleteBucketRequest);
-          return new S3BucketDeleteResponse(createReplayOMResponse(omResponse));
-        }
+        if (dbBucketInfo != null) {
+          // Check if this transaction is a replay of ratis logs.
+          // If this is a replay, then the response has already been returned to
+          // the client. So take no further action and return a dummy
+          // OMClientResponse.
+          if (isReplay(ozoneManager, dbBucketInfo.getUpdateID(),
+              transactionLogIndex)) {
+            LOG.debug("Replayed Transaction {} ignored. Request: {}",
+                transactionLogIndex, s3DeleteBucketRequest);
+            return new S3BucketDeleteResponse(
+                createReplayOMResponse(omResponse));
+          }
 
-        // Update bucket table cache and s3 table cache.
-        omMetadataManager.getBucketTable().addCacheEntry(
-            new CacheKey<>(bucketKey),
-            new CacheValue<>(Optional.absent(), transactionLogIndex));
-        omMetadataManager.getS3Table().addCacheEntry(
-            new CacheKey<>(s3BucketName),
-            new CacheValue<>(Optional.absent(), transactionLogIndex));
+          // Update bucket table cache and s3 table cache.
+          omMetadataManager.getBucketTable().addCacheEntry(
+              new CacheKey<>(bucketKey),
+              new CacheValue<>(Optional.absent(), transactionLogIndex));
+          omMetadataManager.getS3Table().addCacheEntry(
+              new CacheKey<>(s3BucketName),
+              new CacheValue<>(Optional.absent(), transactionLogIndex));
+        } else {
+          LOG.debug("bucket: {} not found ", bucketKey);
+          throw new OMException("Bucket doesn't exist",
+              OMException.ResultCodes.BUCKET_NOT_FOUND);
+        }
       }
 
       omResponse.setDeleteS3BucketResponse(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/OMBucketCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/OMBucketCreateResponse.java
@@ -38,10 +38,20 @@ public final class OMBucketCreateResponse extends OMClientResponse {
 
   private final OmBucketInfo omBucketInfo;
 
-  public OMBucketCreateResponse(@Nullable OmBucketInfo omBucketInfo,
-      @Nonnull OMResponse omResponse) {
+  public OMBucketCreateResponse(@Nonnull OMResponse omResponse,
+      @Nonnull OmBucketInfo omBucketInfo) {
     super(omResponse);
     this.omBucketInfo = omBucketInfo;
+  }
+
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
+  public OMBucketCreateResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+    checkStatusNotOK();
+    omBucketInfo = null;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/OMBucketCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/OMBucketCreateResponse.java
@@ -48,15 +48,11 @@ public final class OMBucketCreateResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    // For OmResponse with failure, this should do nothing. This method is
-    // not called in failure scenario in OM code.
-    if (getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK) {
-      String dbBucketKey =
-          omMetadataManager.getBucketKey(omBucketInfo.getVolumeName(),
-              omBucketInfo.getBucketName());
-      omMetadataManager.getBucketTable().putWithBatch(batchOperation,
-          dbBucketKey, omBucketInfo);
-    }
+    String dbBucketKey =
+        omMetadataManager.getBucketKey(omBucketInfo.getVolumeName(),
+            omBucketInfo.getBucketName());
+    omMetadataManager.getBucketTable().putWithBatch(batchOperation,
+        dbBucketKey, omBucketInfo);
   }
 
   @Nullable

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/OMBucketCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/OMBucketCreateResponse.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/OMBucketDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/OMBucketDeleteResponse.java
@@ -47,14 +47,10 @@ public final class OMBucketDeleteResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    // For OmResponse with failure, this should do nothing. This method is
-    // not called in failure scenario in OM code.
-    if (getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK) {
-      String dbBucketKey =
-          omMetadataManager.getBucketKey(volumeName, bucketName);
-      omMetadataManager.getBucketTable().deleteWithBatch(batchOperation,
-          dbBucketKey);
-    }
+    String dbBucketKey =
+        omMetadataManager.getBucketKey(volumeName, bucketName);
+    omMetadataManager.getBucketTable().deleteWithBatch(batchOperation,
+        dbBucketKey);
   }
 
   public String getVolumeName() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/OMBucketDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/OMBucketDeleteResponse.java
@@ -22,7 +22,8 @@ import java.io.IOException;
 
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+    .OMResponse;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
 import javax.annotation.Nonnull;
@@ -35,12 +36,20 @@ public final class OMBucketDeleteResponse extends OMClientResponse {
   private String volumeName;
   private String bucketName;
 
-  public OMBucketDeleteResponse(
-      String volumeName, String bucketName,
-      @Nonnull OzoneManagerProtocolProtos.OMResponse omResponse) {
+  public OMBucketDeleteResponse(@Nonnull OMResponse omResponse,
+      String volumeName, String bucketName) {
     super(omResponse);
     this.volumeName = volumeName;
     this.bucketName = bucketName;
+  }
+
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
+  public OMBucketDeleteResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+    checkStatusNotOK();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/OMBucketSetPropertyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/OMBucketSetPropertyResponse.java
@@ -22,12 +22,10 @@ import java.io.IOException;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
-import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
 
 /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/OMBucketSetPropertyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/OMBucketSetPropertyResponse.java
@@ -36,10 +36,19 @@ import javax.annotation.Nonnull;
 public class OMBucketSetPropertyResponse extends OMClientResponse {
   private OmBucketInfo omBucketInfo;
 
-  public OMBucketSetPropertyResponse(@Nullable OmBucketInfo omBucketInfo,
-      @Nonnull OMResponse omResponse) {
+  public OMBucketSetPropertyResponse(@Nonnull OMResponse omResponse,
+      @Nonnull OmBucketInfo omBucketInfo) {
     super(omResponse);
     this.omBucketInfo = omBucketInfo;
+  }
+
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
+  public OMBucketSetPropertyResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+    checkStatusNotOK();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/OMBucketSetPropertyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/OMBucketSetPropertyResponse.java
@@ -46,15 +46,11 @@ public class OMBucketSetPropertyResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    // For OmResponse with failure, this should do nothing. This method is
-    // not called in failure scenario in OM code.
-    if (getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK) {
-      String dbBucketKey =
-          omMetadataManager.getBucketKey(omBucketInfo.getVolumeName(),
-              omBucketInfo.getBucketName());
-      omMetadataManager.getBucketTable().putWithBatch(batchOperation,
-          dbBucketKey, omBucketInfo);
-    }
+    String dbBucketKey =
+        omMetadataManager.getBucketKey(omBucketInfo.getVolumeName(),
+            omBucketInfo.getBucketName());
+    omMetadataManager.getBucketTable().putWithBatch(batchOperation,
+        dbBucketKey, omBucketInfo);
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/acl/OMBucketAclResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/acl/OMBucketAclResponse.java
@@ -47,9 +47,8 @@ public class OMBucketAclResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    // If response status is OK and success is true, add to DB batch.
-    if (getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK &&
-        getOMResponse().getSuccess()) {
+    // If response is a success, add to DB batch.
+    if (getOMResponse().getSuccess()) {
       String dbBucketKey =
           omMetadataManager.getBucketKey(omBucketInfo.getVolumeName(),
               omBucketInfo.getBucketName());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/acl/OMBucketAclResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/acl/OMBucketAclResponse.java
@@ -21,13 +21,11 @@ package org.apache.hadoop.ozone.om.response.bucket.acl;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 
 /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/acl/OMBucketAclResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/bucket/acl/OMBucketAclResponse.java
@@ -37,10 +37,20 @@ public class OMBucketAclResponse extends OMClientResponse {
 
   private final OmBucketInfo omBucketInfo;
 
-  public OMBucketAclResponse(@Nullable OmBucketInfo omBucketInfo,
-      @Nonnull OMResponse omResponse) {
+  public OMBucketAclResponse(@Nonnull OMResponse omResponse,
+      @Nonnull OmBucketInfo omBucketInfo) {
     super(omResponse);
     this.omBucketInfo = omBucketInfo;
+  }
+
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
+  public OMBucketAclResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+    checkStatusNotOK();
+    this.omBucketInfo = null;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/bucket/S3BucketCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/bucket/S3BucketCreateResponse.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.om.response.s3.bucket;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 
 import com.google.common.base.Preconditions;
@@ -28,7 +27,6 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.bucket.OMBucketCreateResponse;
 import org.apache.hadoop.ozone.om.response.volume.OMVolumeCreateResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
@@ -43,11 +41,11 @@ public class S3BucketCreateResponse extends OMClientResponse {
   private String s3Bucket;
   private String s3Mapping;
 
-  public S3BucketCreateResponse(
-      @Nullable OMVolumeCreateResponse omVolumeCreateResponse,
-      @Nullable OMBucketCreateResponse omBucketCreateResponse,
-      @Nullable String s3BucketName,
-      @Nullable String s3Mapping, @Nonnull OMResponse omResponse) {
+  public S3BucketCreateResponse(@Nonnull OMResponse omResponse,
+      @Nonnull OMVolumeCreateResponse omVolumeCreateResponse,
+      @Nonnull OMBucketCreateResponse omBucketCreateResponse,
+      @Nonnull String s3BucketName,
+      @Nonnull String s3Mapping) {
     super(omResponse);
     this.omVolumeCreateResponse = omVolumeCreateResponse;
     this.omBucketCreateResponse = omBucketCreateResponse;
@@ -55,12 +53,22 @@ public class S3BucketCreateResponse extends OMClientResponse {
     this.s3Mapping = s3Mapping;
   }
 
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
+  public S3BucketCreateResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+    checkStatusNotOK();
+  }
+
   @Override
-  public void addToDBBatch(OMMetadataManager omMetadataManager,
+  protected void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
     if (omVolumeCreateResponse != null) {
-      omVolumeCreateResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+      omVolumeCreateResponse.checkAndUpdateDB(omMetadataManager,
+          batchOperation);
     }
 
     Preconditions.checkState(omBucketCreateResponse != null);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/bucket/S3BucketCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/bucket/S3BucketCreateResponse.java
@@ -59,19 +59,15 @@ public class S3BucketCreateResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    if (getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK) {
-      if (omVolumeCreateResponse != null) {
-        omVolumeCreateResponse.checkAndUpdateDB(omMetadataManager,
-            batchOperation);
-      }
-
-      Preconditions.checkState(omBucketCreateResponse != null);
-      omBucketCreateResponse.checkAndUpdateDB(omMetadataManager,
-          batchOperation);
-
-      omMetadataManager.getS3Table().putWithBatch(batchOperation, s3Bucket,
-          s3Mapping);
+    if (omVolumeCreateResponse != null) {
+      omVolumeCreateResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
     }
+
+    Preconditions.checkState(omBucketCreateResponse != null);
+    omBucketCreateResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+
+    omMetadataManager.getS3Table().putWithBatch(batchOperation, s3Bucket,
+        s3Mapping);
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/bucket/S3BucketCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/bucket/S3BucketCreateResponse.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import com.google.common.base.Preconditions;
 import com.google.common.annotations.VisibleForTesting;
 
+import javax.annotation.Nullable;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.bucket.OMBucketCreateResponse;
@@ -42,7 +43,7 @@ public class S3BucketCreateResponse extends OMClientResponse {
   private String s3Mapping;
 
   public S3BucketCreateResponse(@Nonnull OMResponse omResponse,
-      @Nonnull OMVolumeCreateResponse omVolumeCreateResponse,
+      @Nullable OMVolumeCreateResponse omVolumeCreateResponse,
       @Nonnull OMBucketCreateResponse omBucketCreateResponse,
       @Nonnull String s3BucketName,
       @Nonnull String s3Mapping) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/bucket/S3BucketDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/bucket/S3BucketDeleteResponse.java
@@ -34,11 +34,21 @@ public class S3BucketDeleteResponse extends OMClientResponse {
 
   private String s3BucketName;
   private String volumeName;
-  public S3BucketDeleteResponse(@Nullable String s3BucketName,
-      @Nullable String volumeName, @Nonnull OMResponse omResponse) {
+
+  public S3BucketDeleteResponse(@Nonnull OMResponse omResponse,
+      @Nonnull String s3BucketName, @Nonnull String volumeName) {
     super(omResponse);
     this.s3BucketName = s3BucketName;
     this.volumeName = volumeName;
+  }
+
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
+  public S3BucketDeleteResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+    checkStatusNotOK();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/bucket/S3BucketDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/bucket/S3BucketDeleteResponse.java
@@ -19,12 +19,10 @@ package org.apache.hadoop.ozone.om.response.s3.bucket;
 
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 
 /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/bucket/S3BucketDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/bucket/S3BucketDeleteResponse.java
@@ -45,11 +45,9 @@ public class S3BucketDeleteResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    if (getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK) {
-      omMetadataManager.getBucketTable().deleteWithBatch(batchOperation,
-          omMetadataManager.getBucketKey(volumeName, s3BucketName));
-      omMetadataManager.getS3Table().deleteWithBatch(batchOperation,
-          s3BucketName);
-    }
+    omMetadataManager.getBucketTable().deleteWithBatch(batchOperation,
+        omMetadataManager.getBucketKey(volumeName, s3BucketName));
+    omMetadataManager.getS3Table().deleteWithBatch(batchOperation,
+        s3BucketName);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
@@ -487,12 +487,11 @@ public class TestOzoneManagerDoubleBufferWithOMResponse {
    */
   private OMBucketDeleteResponse deleteBucket(String volumeName,
       String bucketName) {
-    return new OMBucketDeleteResponse(volumeName, bucketName,
-        OMResponse.newBuilder()
-            .setCmdType(OzoneManagerProtocolProtos.Type.DeleteBucket)
-            .setStatus(OzoneManagerProtocolProtos.Status.OK)
-            .setDeleteBucketResponse(DeleteBucketResponse.newBuilder().build())
-            .build());
+    return new OMBucketDeleteResponse(OMResponse.newBuilder()
+        .setCmdType(OzoneManagerProtocolProtos.Type.DeleteBucket)
+        .setStatus(OzoneManagerProtocolProtos.Status.OK)
+        .setDeleteBucketResponse(DeleteBucketResponse.newBuilder().build())
+        .build(), volumeName, bucketName);
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -215,6 +215,9 @@ public final class TestOMRequestUtils {
       OMMetadataManager omMetadataManager) throws Exception {
     omMetadataManager.getS3Table().put(s3BucketName,
         S3BucketCreateRequest.formatS3MappingName(volumeName, s3BucketName));
+    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName).setBucketName(s3BucketName).build();
+    addBucketToOM(omMetadataManager, omBucketInfo);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestBucketRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestBucketRequest.java
@@ -70,6 +70,7 @@ public class TestBucketRequest {
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration);
     when(ozoneManager.getMetrics()).thenReturn(omMetrics);
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
+    when(ozoneManager.isRatisEnabled()).thenReturn(true);
     auditLogger = Mockito.mock(AuditLogger.class);
     when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
     Mockito.doNothing().when(auditLogger).logWrite(any(AuditMessage.class));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
@@ -153,14 +153,26 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
 
     // As now after validateAndUpdateCache it should add entry to cache, get
     // should return non null value.
-    OmBucketInfo omBucketInfo =
+    OmBucketInfo dbBucketInfo =
         omMetadataManager.getBucketTable().get(bucketKey);
     Assert.assertNotNull(omMetadataManager.getBucketTable().get(bucketKey));
 
     // verify table data with actual request data.
-    Assert.assertEquals(OmBucketInfo.getFromProtobuf(
-        modifiedRequest.getCreateBucketRequest().getBucketInfo()),
-        omBucketInfo);
+    OmBucketInfo bucketInfoFromProto = OmBucketInfo.getFromProtobuf(
+        modifiedRequest.getCreateBucketRequest().getBucketInfo());
+
+    Assert.assertEquals(bucketInfoFromProto.getCreationTime(),
+        dbBucketInfo.getCreationTime());
+    Assert.assertEquals(bucketInfoFromProto.getAcls(),
+        dbBucketInfo.getAcls());
+    Assert.assertEquals(bucketInfoFromProto.getIsVersionEnabled(),
+        dbBucketInfo.getIsVersionEnabled());
+    Assert.assertEquals(bucketInfoFromProto.getStorageType(),
+        dbBucketInfo.getStorageType());
+    Assert.assertEquals(bucketInfoFromProto.getMetadata(),
+        dbBucketInfo.getMetadata());
+    Assert.assertEquals(bucketInfoFromProto.getEncryptionKeyInfo(),
+        dbBucketInfo.getEncryptionKeyInfo());
 
     // verify OMResponse.
     verifySuccessCreateBucketResponse(omClientResponse.getOMResponse());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
@@ -45,7 +45,6 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
 
-
     OMRequest omRequest = createSetBucketPropertyRequest(volumeName,
         bucketName, true);
 
@@ -62,7 +61,6 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
 
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-
 
     OMRequest omRequest = createSetBucketPropertyRequest(volumeName,
         bucketName, true);
@@ -85,7 +83,6 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
 
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
-
   }
 
   @Test
@@ -94,10 +91,8 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
 
-
     OMRequest omRequest = createSetBucketPropertyRequest(volumeName,
         bucketName, true);
-
 
     OMBucketSetPropertyRequest omBucketSetPropertyRequest =
         new OMBucketSetPropertyRequest(omRequest);
@@ -123,5 +118,34 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
                 .setIsVersionEnabled(isVersionEnabled).build()))
         .setCmdType(OzoneManagerProtocolProtos.Type.SetBucketProperty)
         .setClientId(UUID.randomUUID().toString()).build();
+  }
+
+  @Test
+  public void testReplayRequest() throws Exception {
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
+
+    // Create request to enable versioning
+    OMRequest omRequest = createSetBucketPropertyRequest(volumeName,
+        bucketName, true);
+    OMBucketSetPropertyRequest omBucketSetPropertyRequest =
+        new OMBucketSetPropertyRequest(omRequest);
+
+    // Execute the original request
+    omBucketSetPropertyRequest.preExecute(ozoneManager);
+    omBucketSetPropertyRequest.validateAndUpdateCache(ozoneManager, 1,
+        ozoneManagerDoubleBufferHelper);
+
+    // Replay the transaction - Execute the same request again
+    OMClientResponse omClientResponse =
+        omBucketSetPropertyRequest.validateAndUpdateCache(ozoneManager, 1,
+            ozoneManagerDoubleBufferHelper);
+
+    // Replay should result in Replay response
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.REPLAY,
+        omClientResponse.getOMResponse().getStatus());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/bucket/TestS3BucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/bucket/TestS3BucketCreateRequest.java
@@ -74,7 +74,6 @@ public class TestS3BucketCreateRequest extends TestS3BucketRequest {
     }
   }
 
-
   @Test
   public void testValidateAndUpdateCache() throws Exception {
     String userName = UUID.randomUUID().toString();
@@ -85,9 +84,7 @@ public class TestS3BucketCreateRequest extends TestS3BucketRequest {
 
     doValidateAndUpdateCache(userName, s3BucketName,
         s3BucketCreateRequest.getOmRequest());
-
   }
-
 
   @Test
   public void testValidateAndUpdateCacheWithS3BucketAlreadyExists()
@@ -128,7 +125,6 @@ public class TestS3BucketCreateRequest extends TestS3BucketRequest {
         s3BucketCreateRequest.formatOzoneVolumeName(userName),
         s3BucketName, omMetadataManager);
 
-
     // Try create same bucket again
     OMClientResponse omClientResponse =
         s3BucketCreateRequest.validateAndUpdateCache(ozoneManager, 2,
@@ -139,8 +135,6 @@ public class TestS3BucketCreateRequest extends TestS3BucketRequest {
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_ALREADY_EXISTS,
         omResponse.getStatus());
   }
-
-
 
   private S3BucketCreateRequest doPreExecute(String userName,
       String s3BucketName) throws Exception {
@@ -195,8 +189,28 @@ public class TestS3BucketCreateRequest extends TestS3BucketRequest {
         omClientResponse.getOMResponse().getStatus());
     Assert.assertEquals(OzoneManagerProtocolProtos.Type.CreateS3Bucket,
         omClientResponse.getOMResponse().getCmdType());
-
   }
 
+  @Test
+  public void testReplayRequest() throws Exception {
+
+    String userName = UUID.randomUUID().toString();
+    String s3BucketName = UUID.randomUUID().toString();
+
+    // Execute the original request
+    S3BucketCreateRequest s3BucketCreateRequest =
+        doPreExecute(userName, s3BucketName);
+    s3BucketCreateRequest.validateAndUpdateCache(ozoneManager, 2,
+         ozoneManagerDoubleBufferHelper);
+
+    // Replay the transaction - Execute the same request again
+    OMClientResponse omClientResponse =
+        s3BucketCreateRequest.validateAndUpdateCache(ozoneManager, 2,
+            ozoneManagerDoubleBufferHelper);
+
+    // Replay should result in Replay response
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.REPLAY,
+        omClientResponse.getOMResponse().getStatus());
+  }
 }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/bucket/TestS3BucketRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/bucket/TestS3BucketRequest.java
@@ -57,7 +57,6 @@ public class TestS3BucketRequest {
         return null;
       });
 
-
   @Before
   public void setup() throws Exception {
 
@@ -69,6 +68,7 @@ public class TestS3BucketRequest {
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration);
     when(ozoneManager.getMetrics()).thenReturn(omMetrics);
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
+    when(ozoneManager.isRatisEnabled()).thenReturn(true);
     auditLogger = Mockito.mock(AuditLogger.class);
     when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
     Mockito.doNothing().when(auditLogger).logWrite(any(AuditMessage.class));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestOMResponseUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestOMResponseUtils.java
@@ -73,7 +73,7 @@ public final class TestOMResponseUtils {
     OmBucketInfo omBucketInfo = TestOMResponseUtils.createBucket(
         volumeName, s3BucketName);
     OMBucketCreateResponse omBucketCreateResponse =
-        new OMBucketCreateResponse(omBucketInfo, omResponse);
+        new OMBucketCreateResponse(omResponse, omBucketInfo);
 
     String s3Mapping = S3BucketCreateRequest.formatS3MappingName(volumeName,
         s3BucketName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestOMResponseUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestOMResponseUtils.java
@@ -78,7 +78,7 @@ public final class TestOMResponseUtils {
     String s3Mapping = S3BucketCreateRequest.formatS3MappingName(volumeName,
         s3BucketName);
     return
-        new S3BucketCreateResponse(omVolumeCreateResponse,
-            omBucketCreateResponse, s3BucketName, s3Mapping, omResponse);
+        new S3BucketCreateResponse(omResponse, omVolumeCreateResponse,
+            omBucketCreateResponse, s3BucketName, s3Mapping);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/bucket/TestOMBucketCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/bucket/TestOMBucketCreateResponse.java
@@ -70,11 +70,12 @@ public class TestOMBucketCreateResponse {
     Assert.assertEquals(0,
         omMetadataManager.countRowsInTable(omMetadataManager.getBucketTable()));
     OMBucketCreateResponse omBucketCreateResponse =
-        new OMBucketCreateResponse(omBucketInfo, OMResponse.newBuilder()
+        new OMBucketCreateResponse(OMResponse.newBuilder()
             .setCmdType(OzoneManagerProtocolProtos.Type.CreateBucket)
             .setStatus(OzoneManagerProtocolProtos.Status.OK)
             .setCreateBucketResponse(
-                CreateBucketResponse.newBuilder().build()).build());
+                CreateBucketResponse.newBuilder().build()).build(),
+            omBucketInfo);
 
     omBucketCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/bucket/TestOMBucketDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/bucket/TestOMBucketDeleteResponse.java
@@ -70,19 +70,20 @@ public class TestOMBucketDeleteResponse {
     OmBucketInfo omBucketInfo = TestOMResponseUtils.createBucket(
         volumeName, bucketName);
     OMBucketCreateResponse omBucketCreateResponse =
-        new OMBucketCreateResponse(omBucketInfo, OMResponse.newBuilder()
+        new OMBucketCreateResponse(OMResponse.newBuilder()
             .setCmdType(OzoneManagerProtocolProtos.Type.CreateBucket)
             .setStatus(OzoneManagerProtocolProtos.Status.OK)
             .setCreateBucketResponse(
-                CreateBucketResponse.newBuilder().build()).build());
+                CreateBucketResponse.newBuilder().build()).build(),
+            omBucketInfo);
 
     OMBucketDeleteResponse omBucketDeleteResponse =
-        new OMBucketDeleteResponse(volumeName, bucketName,
-            OMResponse.newBuilder()
-                .setCmdType(OzoneManagerProtocolProtos.Type.DeleteBucket)
-                .setStatus(OzoneManagerProtocolProtos.Status.OK)
-                .setDeleteBucketResponse(
-                    DeleteBucketResponse.getDefaultInstance()).build());
+        new OMBucketDeleteResponse(OMResponse.newBuilder()
+            .setCmdType(OzoneManagerProtocolProtos.Type.DeleteBucket)
+            .setStatus(OzoneManagerProtocolProtos.Status.OK)
+            .setDeleteBucketResponse(
+                DeleteBucketResponse.getDefaultInstance()).build(),
+            volumeName, bucketName);
 
     omBucketCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
     omBucketDeleteResponse.addToDBBatch(omMetadataManager, batchOperation);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/bucket/TestOMBucketSetPropertyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/bucket/TestOMBucketSetPropertyResponse.java
@@ -69,11 +69,12 @@ public class TestOMBucketSetPropertyResponse {
     OmBucketInfo omBucketInfo = TestOMResponseUtils.createBucket(
         volumeName, bucketName);
     OMBucketSetPropertyResponse omBucketCreateResponse =
-        new OMBucketSetPropertyResponse(omBucketInfo, OMResponse.newBuilder()
+        new OMBucketSetPropertyResponse(OMResponse.newBuilder()
             .setCmdType(OzoneManagerProtocolProtos.Type.CreateBucket)
             .setStatus(OzoneManagerProtocolProtos.Status.OK)
             .setCreateBucketResponse(
-                CreateBucketResponse.newBuilder().build()).build());
+                CreateBucketResponse.newBuilder().build()).build(),
+            omBucketInfo);
 
     omBucketCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/bucket/TestS3BucketDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/bucket/TestS3BucketDeleteResponse.java
@@ -78,7 +78,7 @@ public class TestS3BucketDeleteResponse {
         .setDeleteS3BucketResponse(S3DeleteBucketResponse.newBuilder()).build();
 
     S3BucketDeleteResponse s3BucketDeleteResponse =
-        new S3BucketDeleteResponse(s3BucketName, volumeName, omResponse);
+        new S3BucketDeleteResponse(omResponse, s3BucketName, volumeName);
 
     s3BucketDeleteResponse.addToDBBatch(omMetadataManager, batchOperation);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This Jira has 2 objectives:
1. Add objectID and updateID to BucketInfo proto persisted to DB.
2. To ensure that bucket operations are idempotent, compare the transactionID with the objectID and updateID to make sure that the transaction is not a replay. If the transactionID <= updateID, then it implies that the transaction is a replay and hence it should be skipped.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2781

## How was this patch tested?

Will add unit tests in the another commit.
