### PR TITLE
HDDS-2786. ITestOzoneContractSeek zero byte file failures

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyInputStream.java
@@ -207,12 +207,12 @@ public class KeyInputStream extends InputStream implements Seekable {
   @Override
   public synchronized void seek(long pos) throws IOException {
     checkOpen();
+    if (pos == 0 && length == 0) {
+      // It is possible for length and pos to be zero in which case
+      // seek should return instead of throwing exception
+      return;
+    }
     if (pos < 0 || pos > length) {
-      if (pos == 0) {
-        // It is possible for length and pos to be zero in which case
-        // seek should return instead of throwing exception
-        return;
-      }
       throw new EOFException(
           "EOF encountered at pos: " + pos + " for key: " + key);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make `KeyInputStream#seek(0)` a no-op if the stream's length is also 0.  This is to fix Seek contract test (and restore the behavior stated in the comment.)

https://issues.apache.org/jira/browse/HDDS-2786

## How was this patch tested?

Ran related integration tests:

```
$ mvn -fn -am -pl :hadoop-ozone-integration-test,:hadoop-ozone-filesystem -Dtest='ITestOzoneContract*,TestKeyInputStream' clean test
...
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 32.508 s - in org.apache.hadoop.ozone.client.rpc.TestKeyInputStream
...
[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 32.2 s - in org.apache.hadoop.fs.ozone.contract.ITestOzoneContractGetFileStatus
[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 31.769 s - in org.apache.hadoop.fs.ozone.contract.ITestOzoneContractSeek
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 29.516 s - in org.apache.hadoop.fs.ozone.contract.ITestOzoneContractDelete
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 29.754 s - in org.apache.hadoop.fs.ozone.contract.ITestOzoneContractRootDir
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 31.006 s - in org.apache.hadoop.fs.ozone.contract.ITestOzoneContractMkdir
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 29.886 s - in org.apache.hadoop.fs.ozone.contract.ITestOzoneContractRename
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 43.292 s - in org.apache.hadoop.fs.ozone.contract.ITestOzoneContractDistCp
[WARNING] Tests run: 11, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 34.242 s - in org.apache.hadoop.fs.ozone.contract.ITestOzoneContractCreate
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 29.32 s - in org.apache.hadoop.fs.ozone.contract.ITestOzoneContractOpen
...
[INFO] BUILD SUCCESS
```

Also clean CI run in fork: https://github.com/adoroszlai/hadoop-ozone/runs/358541310