### PR TITLE
HDDS-2861. Support Freon progressbar in non-interactive environment

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ProgressBar.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ProgressBar.java
@@ -55,12 +55,24 @@ public class ProgressBar {
    */
   public ProgressBar(final PrintStream stream, final long maxValue,
                      final LongSupplier currentValue) {
+    this(stream, maxValue, currentValue, System.console() != null);
+  }
+
+  /**
+   * Creates a new ProgressBar instance which prints the progress on the given
+   * PrintStream when started.
+   *
+   * @param stream       to display the progress
+   * @param maxValue     Maximum value of the progress
+   * @param currentValue Supplier that provides the current value
+   * @param interactive  Print progressbar for interactive environments.
+   */
+  public ProgressBar(final PrintStream stream, final long maxValue,
+      final LongSupplier currentValue, boolean interactive) {
     this.maxValue = maxValue;
     this.currentValue = currentValue;
     this.thread = new Thread(getProgressBar(stream));
-    this.running = false;
-    //This is a shell session if PS1 has been set.
-    this.interactive = System.console() != null;
+    this.interactive = interactive;
   }
 
   /**
@@ -115,11 +127,7 @@ public class ProgressBar {
       while (running && currentValue.getAsLong() < maxValue) {
         print(stream, currentValue.getAsLong());
         try {
-          if (interactive) {
-            Thread.sleep(1000L);
-          } else {
-            Thread.sleep(10000L);
-          }
+          Thread.sleep(1000L);
         } catch (InterruptedException e) {
           LOG.warn("ProgressBar was interrupted.");
           Thread.currentThread().interrupt();

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestProgressBar.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestProgressBar.java
@@ -50,7 +50,8 @@ public class TestProgressBar {
 
     long maxValue = 10L;
 
-    ProgressBar progressbar = new ProgressBar(stream, maxValue, currentValue);
+    ProgressBar progressbar =
+        new ProgressBar(stream, maxValue, currentValue, true);
 
     Runnable task = () -> LongStream.range(0, maxValue)
         .forEach(counter -> numberOfKeysAdded.getAndIncrement());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Freon tests use the `ProgressBar` to show the current progress of the Freon tests.

Progress bar use `\r` to print out a nice, interactive progress bar to the same line.

Unfortunately this doesn't work very well when the standard output is redirected to a file (or in a containerized environment). I would suggest to use a simplified method using log4j in non-interactive environments.

The easiest way to do is to use `System.console()` java method. If it returns with null we are in a non interactive environment. We can also increase the logging period from 1s to 10s in case of non-interactive environment (==long term testing).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2861

## How was this patch tested?

```
cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozone
export OZONE_REPLICATION_FACTOR=3
./run.sh -d
```

Interactive (expected output is the one line progress bar as earlier):

```
docker-compose exec scm bash
ozone freon ockg -n 10
```

Non-interactive (expected output is a log4j based testing):

```
export COMPOSE_FILE=docker-compose.yaml:freon-ockg.yaml
./run.sh -d
docker-compose logs freon
```
