### PR TITLE
HDDS-2814. Fix fail to connect s3g in docker container with network proxy

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-hdfs/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-hdfs/docker-config
@@ -31,3 +31,5 @@ HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300
 
 #Enable this variable to print out all hadoop rpc traffic to the stdout. See http://byteman.jboss.org/ to define your own instrumentation.
 #BYTEMAN_SCRIPT_URL=https://raw.githubusercontent.com/apache/hadoop/trunk/dev-support/byteman/hadooprpc.btm
+
+no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/docker-config
@@ -16,3 +16,5 @@
 
 CORE-SITE.xml_fs.AbstractFileSystem.o3fs.impl=org.apache.hadoop.fs.ozone.BasicOzFs
 MAPRED-SITE.XML_mapreduce.application.classpath=/opt/hadoop/share/hadoop/mapreduce/*:/opt/hadoop/share/hadoop/mapreduce/lib/*:/opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-lib-legacy-@project.version@.jar
+
+no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/docker-config
@@ -16,3 +16,5 @@
 
 CORE-SITE.xml_fs.AbstractFileSystem.o3fs.impl=org.apache.hadoop.fs.ozone.OzFs
 MAPRED-SITE.XML_mapreduce.application.classpath=/opt/hadoop/share/hadoop/mapreduce/*:/opt/hadoop/share/hadoop/mapreduce/lib/*:/opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-lib-current-@project.version@.jar
+
+no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/docker-config
@@ -16,3 +16,5 @@
 
 CORE-SITE.xml_fs.AbstractFileSystem.o3fs.impl=org.apache.hadoop.fs.ozone.OzFs
 MAPRED-SITE.XML_mapreduce.application.classpath=/opt/hadoop/share/hadoop/mapreduce/*:/opt/hadoop/share/hadoop/mapreduce/lib/*:/opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-lib-current-@project.version@.jar
+
+no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha-s3/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha-s3/docker-config
@@ -31,3 +31,5 @@ OZONE-SITE.XML_ozone.scm.client.address=scm
 OZONE-SITE.XML_ozone.replication=3
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 OZONE-SITE.XML_hdds.profiler.endpoint.enabled=true
+
+no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-config
@@ -83,3 +83,5 @@ LOG4J2.PROPERTIES_logger.audit.appenderRef.file.ref=RollingFile
 LOG4J2.PROPERTIES_rootLogger.level=INFO
 LOG4J2.PROPERTIES_rootLogger.appenderRefs=stdout
 LOG4J2.PROPERTIES_rootLogger.appenderRef.stdout.ref=STDOUT
+
+no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-config
@@ -41,3 +41,5 @@ HDFS_SCM_CLI_OPTS=-Dmodule.name=scmcli
 
 #Enable this variable to print out all hadoop rpc traffic to the stdout. See http://byteman.jboss.org/ to define your own instrumentation.
 #BYTEMAN_SCRIPT_URL=https://raw.githubusercontent.com/apache/hadoop/trunk/dev-support/byteman/hadooprpc.btm
+
+no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-config
@@ -24,3 +24,5 @@ OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
 OZONE-SITE.XML_ozone.recon.om.db.dir=/data/metadata/recon
 OZONE-SITE.XML_ozone.scm.client.address=scm
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
+
+no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozoneblockade/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozoneblockade/docker-config
@@ -41,3 +41,5 @@ HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300
 
 #Enable this variable to print out all hadoop rpc traffic to the stdout. See http://byteman.jboss.org/ to define your own instrumentation.
 #BYTEMAN_SCRIPT_URL=https://raw.githubusercontent.com/apache/hadoop/trunk/dev-support/byteman/hadooprpc.btm
+
+no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozones3-haproxy/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozones3-haproxy/docker-config
@@ -28,3 +28,5 @@ HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300
 
 #Enable this variable to print out all hadoop rpc traffic to the stdout. See http://byteman.jboss.org/ to define your own instrumentation.
 #BYTEMAN_SCRIPT_URL=https://raw.githubusercontent.com/apache/hadoop/trunk/dev-support/byteman/hadooprpc.btm
+
+no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-config
@@ -32,3 +32,5 @@ HDFS-SITE.XML_dfs.namenode.name.dir=/data/namenode
 HDFS-SITE.XML_rpc.metrics.quantile.enable=true
 HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300
 HDFS-SITE.XML_dfs.datanode.plugins=org.apache.hadoop.ozone.HddsDatanodeService
+
+no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
@@ -130,3 +130,5 @@ JAVA_HOME=/usr/lib/jvm/jre
 JSVC_HOME=/usr/bin
 SLEEP_SECONDS=5
 KERBEROS_ENABLED=true
+
+no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -87,3 +87,5 @@ JAVA_HOME=/usr/lib/jvm/jre
 JSVC_HOME=/usr/bin
 SLEEP_SECONDS=5
 KERBEROS_ENABLED=true
+
+no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1


### PR DESCRIPTION
## What changes were proposed in this pull request?

How to reproduce the problem:

1. edit ~/.docker/config.json as follow image to connect outer network by proxy
![image](https://user-images.githubusercontent.com/51938049/71514027-db447d80-28d7-11ea-9f71-a6f1571f60cb.png)


2. run compose/ozones3-haproxy/test.sh, it fails to `curl http://scm:9876` as the image of log.html show. Because `curl` try to resolve http://scm:9876 by the network proxy, which caused fail.  Actually, http://scm:9876 is the local realm name used by the docker container which should not resolved by proxy.

![image](https://user-images.githubusercontent.com/51938049/71502925-d66ad400-28ad-11ea-85fd-b48d6d5b8402.png)

How to fix:

config `no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1` in docker-config

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2814

## How was this patch tested?

Execute compose/ozones3-haproxy/test.sh on computer which connect outer network by proxy . 
