### PR TITLE
HDDS-2805. Fix sudo reset the environment variables about proxy

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/test.sh
@@ -27,8 +27,8 @@ execute_robot_test scm createmrenv.robot
 
 
 #rm is the container name (resource manager) and not the rm command
-execute_command_in_container rm sudo apk add --update py-pip
-execute_command_in_container rm sudo pip install robotframework
+execute_command_in_container rm sudo -E apk add --update py-pip
+execute_command_in_container rm sudo -E pip install robotframework
 
 # reinitialize the directories to use
 export OZONE_DIR=/opt/ozone

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/test.sh
@@ -24,7 +24,7 @@ source "$COMPOSE_DIR/../../testlib.sh"
 start_docker_env
 
 #rm is the container name (resource manager) and not the rm command
-execute_command_in_container rm bash -c "if test -e /sbin/apk; then sudo apk add --update py-pip; sudo pip install robotframework; fi"
+execute_command_in_container rm bash -c "if test -e /sbin/apk; then sudo -E apk add --update py-pip; sudo -E pip install robotframework; fi"
 
 execute_robot_test scm createmrenv.robot
 

--- a/hadoop-ozone/dist/src/main/smoketest/s3/commonawslib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/commonawslib.robot
@@ -39,10 +39,10 @@ Execute AWSS3Cli
     [return]          ${output}
 
 Install aws cli s3 centos
-    Execute            sudo yum install -y awscli
+    Execute            sudo -E yum install -y awscli
 
 Install aws cli s3 debian
-    Execute            sudo apt-get install -y awscli
+    Execute            sudo -E apt-get install -y awscli
 
 Setup v2 headers
                         Set Environment Variable   AWS_ACCESS_KEY_ID       ANYID


### PR DESCRIPTION
## What changes were proposed in this pull request?

How to reproduce the problem:

When run the  compose/ozone-mr/hadoop27/test.sh on computer which connect outer network by proxy, it fails to execute `sudo apk add --update py-pip` in docker container. Because `sudo` will reset all environment variables including the proxy, so it fails to download  http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz.

How to fix:

 By `sudo -E`, it will execute the command with the environment of the user, thus the proxy can be valid. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-2805

## How was this patch tested?

Execute  compose/ozone-mr/hadoop27/test.sh on computer which connect outer network by proxy .