### PR TITLE
HDDS-2845. Fix listing keys for setting --start with last key

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -591,10 +591,8 @@ public class OzoneBucket extends WithMetadata {
 
     @Override
     public boolean hasNext() {
-      if(!currentIterator.hasNext()) {
-        currentIterator = getNextListOfKeys(
-            currentValue != null ? currentValue.getName() : null)
-            .iterator();
+      if(!currentIterator.hasNext() && currentValue != null) {
+        currentIterator = getNextListOfKeys(currentValue.getName()).iterator();
       }
       return currentIterator.hasNext();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Cause listing keys with `--start` means that we would get keys after the `--start`, we should get empty result when we set `--start` with last key.

But we get all keys for now, this is caused by this [method](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java#L592#L600).

When we set `--start` with last key, [`getNextListOfKeys(prevKey)`](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java#L589) would be empty list, so the first call of [`hasNext()`](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java#L593#L600) would enter the `if-block` and `currentValue` is `null`.

This situation results in calling `getNextListOfKeys(null)`, and [`currentIterator`](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java#L595#L597) would be iterator of all keys, so we get all keys for now.

#### Proposed fix.
The `currentValue` in [`if-block`](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java#L594#L598) would be `null` if and only if first call [`hasNext()`](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java#L593#L600) of empty list, so`currentValue` is tested ahead by this fix.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2845

## How was this patch tested?
[Github action passed](https://github.com/cxorm/hadoop-ozone/runs/376387142).