### PR TITLE
HDDS-2737. Insight point should provide service type to get correct config

### DIFF
--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/ConfigurationSubCommand.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/ConfigurationSubCommand.java
@@ -52,20 +52,7 @@ public class ConfigurationSubCommand extends BaseInsightSubCommand
             + ")");
     System.out.println();
 
-    Type type;
-    switch (insightName.split("\\.")[0]) {
-    case "scm":
-      type = Type.SCM;
-      break;
-    case "om":
-      type = Type.OM;
-      break;
-    case "datanode":
-      type = Type.DATANODE;
-      break;
-    default:
-      throw new RuntimeException("No such component " + insightName);
-    }
+    Type type = Type.valueOf(insightName.split("\\.")[0].toUpperCase());
 
     for (Class clazz : insight.getConfigurationClasses()) {
       showConfig(clazz, type);

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/ConfigurationSubCommand.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/ConfigurationSubCommand.java
@@ -51,16 +51,31 @@ public class ConfigurationSubCommand extends BaseInsightSubCommand
         "Configuration for `" + insightName + "` (" + insight.getDescription()
             + ")");
     System.out.println();
-    for (Class clazz : insight.getConfigurationClasses()) {
-      showConfig(clazz);
 
+    Type type;
+    switch (insightName.split("\\.")[0]) {
+    case "scm":
+      type = Type.SCM;
+      break;
+    case "om":
+      type = Type.OM;
+      break;
+    case "datanode":
+      type = Type.DATANODE;
+      break;
+    default:
+      throw new RuntimeException("No such component " + insightName);
+    }
+
+    for (Class clazz : insight.getConfigurationClasses()) {
+      showConfig(clazz, type);
     }
     return null;
   }
 
-  private void showConfig(Class clazz) {
+  private void showConfig(Class clazz, Type type) {
     OzoneConfiguration conf = new OzoneConfiguration();
-    conf.addResource(getHost(conf, new Component(Type.SCM)) + "/conf");
+    conf.addResource(getHost(conf, new Component(type)) + "/conf");
     ConfigGroup configGroup =
         (ConfigGroup) clazz.getAnnotation(ConfigGroup.class);
     if (configGroup == null) {

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/ConfigurationSubCommand.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/ConfigurationSubCommand.java
@@ -53,7 +53,19 @@ public class ConfigurationSubCommand extends BaseInsightSubCommand
     System.out.println();
 
     Type type;
-    type = Type.valueOf(insightName.split("\\.")[0].toUpperCase());
+    switch (insightName.split("\\.")[0]) {
+    case "scm":
+      type = Type.SCM;
+      break;
+    case "om":
+      type = Type.OM;
+      break;
+    case "datanode":
+      type = Type.DATANODE;
+      break;
+    default:
+      throw new RuntimeException("No such component " + insightName);
+    }
 
     for (Class clazz : insight.getConfigurationClasses()) {
       showConfig(clazz, type);

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/ConfigurationSubCommand.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/ConfigurationSubCommand.java
@@ -53,19 +53,7 @@ public class ConfigurationSubCommand extends BaseInsightSubCommand
     System.out.println();
 
     Type type;
-    switch (insightName.split("\\.")[0]) {
-    case "scm":
-      type = Type.SCM;
-      break;
-    case "om":
-      type = Type.OM;
-      break;
-    case "datanode":
-      type = Type.DATANODE;
-      break;
-    default:
-      throw new RuntimeException("No such component " + insightName);
-    }
+    type = Type.valueOf(insightName.split("\\.")[0].toUpperCase());
 
     for (Class clazz : insight.getConfigurationClasses()) {
       showConfig(clazz, type);


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR was created for providing correct service type in command 
```ozone insight config [-hV] <insightName>``` to get correct config.

I split the ```insightName``` to get the service name, and set the correct component in ```showConfig(Class, Type)```.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2737

## How was this patch tested?
Build and compiled.
Ran on standalone cluster.