### PR TITLE
HDDS-2817. Fix listing buckets for setting --prefix equal to bucket name

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -661,7 +661,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
 
         // We should return only the keys, whose keys match with prefix and
         // the keys after the startBucket.
-        if (key.startsWith(seekPrefix) && key.compareTo(startKey) > 0) {
+        if (key.startsWith(seekPrefix) && key.compareTo(startKey) >= 0) {
           result.add(omBucketInfo);
           currentCount++;
         }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -149,7 +149,9 @@ public class TestOmMetadataManager {
 
     TreeSet<String> volumeABucketsPrefixWithOzoneOwner = new TreeSet<>();
     TreeSet<String> volumeABucketsPrefixWithHadoopOwner = new TreeSet<>();
-    for (int i=1; i<= 100; i++) {
+    volumeABucketsPrefixWithOzoneOwner.add(prefixBucketNameWithOzoneOwner);
+    addBucketsToCache(volumeName1, prefixBucketNameWithOzoneOwner);
+    for (int i = 1; i < 100; i++) {
       if (i % 2 == 0) {
         volumeABucketsPrefixWithOzoneOwner.add(
             prefixBucketNameWithOzoneOwner + i);
@@ -165,7 +167,9 @@ public class TestOmMetadataManager {
     TreeSet<String> volumeBBucketsPrefixWithOzoneOwner = new TreeSet<>();
     TreeSet<String> volumeBBucketsPrefixWithHadoopOwner = new TreeSet<>();
     TestOMRequestUtils.addVolumeToDB(volumeName2, omMetadataManager);
-    for (int i=1; i<= 100; i++) {
+    volumeABucketsPrefixWithOzoneOwner.add(prefixBucketNameWithOzoneOwner);
+    addBucketsToCache(volumeName2, prefixBucketNameWithOzoneOwner);
+    for (int i = 1; i < 100; i++) {
       if (i % 2 == 0) {
         volumeBBucketsPrefixWithOzoneOwner.add(
             prefixBucketNameWithOzoneOwner + i);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -149,10 +149,12 @@ public class TestOmMetadataManager {
 
     TreeSet<String> volumeABucketsPrefixWithOzoneOwner = new TreeSet<>();
     TreeSet<String> volumeABucketsPrefixWithHadoopOwner = new TreeSet<>();
+
+    // Add strict name in prefixBucketNameWithOzoneOwner without postfix.
     volumeABucketsPrefixWithOzoneOwner.add(prefixBucketNameWithOzoneOwner);
     addBucketsToCache(volumeName1, prefixBucketNameWithOzoneOwner);
     for (int i = 1; i < 100; i++) {
-      if (i % 2 == 0) {
+      if (i % 2 == 0) { // This part adds 49 buckets.
         volumeABucketsPrefixWithOzoneOwner.add(
             prefixBucketNameWithOzoneOwner + i);
         addBucketsToCache(volumeName1, prefixBucketNameWithOzoneOwner + i);
@@ -167,10 +169,12 @@ public class TestOmMetadataManager {
     TreeSet<String> volumeBBucketsPrefixWithOzoneOwner = new TreeSet<>();
     TreeSet<String> volumeBBucketsPrefixWithHadoopOwner = new TreeSet<>();
     TestOMRequestUtils.addVolumeToDB(volumeName2, omMetadataManager);
-    volumeABucketsPrefixWithOzoneOwner.add(prefixBucketNameWithOzoneOwner);
+
+    // Add strict name in prefixBucketNameWithOzoneOwner without postfix.
+    volumeBBucketsPrefixWithOzoneOwner.add(prefixBucketNameWithOzoneOwner);
     addBucketsToCache(volumeName2, prefixBucketNameWithOzoneOwner);
     for (int i = 1; i < 100; i++) {
-      if (i % 2 == 0) {
+      if (i % 2 == 0) { // This part adds 49 buckets.
         volumeBBucketsPrefixWithOzoneOwner.add(
             prefixBucketNameWithOzoneOwner + i);
         addBucketsToCache(volumeName2, prefixBucketNameWithOzoneOwner + i);
@@ -186,7 +190,10 @@ public class TestOmMetadataManager {
         omMetadataManager.listBuckets(volumeName1,
             null, prefixBucketNameWithOzoneOwner, 100);
 
-    Assert.assertEquals(omBucketInfoList.size(),  50);
+    // Cause adding a strict name in prefixBucketNameWithOzoneOwner
+    // and another 49 buckets, so if we list buckets with --prefix
+    // prefixBucketNameWithOzoneOwner, we should get 50 buckets.
+    Assert.assertEquals(omBucketInfoList.size(), 50);
 
     for (OmBucketInfo omBucketInfo : omBucketInfoList) {
       Assert.assertTrue(omBucketInfo.getBucketName().startsWith(
@@ -224,7 +231,10 @@ public class TestOmMetadataManager {
     omBucketInfoList = omMetadataManager.listBuckets(volumeName2,
         null, prefixBucketNameWithHadoopOwner, 100);
 
-    Assert.assertEquals(omBucketInfoList.size(),  50);
+    // Cause adding a strict name in prefixBucketNameWithOzoneOwner
+    // and another 49 buckets, so if we list buckets with --prefix
+    // prefixBucketNameWithOzoneOwner, we should get 50 buckets.
+    Assert.assertEquals(omBucketInfoList.size(), 50);
 
     for (OmBucketInfo omBucketInfo : omBucketInfoList) {
       Assert.assertTrue(omBucketInfo.getBucketName().startsWith(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -150,7 +150,7 @@ public class TestOmMetadataManager {
     TreeSet<String> volumeABucketsPrefixWithOzoneOwner = new TreeSet<>();
     TreeSet<String> volumeABucketsPrefixWithHadoopOwner = new TreeSet<>();
 
-    // Add strict name in prefixBucketNameWithOzoneOwner without postfix.
+    // Add exact name in prefixBucketNameWithOzoneOwner without postfix.
     volumeABucketsPrefixWithOzoneOwner.add(prefixBucketNameWithOzoneOwner);
     addBucketsToCache(volumeName1, prefixBucketNameWithOzoneOwner);
     for (int i = 1; i < 100; i++) {
@@ -170,7 +170,7 @@ public class TestOmMetadataManager {
     TreeSet<String> volumeBBucketsPrefixWithHadoopOwner = new TreeSet<>();
     TestOMRequestUtils.addVolumeToDB(volumeName2, omMetadataManager);
 
-    // Add strict name in prefixBucketNameWithOzoneOwner without postfix.
+    // Add exact name in prefixBucketNameWithOzoneOwner without postfix.
     volumeBBucketsPrefixWithOzoneOwner.add(prefixBucketNameWithOzoneOwner);
     addBucketsToCache(volumeName2, prefixBucketNameWithOzoneOwner);
     for (int i = 1; i < 100; i++) {
@@ -190,7 +190,7 @@ public class TestOmMetadataManager {
         omMetadataManager.listBuckets(volumeName1,
             null, prefixBucketNameWithOzoneOwner, 100);
 
-    // Cause adding a strict name in prefixBucketNameWithOzoneOwner
+    // Cause adding a exact name in prefixBucketNameWithOzoneOwner
     // and another 49 buckets, so if we list buckets with --prefix
     // prefixBucketNameWithOzoneOwner, we should get 50 buckets.
     Assert.assertEquals(omBucketInfoList.size(), 50);
@@ -231,7 +231,7 @@ public class TestOmMetadataManager {
     omBucketInfoList = omMetadataManager.listBuckets(volumeName2,
         null, prefixBucketNameWithHadoopOwner, 100);
 
-    // Cause adding a strict name in prefixBucketNameWithOzoneOwner
+    // Cause adding a exact name in prefixBucketNameWithOzoneOwner
     // and another 49 buckets, so if we list buckets with --prefix
     // prefixBucketNameWithOzoneOwner, we should get 50 buckets.
     Assert.assertEquals(omBucketInfoList.size(), 50);


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR was created to let `--prefix` work without excluding bucket name that is equal to `prefix` when listing buckets.

- Fix.
In this [line](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java#L664), we exclude the bucket name that is equal to `--prefix` when listing buckets for now.
We updated the `>` to `>=`, and this would include the bucket name that is equal to `--prefix` when listing buckets.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2817

## How was this patch tested?
UT updated.
[Github action passed](https://github.com/cxorm/hadoop-ozone/runs/376239895).