### PR TITLE
HDDS-2820. OM Ratis dir creation may fail

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/ServerUtils.java
@@ -172,7 +172,7 @@ public final class ServerUtils {
 
     if (metadirs.size() == 1) {
       final File dbDirPath = new File(metadirs.iterator().next());
-      if (!dbDirPath.exists() && !dbDirPath.mkdirs()) {
+      if (!dbDirPath.mkdirs() && !dbDirPath.exists()) {
         throw new IllegalArgumentException("Unable to create directory " +
             dbDirPath + " specified in configuration setting " +
             key);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -447,7 +447,7 @@ public final class OmUtils {
 
   public static File createOMDir(String dirPath) {
     File dirFile = new File(dirPath);
-    if (!dirFile.exists() && !dirFile.mkdirs()) {
+    if (!dirFile.mkdirs() && !dirFile.exists()) {
       throw new IllegalArgumentException("Unable to create path: " + dirFile);
     }
     return dirFile;

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -34,7 +34,10 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Unit tests for {@link OmUtils}.
@@ -76,6 +79,38 @@ public class TestOmUtils {
       IOUtils.closeStream(fis);
       IOUtils.closeStream(fos);
     }
+  }
+
+  @Test
+  public void createOMDirCreatesDirectoryIfNecessary() throws IOException {
+    File parent = folder.newFolder();
+    File omDir = new File(new File(parent, "sub"), "dir");
+    assertFalse(omDir.exists());
+
+    OmUtils.createOMDir(omDir.getAbsolutePath());
+
+    assertTrue(omDir.exists());
+  }
+
+  @Test
+  public void createOMDirDoesNotThrowIfAlreadyExists() throws IOException {
+    File omDir = folder.newFolder();
+    assertTrue(omDir.exists());
+
+    OmUtils.createOMDir(omDir.getAbsolutePath());
+
+    assertTrue(omDir.exists());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void createOMDirThrowsIfCannotCreate() throws IOException {
+    File parent = folder.newFolder();
+    File omDir = new File(new File(parent, "sub"), "dir");
+    assumeTrue(parent.setWritable(false, false));
+
+    OmUtils.createOMDir(omDir.getAbsolutePath());
+
+    // expecting exception
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

It may happen that `exists()` returns `false` because the dir is does not exist yet, but `mkdirs()` also returns `false` because the dir is created in the meantime by the Ratis thread.  This PR proposes to swap the order of `exists` check and `mkdirs` call to avoid race condition.

https://issues.apache.org/jira/browse/HDDS-2820

## How was this patch tested?

Added unit test.

https://github.com/adoroszlai/hadoop-ozone/runs/366839202