### PR TITLE
HDDS-2819. Fix timeout threshold is too small to exit safemode when security enabled

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -40,8 +40,13 @@ wait_for_safemode_exit(){
   #Reset the timer
   SECONDS=0
 
-  #Don't give it up until 30 seconds
-  while [[ $SECONDS -lt 90 ]]; do
+  timeout_threshold=90
+  if [[ "${SECURITY_ENABLED}" == 'true' ]]; then
+     timeout_threshold=600
+  fi
+
+  #Don't give it up until timeout
+  while [[ $SECONDS -lt $timeout_threshold ]]; do
 
      #This line checks the safemode status in scm
      local command="ozone scmcli safemode status"


### PR DESCRIPTION
#137  What changes were proposed in this pull request?

How to reproduce the problem:

1.  When I run ozone-0.5.0-SNAPSHOT/compose/ozonesecure/test.sh on computer with 8 core 1999.971 Mhz, 16G memory, it always fail and report "Safemode is still on".

2. Then I enlarge the timeout threshold in testlib.sh from 90 seconds to 360 seconds, and record the time to exist safemode 10 times,  and the average time to exit safemode is about 160 seconds, and the maxum time is about 240 seconds. 
![image](https://user-images.githubusercontent.com/51938049/71552146-dabffa00-2a31-11ea-966b-f71a5243b35e.png)

![image](https://user-images.githubusercontent.com/51938049/71552149-e6abbc00-2a31-11ea-9049-3ab708683aca.png)

How to fix the problem:

Enlarge the timeout threshold to 600 seconds when security enabled.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2819

## How was this patch tested?

Run ozone-0.5.0-SNAPSHOT/compose/ozonesecure/test.sh on computer with 8 core 1999.971 Mhz, 16G memory.
