### PR TITLE
HDDS-2889. Make DBStore and RDBStore more commons.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
@@ -159,7 +159,7 @@ public interface DBStore extends AutoCloseable {
   void commitBatchOperation(BatchOperation operation) throws IOException;
 
   /**
-   * Get current snapshot of OM DB store as an artifact stored on
+   * Get current snapshot of DB store as an artifact stored on
    * the local filesystem.
    * @return An object that encapsulates the checkpoint information along with
    * location.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -19,8 +19,6 @@
 
 package org.apache.hadoop.hdds.utils.db;
 
-import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_CHECKPOINTS_DIR_NAME;
-
 import javax.management.ObjectName;
 import java.io.File;
 import java.io.IOException;
@@ -119,8 +117,8 @@ public class RDBStore implements DBStore {
       }
 
       //create checkpoints directory if not exists.
-      checkpointsParentDir = Paths.get(dbLocation.getParent(),
-          OM_DB_CHECKPOINTS_DIR_NAME).toString();
+      checkpointsParentDir =
+              Paths.get(dbLocation.getParent(), "db.checkpoints").toString();
       File checkpointsDir = new File(checkpointsParentDir);
       if (!checkpointsDir.exists()) {
         boolean success = checkpointsDir.mkdir();
@@ -130,7 +128,7 @@ public class RDBStore implements DBStore {
       }
 
       //Initialize checkpoint manager
-      checkPointManager = new RDBCheckpointManager(db, "om");
+      checkPointManager = new RDBCheckpointManager(db, "rdb");
       rdbMetrics = RDBMetrics.create();
 
     } catch (RocksDBException e) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -120,7 +120,6 @@ public final class OzoneConsts {
   public static final String DELETED_BLOCK_DB = "deletedBlock.db";
   public static final String OM_DB_NAME = "om.db";
   public static final String OM_DB_BACKUP_PREFIX = "om.db.backup.";
-  public static final String OM_DB_CHECKPOINTS_DIR_NAME = "om.db.checkpoints";
   public static final String OZONE_MANAGER_TOKEN_DB_NAME = "om-token.db";
   public static final String SCM_DB_NAME = "scm.db";
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

As a user of RDBStore and TypedTable, i only use these class to maintain my rocksdb, i use hadoop-hdds-common as a maven dependency.

But during my progress running, i find a folder named `om.db.checkpoints`, it is terrible, i do not know om, i only want to use a common typedTable which help me maintains rocksdb.

So we should rename it, remove the concept of OM.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2889

## How was this patch tested?

Only change the name of checkpoint and comments, no need to test.