### PR TITLE
HDDS-2851. Some OM Ratis config properties missing from ozone-default.xml

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1600,6 +1600,15 @@
   </property>
 
   <property>
+    <name>ozone.om.ratis.segment.preallocated.size</name>
+    <value>16KB</value>
+    <tag>OZONE, OM, RATIS, PERFORMANCE</tag>
+    <description>The size of the buffer which is preallocated for raft segment
+      used by Apache Ratis on OM.(16 KB by default)
+    </description>
+  </property>
+
+  <property>
     <name>ozone.om.ratis.log.appender.queue.num-elements</name>
     <value>1024</value>
     <tag>OZONE, DEBUG, OM, RATIS</tag>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -154,13 +154,6 @@ public final class OMConfigKeys {
   public static final TimeDuration OZONE_OM_RATIS_MINIMUM_TIMEOUT_DEFAULT
       = TimeDuration.valueOf(1, TimeUnit.SECONDS);
 
-  // OM Ratis client configurations
-  public static final String OZONE_OM_RATIS_CLIENT_REQUEST_TIMEOUT_DURATION_KEY
-      = "ozone.om.ratis.client.request.timeout.duration";
-  public static final TimeDuration
-      OZONE_OM_RATIS_CLIENT_REQUEST_TIMEOUT_DURATION_DEFAULT
-      = TimeDuration.valueOf(3000, TimeUnit.MILLISECONDS);
-
   // OM Ratis Leader Election configurations
   public static final String
       OZONE_OM_LEADER_ELECTION_MINIMUM_TIMEOUT_DURATION_KEY =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -54,7 +54,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.ratis.RaftConfigKeys;
-import org.apache.ratis.client.RaftClientConfigKeys;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.grpc.GrpcConfigKeys;
 import org.apache.ratis.netty.NettyConfigKeys;
@@ -475,18 +474,6 @@ public final class OzoneManagerRatisServer {
 
     // Set the number of maximum cached segments
     RaftServerConfigKeys.Log.setMaxCachedSegmentNum(properties, 2);
-
-    // Set the client request timeout
-    TimeUnit clientRequestTimeoutUnit = OMConfigKeys
-        .OZONE_OM_RATIS_CLIENT_REQUEST_TIMEOUT_DURATION_DEFAULT .getUnit();
-    long clientRequestTimeoutDuration = conf.getTimeDuration(
-        OMConfigKeys.OZONE_OM_RATIS_CLIENT_REQUEST_TIMEOUT_DURATION_KEY,
-        OMConfigKeys.OZONE_OM_RATIS_CLIENT_REQUEST_TIMEOUT_DURATION_DEFAULT
-            .getDuration(), clientRequestTimeoutUnit);
-    final TimeDuration clientRequestTimeout = TimeDuration.valueOf(
-        clientRequestTimeoutDuration, clientRequestTimeoutUnit);
-    RaftClientConfigKeys.Rpc.setRequestTimeout(properties,
-        clientRequestTimeout);
 
     // TODO: set max write buffer size
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removed this ozone.om.ratis.client.request.timeout.duration, as OM ratis client is removed as part of HDDS-1991

ozone.om.ratis.segment.preallocated.size is still needed, added it back. This is the OM Ratis Server configuration.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2851

## How was this patch tested?

UT and IT should cover this change, as this caused TestOzoneConfigurationFields which is failing, now it is passed with this PR. 
