### PR TITLE
HDDS-2875. Add a config in ozone to tune max outstanding requests in …

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
@@ -50,6 +50,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.hadoop.hdds.conf.ConfigTag.CLIENT;
 import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
 import static org.apache.hadoop.hdds.conf.ConfigTag.PERFORMANCE;
 
@@ -322,15 +323,6 @@ public class XceiverClientManager implements Closeable {
     )
     private long staleThreshold;
 
-    @Config(key = "max.outstanding.requests",
-        defaultValue = "100",
-        tags = {OZONE, PERFORMANCE},
-        description =
-            "Controls the maximum number of outstanding async requests that can"
-                + " be handled by the Standalone as well as Ratis client."
-    )
-    private int maxOutstandingRequests;
-
     public long getStaleThreshold(TimeUnit unit) {
       return unit.convert(staleThreshold, MILLISECONDS);
     }
@@ -345,10 +337,30 @@ public class XceiverClientManager implements Closeable {
       this.maxSize = maxSize;
     }
 
+  }
+
+  /**
+   * Configuration for ratis client.
+   */
+  @ConfigGroup(prefix = "dfs.ratis.client")
+  public class DFSRatisClientConfig {
+
+    @Config(key = "async.max.outstanding.requests",
+        defaultValue = "64",
+        tags = {OZONE, CLIENT, PERFORMANCE},
+        description =
+            "Controls the maximum number of outstanding async requests that can"
+                + " be handled by the Standalone as well as Ratis client."
+    )
+    private int maxOutstandingRequests;
+
     public int getMaxOutstandingRequests() {
       return maxOutstandingRequests;
     }
 
+    public void setMaxOutstandingRequests(int maxOutstandingRequests) {
+      this.maxOutstandingRequests = maxOutstandingRequests;
+    }
   }
 
 }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
@@ -343,7 +343,7 @@ public class XceiverClientManager implements Closeable {
    * Configuration for ratis client.
    */
   @ConfigGroup(prefix = "dfs.ratis.client")
-  public class DFSRatisClientConfig {
+  public static class DFSRatisClientConfig {
 
     @Config(key = "async.max.outstanding.requests",
         defaultValue = "64",

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -175,9 +175,7 @@ public final class XceiverClientRatis extends XceiverClientSpi {
       LOG.debug("Connecting to pipeline:{} datanode:{}", getPipeline().getId(),
           RatisHelper.toRaftPeerId(pipeline.getFirstNode()));
     }
-    // TODO : XceiverClient ratis should pass the config value of
-    // maxOutstandingRequests so as to set the upper bound on max no of async
-    // requests to be handled by raft client
+
     if (!client.compareAndSet(null,
         RatisHelper.newRaftClient(rpcType, getPipeline(), retryPolicy,
             maxOutstandingRequests, tlsConfig, clientRequestTimeout))) {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolPB;
-import org.apache.hadoop.hdds.scm.XceiverClientManager.ScmClientConfig;
+import org.apache.hadoop.hdds.scm.XceiverClientManager.DFSRatisClientConfig;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocolPB.ScmBlockLocationProtocolPB;
@@ -280,7 +280,7 @@ public final class HddsClientUtils {
    */
   public static int getMaxOutstandingRequests(Configuration config) {
     return OzoneConfiguration.of(config)
-        .getObject(ScmClientConfig.class)
+        .getObject(DFSRatisClientConfig.class)
         .getMaxOutstandingRequests();
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
@@ -203,8 +203,6 @@ public interface RatisHelper {
 
     GrpcConfigKeys.setMessageSizeMax(properties,
         SizeInBytes.valueOf(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE));
-    GrpcConfigKeys.OutputStream.setOutstandingAppendsMax(properties,
-        maxOutStandingRequest);
 
     // set async max outstanding requests.
     RaftClientConfigKeys.Async.setMaxOutstandingRequests(properties,

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
@@ -206,6 +206,10 @@ public interface RatisHelper {
     GrpcConfigKeys.OutputStream.setOutstandingAppendsMax(properties,
         maxOutStandingRequest);
 
+    // set async max outstanding requests.
+    RaftClientConfigKeys.Async.setMaxOutstandingRequests(properties,
+        maxOutStandingRequest);
+
     RaftClient.Builder builder =  RaftClient.newBuilder()
         .setRaftGroup(group)
         .setLeaderId(leader)


### PR DESCRIPTION
…raft client.

## What changes were proposed in this pull request?

Add a config to tune the config value of "raft.client.async.outstanding-requests.max" config in raft client. 

There is a property scm.container.client.max.outstanding.requests but this is used to set outStandingAppendsMax, but the config of this is mentioned as the "Controls the maximum number of outstanding async requests that can be handled by the Standalone as well as Ratis client". So, I removed this from ScmClientConfig, and created a new class for this property with prefix dfs.ratis.client to be consistent with other ratis client properties. And used the same for outStandingAppendsMax as before, not sure this is the correct way, but to keep same with current code, used it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2875

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

UT and acceptance test run.
