### PR TITLE
HDDS-2779. Fix list volume for --start parameter

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -299,9 +299,8 @@ public class ObjectStore {
 
     @Override
     public boolean hasNext() {
-      if(!currentIterator.hasNext()) {
-        currentIterator = getNextListOfVolumes(
-            currentValue != null ? currentValue.getName() : null)
+      if (!currentIterator.hasNext() && currentValue != null) {
+        currentIterator = getNextListOfVolumes(currentValue.getName())
             .iterator();
       }
       return currentIterator.hasNext();

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -299,6 +299,11 @@ public class ObjectStore {
 
     @Override
     public boolean hasNext() {
+      if(!currentIterator.hasNext()) {
+        currentIterator = getNextListOfVolumes(
+            currentValue != null ? currentValue.getName() : null)
+            .iterator();
+      }
       return currentIterator.hasNext();
     }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -282,6 +282,7 @@ public class ObjectStore {
 
     private Iterator<OzoneVolume> currentIterator;
     private OzoneVolume currentValue;
+    private OzoneVolume repeatedVolume;
 
     /**
      * Creates an Iterator to iterate over all volumes after
@@ -294,6 +295,7 @@ public class ObjectStore {
       this.user = user;
       this.volPrefix = volPrefix;
       this.currentValue = null;
+      this.repeatedVolume = getNextListOfVolumes(prevVolume).iterator().next();
       this.currentIterator = getNextListOfVolumes(prevVolume).iterator();
     }
 
@@ -303,7 +305,16 @@ public class ObjectStore {
         currentIterator = getNextListOfVolumes(
             currentValue != null ? currentValue.getName() : null)
             .iterator();
+
+        /* Cause getNextListOfVolumes never return empty-list,
+         * we should check whether the volume is fetched or not.
+         * */
+        if (currentIterator.hasNext() &&
+            currentIterator.next().equals(repeatedVolume)) {
+          return false;
+        }
       }
+
       return currentIterator.hasNext();
     }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -299,11 +299,6 @@ public class ObjectStore {
 
     @Override
     public boolean hasNext() {
-      if(!currentIterator.hasNext()) {
-        currentIterator = getNextListOfVolumes(
-            currentValue != null ? currentValue.getName() : null)
-            .iterator();
-      }
       return currentIterator.hasNext();
     }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -300,9 +300,12 @@ public class ObjectStore {
     @Override
     public boolean hasNext() {
       if(!currentIterator.hasNext()) {
-        currentIterator = getNextListOfVolumes(
-            currentValue != null ? currentValue.getName() : null)
-            .iterator();
+        if (currentValue != null) {
+          currentIterator = getNextListOfVolumes(currentValue.getName())
+              .iterator();
+        } else {
+          return false;
+        }
       }
       return currentIterator.hasNext();
     }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -282,7 +282,6 @@ public class ObjectStore {
 
     private Iterator<OzoneVolume> currentIterator;
     private OzoneVolume currentValue;
-    private OzoneVolume repeatedVolume;
 
     /**
      * Creates an Iterator to iterate over all volumes after
@@ -295,7 +294,6 @@ public class ObjectStore {
       this.user = user;
       this.volPrefix = volPrefix;
       this.currentValue = null;
-      this.repeatedVolume = getNextListOfVolumes(prevVolume).iterator().next();
       this.currentIterator = getNextListOfVolumes(prevVolume).iterator();
     }
 
@@ -305,16 +303,7 @@ public class ObjectStore {
         currentIterator = getNextListOfVolumes(
             currentValue != null ? currentValue.getName() : null)
             .iterator();
-
-        /* Cause getNextListOfVolumes never return empty-list,
-         * we should check whether the volume is fetched or not.
-         * */
-        if (currentIterator.hasNext() &&
-            currentIterator.next().equals(repeatedVolume)) {
-          return false;
-        }
       }
-
       return currentIterator.hasNext();
     }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -300,12 +300,9 @@ public class ObjectStore {
     @Override
     public boolean hasNext() {
       if(!currentIterator.hasNext()) {
-        if (currentValue != null) {
-          currentIterator = getNextListOfVolumes(currentValue.getName())
-              .iterator();
-        } else {
-          return false;
-        }
+        currentIterator = getNextListOfVolumes(
+            currentValue != null ? currentValue.getName() : null)
+            .iterator();
       }
       return currentIterator.hasNext();
     }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -290,11 +290,11 @@ public class ObjectStore {
      * @param user user name
      * @param volPrefix volume prefix to match
      */
-    VolumeIterator(String user, String volPrefix, String initVolume) {
+    VolumeIterator(String user, String volPrefix, String prevVolume) {
       this.user = user;
       this.volPrefix = volPrefix;
       this.currentValue = null;
-      this.currentIterator = getInitListOfVolumes(initVolume).iterator();
+      this.currentIterator = getNextListOfVolumes(prevVolume).iterator();
     }
 
     @Override
@@ -320,43 +320,20 @@ public class ObjectStore {
     }
 
     /**
-     * Returns the initial set of volume list using proxy.
-     * @return {@code List<OzoneVolume>}
-     */
-    private List<OzoneVolume> getInitListOfVolumes(String initVolume) {
-      try {
-        //if user is null, we do list of all volumes.
-        if(user != null) {
-          return proxy.listVolumes(user, volPrefix, initVolume, listCacheSize);
-        }
-        return proxy.listVolumes(volPrefix, initVolume, listCacheSize);
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    }
-
-    /**
      * Returns the next set of volume list using proxy.
      * @param prevVolume previous volume, this will be excluded from the result
      * @return {@code List<OzoneVolume>}
      */
     private List<OzoneVolume> getNextListOfVolumes(String prevVolume) {
-      List<OzoneVolume> volumeList;
       try {
         //if user is null, we do list of all volumes.
         if(user != null) {
-          volumeList = proxy
-              .listVolumes(user, volPrefix, prevVolume, listCacheSize);
-        } else {
-          volumeList = proxy
-              .listVolumes(volPrefix, prevVolume, listCacheSize);
+          return proxy.listVolumes(user, volPrefix, prevVolume, listCacheSize);
         }
+        return proxy.listVolumes(volPrefix, prevVolume, listCacheSize);
       } catch (IOException e) {
         throw new RuntimeException(e);
       }
-
-      volumeList.remove(0);
-      return  volumeList;
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -807,33 +807,30 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   @Override
   public List<OmVolumeArgs> listVolumes(String userName,
       String prefix, String startKey, int maxKeys) throws IOException {
-    List<OmVolumeArgs> result = Lists.newArrayList();
-    UserVolumeInfo volumes;
+
     if (StringUtil.isBlank(userName)) {
       throw new OMException("User name is required to list Volumes.",
           ResultCodes.USER_NOT_FOUND);
     }
-    volumes = getVolumesByUser(userName);
 
-    if (volumes == null || volumes.getVolumeNamesCount() == 0) {
-      return result;
+    final List<OmVolumeArgs> result = Lists.newArrayList();
+    final List<String> volumes = getVolumesByUser(userName)
+        .getVolumeNamesList();
+
+    int index = 0;
+    if (!Strings.isNullOrEmpty(startKey)) {
+      index = volumes.indexOf(
+          startKey.startsWith(OzoneConsts.OM_KEY_PREFIX) ?
+          startKey.substring(1) :
+          startKey);
     }
+    final String startChar = prefix == null ? "" : prefix;
 
-    boolean startKeyFound = Strings.isNullOrEmpty(startKey);
-    for (String volumeName : volumes.getVolumeNamesList()) {
-      if (!Strings.isNullOrEmpty(prefix)) {
-        if (!volumeName.startsWith(prefix)) {
-          continue;
-        }
-      }
-
-      if (!startKeyFound && volumeName.equals(startKey)) {
-        startKeyFound = true;
-        continue;
-      }
-      if (startKeyFound && result.size() < maxKeys) {
-        OmVolumeArgs volumeArgs =
-            getVolumeTable().get(this.getVolumeKey(volumeName));
+    while (index != -1 && index < volumes.size() && result.size() < maxKeys) {
+      final String volumeName = volumes.get(index);
+      if (volumeName.startsWith(startChar)) {
+        final OmVolumeArgs volumeArgs = getVolumeTable()
+            .get(getVolumeKey(volumeName));
         if (volumeArgs == null) {
           // Could not get volume info by given volume name,
           // since the volume name is loaded from db,
@@ -844,6 +841,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
         }
         result.add(volumeArgs);
       }
+      index++;
     }
 
     return result;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -815,34 +815,55 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
     }
     volumes = getVolumesByUser(userName);
 
-    if (volumes == null || volumes.getVolumeNamesCount() == 0) {
+    if (volumes.getVolumeNamesCount() == 0) {
       return result;
     }
 
+    /* Process listing volumes with startVolume. */
     boolean startKeyFound = Strings.isNullOrEmpty(startKey);
+    if (!startKeyFound) {
+      OmVolumeArgs startVolArgs = getVolumeTable()
+          .get(this.getVolumeKey(startKey));
+
+      if (startVolArgs == null) {
+        throw new OMException("StartVolume info not found for " + startKey,
+            ResultCodes.VOLUME_NOT_FOUND);
+      } else if (!startKey.startsWith(prefix)) {
+        throw new OMException("StartVolume " + startKey + " not found" +
+            " for prefix " + prefix, ResultCodes.VOLUME_NOT_FOUND);
+      }
+
+      result.add(startVolArgs);
+    }
+
+    OmVolumeArgs volumeArgs;
     for (String volumeName : volumes.getVolumeNamesList()) {
+
       if (!Strings.isNullOrEmpty(prefix)) {
         if (!volumeName.startsWith(prefix)) {
           continue;
         }
       }
 
+      volumeArgs = getVolumeTable().get(this.getVolumeKey(volumeName));
+      if (volumeArgs == null) {
+        // Could not get volume info by given volume name,
+        // since the volume name is loaded from db,
+        // this probably means om db is corrupted or some entries are
+        // accidentally removed.
+        throw new OMException("Volume info not found for " + volumeName,
+            ResultCodes.VOLUME_NOT_FOUND);
+      }
+
       if (!startKeyFound && volumeName.equals(startKey)) {
         startKeyFound = true;
         continue;
       }
-      if (startKeyFound && result.size() < maxKeys) {
-        OmVolumeArgs volumeArgs =
-            getVolumeTable().get(this.getVolumeKey(volumeName));
-        if (volumeArgs == null) {
-          // Could not get volume info by given volume name,
-          // since the volume name is loaded from db,
-          // this probably means om db is corrupted or some entries are
-          // accidentally removed.
-          throw new OMException("Volume info not found for " + volumeName,
-              ResultCodes.VOLUME_NOT_FOUND);
-        }
+
+      if (result.size() < maxKeys) {
         result.add(volumeArgs);
+      } else {
+        break;
       }
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -823,6 +823,9 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
           startKey.startsWith(OzoneConsts.OM_KEY_PREFIX) ?
           startKey.substring(1) :
           startKey);
+
+      // Exclude the startVolume as part of the result.
+      index = index != -1 ? index + 1 : index;
     }
     final String startChar = prefix == null ? "" : prefix;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/ListVolumeHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/ListVolumeHandler.java
@@ -51,7 +51,7 @@ public class ListVolumeHandler extends Handler {
   private int maxVolumes;
 
   @Option(names = {"--start", "-s"},
-      description = "The first volume to start the listing")
+      description = "The listing will start from volume after the startVolume")
   private String startVolume;
 
   @Option(names = {"--prefix", "-p"},

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/ListVolumeHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/ListVolumeHandler.java
@@ -51,7 +51,8 @@ public class ListVolumeHandler extends Handler {
   private int maxVolumes;
 
   @Option(names = {"--start", "-s"},
-      description = "The listing will start from volume after the startVolume")
+      description = "The volume to start the listing from.\n" +
+          "This will be excluded from the result.")
   private String startVolume;
 
   @Option(names = {"--prefix", "-p"},

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -55,6 +56,36 @@ public class TestOmMetadataManager {
         folder.getRoot().getAbsolutePath());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration);
   }
+
+  @Test
+  public void testListVolumes() throws Exception {
+    String ownerName = "owner";
+    OmVolumeArgs.Builder argsBuilder = OmVolumeArgs.newBuilder()
+        .setAdminName("admin")
+        .setOwnerName(ownerName);
+
+    String volName;
+    char postfix = 'a';
+    OmVolumeArgs omVolumeArgs;
+    for (int i = 0; i < 26; i++) {
+      volName = "vol" + (char)(postfix + i);
+      omVolumeArgs = argsBuilder
+          .setVolume(volName)
+          .build();
+
+      TestOMRequestUtils.addVolumeToOM(omMetadataManager, omVolumeArgs);
+      TestOMRequestUtils.addUserToDB(volName, ownerName, omMetadataManager);
+    }
+
+    // Test list volumes with setting startVolume.
+    String prefix = "";
+    String startVolume = "volz";
+    List<OmVolumeArgs> volumeList = omMetadataManager.listVolumes(ownerName,
+        prefix, startVolume, 100);
+    Assert.assertEquals(volumeList.get(0).getVolume(), startVolume);
+    Assert.assertEquals(volumeList.size(), 26);
+  }
+
   @Test
   public void testListBuckets() throws Exception {
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -65,10 +65,9 @@ public class TestOmMetadataManager {
         .setOwnerName(ownerName);
 
     String volName;
-    char postfix = 'a';
     OmVolumeArgs omVolumeArgs;
-    for (int i = 0; i < 26; i++) {
-      volName = "vol" + (char)(postfix + i);
+    for (int i = 0; i < 50; i++) {
+      volName = "vol" + i;
       omVolumeArgs = argsBuilder
           .setVolume(volName)
           .build();
@@ -79,11 +78,11 @@ public class TestOmMetadataManager {
 
     // Test list volumes with setting startVolume.
     String prefix = "";
-    String startVolume = "volz";
+    String startVolume = "vol25";
     List<OmVolumeArgs> volumeList = omMetadataManager.listVolumes(ownerName,
         prefix, startVolume, 100);
     Assert.assertEquals(volumeList.get(0).getVolume(), startVolume);
-    Assert.assertEquals(volumeList.size(), 26);
+    Assert.assertEquals(volumeList.size(), 25);
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -76,13 +76,17 @@ public class TestOmMetadataManager {
       TestOMRequestUtils.addUserToDB(volName, ownerName, omMetadataManager);
     }
 
-    // Test list volumes with setting startVolume.
+    // Test list volumes with setting startVolume that
+    // was not part of the result.
     String prefix = "";
-    String startVolume = "vol25";
+    int totalVol = omMetadataManager
+        .listVolumes(ownerName, prefix, null, 100)
+        .size();
+    int startOrder = 10;
+    String startVolume = "vol" + startOrder;
     List<OmVolumeArgs> volumeList = omMetadataManager.listVolumes(ownerName,
         prefix, startVolume, 100);
-    Assert.assertEquals(volumeList.get(0).getVolume(), startVolume);
-    Assert.assertEquals(volumeList.size(), 25);
+    Assert.assertEquals(volumeList.size(), totalVol - startOrder - 1);
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -302,13 +302,22 @@ public final class TestOMRequestUtils {
    */
   public static void addUserToDB(String volumeName, String ownerName,
       OMMetadataManager omMetadataManager) throws Exception {
-    OzoneManagerProtocolProtos.UserVolumeInfo userVolumeInfo =
-        OzoneManagerProtocolProtos.UserVolumeInfo
-            .newBuilder()
-            .addVolumeNames(volumeName)
-            .setObjectID(1)
-            .setUpdateID(1)
-            .build();
+
+    OzoneManagerProtocolProtos.UserVolumeInfo userVolumeInfo = omMetadataManager
+        .getUserTable().get(omMetadataManager.getUserKey(ownerName));
+    if (userVolumeInfo == null) {
+      userVolumeInfo = OzoneManagerProtocolProtos.UserVolumeInfo
+          .newBuilder()
+          .addVolumeNames(volumeName)
+          .setObjectID(1)
+          .setUpdateID(1)
+          .build();
+    } else {
+      userVolumeInfo = userVolumeInfo.toBuilder()
+          .addVolumeNames(volumeName)
+          .build();
+    }
+
     omMetadataManager.getUserTable().put(
         omMetadataManager.getUserKey(ownerName), userVolumeInfo);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR was created to let ```--start``` work well in listing volume.
(In command ```ozone sh vol list --start=<startVolume>```)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2779

## How was this patch tested?
1. UTs is updated, and ran.
2. Ran on standalone cluster.