### PR TITLE
HDDS-2864. TestOMDbCheckpointServlet fails due to real Recon

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -152,11 +152,6 @@ public class TestOMDbCheckpointServlet {
 
       omDbCheckpointServletMock.init();
 
-      Assert.assertTrue(
-          omMetrics.getLastCheckpointCreationTimeTaken() == 0);
-      Assert.assertTrue(
-          omMetrics.getLastCheckpointStreamingTimeTaken() == 0);
-
       omDbCheckpointServletMock.doGet(requestMock, responseMock);
 
       Assert.assertTrue(tempFile.length() > 0);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -151,6 +151,7 @@ public class TestOMDbCheckpointServlet {
           responseMock);
 
       omDbCheckpointServletMock.init();
+      long initialCheckpointCount = omMetrics.getNumCheckpoints();
 
       omDbCheckpointServletMock.doGet(requestMock, responseMock);
 
@@ -159,6 +160,7 @@ public class TestOMDbCheckpointServlet {
           omMetrics.getLastCheckpointCreationTimeTaken() > 0);
       Assert.assertTrue(
           omMetrics.getLastCheckpointStreamingTimeTaken() > 0);
+      Assert.assertTrue(omMetrics.getNumCheckpoints() > initialCheckpointCount);
     } finally {
       FileUtils.deleteQuietly(tempFile);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -162,11 +162,12 @@ public class OMDBCheckpointServlet extends HttpServlet {
       LOG.info("Time taken to write the checkpoint to response output " +
           "stream: " + duration + " milliseconds");
       omMetrics.setLastCheckpointStreamingTimeTaken(duration);
-
+      omMetrics.incNumCheckpoints();
     } catch (Exception e) {
       LOG.error(
           "Unable to process metadata snapshot request. ", e);
       response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      omMetrics.incNumCheckpointFails();
     } finally {
       if (checkpoint != null) {
         try {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -126,6 +126,8 @@ public class OMMetrics {
   // Metrics to track checkpointing statistics from last run.
   private @Metric MutableGaugeLong lastCheckpointCreationTimeTaken;
   private @Metric MutableGaugeLong lastCheckpointStreamingTimeTaken;
+  private @Metric MutableCounterLong numCheckpoints;
+  private @Metric MutableCounterLong numCheckpointFails;
 
   private @Metric MutableCounterLong numBucketS3Creates;
   private @Metric MutableCounterLong numBucketS3CreateFails;
@@ -525,6 +527,14 @@ public class OMMetrics {
     this.lastCheckpointStreamingTimeTaken.set(val);
   }
 
+  public void incNumCheckpoints() {
+    numCheckpoints.incr();
+  }
+
+  public void incNumCheckpointFails() {
+    numCheckpointFails.incr();
+  }
+
   @VisibleForTesting
   public long getNumVolumeCreates() {
     return numVolumeCreates.value();
@@ -769,6 +779,11 @@ public class OMMetrics {
   @VisibleForTesting
   public long getLastCheckpointCreationTimeTaken() {
     return lastCheckpointCreationTimeTaken.value();
+  }
+
+  @VisibleForTesting
+  public long getNumCheckpoints() {
+    return numCheckpoints.value();
   }
 
   @VisibleForTesting


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestOMDbCheckpointServlet` verifies that no checkspoints have been taken before it invokes the servlet.  However, the same servlet is used by the actual Recon server in the mini cluster (added [very recently](https://github.com/apache/hadoop-ozone/commit/8748498b8)).

This PR proposes to remove the assertions about initial state, as they are not strictly necessary to validate behavior.

https://issues.apache.org/jira/browse/HDDS-2864

## How was this patch tested?

Ran the test locally, as well as on branch with integration tests enabled:

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 29.033 s - in org.apache.hadoop.ozone.om.TestOMDbCheckpointServlet
```

https://github.com/adoroszlai/hadoop-ozone/runs/382195722