### PR TITLE
HDDS-2846. Handle Datanode Pipeline & Container Reports reports in Recon.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
@@ -30,6 +30,8 @@ public final class ReconConfigKeys {
   private ReconConfigKeys() {
   }
 
+  public static final String RECON_SCM_CONFIG_PREFIX = "ozone.recon.scmconfig";
+
   public static final String OZONE_RECON_DATANODE_ADDRESS_KEY =
       "ozone.recon.datanode.address";
   public static final String OZONE_RECON_ADDRESS_KEY =

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/EventQueue.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/events/EventQueue.java
@@ -61,6 +61,8 @@ public class EventQueue implements EventPublisher, AutoCloseable {
 
   private static final Gson TRACING_SERIALIZER = new GsonBuilder().create();
 
+  private boolean isSilent = false;
+
   public <PAYLOAD, EVENT_TYPE extends Event<PAYLOAD>> void addHandler(
       EVENT_TYPE event, EventHandler<PAYLOAD> handler) {
     this.addHandler(event, handler, generateHandlerName(handler));
@@ -180,7 +182,9 @@ public class EventQueue implements EventPublisher, AutoCloseable {
       }
 
     } else {
-      LOG.warn("No event handler registered for event {}", event);
+      if (!isSilent) {
+        LOG.warn("No event handler registered for event {}", event);
+      }
     }
 
   }
@@ -258,4 +262,11 @@ public class EventQueue implements EventPublisher, AutoCloseable {
     });
   }
 
