### PR TITLE
HDDS-2872. ozone.recon.scm.db.dirs missing from ozone-default.xml.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -55,7 +55,9 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         HddsConfigKeys.HDDS_SECURITY_PROVIDER,
         OMConfigKeys.OZONE_OM_NODES_KEY,
         OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS_NATIVE,
-        OzoneConfigKeys.OZONE_S3_AUTHINFO_MAX_LIFETIME_KEY
+        OzoneConfigKeys.OZONE_S3_AUTHINFO_MAX_LIFETIME_KEY,
+        "ozone.recon.scm.db.dirs"
+        // TODO HDDS-2856
     ));
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -56,7 +56,7 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         OMConfigKeys.OZONE_OM_NODES_KEY,
         OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS_NATIVE,
         OzoneConfigKeys.OZONE_S3_AUTHINFO_MAX_LIFETIME_KEY,
-        "ozone.recon.scm.db.dirs"
+        ReconServerConfigKeys.OZONE_RECON_SCM_DB_DIR
         // TODO HDDS-2856
     ));
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Skipping this config in the test since there is an action item to move new Recon configs to Java API (HDDS-2856). Added a TODO in the Test.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2872

## How was this patch tested?
Ran the test locally.