### PR TITLE
HDDS-2834. Directly read into ByteBuffer if it has array

### DIFF
--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFSInputStream.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFSInputStream.java
@@ -116,7 +116,9 @@ public final class OzoneFSInputStream extends FSInputStream
     } else {
       byte[] readData = new byte[readLen];
       bytesRead = read(readData, 0, readLen);
-      buf.put(readData);
+      if (bytesRead > 0) {
+        buf.put(readData);
+      }
     }
 
     return bytesRead;

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFSInputStream.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFSInputStream.java
@@ -106,9 +106,18 @@ public final class OzoneFSInputStream extends FSInputStream
 
     int readLen = Math.min(buf.remaining(), available());
 
-    byte[] readData = new byte[readLen];
-    int bytesRead = read(readData, 0, readLen);
-    buf.put(readData);
+    int bytesRead;
+    if (buf.hasArray()) {
+      int pos = buf.position();
+      bytesRead = read(buf.array(), pos, readLen);
+      if (bytesRead > 0) {
+        buf.position(pos + bytesRead);
+      }
+    } else {
+      byte[] readData = new byte[readLen];
+      bytesRead = read(readData, 0, readLen);
+      buf.put(readData);
+    }
 
     return bytesRead;
   }

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
@@ -15,11 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.fs.ozone.contract;
+package org.apache.hadoop.fs.ozone;
 
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.ozone.OzoneFSInputStream;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -31,11 +30,10 @@ import java.util.Arrays;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
-// TODO rename to TestOzoneFSInputStream after HDDS-2785
 /**
  * Tests for {@link OzoneFSInputStream}.
  */
-public class TestOzoneFSInputStreamUnit {
+public class TestOzoneFSInputStream {
 
   @Test
   public void readToByteBuffer() throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Use target `ByteBuffer`'s array, if it has one, to avoid buffer copy in `OzoneFSInputStream`.
 * Skip `ByteBuffer#put` on EOF (see similar logic in `CryptoInputStream`).
 * Rename `TestOzoneFSInputStreamUnit` to `TestOzoneFSInputStream` since integration test with same name was moved out to `integration-test`.  Also move it to the correct package (where `OzoneFSInputStream` resides).

https://issues.apache.org/jira/browse/HDDS-2834

## How was this patch tested?

Tweaked unit test to exercise the `read` method with both heap and direct buffers.

https://github.com/adoroszlai/hadoop-ozone/runs/377273986