### PR TITLE
HDDS-2894. Handle replay of KeyDelete and KeyRename Requests

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -142,6 +142,22 @@ public final class OmKeyInfo extends WithMetadata {
   }
 
   /**
+   * Set the Object ID. If this value is already set then this function throws.
+   * There is a reason why we cannot use the final here. The OMKeyInfo is
+   * deserialized from the protobuf in many places in code. We need to set
+   * this object ID, after it is deserialized.
+   *
+   * @param obId - long
+   */
+  public void setObjectID(long obId) {
+    if(this.objectID != 0) {
+      throw new UnsupportedOperationException("Attempt to modify object ID " +
+          "which is not zero. Current Object ID is " + this.objectID);
+    }
+    this.objectID = obId;
+  }
+
+  /**
    * Sets the update ID. For each modification of this object, we will set
    * this to a value greater than the current value.
    * @param updateId  long

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -513,6 +513,14 @@ public final class OmKeyInfo extends WithMetadata {
    * Return a new copy of the object.
    */
   public OmKeyInfo copyObject() {
+    return copyObject(true);
+  }
+
+  /**
+   * Return a copy of the OMKeyInfo without setting the objectID and updateID.
+   * This is used during key renames.
+   */
+  public OmKeyInfo copyObject(boolean copyObjectID) {
     OmKeyInfo.Builder builder = new OmKeyInfo.Builder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
@@ -522,9 +530,11 @@ public final class OmKeyInfo extends WithMetadata {
         .setDataSize(dataSize)
         .setReplicationType(type)
         .setReplicationFactor(factor)
-        .setFileEncryptionInfo(encInfo)
-        .setObjectID(objectID)
-        .setUpdateID(updateID);
+        .setFileEncryptionInfo(encInfo);
+
+    if (copyObjectID) {
+      builder.setObjectID(objectID).setUpdateID(updateID);
+    }
 
     keyLocationVersions.forEach(keyLocationVersion -> {
       List<OmKeyLocationInfo> keyLocationInfos = new ArrayList<>();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -175,7 +175,8 @@ public class OMKeyRenameRequest extends OMKeyRequest {
               // Add to cache. Only fromKey should be deleted. ToKey already
               // exists in DB as this transaction is a replay.
               result = Result.DELETE_FROM_KEY_ONLY;
-              Table<String, OmKeyInfo> keyTable = omMetadataManager.getKeyTable();
+              Table<String, OmKeyInfo> keyTable = omMetadataManager
+                  .getKeyTable();
               keyTable.addCacheEntry(new CacheKey<>(fromKey),
                   new CacheValue<>(Optional.absent(), trxnLogIndex));
 
@@ -258,26 +259,27 @@ public class OMKeyRenameRequest extends OMKeyRequest {
     }
 
     switch (result) {
-      case SUCCESS:
-        LOG.debug("Rename Key is successfully completed for volume:{} " +
-                "bucket:{} fromKey:{} toKey:{}. ", volumeName, bucketName,
-            fromKeyName, toKeyName);
-        break;
-      case DELETE_FROM_KEY_ONLY:
-        LOG.debug("Replayed transaction {}: {}. Renamed Key {} already " +
-                "exists. Deleting old key {}.", trxnLogIndex,
-            renameKeyRequest, toKey, fromKey);
-      case REPLAY:
-        LOG.debug("Replayed Transaction {} ignored. Request: {}",
-            trxnLogIndex, renameKeyRequest);
-      case FAILURE:
-      default:
-        ozoneManager.getMetrics().incNumKeyRenameFails();
-        LOG.error(
-            "Rename key failed for volume:{} bucket:{} fromKey:{} toKey:{}. "
-                + "Key: {} not found.", volumeName, bucketName, fromKeyName,
-            toKeyName, fromKeyName);
-        break;
+    case SUCCESS:
+      LOG.debug("Rename Key is successfully completed for volume:{} bucket:{}" +
+              " fromKey:{} toKey:{}. ", volumeName, bucketName, fromKeyName,
+          toKeyName);
+      break;
+    case DELETE_FROM_KEY_ONLY:
+      LOG.debug("Replayed transaction {}: {}. Renamed Key {} already exists. " +
+              "Deleting old key {}.", trxnLogIndex, renameKeyRequest, toKey,
+          fromKey);
+    case REPLAY:
+      LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
+          renameKeyRequest);
+    case FAILURE:
+      ozoneManager.getMetrics().incNumKeyRenameFails();
+      LOG.error("Rename key failed for volume:{} bucket:{} fromKey:{} " +
+              "toKey:{}. Key: {} not found.", volumeName, bucketName,
+          fromKeyName, toKeyName, fromKeyName);
+      break;
+    default:
+      LOG.error("Unrecognized Result for OMKeyRenameRequest: {}",
+          renameKeyRequest);
     }
     return omClientResponse;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -268,9 +268,11 @@ public class OMKeyRenameRequest extends OMKeyRequest {
       LOG.debug("Replayed transaction {}: {}. Renamed Key {} already exists. " +
               "Deleting old key {}.", trxnLogIndex, renameKeyRequest, toKey,
           fromKey);
+      break;
     case REPLAY:
       LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
           renameKeyRequest);
+      break;
     case FAILURE:
       ozoneManager.getMetrics().incNumKeyRenameFails();
       LOG.error("Rename key failed for volume:{} bucket:{} fromKey:{} " +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponse.java
@@ -39,10 +39,19 @@ import javax.annotation.Nonnull;
 public class OMKeyDeleteResponse extends OMClientResponse {
   private OmKeyInfo omKeyInfo;
 
-  public OMKeyDeleteResponse(@Nullable OmKeyInfo omKeyInfo,
-      @Nonnull OMResponse omResponse) {
+  public OMKeyDeleteResponse(@Nonnull OMResponse omResponse,
+      @Nonnull OmKeyInfo omKeyInfo) {
     super(omResponse);
     this.omKeyInfo = omKeyInfo;
+  }
+
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
+  public OMKeyDeleteResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+    checkStatusNotOK();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyRenameResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyRenameResponse.java
@@ -21,13 +21,11 @@ package org.apache.hadoop.ozone.om.response.key;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
 import java.io.IOException;
-import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
 
 /**
@@ -87,7 +85,7 @@ public class OMKeyRenameResponse extends OMClientResponse {
     if (toKeyName == null && fromKeyName != null) {
       omMetadataManager.getKeyTable().deleteWithBatch(batchOperation,
           omMetadataManager.getOzoneKey(volumeName, bucketName, fromKeyName));
-    } else if (!toKeyName.equals(fromKeyName)) {
+    } else if (toKeyName != null && !toKeyName.equals(fromKeyName)) {
       // If both from and toKeyName are equal do nothing
       omMetadataManager.getKeyTable().deleteWithBatch(batchOperation,
           omMetadataManager.getOzoneKey(volumeName, bucketName, fromKeyName));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyRenameResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyRenameResponse.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -82,10 +83,10 @@ public class OMKeyRenameResponse extends OMClientResponse {
     // If toKeyName is null, then we need to only delete the fromKeyName from
     // KeyTable. This is the case of replay where toKey exists but fromKey
     // has not been deleted.
-    if (toKeyName == null && fromKeyName != null) {
+    if (deleteFromKeyOnly()) {
       omMetadataManager.getKeyTable().deleteWithBatch(batchOperation,
           omMetadataManager.getOzoneKey(volumeName, bucketName, fromKeyName));
-    } else if (toKeyName != null && !toKeyName.equals(fromKeyName)) {
+    } else if (createToKeyAndDeleteFromKey()) {
       // If both from and toKeyName are equal do nothing
       omMetadataManager.getKeyTable().deleteWithBatch(batchOperation,
           omMetadataManager.getOzoneKey(volumeName, bucketName, fromKeyName));
@@ -93,5 +94,15 @@ public class OMKeyRenameResponse extends OMClientResponse {
           omMetadataManager.getOzoneKey(volumeName, bucketName, toKeyName),
           newKeyInfo);
     }
+  }
+
+  @VisibleForTesting
+  public boolean deleteFromKeyOnly() {
+    return toKeyName == null && fromKeyName != null;
+  }
+
+  @VisibleForTesting
+  public boolean createToKeyAndDeleteFromKey() {
+    return toKeyName != null && !toKeyName.equals(fromKeyName);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyRenameResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyRenameResponse.java
@@ -35,35 +35,65 @@ import javax.annotation.Nonnull;
  */
 public class OMKeyRenameResponse extends OMClientResponse {
 
-  private final OmKeyInfo renameKeyInfo;
-  private final String toKeyName;
-  private final String fromKeyName;
+  private String fromKeyName;
+  private String toKeyName;
+  private OmKeyInfo newKeyInfo;
 
-  public OMKeyRenameResponse(@Nullable OmKeyInfo renameKeyInfo,
-      String toKeyName, String fromKeyName, @Nonnull OMResponse omResponse) {
+  public OMKeyRenameResponse(@Nonnull OMResponse omResponse,
+      String fromKeyName, String toKeyName, @Nonnull OmKeyInfo renameKeyInfo) {
     super(omResponse);
-    this.renameKeyInfo = renameKeyInfo;
-    this.toKeyName = toKeyName;
     this.fromKeyName = fromKeyName;
+    this.toKeyName = toKeyName;
+    this.newKeyInfo = renameKeyInfo;
+  }
+
+  /**
+   * When Rename request is replayed and toKey already exists, but fromKey
+   * has not been deleted.
+   * For example, lets say we have the following sequence of transactions
+   *  Trxn 1 : Create Key1
+   *  Trnx 2 : Rename Key1 to Key2 -> Deletes Key1 and Creates Key2
+   *  Now if these transactions are replayed:
+   *  Replay Trxn 1 : Creates Key1 again as Key1 does not exist in DB
+   *  Replay Trxn 2 : Key2 is not created as it exists in DB and the request
+   *  would be deemed a replay. But Key1 is still in the DB and needs to be
+   *  deleted.
+   */
+  public OMKeyRenameResponse(@Nonnull OMResponse omResponse,
+      String fromKeyName, OmKeyInfo fromKeyInfo) {
+    super(omResponse);
+    this.fromKeyName = fromKeyName;
+    this.newKeyInfo = fromKeyInfo;
+    this.toKeyName = null;
+  }
+
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
+  public OMKeyRenameResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+    checkStatusNotOK();
   }
 
   @Override
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
-    // For OmResponse with failure, this should do nothing. This method is
-    // not called in failure scenario in OM code.
-    if (getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK) {
-
+    String volumeName = newKeyInfo.getVolumeName();
+    String bucketName = newKeyInfo.getBucketName();
+    // If toKeyName is null, then we need to only delete the fromKeyName from
+    // KeyTable. This is the case of replay where toKey exists but fromKey
+    // has not been deleted.
+    if (toKeyName == null && fromKeyName != null) {
+      omMetadataManager.getKeyTable().deleteWithBatch(batchOperation,
+          omMetadataManager.getOzoneKey(volumeName, bucketName, fromKeyName));
+    } else if (!toKeyName.equals(fromKeyName)) {
       // If both from and toKeyName are equal do nothing
-      if (!toKeyName.equals(fromKeyName)) {
-        String volumeName = renameKeyInfo.getVolumeName();
-        String bucketName = renameKeyInfo.getBucketName();
-        omMetadataManager.getKeyTable().deleteWithBatch(batchOperation,
-            omMetadataManager.getOzoneKey(volumeName, bucketName, fromKeyName));
-        omMetadataManager.getKeyTable().putWithBatch(batchOperation,
-            omMetadataManager.getOzoneKey(volumeName, bucketName, toKeyName),
-            renameKeyInfo);
-      }
+      omMetadataManager.getKeyTable().deleteWithBatch(batchOperation,
+          omMetadataManager.getOzoneKey(volumeName, bucketName, fromKeyName));
+      omMetadataManager.getKeyTable().putWithBatch(batchOperation,
+          omMetadataManager.getOzoneKey(volumeName, bucketName, toKeyName),
+          newKeyInfo);
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -142,8 +142,11 @@ public final class TestOMRequestUtils {
           omMetadataManager.getOpenKey(volumeName, bucketName, keyName,
               clientID), omKeyInfo);
     } else {
-      omMetadataManager.getKeyTable().put(omMetadataManager.getOzoneKey(
-          volumeName, bucketName, keyName), omKeyInfo);
+      String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
+          keyName);
+      omMetadataManager.getKeyTable().addCacheEntry(new CacheKey<>(ozoneKey),
+          new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
+      omMetadataManager.getKeyTable().put(ozoneKey, omKeyInfo);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -98,6 +98,7 @@ public final class TestOMRequestUtils {
         new CacheValue<>(Optional.of(omBucketInfo), 1L));
   }
 
+  @SuppressWarnings("parameterNumber")
   public static void addKeyToTableAndCache(String volumeName, String bucketName,
       String keyName, long clientID, HddsProtos.ReplicationType replicationType,
       HddsProtos.ReplicationFactor replicationFactor, long trxnLogIndex,
@@ -157,8 +158,8 @@ public final class TestOMRequestUtils {
       String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
           keyName);
       if (addToCache) {
-      omMetadataManager.getKeyTable().addCacheEntry(new CacheKey<>(ozoneKey),
-          new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
+        omMetadataManager.getKeyTable().addCacheEntry(new CacheKey<>(ozoneKey),
+            new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
       }
       omMetadataManager.getKeyTable().put(ozoneKey, omKeyInfo);
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -98,6 +98,14 @@ public final class TestOMRequestUtils {
         new CacheValue<>(Optional.of(omBucketInfo), 1L));
   }
 
+  public static void addKeyToTableAndCache(String volumeName, String bucketName,
+      String keyName, long clientID, HddsProtos.ReplicationType replicationType,
+      HddsProtos.ReplicationFactor replicationFactor, long trxnLogIndex,
+      OMMetadataManager omMetadataManager) throws Exception {
+    addKeyToTable(false, true, volumeName, bucketName, keyName, clientID,
+        replicationType, replicationFactor, trxnLogIndex, omMetadataManager);
+  }
+
   /**
    * Add key entry to KeyTable. if openKeyTable flag is true, add's entries
    * to openKeyTable, else add's it to keyTable.
@@ -113,13 +121,12 @@ public final class TestOMRequestUtils {
    */
   @SuppressWarnings("parameterNumber")
   public static void addKeyToTable(boolean openKeyTable, String volumeName,
-      String bucketName,
-      String keyName, long clientID,
+      String bucketName, String keyName, long clientID,
       HddsProtos.ReplicationType replicationType,
       HddsProtos.ReplicationFactor replicationFactor,
       OMMetadataManager omMetadataManager) throws Exception {
-    addKeyToTable(openKeyTable, volumeName, bucketName, keyName, clientID,
-        replicationType, replicationFactor, 0L, omMetadataManager);
+    addKeyToTable(openKeyTable, false, volumeName, bucketName, keyName,
+        clientID, replicationType, replicationFactor, 0L, omMetadataManager);
   }
 
   /**
@@ -128,8 +135,8 @@ public final class TestOMRequestUtils {
    * @throws Exception
    */
   @SuppressWarnings("parameternumber")
-  public static void addKeyToTable(boolean openKeyTable, String volumeName,
-      String bucketName, String keyName, long clientID,
+  public static void addKeyToTable(boolean openKeyTable, boolean addToCache,
+      String volumeName, String bucketName, String keyName, long clientID,
       HddsProtos.ReplicationType replicationType,
       HddsProtos.ReplicationFactor replicationFactor, long trxnLogIndex,
       OMMetadataManager omMetadataManager) throws Exception {
@@ -138,14 +145,21 @@ public final class TestOMRequestUtils {
         replicationType, replicationFactor, trxnLogIndex);
 
     if (openKeyTable) {
-      omMetadataManager.getOpenKeyTable().put(
-          omMetadataManager.getOpenKey(volumeName, bucketName, keyName,
-              clientID), omKeyInfo);
+      String ozoneKey = omMetadataManager.getOpenKey(volumeName, bucketName,
+          keyName, clientID);
+      if (addToCache) {
+        omMetadataManager.getOpenKeyTable().addCacheEntry(
+            new CacheKey<>(ozoneKey),
+            new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
+      }
+      omMetadataManager.getOpenKeyTable().put(ozoneKey, omKeyInfo);
     } else {
       String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
           keyName);
+      if (addToCache) {
       omMetadataManager.getKeyTable().addCacheEntry(new CacheKey<>(ozoneKey),
           new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
+      }
       omMetadataManager.getKeyTable().put(ozoneKey, omKeyInfo);
     }
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequest.java
@@ -396,7 +396,7 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
 
     // Manually add volume, bucket and key to DB table
     addVolumeAndBucketToDB(volumeName, bucketName, omMetadataManager);
-    addKeyToTable(false, volumeName, bucketName, keyName, clientID,
+    addKeyToTable(false, false, volumeName, bucketName, keyName, clientID,
         replicationType, replicationFactor, 1L, omMetadataManager);
 
     // Replay the transaction - Execute the createFile request again

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -359,7 +359,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
 
     // Manually add volume, bucket and key to DB table
     addVolumeAndBucketToDB(volumeName, bucketName, omMetadataManager);
-    addKeyToTable(false, volumeName, bucketName, keyName, clientID,
+    addKeyToTable(false, false, volumeName, bucketName, keyName, clientID,
         replicationType, replicationFactor, 1L, omMetadataManager);
 
     // Replay the transaction - Execute the createKey request again

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequest.java
@@ -52,14 +52,12 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
     OMKeyDeleteRequest omKeyDeleteRequest =
         new OMKeyDeleteRequest(modifiedOmRequest);
 
-
     // Add volume, bucket and key entries to OM DB.
     TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager);
 
     TestOMRequestUtils.addKeyToTable(false, volumeName, bucketName, keyName,
         clientID, replicationType, replicationFactor, omMetadataManager);
-
 
     String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
         keyName);
@@ -80,9 +78,7 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
     omKeyInfo = omMetadataManager.getKeyTable().get(ozoneKey);
 
     Assert.assertNull(omKeyInfo);
-
   }
-
 
   @Test
   public void testValidateAndUpdateCacheWithKeyNotFound() throws Exception {
@@ -98,7 +94,6 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
     TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager);
 
-
     OMClientResponse omClientResponse =
         omKeyDeleteRequest.validateAndUpdateCache(ozoneManager,
             100L, ozoneManagerDoubleBufferHelper);
@@ -106,7 +101,6 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
   }
-
 
   @Test
   public void testValidateAndUpdateCacheWithVolumeNotFound() throws Exception {
@@ -140,6 +134,43 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
 
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
             omClientResponse.getOMResponse().getStatus());
+  }
+
+  @Test
+  public void testReplayRequest() throws Exception {
+    OMRequest modifiedOmRequest =
+        doPreExecute(createDeleteKeyRequest());
+
+    OMKeyDeleteRequest omKeyDeleteRequest =
+        new OMKeyDeleteRequest(modifiedOmRequest);
+
+    // Add volume, bucket and key entries to OM DB.
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
+
+    TestOMRequestUtils.addKeyToTable(false, volumeName, bucketName, keyName,
+        clientID, replicationType, replicationFactor, 1L, omMetadataManager);
+
+    // Delete the key manually. Lets say the Delete Requests
+    // TransactionLogIndex is 10.
+    long deleteTrxnLogIndex = 10L;
+    String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
+        keyName);
+    TestOMRequestUtils.deleteKey(ozoneKey, omMetadataManager);
+
+    // Create the same key again with TransactionLogIndex > Delete requests
+    // TransactionLogIndex
+    TestOMRequestUtils.addKeyToTable(false, volumeName, bucketName, keyName,
+        clientID, replicationType, replicationFactor, 20L, omMetadataManager);
+
+    // Replay the original DeleteRequest.
+    OMClientResponse omClientResponse = omKeyDeleteRequest
+        .validateAndUpdateCache(ozoneManager, deleteTrxnLogIndex,
+            ozoneManagerDoubleBufferHelper);
+
+    // Replay should result in Replay response
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.REPLAY,
+        omClientResponse.getOMResponse().getStatus());
   }
 
   /**
@@ -176,5 +207,4 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
         .setCmdType(OzoneManagerProtocolProtos.Type.DeleteKey)
         .setClientId(UUID.randomUUID().toString()).build();
   }
-
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequest.java
@@ -148,7 +148,7 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
     TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager);
 
-    TestOMRequestUtils.addKeyToTable(false, volumeName, bucketName, keyName,
+    TestOMRequestUtils.addKeyToTableAndCache(volumeName, bucketName, keyName,
         clientID, replicationType, replicationFactor, 1L, omMetadataManager);
 
     // Delete the key manually. Lets say the Delete Requests
@@ -160,7 +160,7 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
 
     // Create the same key again with TransactionLogIndex > Delete requests
     // TransactionLogIndex
-    TestOMRequestUtils.addKeyToTable(false, volumeName, bucketName, keyName,
+    TestOMRequestUtils.addKeyToTableAndCache(volumeName, bucketName, keyName,
         clientID, replicationType, replicationFactor, 20L, omMetadataManager);
 
     // Replay the original DeleteRequest.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequest.java
@@ -22,9 +22,11 @@ import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Test;
 
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.key.OMKeyRenameResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMRequest;
@@ -85,9 +87,7 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
 
     // KeyName should be updated in OmKeyInfo to toKeyName.
     Assert.assertEquals(omKeyInfo.getKeyName(), toKeyName);
-
   }
-
 
   @Test
   public void testValidateAndUpdateCacheWithKeyNotFound() throws Exception {
@@ -111,7 +111,6 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
 
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND,
         omKeyRenameResponse.getOMResponse().getStatus());
-
   }
 
   @Test
@@ -129,7 +128,6 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
 
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
         omKeyRenameResponse.getOMResponse().getStatus());
-
   }
 
   @Test
@@ -150,7 +148,6 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
 
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
         omKeyRenameResponse.getOMResponse().getStatus());
-
   }
 
   @Test
@@ -175,7 +172,6 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
 
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.INVALID_KEY_NAME,
         omKeyRenameResponse.getOMResponse().getStatus());
-
   }
 
   @Test
@@ -201,9 +197,106 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
 
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.INVALID_KEY_NAME,
         omKeyRenameResponse.getOMResponse().getStatus());
-
   }
 
+  /**
+   * Test replay of RenameRequest when fromKey does not exist in DB.
+   */
+  @Test
+  public void testReplayRequest() throws Exception {
+    String toKeyName = UUID.randomUUID().toString();
+    OMRequest modifiedOmRequest = doPreExecute(
+        createRenameKeyRequest(toKeyName));
+
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
+    TestOMRequestUtils.addKeyToTable(false, volumeName, bucketName, keyName,
+        clientID, replicationType, replicationFactor, 1L, omMetadataManager);
+
+    // Execute RenameRequest
+    OMKeyRenameRequest omKeyRenameRequest =
+        new OMKeyRenameRequest(modifiedOmRequest);
+    OMClientResponse omKeyRenameResponse =
+        omKeyRenameRequest.validateAndUpdateCache(ozoneManager, 10L,
+            ozoneManagerDoubleBufferHelper);
+
+    // Commit Batch operation to add the transaction to DB
+    BatchOperation batchOperation = omMetadataManager.getStore()
+        .initBatchOperation();
+    omKeyRenameResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+
+    // Replay the RenameRequest.
+    OMClientResponse replayResponse = omKeyRenameRequest.validateAndUpdateCache(
+        ozoneManager, 10L, ozoneManagerDoubleBufferHelper);
+
+    // Replay should result in Replay response
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.REPLAY,
+        replayResponse.getOMResponse().getStatus());
+  }
+
+  /**
+   * Test replay of RenameRequest when fromKey exists in DB.
+   */
+  @Test
+  public void testReplayRequestWhenFromKeyExists() throws Exception {
+
+    String toKeyName = UUID.randomUUID().toString();
+    OMRequest modifiedOmRequest = doPreExecute(
+        createRenameKeyRequest(toKeyName));
+
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
+    TestOMRequestUtils.addKeyToTable(false, volumeName, bucketName, keyName,
+        clientID, replicationType, replicationFactor, 1L, omMetadataManager);
+
+    // Execute RenameRequest
+    OMKeyRenameRequest omKeyRenameRequest =
+        new OMKeyRenameRequest(modifiedOmRequest);
+    OMClientResponse omKeyRenameResponse = omKeyRenameRequest
+        .validateAndUpdateCache(ozoneManager, 10L,
+            ozoneManagerDoubleBufferHelper);
+
+    // Commit Batch operation to add the transaction to DB
+    BatchOperation batchOperation = omMetadataManager.getStore()
+        .initBatchOperation();
+    omKeyRenameResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+
+    // Let's say the fromKey create transaction was also replayed. In this
+    // case, fromKey and toKey will both exist in the DB. Replaying the
+    // RenameRequest should then delete fromKey but not add toKey again.
+
+    // Replay CreateKey request for fromKey
+    TestOMRequestUtils.addKeyToTable(false, volumeName, bucketName, keyName,
+        clientID, replicationType, replicationFactor, 1L, omMetadataManager);
+
+    // Verify fromKey exists in DB
+    String fromKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
+        keyName);
+    OmKeyInfo dbFromKeyInfo = omMetadataManager.getKeyTable().get(fromKey);
+    Assert.assertNotNull(dbFromKeyInfo);
+
+    // Replay original RenameRequest
+    OMKeyRenameResponse replayResponse =
+        (OMKeyRenameResponse) omKeyRenameRequest.validateAndUpdateCache(
+            ozoneManager, 10L, ozoneManagerDoubleBufferHelper);
+
+    // This replay response should delete fromKey from DB
+    // Replay should result in Replay response
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        replayResponse.getOMResponse().getStatus());
+    Assert.assertTrue(replayResponse.deleteFromKeyOnly());
+
+    // Commit response to DB
+    batchOperation = omMetadataManager.getStore().initBatchOperation();
+    replayResponse.addToDBBatch(omMetadataManager, batchOperation);
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+
+    // Verify fromKey is deleted from DB
+    dbFromKeyInfo = omMetadataManager.getKeyTable().get(fromKey);
+    Assert.assertNull(dbFromKeyInfo);
+  }
 
   /**
    * This method calls preExecute and verify the modified request.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequest.java
@@ -210,8 +210,9 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
 
     TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager);
-    TestOMRequestUtils.addKeyToTable(false, volumeName, bucketName, keyName,
-        clientID, replicationType, replicationFactor, 1L, omMetadataManager);
+    TestOMRequestUtils.addKeyToTableAndCache(volumeName, bucketName,
+        keyName, clientID, replicationType, replicationFactor, 1L,
+        omMetadataManager);
 
     // Execute RenameRequest
     OMKeyRenameRequest omKeyRenameRequest =
@@ -247,7 +248,7 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
 
     TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager);
-    TestOMRequestUtils.addKeyToTable(false, volumeName, bucketName, keyName,
+    TestOMRequestUtils.addKeyToTableAndCache(volumeName, bucketName, keyName,
         clientID, replicationType, replicationFactor, 1L, omMetadataManager);
 
     // Execute RenameRequest
@@ -268,7 +269,7 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
     // RenameRequest should then delete fromKey but not add toKey again.
 
     // Replay CreateKey request for fromKey
-    TestOMRequestUtils.addKeyToTable(false, volumeName, bucketName, keyName,
+    TestOMRequestUtils.addKeyToTableAndCache(volumeName, bucketName, keyName,
         clientID, replicationType, replicationFactor, 1L, omMetadataManager);
 
     // Verify fromKey exists in DB

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
@@ -50,8 +50,8 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
             .setCmdType(OzoneManagerProtocolProtos.Type.DeleteKey)
             .build();
 
-    OMKeyDeleteResponse omKeyDeleteResponse =
-        new OMKeyDeleteResponse(omKeyInfo, omResponse);
+    OMKeyDeleteResponse omKeyDeleteResponse = new OMKeyDeleteResponse(
+        omResponse, omKeyInfo);
 
     String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
         keyName);
@@ -112,8 +112,8 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
             .setCmdType(OzoneManagerProtocolProtos.Type.DeleteKey)
             .build();
 
-    OMKeyDeleteResponse omKeyDeleteResponse =
-        new OMKeyDeleteResponse(omKeyInfo, omResponse);
+    OMKeyDeleteResponse omKeyDeleteResponse = new OMKeyDeleteResponse(
+        omResponse, omKeyInfo);
 
     Assert.assertTrue(omMetadataManager.getKeyTable().isExist(ozoneKey));
     omKeyDeleteResponse.addToDBBatch(omMetadataManager, batchOperation);
@@ -141,8 +141,8 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
             .setCmdType(OzoneManagerProtocolProtos.Type.DeleteKey)
             .build();
 
-    OMKeyDeleteResponse omKeyDeleteResponse =
-        new OMKeyDeleteResponse(omKeyInfo, omResponse);
+    OMKeyDeleteResponse omKeyDeleteResponse = new OMKeyDeleteResponse(
+        omResponse, omKeyInfo);
 
     String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
         keyName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponse.java
@@ -100,7 +100,7 @@ public class TestOMKeyRenameResponse extends TestOMKeyResponse {
     Assert.assertTrue(omMetadataManager.getKeyTable().isExist(ozoneFromKey));
     Assert.assertFalse(omMetadataManager.getKeyTable().isExist(ozoneToKey));
 
-    omKeyRenameResponse.addToDBBatch(omMetadataManager, batchOperation);
+    omKeyRenameResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
 
     // Do manual commit and see whether addToBatch is successful or not.
     omMetadataManager.getStore().commitBatchOperation(batchOperation);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponse.java
@@ -46,8 +46,8 @@ public class TestOMKeyRenameResponse extends TestOMKeyResponse {
 
     String toKeyName = UUID.randomUUID().toString();
 
-    OMKeyRenameResponse omKeyRenameResponse =
-        new OMKeyRenameResponse(omKeyInfo, toKeyName, keyName, omResponse);
+    OMKeyRenameResponse omKeyRenameResponse = new OMKeyRenameResponse(
+        omResponse, keyName, toKeyName, omKeyInfo);
 
     String ozoneFromKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
         keyName);
@@ -85,8 +85,8 @@ public class TestOMKeyRenameResponse extends TestOMKeyResponse {
 
     String toKeyName = UUID.randomUUID().toString();
 
-    OMKeyRenameResponse omKeyRenameResponse =
-        new OMKeyRenameResponse(omKeyInfo, toKeyName, keyName, omResponse);
+    OMKeyRenameResponse omKeyRenameResponse = new OMKeyRenameResponse(
+        omResponse, keyName, toKeyName, omKeyInfo);
 
     String ozoneFromKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
         keyName);
@@ -126,8 +126,8 @@ public class TestOMKeyRenameResponse extends TestOMKeyResponse {
 
 
     // Passing toKeyName also same as KeyName.
-    OMKeyRenameResponse omKeyRenameResponse =
-        new OMKeyRenameResponse(omKeyInfo, keyName, keyName, omResponse);
+    OMKeyRenameResponse omKeyRenameResponse = new OMKeyRenameResponse(
+        omResponse, keyName, keyName, omKeyInfo);
 
     String ozoneFromKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
         keyName);


### PR DESCRIPTION
## What changes were proposed in this pull request?

To ensure that key deletion and rename operations are idempotent, compare the transactionID with the objectID and updateID to make sure that the transaction is not a replay. If the transactionID <= updateID, then it implies that the transaction is a replay and hence it should be skipped.

OMKeyDeleteRequest and OMKeyRenameRequest are made idempotent in this Jira.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2894

## How was this patch tested?

Unit tests to verify replayed transactions are executed as expected.
