### PR TITLE
HDDS-2870. Handle replay of KeyCreate requests.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMReplayException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMReplayException.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.exceptions;
+
+import java.io.IOException;
+
+/**
+ * Exception thrown by Ozone Manager when a transaction is replayed. This
+ * exception should not be thrown to client. It is used in
+ * OMClientRequest#validateAndUpdateCache to log error and continue in case
+ * of replay transaction.
+ */
+public class OMReplayException extends IOException {
+
+  public OMReplayException() {
+    // Dummy message. This exception is not thrown to client.
+    super("Replayed transaction");
+  }
+
+  public OMReplayException(String message) {
+    super(message);
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -219,7 +219,6 @@ public class OMFileCreateRequest extends OMKeyRequest {
       OmKeyInfo dbKeyInfo = omMetadataManager.getKeyTable().get(ozoneKey);
       if (dbKeyInfo != null) {
         // Check if this transaction is a replay of ratis logs.
-        // Check if this transaction is a replay of ratis logs.
         // We check only the KeyTable here and not the OpenKeyTable. In case
         // this transaction is a replay but the transaction was not committed
         // to the KeyTable, then we recreate the key in OpenKey table. This is

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -82,6 +82,12 @@ public abstract class OMKeyRequest extends OMClientRequest {
 
   private static final Logger LOG = LoggerFactory.getLogger(OMKeyRequest.class);
 
+  public enum Result {
+    SUCCESS,
+    REPLAY,
+    FAILURE
+  }
+
   public OMKeyRequest(OMRequest omRequest) {
     super(omRequest);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -27,8 +27,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -57,40 +55,24 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.ipc.Server;
-import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.ScmClient;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
-import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.om.response.file.OMFileCreateResponse;
-import org.apache.hadoop.ozone.om.response.key.OMKeyCreateResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .CreateFileResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .CreateKeyResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .OMResponse;
 import org.apache.hadoop.ozone.security.OzoneBlockTokenSecretManager;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
-import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes
     .BUCKET_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes
     .VOLUME_NOT_FOUND;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.CreateFile;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.CreateKey;
 import static org.apache.hadoop.util.Time.monotonicNow;
 
 /**
@@ -246,99 +228,6 @@ public abstract class OMKeyRequest extends OMClientRequest {
   }
 
   /**
-   * Prepare the response returned to the client.
-   * @return OMClientResponse
-   */
-  @SuppressWarnings("parameternumber")
-  protected OMClientResponse prepareCreateKeyResponse(@Nonnull KeyArgs keyArgs,
-      OmKeyInfo omKeyInfo, @Nonnull List<OmKeyLocationInfo> locations,
-      FileEncryptionInfo encryptionInfo, @Nullable IOException exception,
-      long clientID, long transactionLogIndex, @Nonnull String volumeName,
-      @Nonnull String bucketName, @Nonnull String keyName,
-      @Nonnull OzoneManager ozoneManager, @Nonnull OMAction omAction,
-      @Nonnull PrefixManager prefixManager,
-      @Nullable OmBucketInfo omBucketInfo) {
-
-    OMResponse.Builder omResponse = OMResponse.newBuilder()
-        .setStatus(OzoneManagerProtocolProtos.Status.OK);
-    OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
-
-    Map<String, String> auditMap = buildKeyArgsAuditMap(keyArgs);
-
-    OMClientResponse omClientResponse = null;
-    if (exception == null) {
-      if (omKeyInfo == null) {
-        // the key does not exist, create a new object, the new blocks are the
-        // version 0
-        omKeyInfo = createKeyInfo(keyArgs, locations, keyArgs.getFactor(),
-            keyArgs.getType(), keyArgs.getDataSize(), encryptionInfo,
-            prefixManager, omBucketInfo, transactionLogIndex);
-      }
-
-      long openVersion = omKeyInfo.getLatestVersionLocations().getVersion();
-
-      // Append blocks
-      try {
-        omKeyInfo.appendNewBlocks(keyArgs.getKeyLocationsList().stream()
-            .map(OmKeyLocationInfo::getFromProtobuf)
-            .collect(Collectors.toList()), false);
-
-      } catch (IOException ex) {
-        exception = ex;
-      }
-
-      if (exception != null) {
-        LOG.error("{} failed for Key: {} in volume/bucket:{}/{}",
-            omAction.getAction(), keyName, bucketName, volumeName, exception);
-        omClientResponse = createKeyErrorResponse(ozoneManager.getMetrics(),
-            omAction, exception, omResponse);
-      } else {
-        String dbOpenKeyName = omMetadataManager.getOpenKey(volumeName,
-            bucketName, keyName, clientID);
-
-        // Add to cache entry can be done outside of lock for this openKey.
-        // Even if bucket gets deleted, when commitKey we shall identify if
-        // bucket gets deleted.
-        omMetadataManager.getOpenKeyTable().addCacheEntry(
-            new CacheKey<>(dbOpenKeyName),
-            new CacheValue<>(Optional.of(omKeyInfo), transactionLogIndex));
-
-        LOG.debug("{} for Key: {} in volume/bucket: {}/{}",
-            omAction.getAction(), keyName, volumeName, bucketName);
-
-
-        if (omAction == OMAction.CREATE_FILE) {
-          omResponse.setCreateFileResponse(CreateFileResponse.newBuilder()
-                  .setKeyInfo(omKeyInfo.getProtobuf())
-                  .setID(clientID)
-                  .setOpenVersion(openVersion).build());
-          omResponse.setCmdType(CreateFile);
-          omClientResponse = new OMFileCreateResponse(omKeyInfo, clientID,
-              omResponse.build());
-        } else {
-          omResponse.setCreateKeyResponse(CreateKeyResponse.newBuilder()
-              .setKeyInfo(omKeyInfo.getProtobuf())
-              .setID(clientID).setOpenVersion(openVersion)
-              .build());
-          omResponse.setCmdType(CreateKey);
-          omClientResponse = new OMKeyCreateResponse(omKeyInfo, clientID,
-              omResponse.build());
-        }
-      }
-
-    } else {
-      LOG.error("{} failed for Key: {} in volume/bucket:{}/{}",
-          omAction.getAction(), keyName, volumeName, bucketName, exception);
-      omClientResponse = createKeyErrorResponse(ozoneManager.getMetrics(),
-          omAction, exception, omResponse);
-    }
-    // audit log
-    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(omAction,
-        auditMap, exception, getOmRequest().getUserInfo()));
-    return omClientResponse;
-  }
-
-  /**
    * Create OmKeyInfo object.
    * @return OmKeyInfo
    */
@@ -416,33 +305,39 @@ public abstract class OMKeyRequest extends OMClientRequest {
   @SuppressWarnings("parameternumber")
   protected OmKeyInfo prepareKeyInfo(
       @Nonnull OMMetadataManager omMetadataManager,
-      @Nonnull KeyArgs keyArgs, @Nonnull String dbKeyName, long size,
+      @Nonnull KeyArgs keyArgs, OmKeyInfo dbKeyInfo, long size,
       @Nonnull List<OmKeyLocationInfo> locations,
       @Nullable FileEncryptionInfo encInfo,
       @Nonnull PrefixManager prefixManager,
       @Nullable OmBucketInfo omBucketInfo,
       long transactionLogIndex)
       throws IOException {
-    OmKeyInfo keyInfo = null;
     if (keyArgs.getIsMultipartKey()) {
-      keyInfo = prepareMultipartKeyInfo(omMetadataManager, keyArgs, size,
-          locations, encInfo, prefixManager, omBucketInfo, transactionLogIndex);
+      return prepareMultipartKeyInfo(omMetadataManager, keyArgs,
+          size, locations, encInfo, prefixManager, omBucketInfo,
+          transactionLogIndex);
       //TODO args.getMetadata
-    } else if (omMetadataManager.getKeyTable().isExist(dbKeyName)) {
+    }
+    if (dbKeyInfo != null) {
       // TODO: Need to be fixed, as when key already exists, we are
       //  appending new blocks to existing key.
-      keyInfo = omMetadataManager.getKeyTable().get(dbKeyName);
-      // the key already exist, the new blocks will be added as new version
+      // The key already exist, the new blocks will be added as new version
       // when locations.size = 0, the new version will have identical blocks
       // as its previous version
-      keyInfo.addNewVersion(locations, false);
-      keyInfo.setDataSize(size + keyInfo.getDataSize());
-      // The modification time is set in preExecute, use the same as
-      // modification time when key already exists.
-      keyInfo.setModificationTime(keyArgs.getModificationTime());
-      keyInfo.setUpdateID(transactionLogIndex);
+      dbKeyInfo.addNewVersion(locations, false);
+      dbKeyInfo.setDataSize(size + dbKeyInfo.getDataSize());
+      // The modification time is set in preExecute. Use the same
+      // modification time.
+      dbKeyInfo.setModificationTime(keyArgs.getModificationTime());
+      dbKeyInfo.setUpdateID(transactionLogIndex);
+      return dbKeyInfo;
     }
-    return keyInfo;
+
+    // the key does not exist, create a new object.
+    // Blocks will be appended as version 0.
+    return createKeyInfo(keyArgs, locations, keyArgs.getFactor(),
+        keyArgs.getType(), keyArgs.getDataSize(), encInfo, prefixManager,
+        omBucketInfo, transactionLogIndex);
   }
 
   /**
@@ -487,22 +382,6 @@ public abstract class OMKeyRequest extends OMClientRequest {
     // is not an actual key, it is a part of the key.
     return createKeyInfo(args, locations, factor, type, size, encInfo,
         prefixManager, omBucketInfo, transactionLogIndex);
-  }
-
-  private OMClientResponse createKeyErrorResponse(@Nonnull OMMetrics omMetrics,
-      @Nonnull OMAction omAction, @Nonnull IOException exception,
-      @Nonnull OMResponse.Builder omResponse) {
-    if (omAction == OMAction.CREATE_FILE) {
-      omMetrics.incNumCreateFileFails();
-      omResponse.setCmdType(CreateFile);
-      return new OMFileCreateResponse(null, -1L,
-          createErrorOMResponse(omResponse, exception));
-    } else {
-      omMetrics.incNumKeyAllocateFails();
-      omResponse.setCmdType(CreateKey);
-      return new OMKeyCreateResponse(null, -1L,
-          createErrorOMResponse(omResponse, exception));
-    }
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -82,10 +82,16 @@ public abstract class OMKeyRequest extends OMClientRequest {
 
   private static final Logger LOG = LoggerFactory.getLogger(OMKeyRequest.class);
 
+  /**
+   * Stores the result of request execution in
+   * OMClientRequest#validateAndUpdateCache.
+   */
   public enum Result {
-    SUCCESS,
-    REPLAY,
-    FAILURE
+    SUCCESS, // The request was executed successfully
+
+    REPLAY, // The request is a replay and was ignored
+
+    FAILURE // The request failed and exception was thrown
   }
 
   public OMKeyRequest(OMRequest omRequest) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponse.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.response.file;
 
-import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
 
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -26,16 +25,18 @@ import org.apache.hadoop.ozone.om.response.key.OMKeyCreateResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 
-
-
 /**
  * Response for crate file request.
  */
 public class OMFileCreateResponse extends OMKeyCreateResponse {
 
-  public OMFileCreateResponse(@Nullable OmKeyInfo omKeyInfo,
-      long openKeySessionID, @Nonnull OMResponse omResponse) {
-    super(omKeyInfo, openKeySessionID, omResponse);
+  public OMFileCreateResponse(@Nonnull OMResponse omResponse,
+      @Nonnull OmKeyInfo omKeyInfo, long openKeySessionID) {
+    super(omResponse, omKeyInfo, openKeySessionID);
+  }
+
+  public OMFileCreateResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -118,10 +118,24 @@ public final class TestOMRequestUtils {
       HddsProtos.ReplicationType replicationType,
       HddsProtos.ReplicationFactor replicationFactor,
       OMMetadataManager omMetadataManager) throws Exception {
+    addKeyToTable(openKeyTable, volumeName, bucketName, keyName, clientID,
+        replicationType, replicationFactor, 0L, omMetadataManager);
+  }
 
+  /**
+   * Add key entry to KeyTable. if openKeyTable flag is true, add's entries
+   * to openKeyTable, else add's it to keyTable.
+   * @throws Exception
+   */
+  @SuppressWarnings("parameternumber")
+  public static void addKeyToTable(boolean openKeyTable, String volumeName,
+      String bucketName, String keyName, long clientID,
+      HddsProtos.ReplicationType replicationType,
+      HddsProtos.ReplicationFactor replicationFactor, long trxnLogIndex,
+      OMMetadataManager omMetadataManager) throws Exception {
 
     OmKeyInfo omKeyInfo = createOmKeyInfo(volumeName, bucketName, keyName,
-        replicationType, replicationFactor);
+        replicationType, replicationFactor, trxnLogIndex);
 
     if (openKeyTable) {
       omMetadataManager.getOpenKeyTable().put(
@@ -131,7 +145,6 @@ public final class TestOMRequestUtils {
       omMetadataManager.getKeyTable().put(omMetadataManager.getOzoneKey(
           volumeName, bucketName, keyName), omKeyInfo);
     }
-
   }
 
   /**
@@ -151,15 +164,12 @@ public final class TestOMRequestUtils {
       HddsProtos.ReplicationFactor replicationFactor,
       OMMetadataManager omMetadataManager) {
 
-
     OmKeyInfo omKeyInfo = createOmKeyInfo(volumeName, bucketName, keyName,
         replicationType, replicationFactor);
 
     omMetadataManager.getKeyTable().addCacheEntry(
         new CacheKey<>(omMetadataManager.getOzoneKey(volumeName, bucketName,
-            keyName)), new CacheValue<>(Optional.of(omKeyInfo),
-            1L));
-
+            keyName)), new CacheValue<>(Optional.of(omKeyInfo), 1L));
   }
 
   private OmKeyInfo createKeyInfo(String volumeName, String bucketName,
@@ -178,14 +188,22 @@ public final class TestOMRequestUtils {
         .setReplicationFactor(replicationFactor).build();
   }
 
+  /**
+   * Create OmKeyInfo.
+   */
+  public static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
+      String keyName, HddsProtos.ReplicationType replicationType,
+      HddsProtos.ReplicationFactor replicationFactor) {
+    return createOmKeyInfo(volumeName, bucketName, keyName, replicationType,
+        replicationFactor, 0L);
+  }
 
   /**
    * Create OmKeyInfo.
    */
-
   public static OmKeyInfo createOmKeyInfo(String volumeName, String bucketName,
       String keyName, HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor) {
+      HddsProtos.ReplicationFactor replicationFactor, long objectID) {
     return new OmKeyInfo.Builder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
@@ -196,9 +214,11 @@ public final class TestOMRequestUtils {
         .setModificationTime(Time.now())
         .setDataSize(1000L)
         .setReplicationType(replicationType)
-        .setReplicationFactor(replicationFactor).build();
+        .setReplicationFactor(replicationFactor)
+        .setObjectID(objectID)
+        .setUpdateID(objectID)
+        .build();
   }
-
 
   /**
    * Add volume creation entry to OM DB.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequest.java
@@ -38,6 +38,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMRequest;
 
+import static org.apache.hadoop.ozone.om.request.TestOMRequestUtils.addKeyToTable;
+import static org.apache.hadoop.ozone.om.request.TestOMRequestUtils.addVolumeAndBucketToDB;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.FILE_ALREADY_EXISTS;
@@ -47,7 +49,6 @@ import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.
  * Tests OMFileCreateRequest.
  */
 public class TestOMFileCreateRequest extends TestOMKeyRequest {
-
 
   @Test
   public void testPreExecute() throws Exception{
@@ -60,7 +61,6 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
 
     OMRequest modifiedOmRequest = omFileCreateRequest.preExecute(ozoneManager);
     Assert.assertNotEquals(omRequest, modifiedOmRequest);
-
 
     // Check clientID and modification time is set or not.
     Assert.assertTrue(modifiedOmRequest.hasCreateFileRequest());
@@ -103,7 +103,6 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
     OMRequest modifiedOmRequest = omFileCreateRequest.preExecute(ozoneManager);
     Assert.assertNotEquals(omRequest, modifiedOmRequest);
 
-
     // When KeyName is root, nothing will be set.
     Assert.assertTrue(modifiedOmRequest.hasCreateFileRequest());
     Assert.assertFalse(
@@ -127,7 +126,6 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
         omRequest);
 
     OMRequest modifiedOmRequest = omFileCreateRequest.preExecute(ozoneManager);
-
 
     long id = modifiedOmRequest.getCreateFileRequest().getClientID();
 
@@ -165,7 +163,6 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
     Assert.assertEquals(omKeyInfo.getModificationTime(),
         omKeyInfo.getCreationTime());
 
-
     // Check data of the block
     OzoneManagerProtocolProtos.KeyLocation keyLocation =
         modifiedOmRequest.getCreateFileRequest().getKeyArgs()
@@ -175,7 +172,6 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
         .getContainerID(), omKeyLocationInfo.getContainerID());
     Assert.assertEquals(keyLocation.getBlockID().getContainerBlockID()
         .getLocalID(), omKeyLocationInfo.getLocalID());
-
   }
 
   @Test
@@ -196,7 +192,6 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
             ozoneManagerDoubleBufferHelper);
     Assert.assertEquals(VOLUME_NOT_FOUND,
         omFileCreateResponse.getOMResponse().getStatus());
-
   }
 
   @Test
@@ -219,7 +214,6 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
             ozoneManagerDoubleBufferHelper);
     Assert.assertEquals(BUCKET_NOT_FOUND,
         omFileCreateResponse.getOMResponse().getStatus());
-
   }
 
   @Test
@@ -242,7 +236,6 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
         "a/b/", 0L,  HddsProtos.ReplicationType.RATIS,
         HddsProtos.ReplicationFactor.ONE, omMetadataManager);
     testNonRecursivePath("a/b/e", false, false, false);
-
   }
 
   @Test
@@ -259,8 +252,6 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
         "a/b/c/d", 0L,  HddsProtos.ReplicationType.RATIS,
         HddsProtos.ReplicationFactor.ONE, omMetadataManager);
     testNonRecursivePath("a/b/c", false, true, false);
-
-
   }
 
   @Test
@@ -347,7 +338,6 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
       Assert.assertEquals(modifiedOmRequest.getCreateFileRequest()
           .getKeyArgs().getModificationTime(), omKeyInfo.getModificationTime());
 
-
       // Check data of the block
       OzoneManagerProtocolProtos.KeyLocation keyLocation =
           modifiedOmRequest.getCreateFileRequest().getKeyArgs()
@@ -359,7 +349,6 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
           .getLocalID(), omKeyLocationInfo.getLocalID());
     }
   }
