### PR TITLE
HDDS-2863. BindException in TestSCMRestart

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -164,7 +164,7 @@ public class SCMDatanodeProtocolServer implements
 
     datanodeRpcAddress =
         updateRPCListenAddress(
-            conf, OZONE_SCM_DATANODE_ADDRESS_KEY, datanodeRpcAddr,
+            conf, getScmDatanodeAddressKey(), datanodeRpcAddr,
             datanodeRpcServer);
 
     if (conf.getBoolean(CommonConfigurationKeys.HADOOP_SECURITY_AUTHORIZATION,
@@ -405,6 +405,10 @@ public class SCMDatanodeProtocolServer implements
         .replaceAll(System.lineSeparator(), " ")
         .trim()
         .replaceAll(" +", " ");
+  }
+
+  protected String getScmDatanodeAddressKey() {
+    return OZONE_SCM_DATANODE_ADDRESS_KEY;
   }
 
   protected InetSocketAddress getDataNodeBindAddress(OzoneConfiguration conf) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconDatanodeProtocolServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconDatanodeProtocolServer.java
@@ -36,6 +36,8 @@ import org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_DATANODE_ADDRESS_KEY;
+
 /**
  * Recon's Datanode protocol server extended from SCM.
  */
@@ -67,6 +69,11 @@ public class ReconDatanodeProtocolServer extends SCMDatanodeProtocolServer {
       ContainerReportsProto containerReportsRequestProto,
       PipelineReportsProto pipelineReports) throws IOException {
     return null;
+  }
+
+  @Override
+  protected String getScmDatanodeAddressKey() {
+    return OZONE_RECON_DATANODE_ADDRESS_KEY;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Recon exposes SCM-like RPC endpoint on (possibly) different port than SCM. However, when the RPC server [updates the config with the actual address](https://github.com/apache/hadoop-ozone/blob/046a06f02783da516179ee8d8d1bed862d22f78d/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java#L166-L168) after startup, it does so using the SCM-specific config key.  It should use the Recon-specific one.

https://issues.apache.org/jira/browse/HDDS-2863

## How was this patch tested?

[Successful execution](https://github.com/adoroszlai/hadoop-ozone/runs/382069628) on the branch where integration tests are enabled:

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 33.547 s - in org.apache.hadoop.hdds.scm.pipeline.TestSCMRestart
```

CI run (without integration tests) on top of master: https://github.com/adoroszlai/hadoop-ozone/runs/382180979