+  /**
+   * Dont log messages when there are no consumers of a message.
+   * @param silent flag.
+   */
+  public void setSilent(boolean silent) {
+    isSilent = silent;
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
@@ -87,8 +87,7 @@ public class SCMContainerManager implements ContainerManager {
   public SCMContainerManager(final Configuration conf,
       PipelineManager pipelineManager) throws IOException {
 
-    final File metaDir = ServerUtils.getScmDbDir(conf);
-    final File containerDBPath = new File(metaDir, SCM_CONTAINER_DB);
+    final File containerDBPath = getContainerDBPath(conf);
     final int cacheSize = conf.getInt(OZONE_SCM_DB_CACHE_SIZE_MB,
         OZONE_SCM_DB_CACHE_SIZE_DEFAULT);
 
@@ -578,5 +577,10 @@ public class SCMContainerManager implements ContainerManager {
         scmContainerManagerMetrics.incNumICRReportsProcessedFailed();
       }
     }
+  }
+
+  protected File getContainerDBPath(Configuration conf) {
+    File metaDir = ServerUtils.getScmDbDir(conf);
+    return new File(metaDir, SCM_CONTAINER_DB);
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.hdds.protocol.proto
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
-import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
+import org.apache.hadoop.hdds.scm.safemode.SafeModeManager;
 import org.apache.hadoop.hdds.scm.server
     .SCMDatanodeHeartbeatDispatcher.PipelineReportFromDatanode;
 import org.apache.hadoop.hdds.server.events.EventHandler;
@@ -51,10 +51,10 @@ public class PipelineReportHandler implements
       PipelineReportHandler.class);
   private final PipelineManager pipelineManager;
   private final Configuration conf;
-  private final SCMSafeModeManager scmSafeModeManager;
+  private final SafeModeManager scmSafeModeManager;
   private final boolean pipelineAvailabilityCheck;
 
-  public PipelineReportHandler(SCMSafeModeManager scmSafeModeManager,
+  public PipelineReportHandler(SafeModeManager scmSafeModeManager,
       PipelineManager pipelineManager, Configuration conf) {
     Preconditions.checkNotNull(pipelineManager);
     this.scmSafeModeManager = scmSafeModeManager;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -100,8 +100,7 @@ public class SCMPipelineManager implements PipelineManager {
         new BackgroundPipelineCreator(this, scheduler, conf);
     int cacheSize = conf.getInt(OZONE_SCM_DB_CACHE_SIZE_MB,
         OZONE_SCM_DB_CACHE_SIZE_DEFAULT);
-    final File metaDir = ServerUtils.getScmDbDir(conf);
-    final File pipelineDBPath = new File(metaDir, SCM_PIPELINE_DB);
+    final File pipelineDBPath = getPipelineDBPath(conf);
     this.pipelineStore =
         MetadataStoreBuilder.newBuilder()
             .setCreateIfMissing(true)
@@ -330,7 +329,7 @@ public class SCMPipelineManager implements PipelineManager {
   @Override
   public void finalizeAndDestroyPipeline(Pipeline pipeline, boolean onTimeout)
       throws IOException {
-    LOG.info("destroying pipeline:{}", pipeline);
+    LOG.info("Destroying pipeline:{}", pipeline);
     finalizePipeline(pipeline.getId());
     if (onTimeout) {
       long pipelineDestroyTimeoutInMillis =
@@ -465,7 +464,7 @@ public class SCMPipelineManager implements PipelineManager {
    * @param pipeline        - Pipeline to be destroyed
    * @throws IOException
    */
-  private void destroyPipeline(Pipeline pipeline) throws IOException {
+  protected void destroyPipeline(Pipeline pipeline) throws IOException {
     pipelineFactory.close(pipeline.getType(), pipeline);
     // remove the pipeline from the pipeline manager
     removePipeline(pipeline.getId());
@@ -478,7 +477,7 @@ public class SCMPipelineManager implements PipelineManager {
    * @param pipelineId - ID of the pipeline to be removed
    * @throws IOException
    */
-  private void removePipeline(PipelineID pipelineId) throws IOException {
+  protected void removePipeline(PipelineID pipelineId) throws IOException {
     lock.writeLock().lock();
     try {
       pipelineStore.delete(pipelineId.getProtobuf().toByteArray());
@@ -518,5 +517,10 @@ public class SCMPipelineManager implements PipelineManager {
     }
     // shutdown pipeline provider.
     pipelineFactory.shutdown();
+  }
+
+  protected File getPipelineDBPath(Configuration configuration) {
+    File metaDir = ServerUtils.getScmDbDir(configuration);
+    return new File(metaDir, SCM_PIPELINE_DB);
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -75,7 +75,7 @@ import org.slf4j.LoggerFactory;
  * per pipeline is met or not.
  *
  */
-public class SCMSafeModeManager {
+public class SCMSafeModeManager implements SafeModeManager {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(SCMSafeModeManager.class);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeManager.java
@@ -15,24 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.ozone.recon.scm;
 
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.scm.net.NetworkTopology;
-import org.apache.hadoop.hdds.scm.node.SCMNodeManager;
-import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
-import org.apache.hadoop.hdds.server.events.EventPublisher;
+package org.apache.hadoop.hdds.scm.safemode;
 
 /**
- * Recon's version of SCM Node Manager.
- * TODO This is just an initial implementation. Will be revisited in future.
+ * Interface for SafeModeManager.
  */
-public class ReconNodeManager extends SCMNodeManager {
+public interface SafeModeManager {
 
-  public ReconNodeManager(OzoneConfiguration conf,
-                          SCMStorageConfig scmStorageConfig,
-                          EventPublisher eventPublisher,
-                          NetworkTopology networkTopology) {
-    super(conf, scmStorageConfig, eventPublisher, networkTopology);
-  }
+  /**
+   * Returns if the component is in Safemode or not.
+   * @return true/false.
+   */
+  boolean getInSafeMode();
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -776,6 +776,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       conf.set(RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY, "2s");
       conf.set(RECON_OM_SNAPSHOT_TASK_INTERVAL, "10s");
       conf.set(OZONE_RECON_DATANODE_ADDRESS_KEY, "0.0.0.0:0");
+      conf.set(OZONE_RECON_DATANODE_ADDRESS_KEY, "0.0.0.0:0");
     }
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.recon;
 
 import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_DB_SUFFIX;
+import static org.apache.hadoop.ozone.OzoneConsts.PIPELINE_DB_SUFFIX;
 
 /**
  * Recon Server constants file.
@@ -29,8 +30,7 @@ public final class ReconConstants {
     // Never Constructed
   }
 
-  public static final String RECON_CONTAINER_DB = "recon-" +
-      CONTAINER_DB_SUFFIX;
+  public static final String RECON_CONTAINER_KEY_DB = "recon-container-key.db";
 
   public static final String CONTAINER_COUNT_KEY = "totalCount";
 
@@ -48,4 +48,8 @@ public final class ReconConstants {
   public static final String PREV_CONTAINER_ID_DEFAULT_VALUE = "0";
   public static final String RECON_QUERY_LIMIT = "limit";
 
+  public static final String RECON_SCM_CONTAINER_DB =
+      "recon-" + CONTAINER_DB_SUFFIX;
+  public static final String RECON_SCM_PIPELINE_DB = "recon-"
+      + PIPELINE_DB_SUFFIX;
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconControllerModule.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconControllerModule.java
@@ -39,7 +39,7 @@ import org.apache.hadoop.ozone.recon.persistence.DataSourceConfiguration;
 import org.apache.hadoop.ozone.recon.persistence.JooqPersistenceModule;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.recovery.ReconOmMetadataManagerImpl;
-import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManager;
+import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
 import org.apache.hadoop.ozone.recon.spi.ContainerDBServiceProvider;
 import org.apache.hadoop.ozone.recon.spi.OzoneManagerServiceProvider;
 import org.apache.hadoop.ozone.recon.spi.impl.ReconContainerDBProvider;
@@ -85,7 +85,7 @@ public class ReconControllerModule extends AbstractModule {
 
     bind(ReconTaskController.class)
         .to(ReconTaskControllerImpl.class).in(Singleton.class);
-    bind(ReconStorageContainerManager.class).in(Singleton.class);
+    bind(ReconStorageContainerManagerFacade.class).in(Singleton.class);
   }
 
   @Provides

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.scm;
+
+import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_SCM_CONTAINER_DB;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.scm.container.SCMContainerManager;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
+import org.apache.hadoop.ozone.recon.ReconUtils;
+
+/**
+ * Recon's overriding implementation of SCM's Container Manager.
+ */
+public class ReconContainerManager extends SCMContainerManager {
+
+  /**
+   * Constructs a mapping class that creates mapping between container names
+   * and pipelines.
+   * <p>
+   * passed to LevelDB and this memory is allocated in Native code space.
+   * CacheSize is specified
+   * in MB.
+   *
+   * @param conf            - {@link Configuration}
+   * @param pipelineManager - {@link PipelineManager}
+   * @throws IOException on Failure.
+   */
+  public ReconContainerManager(
+      Configuration conf, PipelineManager pipelineManager) throws IOException {
+    super(conf, pipelineManager);
+  }
+
+  @Override
+  protected File getContainerDBPath(Configuration conf) {
+    File metaDir = ReconUtils.getReconScmDbDir(conf);
+    return new File(metaDir, RECON_SCM_CONTAINER_DB);
+  }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconDatanodeProtocolServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconDatanodeProtocolServer.java
@@ -22,19 +22,10 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReportsProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMHeartbeatRequestProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMHeartbeatResponseProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMRegisteredResponseProto;
 import org.apache.hadoop.hdds.scm.HddsServerUtil;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_DATANODE_ADDRESS_KEY;
 
@@ -43,34 +34,11 @@ import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_DATANODE_
  */
 public class ReconDatanodeProtocolServer extends SCMDatanodeProtocolServer {
 
-  private static final Logger LOG = LoggerFactory.getLogger(
-      ReconDatanodeProtocolServer.class);
-
   public ReconDatanodeProtocolServer(OzoneConfiguration conf,
                                      OzoneStorageContainerManager scm,
                                      EventPublisher eventPublisher)
       throws IOException {
     super(conf, scm, eventPublisher);
-  }
-
-  @Override
-  public SCMHeartbeatResponseProto sendHeartbeat(
-      SCMHeartbeatRequestProto heartbeat) throws IOException {
-    LOG.info("Heartbeart from Datanode {}",
-        heartbeat.getDatanodeDetails().getHostName());
-    return super.sendHeartbeat(heartbeat);
-  }
-
-  @Override
-  public SCMRegisteredResponseProto register(
-      DatanodeDetailsProto datanodeDetails,
-      NodeReportProto nodeReport,
-      ContainerReportsProto containerReportsRequestProto,
-      PipelineReportsProto pipelineReports) throws IOException {
-    LOG.info("Datanode {} registered with Recon",
-        datanodeDetails.getHostName());
-    return super.register(datanodeDetails, nodeReport,
-        containerReportsRequestProto, pipelineReports);
   }
 
   @Override

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineManager.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.scm;
+
+import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_SCM_PIPELINE_DB;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.SCMPipelineManager;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.apache.hadoop.ozone.recon.ReconUtils;
+
+/**
+ * Recon's overriding implementation of SCM's Pipeline Manager.
+ */
+public class ReconPipelineManager extends SCMPipelineManager {
+
+  public ReconPipelineManager(Configuration conf,
+                              NodeManager nodeManager,
+                              EventPublisher eventPublisher)
+      throws IOException {
+    super(conf, nodeManager, eventPublisher);
+  }
+
+  @Override
+  protected File getPipelineDBPath(Configuration conf) {
+    File metaDir = ReconUtils.getReconScmDbDir(conf);
+    return new File(metaDir, RECON_SCM_PIPELINE_DB);
+  }
+
+  @Override
+  public void triggerPipelineCreation() {
+    // Don't do anything in Recon.
+  }
+
+  @Override
+  protected void destroyPipeline(Pipeline pipeline) throws IOException {
+    // remove the pipeline from the pipeline manager
+    removePipeline(pipeline.getId());
+  }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconSafeModeManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconSafeModeManager.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.scm;
+
+import org.apache.hadoop.hdds.scm.safemode.SafeModeManager;
+
+/**
+ * Recon's stub implementation of SCM's SafeMode manager.
+ */
+
+public class ReconSafeModeManager implements SafeModeManager {
+
+  @Override
+  public boolean getInSafeMode() {
+    return false;
+  }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ContainerDBServiceProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ContainerDBServiceProvider.java
@@ -32,11 +32,6 @@ import org.apache.hadoop.hdds.utils.db.TableIterator;
 @InterfaceStability.Unstable
 public interface ContainerDBServiceProvider {
 
-  /**
-   * Start the Recon container DB provider service.
-   */
-  void start();
-
   /*
    * Close the container DB
    */

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImpl.java
@@ -85,12 +85,6 @@ public class ContainerDBServiceProviderImpl
   }
 
   @Override
-  public void start() {
-    // Makes sure the ContainerDBServiceProvider is injected and
-    // available. Nothing else to do here.
-  }
-
-  @Override
   public void stop() throws Exception {
     if (containerDbStore != null) {
       containerDbStore.close();
@@ -286,7 +280,8 @@ public class ContainerDBServiceProviderImpl
               containerKeyPrefix.getKeyVersion()),
               keyValue.getValue());
         } else {
-          LOG.warn("Null key prefix returned for containerId = " + containerId);
+          LOG.warn("Null key prefix returned for containerId = {} ",
+              containerId);
         }
       } else {
         break; //Break when the first mismatch occurs.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerDBProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerDBProvider.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.ozone.recon.spi.impl;
 
 import static org.apache.hadoop.ozone.recon.ReconConstants.CONTAINER_KEY_COUNT_TABLE;
-import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_CONTAINER_DB;
+import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_CONTAINER_KEY_DB;
 import static org.apache.hadoop.ozone.recon.ReconConstants.CONTAINER_KEY_TABLE;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_DB_DIR;
 
@@ -65,7 +65,7 @@ public class ReconContainerDBProvider implements Provider<DBStore> {
     File reconDbDir =
         reconUtils.getReconDbDir(configuration, OZONE_RECON_DB_DIR);
     File lastKnownOMSnapshot =
-        reconUtils.getLastKnownDB(reconDbDir, RECON_CONTAINER_DB);
+        reconUtils.getLastKnownDB(reconDbDir, RECON_CONTAINER_KEY_DB);
     if (lastKnownOMSnapshot != null) {
       dbStore = getDBStore(configuration, reconUtils,
           lastKnownOMSnapshot.getName());
@@ -101,7 +101,7 @@ public class ReconContainerDBProvider implements Provider<DBStore> {
 
   static DBStore getNewDBStore(OzoneConfiguration configuration,
                                ReconUtils reconUtils) {
-    String dbName = RECON_CONTAINER_DB + "_" + System.currentTimeMillis();
+    String dbName = RECON_CONTAINER_KEY_DB + "_" + System.currentTimeMillis();
     return getDBStore(configuration, reconUtils, dbName);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Recon should be able to process Container and Pipeline reports from registered Datanodes. It still wont be able to understand new containers and pipelines though. Along with HDDS-2850, HDDS-2852 and HDDS-2869, Recon will be a fully functional passive SCM. 
In addition to the above, some refactoring work also has been done.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2846

## How was this patch tested?
Manually tested on docker.
Created key (container) on ozone cluster, and verified Recon gets the container info in Datanode heartbeat.