-
 
   /**
    * Create OMRequest which encapsulates OMFileCreateRequest.
@@ -391,5 +380,32 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
         .setClientId(UUID.randomUUID().toString())
         .setCreateFileRequest(createFileRequest).build();
 
+  }
+
+  @Test
+  public void testReplayRequest() throws Exception {
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+
+    OMRequest originalRequest = createFileRequest(volumeName, bucketName,
+        keyName, replicationFactor, replicationType, false, false);
+    OMFileCreateRequest omFileCreateRequest = new OMFileCreateRequest(
+        originalRequest);
+
+    // Manually add volume, bucket and key to DB table
+    addVolumeAndBucketToDB(volumeName, bucketName, omMetadataManager);
+    addKeyToTable(false, volumeName, bucketName, keyName, clientID,
+        replicationType, replicationFactor, 1L, omMetadataManager);
+
+    // Replay the transaction - Execute the createFile request again
+    OMClientResponse omClientResponse =
+        omFileCreateRequest.validateAndUpdateCache(ozoneManager, 1,
+            ozoneManagerDoubleBufferHelper);
+
+    // Replay should result in Replay response
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.REPLAY,
+        omClientResponse.getOMResponse().getStatus());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -37,6 +37,9 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMRequest;
 
+import static org.apache.hadoop.ozone.om.request.TestOMRequestUtils.addKeyToTable;
+import static org.apache.hadoop.ozone.om.request.TestOMRequestUtils.addVolumeAndBucketToDB;
+
 /**
  * Tests OMCreateKeyRequest class.
  */
