### PR TITLE
HDDS-2113 Update JMX metrics for node count in SCMNodeMetrics for Decommission and Maintenance

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManagerMXBean.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManagerMXBean.java
@@ -34,7 +34,7 @@ public interface NodeManagerMXBean {
    *
    * @return A state to number of nodes that in this state mapping
    */
-  Map<String, Integer> getNodeCount();
+  Map<String, Map<String, Integer>> getNodeCount();
 
   /**
    * Get the disk metrics like capacity, usage and remaining based on the

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeMetrics.java
@@ -18,15 +18,12 @@
 
 package org.apache.hadoop.hdds.scm.node;
 
-import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.DEAD;
-import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY;
-import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.STALE;
-
 import java.util.Map;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsInfo;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.metrics2.MetricsSource;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
@@ -36,6 +33,7 @@ import org.apache.hadoop.metrics2.lib.Interns;
 import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.util.StringUtils;
 
 /**
  * This class maintains Node related metrics.
@@ -51,6 +49,7 @@ public final class SCMNodeMetrics implements MetricsSource {
   private @Metric MutableCounterLong numHBProcessingFailed;
   private @Metric MutableCounterLong numNodeReportProcessed;
   private @Metric MutableCounterLong numNodeReportProcessingFailed;
+  private @Metric String textMetric;
 
   private final MetricsRegistry registry;
   private final NodeManagerMXBean managerMXBean;
@@ -61,6 +60,7 @@ public final class SCMNodeMetrics implements MetricsSource {
   private SCMNodeMetrics(NodeManagerMXBean managerMXBean) {
     this.managerMXBean = managerMXBean;
     this.registry = new MetricsRegistry(recordInfo);
+    this.textMetric = "my_test_metric";
   }
 
   /**
@@ -116,39 +116,48 @@ public final class SCMNodeMetrics implements MetricsSource {
   @Override
   @SuppressWarnings("SuspiciousMethodCalls")
   public void getMetrics(MetricsCollector collector, boolean all) {
-    Map<String, Integer> nodeCount = managerMXBean.getNodeCount();
+    Map<String, Map<String, Integer>> nodeCount = managerMXBean.getNodeCount();
     Map<String, Long> nodeInfo = managerMXBean.getNodeInfo();
 
-    registry.snapshot(
-        collector.addRecord(registry.info()) // Add annotated ones first
-            .addGauge(Interns.info(
-                "HealthyNodes",
-                "Number of healthy datanodes"),
-                nodeCount.get(HEALTHY.toString()))
-            .addGauge(Interns.info("StaleNodes",
-                "Number of stale datanodes"),
-                nodeCount.get(STALE.toString()))
-            .addGauge(Interns.info("DeadNodes",
-                "Number of dead datanodes"),
-                nodeCount.get(DEAD.toString()))
-            .addGauge(Interns.info("DiskCapacity",
-                "Total disk capacity"),
-                nodeInfo.get("DISKCapacity"))
-            .addGauge(Interns.info("DiskUsed",
-                "Total disk capacity used"),
-                nodeInfo.get("DISKUsed"))
-            .addGauge(Interns.info("DiskRemaining",
-                "Total disk capacity remaining"),
-                nodeInfo.get("DISKRemaining"))
-            .addGauge(Interns.info("SSDCapacity",
-                "Total ssd capacity"),
-                nodeInfo.get("SSDCapacity"))
-            .addGauge(Interns.info("SSDUsed",
-                "Total ssd capacity used"),
-                nodeInfo.get("SSDUsed"))
-            .addGauge(Interns.info("SSDRemaining",
-                "Total disk capacity remaining"),
-                nodeInfo.get("SSDRemaining")),
+    /**
+     * Loop over the Node map and create a metric for the cross product of all
+     * Operational and health states, ie:
+     *     InServiceHealthy
+     *     InServiceStale
+     *     ...
+     *     EnteringMaintenanceHealthy
+     *     ...
+     */
+    MetricsRecordBuilder metrics = collector.addRecord(registry.info());
+    for(Map.Entry<String, Map<String, Integer>> e : nodeCount.entrySet()) {
+      for(Map.Entry<String, Integer> h : e.getValue().entrySet()) {
+        metrics.addGauge(
+            Interns.info(
+                StringUtils.camelize(e.getKey()+"_"+h.getKey()+"_nodes"),
+                "Number of "+e.getKey()+" "+h.getKey()+" datanodes"),
+            h.getValue());
+      }
+    }
+
+    registry.snapshot(metrics
+        .addGauge(Interns.info("DiskCapacity",
+            "Total disk capacity"),
+            nodeInfo.get("DISKCapacity"))
+        .addGauge(Interns.info("DiskUsed",
+            "Total disk capacity used"),
+            nodeInfo.get("DISKUsed"))
+        .addGauge(Interns.info("DiskRemaining",
+            "Total disk capacity remaining"),
+            nodeInfo.get("DISKRemaining"))
+        .addGauge(Interns.info("SSDCapacity",
+            "Total ssd capacity"),
+            nodeInfo.get("SSDCapacity"))
+        .addGauge(Interns.info("SSDUsed",
+            "Total ssd capacity used"),
+            nodeInfo.get("SSDUsed"))
+        .addGauge(Interns.info("SSDRemaining",
+            "Total disk capacity remaining"),
+            nodeInfo.get("SSDRemaining")),
         all);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdds.scm.node.states.Node2PipelineMap;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.NodeReportProto;
 import org.apache.hadoop.hdds.protocol.proto
@@ -471,12 +472,23 @@ public class MockNodeManager implements NodeManager {
   }
 
   @Override
-  public Map<String, Integer> getNodeCount() {
-    Map<String, Integer> nodeCountMap = new HashMap<String, Integer>();
-    for (HddsProtos.NodeState state : HddsProtos.NodeState.values()) {
-      nodeCountMap.put(state.toString(), getNodeCount(null, state));
+  public Map<String, Map<String, Integer>> getNodeCount() {
+    Map<String, Map<String, Integer>> nodes = new HashMap<>();
+    for (NodeOperationalState opState : NodeOperationalState.values()) {
+      Map<String, Integer> states = new HashMap<>();
+      for (HddsProtos.NodeState health : HddsProtos.NodeState.values()) {
+        states.put(health.name(), 0);
+      }
+      nodes.put(opState.name(), states);
     }
-    return nodeCountMap;
+    // At the moment MockNodeManager is not aware of decommission and
+    // maintenance states, therefore loop over all nodes and assume all nodes
+    // are IN_SERVICE. This will be fixed as part of HDDS-2673
+    for (HddsProtos.NodeState state : HddsProtos.NodeState.values()) {
+      nodes.get(NodeOperationalState.IN_SERVICE.name())
+          .compute(state.name(), (k, v) -> v + 1);
+    }
+    return nodes;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -243,7 +243,7 @@ public class SimpleMockNodeManager implements NodeManager {
   }
 
   @Override
-  public Map<String, Integer> getNodeCount() {
+  public Map<String, Map<String, Integer>> getNodeCount() {
     return null;
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -53,6 +53,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
@@ -240,6 +241,11 @@ public class TestSCMNodeManager {
       Thread.sleep(4 * 1000);
       assertEquals(count, nodeManager.getNodeCount(
           NodeStatus.inServiceHealthy()));
+
+      Map<String, Map<String, Integer>> nodeCounts = nodeManager.getNodeCount();
+      assertEquals(count,
+          nodeCounts.get(HddsProtos.NodeOperationalState.IN_SERVICE.name())
+              .get(HddsProtos.NodeState.HEALTHY.name()).intValue());
     }
   }
 
@@ -323,6 +329,11 @@ public class TestSCMNodeManager {
           .getUuid(), staleNodeList.get(0).getUuid());
       Thread.sleep(1000);
 
+      Map<String, Map<String, Integer>> nodeCounts = nodeManager.getNodeCount();
+      assertEquals(1,
+          nodeCounts.get(HddsProtos.NodeOperationalState.IN_SERVICE.name())
+              .get(HddsProtos.NodeState.STALE.name()).intValue());
+
       // heartbeat good nodes again.
       for (DatanodeDetails dn : nodeList) {
         nodeManager.processHeartbeat(dn);
@@ -334,10 +345,14 @@ public class TestSCMNodeManager {
 
       // the stale node has been removed
       staleNodeList = nodeManager.getNodes(NodeStatus.inServiceStale());
+      nodeCounts = nodeManager.getNodeCount();
       assertEquals("Expected to find 1 stale node",
           0, nodeManager.getNodeCount(NodeStatus.inServiceStale()));
       assertEquals("Expected to find 1 stale node",
           0, staleNodeList.size());
+      assertEquals(0,
+          nodeCounts.get(HddsProtos.NodeOperationalState.IN_SERVICE.name())
+              .get(HddsProtos.NodeState.STALE.name()).intValue());
 
       // Check for the dead node now.
       List<DatanodeDetails> deadNodeList =
@@ -346,6 +361,9 @@ public class TestSCMNodeManager {
           nodeManager.getNodeCount(NodeStatus.inServiceDead()));
       assertEquals("Expected to find 1 dead node",
           1, deadNodeList.size());
+      assertEquals(1,
+          nodeCounts.get(HddsProtos.NodeOperationalState.IN_SERVICE.name())
+              .get(HddsProtos.NodeState.DEAD.name()).intValue());
       assertEquals("Dead node is not the expected ID", staleNode
           .getUuid(), deadNodeList.get(0).getUuid());
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
@@ -72,7 +72,7 @@ public class ReplicationNodeManagerMock implements NodeManager {
    * @return A state to number of nodes that in this state mapping
    */
   @Override
-  public Map<String, Integer> getNodeCount() {
+  public Map<String, Map<String, Integer>> getNodeCount() {
     return null;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMNodeManagerMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMNodeManagerMXBean.java
@@ -92,10 +92,32 @@ public class TestSCMNodeManagerMXBean {
             + "name=SCMNodeManagerInfo");
 
     TabularData data = (TabularData) mbs.getAttribute(bean, "NodeCount");
-    Map<String, Integer> nodeCount = scm.getScmNodeManager().getNodeCount();
-    Map<String, Long> nodeCountLong = new HashMap<>();
-    nodeCount.forEach((k, v) -> nodeCountLong.put(k, new Long(v)));
-    verifyEquals(data, nodeCountLong);
+    Map<String, Map<String, Integer>> mbeanMap = convertNodeCountToMap(data);
+    Map<String, Map<String, Integer>> nodeMap =
+        scm.getScmNodeManager().getNodeCount();
+    assertTrue(nodeMap.equals(mbeanMap));
+  }
+
+  private Map<String, Map<String, Integer>> convertNodeCountToMap(
+      TabularData data) {
+    Map<String, Map<String, Integer>> map = new HashMap<>();
+    for (Object o : data.values()) {
+      CompositeData cds = (CompositeData) o;
+      Iterator<?> it = cds.values().iterator();
+      String opState = it.next().toString();
+      TabularData states = (TabularData) it.next();
+
+      Map<String, Integer> healthStates = new HashMap<>();
+      for (Object obj : states.values()) {
+        CompositeData stateData = (CompositeData) obj;
+        Iterator<?> stateIt = stateData.values().iterator();
+        String health = stateIt.next().toString();
+        Integer value = Integer.parseInt(stateIt.next().toString());
+        healthStates.put(health, value);
+      }
+      map.put(opState, healthStates);
+    }
+    return map;
   }
 
   private void verifyEquals(TabularData actualData, Map<String, Long>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestSCMNodeMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestSCMNodeMetrics.java
@@ -146,11 +146,35 @@ public class TestSCMNodeMetrics {
     cluster.getStorageContainerManager().getScmNodeManager()
         .processNodeReport(datanode.getDatanodeDetails(), nodeReport);
 
-    assertGauge("HealthyNodes", 1,
+    assertGauge("InServiceHealthyNodes", 1,
         getMetrics(SCMNodeMetrics.class.getSimpleName()));
-    assertGauge("StaleNodes", 0,
+    assertGauge("InServiceStaleNodes", 0,
         getMetrics(SCMNodeMetrics.class.getSimpleName()));
-    assertGauge("DeadNodes", 0,
+    assertGauge("InServiceDeadNodes", 0,
+        getMetrics(SCMNodeMetrics.class.getSimpleName()));
+    assertGauge("DecommissioningHealthyNodes", 0,
+        getMetrics(SCMNodeMetrics.class.getSimpleName()));
+    assertGauge("DecommissioningStaleNodes", 0,
+        getMetrics(SCMNodeMetrics.class.getSimpleName()));
+    assertGauge("DecommissioningDeadNodes", 0,
+        getMetrics(SCMNodeMetrics.class.getSimpleName()));
+    assertGauge("DecommissionedHealthyNodes", 0,
+        getMetrics(SCMNodeMetrics.class.getSimpleName()));
+    assertGauge("DecommissionedStaleNodes", 0,
+        getMetrics(SCMNodeMetrics.class.getSimpleName()));
+    assertGauge("DecommissionedDeadNodes", 0,
+        getMetrics(SCMNodeMetrics.class.getSimpleName()));
+    assertGauge("EnteringMaintenanceHealthyNodes", 0,
+        getMetrics(SCMNodeMetrics.class.getSimpleName()));
+    assertGauge("EnteringMaintenanceStaleNodes", 0,
+        getMetrics(SCMNodeMetrics.class.getSimpleName()));
+    assertGauge("EnteringMaintenanceDeadNodes", 0,
+        getMetrics(SCMNodeMetrics.class.getSimpleName()));
+    assertGauge("InMaintenanceHealthyNodes", 0,
+        getMetrics(SCMNodeMetrics.class.getSimpleName()));
+    assertGauge("InMaintenanceStaleNodes", 0,
+        getMetrics(SCMNodeMetrics.class.getSimpleName()));
+    assertGauge("InMaintenanceDeadNodes", 0,
         getMetrics(SCMNodeMetrics.class.getSimpleName()));
     assertGauge("DiskCapacity", 100L,
         getMetrics(SCMNodeMetrics.class.getSimpleName()));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Prior to decommission, the count of nodes registed with SCM is report by JMX in 3 buckets, giving the count of healthy, stale and dead nodes. Under JMX this data appears in two places:

1. Under the JMX key "Hadoop:service=StorageContainerManager,name=SCMNodeMetrics" using Hadoop Metrics. This is also exposed in the /prom end point.

2. Under the JMX key "Hadoop:service=SCMNodeManager,name=SCMNodeManagerInfo" using plain JMX

For (1) the metrics are called HealthyNodes, StaleNodes and DeadNodes. This is an example of the data:

```
  "name" : "Hadoop:service=StorageContainerManager,name=SCMNodeMetrics",
    "modelerType" : "SCMNodeMetrics",
    "tag.Context" : "ozone",
    "tag.Hostname" : "84de7434ed9e",
    "HealthyNodes" : 1,
    "StaleNodes" : 0,
    "DeadNodes" : 0,

```
For (2) the metrics are simply the state name: HEALTHY, STALE and DEAD, eg:
```
    "name" : "Hadoop:service=SCMNodeManager,name=SCMNodeManagerInfo",
    "modelerType" : "org.apache.hadoop.hdds.scm.node.SCMNodeManager",
    "NodeCount" : [ {
      "key" : "STALE",
      "value" : 0
    }, {
      "key" : "HEALTHY",
      "value" : 1
    }, {
      "key" : "DEAD",
      "value" : 0
    } ],
```

In this Jira, in order to support decommission states, I propose we do the following:

For (1) have a top level metric for the cross product of each health and operational state, ie:

* InServiceHealthy
* InServiceStale
* ...
* DecommissioningHealthy
* ...
* InMaintenanceDead

On the /prom endpoint, these metrics will appear like:

```
scm_node_manager_in_service_healthy_nodes
...
scm_node_manager_decommissioning_dead_nodes
...
```
For (2), as it is plain JMX, we can adopt a nested structure:
```
IN_SERVICE => {
  HEALTHY: 0
  STALE: 0
  DEAD: 0
}
DECOMMISSIONING => {
...
}
```
After making this change, the same sampled data looks like:

```
   "name" : "Hadoop:service=StorageContainerManager,name=SCMNodeMetrics",
    "modelerType" : "SCMNodeMetrics",
    "tag.Context" : "ozone",
    "tag.Hostname" : "4d4c52ca0908",
    "InMaintenanceStale" : 0,
    "InMaintenanceHealthy" : 0,
    "InMaintenanceDead" : 0,
    "InServiceStale" : 0,
    "InServiceHealthy" : 1,
    "InServiceDead" : 0,
    "DecommissioningStale" : 0,
    "DecommissioningHealthy" : 0,
    "DecommissioningDead" : 0,
    "DecommissionedStale" : 0,
    "DecommissionedHealthy" : 0,
    "DecommissionedDead" : 0,
    "EnteringMaintenanceStale" : 0,
    "EnteringMaintenanceHealthy" : 0,
    "EnteringMaintenanceDead" : 0,
```
And for (2):
```
"NodeCount" : [ {
      "key" : "IN_MAINTENANCE",
      "value" : [ {
        "key" : "STALE",
        "value" : 0
      }, {
        "key" : "HEALTHY",
        "value" : 0
      }, {
        "key" : "DEAD",
        "value" : 0
	} ]
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2113

## How was this patch tested?

This change was tested by modifying existing unit tests and also check the /jmx and /prom endpoint data in SCM.