### PR TITLE
HDDS-2815. Fix shell description for --start parameter of listing buckets

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/ListBucketHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/ListBucketHandler.java
@@ -51,7 +51,7 @@ public class ListBucketHandler extends Handler {
   private int maxBuckets;
 
   @Option(names = {"--start", "-s"},
-      description = "The first bucket to start the listing")
+      description = "The listing will start from bucket after the startBucket.")
   private String startBucket;
 
   @Option(names = {"--prefix", "-p"},

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/ListBucketHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/bucket/ListBucketHandler.java
@@ -51,7 +51,8 @@ public class ListBucketHandler extends Handler {
   private int maxBuckets;
 
   @Option(names = {"--start", "-s"},
-      description = "The listing will start from bucket after the startBucket.")
+      description = "The bucket to start the listing from.\n" +
+          "This will be excluded from the result.")
   private String startBucket;
 
   @Option(names = {"--prefix", "-p"},


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR was created to let description of ```--start``` be consistent with older version in listing buckets.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2815

## How was this patch tested?
Just shell description updated.
Ran the CLI command on my standalone cluster.