### PR TITLE
HDDS-2504. Handle InterruptedException properly.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
@@ -134,7 +134,13 @@ public abstract class BackgroundService {
           if (LOG.isDebugEnabled()) {
             LOG.debug("task execution result size {}", result.getSize());
           }
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (InterruptedException e) {
+          LOG.warn(
+              "Background task failed due to interruption, retrying in " +
+                  "next interval", e);
+          // Re-interrupt the thread while catching InterruptedException
+          Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
           LOG.warn(
               "Background task fails to execute, "
                   + "retrying in next interval", e);
@@ -155,6 +161,8 @@ public abstract class BackgroundService {
         exec.shutdownNow();
       }
     } catch (InterruptedException e) {
+      // Re-interrupt the thread while catching InterruptedException
+      Thread.currentThread().interrupt();
       exec.shutdownNow();
     }
     if (threadGroup.activeCount() == 0 && !threadGroup.isDestroyed()) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/Scheduler.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/Scheduler.java
@@ -50,11 +50,11 @@ public class Scheduler {
   public Scheduler(String threadName, boolean isDaemon, int numCoreThreads) {
     scheduledExecutorService = Executors.newScheduledThreadPool(numCoreThreads,
         r -> {
-      Thread t = new Thread(r);
-      t.setName(threadName);
-      t.setDaemon(isDaemon);
-      return t;
-    });
+        Thread t = new Thread(r);
+        t.setName(threadName);
+        t.setDaemon(isDaemon);
+        return t;
+      });
     this.threadName = threadName;
     isClosed = false;
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/Scheduler.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/Scheduler.java
@@ -34,7 +34,7 @@ public class Scheduler {
   private static final Logger LOG =
       LoggerFactory.getLogger(Scheduler.class);
 
-  private ScheduledExecutorService scheduler;
+  private ScheduledExecutorService scheduledExecutorService;
 
   private volatile boolean isClosed;
 
@@ -48,7 +48,8 @@ public class Scheduler {
    * @param numCoreThreads - number of core threads to maintain in the scheduler
    */
   public Scheduler(String threadName, boolean isDaemon, int numCoreThreads) {
-    scheduler = Executors.newScheduledThreadPool(numCoreThreads, r -> {
+    scheduledExecutorService = Executors.newScheduledThreadPool(numCoreThreads,
+        r -> {
       Thread t = new Thread(r);
       t.setName(threadName);
       t.setDaemon(isDaemon);
@@ -59,12 +60,12 @@ public class Scheduler {
   }
 
   public void schedule(Runnable runnable, long delay, TimeUnit timeUnit) {
-    scheduler.schedule(runnable, delay, timeUnit);
+    scheduledExecutorService.schedule(runnable, delay, timeUnit);
   }
 
   public void schedule(CheckedRunnable runnable, long delay,
       TimeUnit timeUnit, Logger logger, String errMsg) {
-    scheduler.schedule(() -> {
+    scheduledExecutorService.schedule(() -> {
       try {
         runnable.run();
       } catch (Throwable throwable) {
@@ -75,7 +76,7 @@ public class Scheduler {
 
   public ScheduledFuture<?> scheduleWithFixedDelay(Runnable runnable,
       long initialDelay, long fixedDelay, TimeUnit timeUnit) {
-    return scheduler
+    return scheduledExecutorService
         .scheduleWithFixedDelay(runnable, initialDelay, fixedDelay, timeUnit);
   }
 
@@ -90,16 +91,18 @@ public class Scheduler {
    */
   public synchronized void close() {
     isClosed = true;
-    if (scheduler != null) {
-      scheduler.shutdownNow();
+    if (scheduledExecutorService != null) {
+      scheduledExecutorService.shutdownNow();
       try {
-        scheduler.awaitTermination(60, TimeUnit.SECONDS);
+        scheduledExecutorService.awaitTermination(60, TimeUnit.SECONDS);
       } catch (InterruptedException e) {
         LOG.info(
             threadName + " interrupted while waiting for task completion {}",
             e);
+        // Re-interrupt the thread while catching InterruptedException
+        Thread.currentThread().interrupt();
       }
     }
-    scheduler = null;
+    scheduledExecutorService = null;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/Scheduler.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/Scheduler.java
@@ -50,11 +50,11 @@ public class Scheduler {
   public Scheduler(String threadName, boolean isDaemon, int numCoreThreads) {
     scheduledExecutorService = Executors.newScheduledThreadPool(numCoreThreads,
         r -> {
-        Thread t = new Thread(r);
-        t.setName(threadName);
-        t.setDaemon(isDaemon);
-        return t;
-      });
+          Thread t = new Thread(r);
+          t.setName(threadName);
+          t.setDaemon(isDaemon);
+          return t;
+        });
     this.threadName = threadName;
     isClosed = false;
   }


### PR DESCRIPTION
HDDS-2557. Handle InterruptedException in CommitWatcher
HDDS-2558. Handle InterruptedException in XceiverClientSpi
HDDS-2559. Handle InterruptedException in BackgroundService
HDDS-2560. Handle InterruptedException in Scheduler

## What changes were proposed in this pull request?

Sonar lint fixes for CommitWatcher, XceiverClientSpi, BackgroundService and Scheduler

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2557
https://issues.apache.org/jira/browse/HDDS-2558
https://issues.apache.org/jira/browse/HDDS-2559
https://issues.apache.org/jira/browse/HDDS-2560

## How was this patch tested?

Compiles successfully without any errors in local.