### PR TITLE
HDDS-2832. Fix listing buckets for setting --start with last bucket

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
@@ -296,9 +296,8 @@ public class OzoneVolume extends WithMetadata {
 
     @Override
     public boolean hasNext() {
-      if(!currentIterator.hasNext()) {
-        currentIterator = getNextListOfBuckets(
-            currentValue != null ? currentValue.getName() : null)
+      if (!currentIterator.hasNext() && currentValue != null) {
+        currentIterator = getNextListOfBuckets(currentValue.getName())
             .iterator();
       }
       return currentIterator.hasNext();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/ozShell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/ozShell/TestOzoneShellHA.java
@@ -422,8 +422,8 @@ public class TestOzoneShellHA {
     Assert.assertEquals(0, getNumOfKeys());
 
     // Part of listing buckets test.
-    generateBuckets("volume5", 100);
-    final String destinationVolume = "o3://" + omServiceId + "volume5";
+    generateBuckets("/volume5", 100);
+    final String destinationVolume = "o3://" + omServiceId + "/volume5";
 
     // Test case 1: test listing buckets.
     // ozone sh bucket list /volume5

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/ozShell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/ozShell/TestOzoneShellHA.java
@@ -311,6 +311,30 @@ public class TestOzoneShellHA {
   }
 
   /**
+   * Helper function to generate buckets for testing shell command of buckets.
+   */
+  private void generateBuckets(String volumeName, int numOfBuckets) {
+    String[] args = new String[] {
+        "volume", "create", "o3://" + omServiceId + volumeName};
+    execute(ozoneShell, args);
+
+    String bucketName = volumeName + OzoneConsts.OZONE_URI_DELIMITER + "bucket";
+    for (int i = 0; i < numOfBuckets; i++) {
+      args = new String[] {
+          "bucket", "create", "o3://" + omServiceId + bucketName + i};
+      execute(ozoneShell, args);
+    }
+  }
+
+  /**
+   * Helper function to get nums of buckets from info of listing command.
+   */
+  private int getNumOfBuckets(String bucketPrefix) {
+    return out.toString().split(bucketPrefix).length - 1;
+  }
+
+
+  /**
    * Tests ozone sh command URI parsing with volume and bucket create commands.
    */
   @Test
@@ -375,6 +399,7 @@ public class TestOzoneShellHA {
    */
   @Test
   public void testOzoneShCmdList() {
+    // Part of listing keys test.
     generateKeys("/volume4", "/bucket");
     final String destinationBucket = "o3://" + omServiceId + "/volume4/bucket";
 
@@ -395,6 +420,28 @@ public class TestOzoneShellHA {
     execute(ozoneShell, args);
     Assert.assertEquals(0, out.size());
     Assert.assertEquals(0, getNumOfKeys());
+
+    // Part of listing buckets test.
+    generateBuckets("volume5", 100);
+    final String destinationVolume = "o3://" + omServiceId + "volume5";
+
+    // Test case 1: test listing buckets.
+    // ozone sh bucket list /volume5
+    // Expectation: Get list including all buckets.
+    args = new String[] {"bucket", "list", destinationVolume};
+    out.reset();
+    execute(ozoneShell, args);
+    Assert.assertEquals(100, getNumOfBuckets("bucket"));
+
+    // Test case 2: test listing buckets for setting --start with last bucket.
+    // ozone sh bucket list /volume5 --start=bucket99 /volume5
+    // Expectation: Get empty list.
+    final String startBucket = "--start=bucket99";
+    out.reset();
+    args = new String[] {"bucket", "list", startBucket, destinationVolume};
+    execute(ozoneShell, args);
+    Assert.assertEquals(0, out.size());
+    Assert.assertEquals(0, getNumOfBuckets("bucket"));
   }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Cause listing buckets with `--start` means that we would get buckets after the `--start`, we should get empty result when we set `--start` with last bucket.

But we get all buckets for now, this is caused by this [method](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java#L298#L305).

When we set `--start` with last bucket, [`getNextListOfBuckets(prevBucket)`](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java#L294) would be empty list, so the first call of [`hasNext()`](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java#L298#L305) would enter the `if-block` and `currentValue` is `null`.

This situation results in calling `getNextListOfBuckets(null)`, and [`currentIterator`](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java#L300#L302) would be iterator of all buckets with this length size, so we get all buckets for now.

#### Proposed fix.
The `currentValue` in [`if-block`](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java#L299#L303) would be `null` if and only if first call [`hasNext()`](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java#L298#L305) of empty list, so`currentValue` is tested ahead by this fix.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2832

## How was this patch tested?
[Github action passed](https://github.com/cxorm/hadoop-ozone/runs/376330188).