### PR TITLE
HDDS-2900. Avoid logging NPE when space usage check is not configured

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/SpaceUsageCheckFactory.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/SpaceUsageCheckFactory.java
@@ -71,13 +71,16 @@ public interface SpaceUsageCheckFactory {
   static SpaceUsageCheckFactory create(Configuration config) {
     Conf conf = OzoneConfiguration.of(config).getObject(Conf.class);
     Class<? extends SpaceUsageCheckFactory> aClass = null;
-    try {
-      aClass = config.getClassByName(conf.getClassName())
-          .asSubclass(SpaceUsageCheckFactory.class);
-    } catch (ClassNotFoundException | RuntimeException e) {
-      Logger log = LoggerFactory.getLogger(SpaceUsageCheckFactory.class);
-      log.warn("Error trying to create SpaceUsageCheckFactory: '{}'",
-          conf.getClassName(), e);
+    String className = conf.getClassName();
+    if (className != null && !className.isEmpty()) {
+      try {
+        aClass = config.getClassByName(className)
+            .asSubclass(SpaceUsageCheckFactory.class);
+      } catch (ClassNotFoundException | RuntimeException e) {
+        Logger log = LoggerFactory.getLogger(SpaceUsageCheckFactory.class);
+        log.warn("Error trying to create SpaceUsageCheckFactory: '{}'",
+            className, e);
+      }
     }
 
     SpaceUsageCheckFactory instance = null;


### PR DESCRIPTION
## What changes were proposed in this pull request?

If `hdds.datanode.du.factory.classname` is not configured, a harmless but annoying NPE appears in datanode log during startup.  This change avoids the NPE by explicitly checking for empty config.

https://issues.apache.org/jira/browse/HDDS-2900

## How was this patch tested?

Tweaked unit test.  Verified acceptance test docker output.

https://github.com/adoroszlai/hadoop-ozone/runs/394927391