### PR TITLE
HDDS-2888. Refactor Datanode StateContext to send reports and actions…

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/datanode/InitDatanodeState.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/datanode/InitDatanodeState.java
@@ -105,10 +105,12 @@ public class InitDatanodeState implements DatanodeState,
       }
       for (InetSocketAddress addr : addresses) {
         connectionManager.addSCMServer(addr);
+        this.context.addEndpoint(addr.toString());
       }
       InetSocketAddress reconAddress = getReconAddresses(conf);
       if (reconAddress != null) {
         connectionManager.addReconServer(reconAddress);
+        this.context.addEndpoint(reconAddress.toString());
       }
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -173,7 +173,7 @@ public class HeartbeatEndpointTask
     if (requestBuilder.getIncrementalContainerReportCount() != 0) {
       reports.addAll(requestBuilder.getIncrementalContainerReportList());
     }
-    context.putBackReports(reports);
+    context.putBackReports(reports, rpcEndpoint.getAddressString());
   }
 
   /**
@@ -182,7 +182,8 @@ public class HeartbeatEndpointTask
    * @param requestBuilder builder to which the report has to be added.
    */
   private void addReports(SCMHeartbeatRequestProto.Builder requestBuilder) {
-    for (GeneratedMessage report : context.getAllAvailableReports()) {
+    for (GeneratedMessage report :
+        context.getAllAvailableReports(rpcEndpoint.getAddressString())) {
       String reportName = report.getDescriptorForType().getFullName();
       for (Descriptors.FieldDescriptor descriptor :
           SCMHeartbeatRequestProto.getDescriptor().getFields()) {
@@ -206,7 +207,7 @@ public class HeartbeatEndpointTask
   private void addContainerActions(
       SCMHeartbeatRequestProto.Builder requestBuilder) {
     List<ContainerAction> actions = context.getPendingContainerAction(
-        maxContainerActionsPerHB);
+        rpcEndpoint.getAddressString(), maxContainerActionsPerHB);
     if (!actions.isEmpty()) {
       ContainerActionsProto cap = ContainerActionsProto.newBuilder()
           .addAllContainerActions(actions)
@@ -223,7 +224,7 @@ public class HeartbeatEndpointTask
   private void addPipelineActions(
       SCMHeartbeatRequestProto.Builder requestBuilder) {
     List<PipelineAction> actions = context.getPendingPipelineAction(
-        maxPipelineActionsPerHB);
+        rpcEndpoint.getAddressString(), maxPipelineActionsPerHB);
     if (!actions.isEmpty()) {
       PipelineActionsProto pap = PipelineActionsProto.newBuilder()
           .addAllPipelineActions(actions)

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestStateContext.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestStateContext.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.statemachine;
+
+import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerAction.Action.CLOSE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerAction;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineAction;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine.DatanodeStates;
+import org.junit.Test;
+
+import com.google.protobuf.GeneratedMessage;
+
+/**
+ * Test class for Datanode StateContext.
+ */
+public class TestStateContext {
+
+  @Test
+  public void testReportAPIs() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    DatanodeStateMachine datanodeStateMachineMock =
+        mock(DatanodeStateMachine.class);
+    StateContext stateContext = new StateContext(conf,
+        DatanodeStates.getInitState(), datanodeStateMachineMock);
+
+    String scm1 = "scm1:9001";
+    String scm2 = "scm2:9001";
+
+    // Try to add report with endpoint. Should not be stored.
+    stateContext.addReport(mock(GeneratedMessage.class));
+    assertTrue(stateContext.getAllAvailableReports(scm1).isEmpty());
+
+    // Add 2 scm endpoints.
+    stateContext.addEndpoint(scm1);
+    stateContext.addEndpoint(scm2);
+
+    // Add report. Should be added to all endpoints.
+    stateContext.addReport(mock(GeneratedMessage.class));
+    List<GeneratedMessage> allAvailableReports =
+        stateContext.getAllAvailableReports(scm1);
+    assertEquals(1, allAvailableReports.size());
+    assertEquals(1, stateContext.getAllAvailableReports(scm2).size());
+
+    // Assert the reports are no longer available.
+    assertTrue(stateContext.getAllAvailableReports(scm1).isEmpty());
+
+    // Put back reports.
+    stateContext.putBackReports(allAvailableReports, scm1);
+    assertFalse(stateContext.getAllAvailableReports(scm1).isEmpty());
+  }
+
+  @Test
+  public void testActionAPIs() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    DatanodeStateMachine datanodeStateMachineMock =
+        mock(DatanodeStateMachine.class);
+    StateContext stateContext = new StateContext(conf,
+        DatanodeStates.getInitState(), datanodeStateMachineMock);
+
+    String scm1 = "scm1:9001";
+    String scm2 = "scm2:9001";
+
+    // Try to get containerActions for endpoint which is not yet added.
+    List<ContainerAction> containerActions =
+        stateContext.getPendingContainerAction(scm1, 10);
+    assertTrue(containerActions.isEmpty());
+
+    // Try to get pipelineActions for endpoint which is not yet added.
+    List<PipelineAction> pipelineActions =
+        stateContext.getPendingPipelineAction(scm1, 10);
+    assertTrue(pipelineActions.isEmpty());
+
+    // Add 2 scm endpoints.
+    stateContext.addEndpoint(scm1);
+    stateContext.addEndpoint(scm2);
+
+    // Add PipelineAction. Should be added to all endpoints.
+    stateContext.addPipelineActionIfAbsent(
+        PipelineAction.newBuilder().setAction(
+            PipelineAction.Action.CLOSE).build());
+
+    pipelineActions = stateContext.getPendingPipelineAction(scm1, 10);
+    assertEquals(1, pipelineActions.size());
+
+    // Add ContainerAction. Should be added to all endpoints.
+    stateContext.addContainerAction(ContainerAction.newBuilder()
+        .setAction(CLOSE).setContainerID(100L).build());
+
+    containerActions = stateContext.getPendingContainerAction(scm2, 10);
+    assertEquals(1, containerActions.size());
+  }
+
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
@@ -55,6 +55,7 @@ import java.util.UUID;
  */
 public class TestHeartbeatEndpointTask {
 
+  private static final String TEST_SCM_ENDPOINT = "test-scm-1:9861";
 
   @Test
   public void testheartbeatWithoutReports() throws Exception {
@@ -102,6 +103,7 @@ public class TestHeartbeatEndpointTask {
 
     HeartbeatEndpointTask endpointTask = getHeartbeatEndpointTask(
         conf, context, scm);
+    context.addEndpoint(TEST_SCM_ENDPOINT);
     context.addReport(NodeReportProto.getDefaultInstance());
     endpointTask.call();
     SCMHeartbeatRequestProto heartbeat = argument.getValue();
@@ -133,6 +135,7 @@ public class TestHeartbeatEndpointTask {
 
     HeartbeatEndpointTask endpointTask = getHeartbeatEndpointTask(
         conf, context, scm);
+    context.addEndpoint(TEST_SCM_ENDPOINT);
     context.addReport(ContainerReportsProto.getDefaultInstance());
     endpointTask.call();
     SCMHeartbeatRequestProto heartbeat = argument.getValue();
@@ -164,6 +167,7 @@ public class TestHeartbeatEndpointTask {
 
     HeartbeatEndpointTask endpointTask = getHeartbeatEndpointTask(
         conf, context, scm);
+    context.addEndpoint(TEST_SCM_ENDPOINT);
     context.addReport(CommandStatusReportsProto.getDefaultInstance());
     endpointTask.call();
     SCMHeartbeatRequestProto heartbeat = argument.getValue();
@@ -195,6 +199,7 @@ public class TestHeartbeatEndpointTask {
 
     HeartbeatEndpointTask endpointTask = getHeartbeatEndpointTask(
         conf, context, scm);
+    context.addEndpoint(TEST_SCM_ENDPOINT);
     context.addContainerAction(getContainerAction());
     endpointTask.call();
     SCMHeartbeatRequestProto heartbeat = argument.getValue();
@@ -226,6 +231,7 @@ public class TestHeartbeatEndpointTask {
 
     HeartbeatEndpointTask endpointTask = getHeartbeatEndpointTask(
         conf, context, scm);
+    context.addEndpoint(TEST_SCM_ENDPOINT);
     context.addReport(NodeReportProto.getDefaultInstance());
     context.addReport(ContainerReportsProto.getDefaultInstance());
     context.addReport(CommandStatusReportsProto.getDefaultInstance());
@@ -277,6 +283,8 @@ public class TestHeartbeatEndpointTask {
     EndpointStateMachine endpointStateMachine = Mockito
         .mock(EndpointStateMachine.class);
     Mockito.when(endpointStateMachine.getEndPoint()).thenReturn(proxy);
+    Mockito.when(endpointStateMachine.getAddressString())
+        .thenReturn(TEST_SCM_ENDPOINT);
     return HeartbeatEndpointTask.newBuilder()
         .setConfig(conf)
         .setDatanodeDetails(datanodeDetails)


### PR DESCRIPTION
… to all configured SCMs

## What changes were proposed in this pull request?

Currently the StateContext in Datanode has the set of actions and reports to be pushed to SCM(s) in the next Heartbeat. Since the state context is shared across all the configured SCM (& Recon) endpoints, an action or report is only pushed to one SCM server based on FCFS. This needs to be changed to a model every SCM server gets the reports and actions.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2888

## How was this patch tested?
Manually tested. Added unit test.