### PR TITLE
HDDS-2812. Fix low version wget cannot resolve the proxy of https

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-image/docker-krb5/Dockerfile-krb5
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-image/docker-krb5/Dockerfile-krb5
@@ -17,6 +17,7 @@
 
 FROM openjdk:8u191-jdk-alpine3.9
 # hadolint ignore=DL3018
+RUN apk add --no-cache --update wget
 RUN apk add --no-cache bash ca-certificates openssl krb5-server krb5 && rm -rf /var/cache/apk/* && update-ca-certificates
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64
 RUN chmod +x /usr/local/bin/dumb-init

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-image/docker-krb5/Dockerfile-krb5
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-image/docker-krb5/Dockerfile-krb5
@@ -16,6 +16,7 @@
 
 
 FROM openjdk:8u191-jdk-alpine3.9
+RUN apk add --no-cache --update wget
 RUN apk add --update bash ca-certificates openssl krb5-server krb5 && rm -rf /var/cache/apk/* && update-ca-certificates
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64
 RUN chmod +x /usr/local/bin/dumb-init


### PR DESCRIPTION
## What changes were proposed in this pull request?

How to reproduce the problem:
1. edit ~/.docker/config.json as follow image to connect outer network by proxy
![image](https://user-images.githubusercontent.com/51938049/71514081-09c25880-28d8-11ea-9f6f-2d1e378c36b7.png)


2. run compose/ozonesecure/test.sh and compose/ozonesecure-mr/test.sh, it fails to `wget https://github.com` as the image show. Because the version of wget in` openjdk:8u191-jdk-alpine3.9` is too low,  it cannot resolve the proxy of https.

` openjdk:8u191-jdk-alpine3.9` was used at https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-image/docker-krb5/Dockerfile-krb5#L18.

![image](https://user-images.githubusercontent.com/51938049/71474663-86413280-2817-11ea-9f22-a01c94cae59e.png)

How to fix:

Execute `apk add --no-cache --update wget` before `wget`.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2812

## How was this patch tested?

Execute compose/ozonesecure/test.sh and compose/ozonesecure-mr/test.sh with network proxy. Or test it in ` openjdk:8u191-jdk-alpine3.9` with network proxy as the image show:
1. Before `update wget`, execute `wget https://github.com`, it failed.
2. `update wget`
3. `wget https://github.com` again, it succeed.

![image](https://user-images.githubusercontent.com/51938049/71474873-8130b300-2818-11ea-814e-fd3ff9bce453.png)
