### PR TITLE
HDDS-2893. Handle replay of KeyPurge Request.

### DIFF
--- a/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
+++ b/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
@@ -853,8 +853,14 @@ message DeleteKeyResponse {
     optional uint64 openVersion = 4;
 }
 
+message DeleteKeysInBucket {
+    required string volumeName = 1;
+    required string bucketName = 2;
+    repeated string keys = 3;
+}
+
 message PurgeKeysRequest {
-    repeated string keys = 1;
+    repeated DeleteKeysInBucket deleteKeysInBuckets = 1;
 }
 
 message PurgeKeysResponse {

--- a/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
+++ b/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
@@ -853,14 +853,14 @@ message DeleteKeyResponse {
     optional uint64 openVersion = 4;
 }
 
-message DeleteKeysInBucket {
+message DeletedKeys {
     required string volumeName = 1;
     required string bucketName = 2;
     repeated string keys = 3;
 }
 
 message PurgeKeysRequest {
-    repeated DeleteKeysInBucket deleteKeysInBuckets = 1;
+    repeated DeletedKeys deletedKeys = 1;
 }
 
 message PurgeKeysResponse {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyDeletingService.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;submitPurgeKeysRequest
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -30,7 +30,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.common.DeleteBlockGroupResult;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeysInBucket;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeletedKeys;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PurgeKeysRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
@@ -247,12 +247,12 @@ public class KeyDeletingService extends BackgroundService {
       for (Map.Entry<Pair<String, String>, List<String>> entry :
           purgeKeysMapPerBucket.entrySet()) {
         Pair<String, String> volumeBucketPair = entry.getKey();
-        DeleteKeysInBucket deleteKeysInBucket = DeleteKeysInBucket.newBuilder()
+        DeletedKeys deletedKeysInBucket = DeletedKeys.newBuilder()
             .setVolumeName(volumeBucketPair.getLeft())
             .setBucketName(volumeBucketPair.getRight())
             .addAllKeys(entry.getValue())
             .build();
-        purgeKeysRequest.addDeleteKeysInBuckets(deleteKeysInBucket);
+        purgeKeysRequest.addDeletedKeys(deletedKeysInBucket);
       }
 
       OMRequest omRequest = OMRequest.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyDeletingService.java
@@ -18,15 +18,19 @@ package org.apache.hadoop.ozone.om;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;submitPurgeKeysRequest
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.protobuf.ServiceException;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.common.DeleteBlockGroupResult;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeysInBucket;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PurgeKeysRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
@@ -38,6 +42,8 @@ import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
 import org.apache.hadoop.hdds.utils.BackgroundTaskResult.EmptyTaskResult;
 
 import com.google.common.annotations.VisibleForTesting;
+
+import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_DELETING_LIMIT_PER_TASK;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_KEY_DELETING_LIMIT_PER_TASK_DEFAULT;
 
@@ -45,6 +51,7 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.util.Preconditions;
 import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -218,7 +225,8 @@ public class KeyDeletingService extends BackgroundService {
      * @throws IOException      on Error
      */
     public int submitPurgeKeysRequest(List<DeleteBlockGroupResult> results) {
-      List<String> purgeKeysList = new ArrayList<>();
+      Map<Pair<String, String>, List<String>> purgeKeysMapPerBucket =
+          new HashMap<>();
 
       // Put all keys to be purged in a list
       int deletedCount = 0;
@@ -226,15 +234,26 @@ public class KeyDeletingService extends BackgroundService {
         if (result.isSuccess()) {
           // Add key to PurgeKeys list.
           String deletedKey = result.getObjectKey();
-          purgeKeysList.add(deletedKey);
+          // Parse Volume and BucketName
+          addToMap(purgeKeysMapPerBucket, deletedKey);
           LOG.debug("Key {} set to be purged from OM DB", deletedKey);
           deletedCount++;
         }
       }
 
-      PurgeKeysRequest purgeKeysRequest = PurgeKeysRequest.newBuilder()
-          .addAllKeys(purgeKeysList)
-          .build();
+      PurgeKeysRequest.Builder purgeKeysRequest = PurgeKeysRequest.newBuilder();
+
+      // Add keys to PurgeKeysRequest bucket wise.
+      for (Map.Entry<Pair<String, String>, List<String>> entry :
+          purgeKeysMapPerBucket.entrySet()) {
+        Pair<String, String> volumeBucketPair = entry.getKey();
+        DeleteKeysInBucket deleteKeysInBucket = DeleteKeysInBucket.newBuilder()
+            .setVolumeName(volumeBucketPair.getLeft())
+            .setBucketName(volumeBucketPair.getRight())
+            .addAllKeys(entry.getValue())
+            .build();
+        purgeKeysRequest.addDeleteKeysInBuckets(deleteKeysInBucket);
+      }
 
       OMRequest omRequest = OMRequest.newBuilder()
           .setCmdType(Type.PurgeKeys)
@@ -252,5 +271,22 @@ public class KeyDeletingService extends BackgroundService {
 
       return deletedCount;
     }
+  }
+
+  /**
+   * Parse Volume and Bucket Name from ObjectKey and add it to given map of
+   * keys to be purged per bucket.
+   */
+  private void addToMap(Map<Pair<String, String>, List<String>> map,
+      String objectKey) {
+    // Parse volume and bucket name
+    String[] split = objectKey.split(OM_KEY_PREFIX);
+    Preconditions.assertTrue(split.length > 3, "Volume and/or Bucket Name " +
+        "missing from Key Name.");
+    Pair<String, String> volumeBucketPair = Pair.of(split[1], split[2]);
+    if (!map.containsKey(volumeBucketPair)) {
+      map.put(volumeBucketPair, new ArrayList<>());
+    }
+    map.get(volumeBucketPair).add(objectKey);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyPurgeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyPurgeRequest.java
@@ -142,16 +142,15 @@ public class OMKeyPurgeRequest extends OMKeyRequest {
     }
 
     if (success) {
-      if (keysToBePurgedList.isEmpty()) {
-        LOG.debug("No keys will be purged as part of KeyPurgeRequest: {}",
-            purgeKeysRequest);
-      } else {
-        StringBuilder purgeList = new StringBuilder();
-        for (String key : keysToBePurgedList) {
-          purgeList.append(", ").append(key);
+      if (LOG.isDebugEnabled()) {
+        if (keysToBePurgedList.isEmpty()) {
+          LOG.debug("No keys will be purged as part of KeyPurgeRequest: {}",
+              purgeKeysRequest);
+        } else {
+          LOG.debug("Following keys will be purged as part of " +
+              "KeyPurgeRequest: {} - {}", purgeKeysRequest,
+              String.join(",", keysToBePurgedList));
         }
-        LOG.debug("Following keys will be purged as part of KeyPurgeRequest: " +
-            "{} - {}", purgeKeysRequest, purgeList.toString().substring(2));
       }
       omClientResponse = new OMKeyPurgeResponse(omResponse.build(),
           keysToBePurgedList);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyPurgeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyPurgeResponse.java
@@ -55,11 +55,9 @@ public class OMKeyPurgeResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    if (getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK) {
-      for (String key : purgeKeyList) {
-        omMetadataManager.getDeletedTable().deleteWithBatch(batchOperation,
-            key);
-      }
+    for (String key : purgeKeyList) {
+      omMetadataManager.getDeletedTable().deleteWithBatch(batchOperation,
+          key);
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyPurgeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyPurgeResponse.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om.response.key;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.request.key.OMKeyPurgeRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyPurgeResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyPurgeResponse.java
@@ -36,10 +36,19 @@ public class OMKeyPurgeResponse extends OMClientResponse {
 
   private List<String> purgeKeyList;
 
-  public OMKeyPurgeResponse(List<String> keyList,
-      @Nonnull OMResponse omResponse) {
+  public OMKeyPurgeResponse(@Nonnull OMResponse omResponse,
+      List<String> keyList) {
     super(omResponse);
     this.purgeKeyList = keyList;
+  }
+
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
+  public OMKeyPurgeResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+    checkStatusNotOK();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -19,7 +19,6 @@
 
 package org.apache.hadoop.ozone.om.request;
 
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -135,26 +134,6 @@ public final class TestOMRequestUtils {
       HddsProtos.ReplicationFactor replicationFactor, long trxnLogIndex,
       OMMetadataManager omMetadataManager) throws Exception {
 
-  /**
-   * Add key entry to KeyTable. if openKeyTable flag is true, add's entries
-   * to openKeyTable, else add's it to keyTable.
-   * @param openKeyTable
-   * @param volumeName
-   * @param bucketName
-   * @param keyName
-   * @param clientID
-   * @param replicationType
-   * @param replicationFactor
-   * @param trxnLogIndex
-   * @param omMetadataManager
-   * @throws Exception
-   */
-  @SuppressWarnings("parameternumber")
-  public static void addKeyToTable(boolean openKeyTable, String volumeName,
-      String bucketName, String keyName, long clientID,
-      HddsProtos.ReplicationType replicationType,
-      HddsProtos.ReplicationFactor replicationFactor, long trxnLogIndex,
-      OMMetadataManager omMetadataManager) throws Exception {
     OmKeyInfo omKeyInfo = createOmKeyInfo(volumeName, bucketName, keyName,
         replicationType, replicationFactor, trxnLogIndex);
 
@@ -294,7 +273,7 @@ public final class TestOMRequestUtils {
   }
 
   /**
-   * Add volume creation entry to OM DB.
+   * Add bucket creation entry to OM DB.
    * @param volumeName
    * @param bucketName
    * @param omMetadataManager

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequest.java
@@ -156,7 +156,7 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
     long deleteTrxnLogIndex = 10L;
     String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
         keyName);
-    TestOMRequestUtils.deleteKey(ozoneKey, omMetadataManager);
+    TestOMRequestUtils.deleteKey(ozoneKey, omMetadataManager, 10L);
 
     // Create the same key again with TransactionLogIndex > Delete requests
     // TransactionLogIndex

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.key.OMKeyPurgeResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeletedKeys;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PurgeKeysRequest;
@@ -48,7 +49,11 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
    * Creates volume, bucket and key entries and adds to OM DB and then
    * deletes these keys to move them to deletedKeys table.
    */
-  private List<String> createAndDeleteKeys() throws Exception {
+  private List<String> createAndDeleteKeys(Integer trxnIndex, String bucket)
+      throws Exception {
+    if (bucket == null) {
+      bucket = bucketName;
+    }
     // Add volume, bucket and key entries to OM DB.
     TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager);
@@ -57,15 +62,16 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
     for (int i = 1; i <= numKeys; i++) {
       String key = keyName + "-" + i;
       TestOMRequestUtils.addKeyToTable(false, volumeName, bucketName, key,
-          clientID, replicationType, replicationFactor, omMetadataManager);
-      ozoneKeyNames.add(
-          omMetadataManager.getOzoneKey(volumeName, bucketName, key));
+          clientID, replicationType, replicationFactor, trxnIndex++,
+          omMetadataManager);
+      ozoneKeyNames.add(omMetadataManager.getOzoneKey(
+          volumeName, bucketName, key));
     }
 
     List<String> deletedKeyNames = new ArrayList<>(numKeys);
     for (String ozoneKey : ozoneKeyNames) {
       String deletedKeyName = TestOMRequestUtils.deleteKey(
-          ozoneKey, omMetadataManager);
+          ozoneKey, omMetadataManager, trxnIndex++);
       deletedKeyNames.add(deletedKeyName);
     }
 
@@ -77,8 +83,13 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
    * @return OMRequest
    */
   private OMRequest createPurgeKeysRequest(List<String> deletedKeys) {
-    PurgeKeysRequest purgeKeysRequest = PurgeKeysRequest.newBuilder()
+    DeletedKeys deletedKeysInBucket = DeletedKeys.newBuilder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
         .addAllKeys(deletedKeys)
+        .build();
+    PurgeKeysRequest purgeKeysRequest = PurgeKeysRequest.newBuilder()
+        .addDeletedKeys(deletedKeysInBucket)
         .build();
 
     return OMRequest.newBuilder()
@@ -88,10 +99,22 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
         .build();
   }
 
+  private OMRequest preExecute(OMRequest originalOmRequest) throws IOException {
+    OMKeyPurgeRequest omKeyPurgeRequest =
+        new OMKeyPurgeRequest(originalOmRequest);
+
+    OMRequest modifiedOmRequest = omKeyPurgeRequest.preExecute(ozoneManager);
+
+    // Will not be equal, as UserInfo will be set.
+    Assert.assertNotEquals(originalOmRequest, modifiedOmRequest);
+
+    return modifiedOmRequest;
+  }
+
   @Test
   public void testValidateAndUpdateCache() throws Exception {
     // Create and Delete keys. The keys should be moved to DeletedKeys table
-    List<String> deletedKeyNames = createAndDeleteKeys();
+    List<String> deletedKeyNames = createAndDeleteKeys(1, null);
 
     // The keys should be present in the DeletedKeys table before purging
     for (String deletedKey : deletedKeyNames) {
@@ -106,9 +129,8 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
     OMKeyPurgeRequest omKeyPurgeRequest =
         new OMKeyPurgeRequest(preExecutedRequest);
 
-    OMClientResponse omClientResponse =
-        omKeyPurgeRequest.validateAndUpdateCache(ozoneManager, 100L,
-            ozoneManagerDoubleBufferHelper);
+    omKeyPurgeRequest.validateAndUpdateCache(ozoneManager, 100L,
+        ozoneManagerDoubleBufferHelper);
 
     OMResponse omResponse = OMResponse.newBuilder()
         .setPurgeKeysResponse(PurgeKeysResponse.getDefaultInstance())
@@ -133,15 +155,119 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
     }
   }
 
-  private OMRequest preExecute(OMRequest originalOmRequest) throws IOException {
+  @Test
+  public void testPurgeKeysAcrossBuckets() throws Exception {
+    String bucket1 = bucketName;
+    String bucket2 = UUID.randomUUID().toString();
+
+    // bucket1 is created during setup. Create bucket2 manually.
+    TestOMRequestUtils.addBucketToDB(volumeName, bucket2, omMetadataManager);
+
+    // Create and Delete keys in Bucket1 and Bucket2.
+    List<String> deletedKeyInBucket1 = createAndDeleteKeys(1, bucket1);
+    List<String> deletedKeyInBucket2 = createAndDeleteKeys(1, bucket2);
+    List<String> deletedKeyNames = new ArrayList<>();
+    deletedKeyNames.addAll(deletedKeyInBucket1);
+    deletedKeyNames.addAll(deletedKeyInBucket2);
+
+    // The keys should be present in the DeletedKeys table before purging
+    for (String deletedKey : deletedKeyNames) {
+      Assert.assertTrue(omMetadataManager.getDeletedTable().isExist(
+          deletedKey));
+    }
+
+    // Create PurgeKeysRequest to purge the deleted keys
+    DeletedKeys deletedKeysInBucket1 = DeletedKeys.newBuilder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucket1)
+        .addAllKeys(deletedKeyInBucket1)
+        .build();
+    DeletedKeys deletedKeysInBucket2 = DeletedKeys.newBuilder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucket2)
+        .addAllKeys(deletedKeyInBucket1)
+        .build();
+    PurgeKeysRequest purgeKeysRequest = PurgeKeysRequest.newBuilder()
+        .addDeletedKeys(deletedKeysInBucket1)
+        .addDeletedKeys(deletedKeysInBucket2)
+        .build();
+
+    OMRequest omRequest = OMRequest.newBuilder()
+        .setPurgeKeysRequest(purgeKeysRequest)
+        .setCmdType(Type.PurgeKeys)
+        .setClientId(UUID.randomUUID().toString())
+        .build();
+
+    OMRequest preExecutedRequest = preExecute(omRequest);
     OMKeyPurgeRequest omKeyPurgeRequest =
-        new OMKeyPurgeRequest(originalOmRequest);
+        new OMKeyPurgeRequest(preExecutedRequest);
 
-    OMRequest modifiedOmRequest = omKeyPurgeRequest.preExecute(ozoneManager);
+    omKeyPurgeRequest.validateAndUpdateCache(ozoneManager, 100L,
+        ozoneManagerDoubleBufferHelper);
 
-    // Will not be equal, as UserInfo will be set.
-    Assert.assertNotEquals(originalOmRequest, modifiedOmRequest);
+    OMResponse omResponse = OMResponse.newBuilder()
+        .setPurgeKeysResponse(PurgeKeysResponse.getDefaultInstance())
+        .setCmdType(Type.PurgeKeys)
+        .setStatus(Status.OK)
+        .build();
 
-    return modifiedOmRequest;
+    BatchOperation batchOperation =
+        omMetadataManager.getStore().initBatchOperation();
+
+    OMKeyPurgeResponse omKeyPurgeResponse = new OMKeyPurgeResponse(
+        omResponse, deletedKeyNames);
+    omKeyPurgeResponse.addToDBBatch(omMetadataManager, batchOperation);
+
+    // Do manual commit and see whether addToBatch is successful or not.
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+
+    // The keys should not exist in the DeletedKeys table
+    for (String deletedKey : deletedKeyNames) {
+      Assert.assertFalse(omMetadataManager.getDeletedTable().isExist(
+          deletedKey));
+    }
+  }
+
+  @Test
+  public void testReplayRequest() throws Exception {
+
+    // Create and Delete keys. The keys should be moved to DeletedKeys table
+    Integer trxnLogIndex = new Integer(1);
+    List<String> deletedKeyNames = createAndDeleteKeys(trxnLogIndex, null);
+    int purgeRequestTrxnLogIndex = ++trxnLogIndex;
+
+    // The keys should be present in the DeletedKeys table before purging
+    for (String deletedKey : deletedKeyNames) {
+      Assert.assertTrue(omMetadataManager.getDeletedTable().isExist(
+          deletedKey));
+    }
+
+    // Execute PurgeKeys request to purge the keys from Deleted table.
+    // Create PurgeKeysRequest to replay the purge request
+    OMRequest omRequest = createPurgeKeysRequest(deletedKeyNames);
+    OMRequest preExecutedRequest = preExecute(omRequest);
+    OMKeyPurgeRequest omKeyPurgeRequest =
+        new OMKeyPurgeRequest(preExecutedRequest);
+    OMClientResponse omClientResponse = omKeyPurgeRequest
+        .validateAndUpdateCache(ozoneManager, purgeRequestTrxnLogIndex,
+            ozoneManagerDoubleBufferHelper);
+
+    Assert.assertTrue(omClientResponse.getOMResponse().getStatus().equals(
+        Status.OK));
+
+    // Create and delete the same keys again
+    createAndDeleteKeys(++trxnLogIndex, null);
+
+    // Replay the PurgeKeys request. It should not purge the keys deleted
+    // after the original request was played.
+    OMClientResponse replayResponse = omKeyPurgeRequest
+        .validateAndUpdateCache(ozoneManager, purgeRequestTrxnLogIndex,
+            ozoneManagerDoubleBufferHelper);
+
+    // Verify that the new deletedKeys exist in the DeletedKeys table
+    for (String deletedKey : deletedKeyNames) {
+      Assert.assertTrue(omMetadataManager.getDeletedTable().isExist(
+          deletedKey));
+    }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
@@ -55,17 +55,17 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
       bucket = bucketName;
     }
     // Add volume, bucket and key entries to OM DB.
-    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucket,
         omMetadataManager);
 
     List<String> ozoneKeyNames = new ArrayList<>(numKeys);
     for (int i = 1; i <= numKeys; i++) {
       String key = keyName + "-" + i;
-      TestOMRequestUtils.addKeyToTable(false, volumeName, bucketName, key,
-          clientID, replicationType, replicationFactor, trxnIndex++,
+      TestOMRequestUtils.addKeyToTable(false, false, volumeName, bucket,
+          key, clientID, replicationType, replicationFactor, trxnIndex++,
           omMetadataManager);
       ozoneKeyNames.add(omMetadataManager.getOzoneKey(
-          volumeName, bucketName, key));
+          volumeName, bucket, key));
     }
 
     List<String> deletedKeyNames = new ArrayList<>(numKeys);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyPurgeRequestAndResponse.java
@@ -119,8 +119,8 @@ public class TestOMKeyPurgeRequestAndResponse extends TestOMKeyRequest {
     BatchOperation batchOperation =
         omMetadataManager.getStore().initBatchOperation();
 
-    OMKeyPurgeResponse omKeyPurgeResponse =
-        new OMKeyPurgeResponse(deletedKeyNames, omResponse);
+    OMKeyPurgeResponse omKeyPurgeResponse = new OMKeyPurgeResponse(
+        omResponse, deletedKeyNames);
     omKeyPurgeResponse.addToDBBatch(omMetadataManager, batchOperation);
 
     // Do manual commit and see whether addToBatch is successful or not.


### PR DESCRIPTION
## What changes were proposed in this pull request?

If KeyPurgeRequest is replayed, we do not want to purge the keys which were created after the original purge request was received. This could happen if a key was deleted, purged and then created and deleted again. The the purge request was replayed, it would purge the key deleted after the original purge request was completed.
Hence, to maintain idempotence, we should only purge those keys from DeletedKeys table that have updateID < transactionLogIndex of the request.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2893

## How was this patch tested?

Unit tests to verify replayed transactions are executed as expected.