### PR TITLE
HDDS-2690. Improve the command usage of audit parser tool

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/audit/parser/AuditParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/audit/parser/AuditParser.java
@@ -42,7 +42,12 @@ public class AuditParser extends GenericCli {
   <.db file path> template <template name>
   <.db file path> query <custom sql>
    */
-  @Parameters(arity = "1..1", description = "Existing or new .db file")
+  @Parameters(arity = "1..1", description = "Existing or new .db file.\n" +
+      "The database contains only one table called audit defined as:\n" +
+      "audit (datetime text, level varchar(7), logger varchar(7), " +
+      "user text, ip text, op text, params text, result varchar(7), " +
+      "exception text, " +
+      "UNIQUE(datetime,level,logger,user,ip,op,params,result))")
   private String database;
 
   public static void main(String[] argv) throws Exception {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/audit/parser/handler/LoadCommandHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/audit/parser/handler/LoadCommandHandler.java
@@ -31,7 +31,9 @@ import picocli.CommandLine.ParentCommand;
  */
 @Command(name = "load",
     aliases = "l",
-    description = "Load ozone audit log files",
+    description = "Load ozone audit log files.\n\n" +
+        "To load an audit log to database:\n" +
+        "ozone auditparser <path to db file> load <logs>\n",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
 public class LoadCommandHandler implements Callable<Void> {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/audit/parser/handler/QueryCommandHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/audit/parser/handler/QueryCommandHandler.java
@@ -33,7 +33,9 @@ import picocli.CommandLine.ParentCommand;
  */
 @Command(name = "query",
     aliases = "q",
-    description = "Execute custom query",
+    description = "Execute custom query.\n\n" +
+        "To run a custom read-only query:\n" +
+        "ozone auditparser <path to db file> query <query>\n",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
 public class QueryCommandHandler implements Callable<Void> {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/audit/parser/handler/TemplateCommandHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/audit/parser/handler/TemplateCommandHandler.java
@@ -32,7 +32,14 @@ import picocli.CommandLine.ParentCommand;
  */
 @Command(name = "template",
     aliases = "t",
-    description = "Execute template query",
+    description = "Execute template query.\n\n" +
+        "To run a template query:\n" +
+        "ozone auditparser <path to db file> template <template>\n\n" +
+        "Following templates are available:\n" +
+        "(Template)              (Description)\n" +
+        "top5users              : Top 5 users.\n" +
+        "top5cmds               : Top 5 commands.\n" +
+        "top5activetimebyseconds: Top 5 active times, grouped by seconds.\n",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
 public class TemplateCommandHandler implements Callable<Void> {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR was created for improving the command usage of audit parser tool.

Fix 1. Show the structure of table ```audit``` to user.
Fix 2. Add the detailed description with ```<path to db file>``` to use the tool effectively.
Fix 3. Show the avaliable ```template``` to use the tool easily.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2690

## How was this patch tested?
Just UI changed. (UI shots were updated in [Jira](https://issues.apache.org/jira/browse/HDDS-2690
))
Build and compiled.
Ran on standalone cluster.