@@ -63,7 +66,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
         new OMKeyCreateRequest(modifiedOmRequest);
 
     // Add volume and bucket entries to DB.
-    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager);
 
     long id = modifiedOmRequest.getCreateKeyRequest().getClientID();
@@ -127,7 +130,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
         new OMKeyCreateRequest(modifiedOmRequest);
 
     // Add volume and bucket entries to DB.
-    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager);
 
     long id = modifiedOmRequest.getCreateKeyRequest().getClientID();
@@ -326,6 +329,47 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
         .setClientId(UUID.randomUUID().toString())
         .setCreateKeyRequest(createKeyRequest).build();
 
+  }
+
+  @Test
+  public void testReplayRequest() throws Exception {
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+
+    KeyArgs keyArgs = KeyArgs.newBuilder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setFactor(replicationFactor)
+        .setType(replicationType)
+        .build();
+
+    CreateKeyRequest.Builder req = CreateKeyRequest.newBuilder()
+        .setKeyArgs(keyArgs);
+    OMRequest originalRequest = OMRequest.newBuilder()
+        .setCreateKeyRequest(req)
+        .setCmdType(OzoneManagerProtocolProtos.Type.CreateKey)
+        .setClientId(UUID.randomUUID().toString())
+        .build();
+
+    OMKeyCreateRequest omKeyCreateRequest = new OMKeyCreateRequest(
+        originalRequest);
+
+    // Manually add volume, bucket and key to DB table
+    addVolumeAndBucketToDB(volumeName, bucketName, omMetadataManager);
+    addKeyToTable(false, volumeName, bucketName, keyName, clientID,
+        replicationType, replicationFactor, 1L, omMetadataManager);
+
+    // Replay the transaction - Execute the createKey request again
+    OMClientResponse omClientResponse =
+        omKeyCreateRequest.validateAndUpdateCache(ozoneManager, 1,
+            ozoneManagerDoubleBufferHelper);
+
+    // Replay should result in Replay response
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.REPLAY,
+        omClientResponse.getOMResponse().getStatus());
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -101,6 +101,7 @@ public class TestOMKeyRequest {
     when(ozoneManager.getMetrics()).thenReturn(omMetrics);
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
     when(ozoneManager.getConfiguration()).thenReturn(ozoneConfiguration);
+    when(ozoneManager.isRatisEnabled()).thenReturn(true);
     auditLogger = Mockito.mock(AuditLogger.class);
     when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
     Mockito.doNothing().when(auditLogger).logWrite(any(AuditMessage.class));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
@@ -48,7 +48,7 @@ public class TestOMKeyCreateResponse extends TestOMKeyResponse {
             .build();
 
     OMKeyCreateResponse omKeyCreateResponse =
-        new OMKeyCreateResponse(omKeyInfo, clientID, omResponse);
+        new OMKeyCreateResponse(omResponse, omKeyInfo, clientID);
 
     String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,
         keyName, clientID);
@@ -73,14 +73,14 @@ public class TestOMKeyCreateResponse extends TestOMKeyResponse {
         .build();
 
     OMKeyCreateResponse omKeyCreateResponse =
-        new OMKeyCreateResponse(omKeyInfo, clientID, omResponse);
+        new OMKeyCreateResponse(omResponse, omKeyInfo, clientID);
 
     // Before calling addToDBBatch
     String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,
         keyName, clientID);
     Assert.assertFalse(omMetadataManager.getOpenKeyTable().isExist(openKey));
 
-    omKeyCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
+    omKeyCreateResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
 
     // Do manual commit and see whether addToBatch is successful or not.
     omMetadataManager.getStore().commitBatchOperation(batchOperation);


### PR DESCRIPTION
## What changes were proposed in this pull request?

To ensure that key creation operation is idempotent, compare the transactionID with the objectID and updateID to make sure that the transaction is not a replay. If the transactionID <= updateID, then it implies that the transaction is a replay and hence it should be skipped.

OMKeyCreateRequest and OMFileCreateRequest are made idempotent in this Jira.

https://issues.apache.org/jira/browse/HDDS-2870

## How was this patch tested?

Unit tests to verify replayed transactions return expected response.
