### PR TITLE
HDDS-2813. Provide a ByteArrayCodec to CodecRegistry

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/ByteArrayCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/ByteArrayCodec.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.hadoop.hdds.utils.db;
+
+/**
+ * Codec to convert byte array to/from byte array.
+ */
+public class ByteArrayCodec implements Codec<byte[]> {
+
+  @Override
+  public byte[] toPersistedFormat(byte[] bytes) {
+    return bytes;
+  }
+
+    @Override
+  public byte[] fromPersistedFormat(byte[] bytes) {
+    return bytes;
+  }
+
+  @Override
+  public byte[] copyObject(byte[] bytes) {
+    return bytes;
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/ByteArrayCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/ByteArrayCodec.java
@@ -28,7 +28,7 @@ public class ByteArrayCodec implements Codec<byte[]> {
     return bytes;
   }
 
-    @Override
+  @Override
   public byte[] fromPersistedFormat(byte[] bytes) {
     return bytes;
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecRegistry.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/CodecRegistry.java
@@ -35,6 +35,7 @@ public class CodecRegistry {
     valueCodecs = new HashMap<>();
     valueCodecs.put(String.class, new StringCodec());
     valueCodecs.put(Long.class, new LongCodec());
+    valueCodecs.put(byte[].class, new ByteArrayCodec());
   }
 
   /**

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
@@ -374,7 +374,7 @@ public class TestTypedRDBTableStore {
 
   @Test
   public void testByteArrayTypedTable() throws Exception {
-    try (Table<byte[], byte[]> testTable = new TypedTable<> (
+    try (Table<byte[], byte[]> testTable = new TypedTable<>(
             rdbStore.getTable("Ten"),
             codecRegistry,
             byte[].class, byte[].class)) {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
@@ -57,7 +57,7 @@ public class TestTypedRDBTableStore {
           "First", "Second", "Third",
           "Fourth", "Fifth",
           "Sixth", "Seven", "Eighth",
-          "Ninth");
+          "Ninth", "Ten");
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
   private RDBStore rdbStore = null;
@@ -369,6 +369,24 @@ public class TestTypedRDBTableStore {
       long keyCount = testTable.getEstimatedKeyCount();
       // The result should be larger than zero but not exceed(?) numKeys
       Assert.assertTrue(keyCount > 0 && keyCount <= numKeys);
+    }
+  }
+
+  @Test
+  public void testByteArrayTypedTable() throws Exception {
+    try (Table<byte[], byte[]> testTable = new TypedTable<> (
+            rdbStore.getTable("Ten"),
+            codecRegistry,
+            byte[].class, byte[].class)) {
+      byte[] key = new byte[] {1, 2, 3};
+      byte[] value = new byte[] {4, 5, 6};
+      testTable.put(key, value);
+      byte[] actualValue = testTable.get(key);
+      Assert.assertArrayEquals(value, testTable.get(key));
+      Assert.assertNotSame(value, actualValue);
+      testTable.addCacheEntry(new CacheKey<>(key),
+              new CacheValue<>(Optional.of(value), 1L));
+      Assert.assertSame(value, testTable.get(key));
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

TypedTable as a special RDBTable, it should compatible with RDBTable, so byte[] should be support by default. In my case, i use TypedTable as a manager to manage my rocksdb, the key is byte[], the value is a structed class.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2813

## How was this patch tested?

The PR with a unit test inside.
