### PR TITLE
HDDS-2895. Generate only the required keytabs for docker based secure tests

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
@@ -46,6 +46,8 @@ services:
     command: ["/opt/hadoop/bin/ozone","datanode"]
     env_file:
       - docker-config
+    environment:
+      KERBEROS_KEYTABS: dn HTTP
   om:
     image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
     hostname: om
@@ -57,6 +59,7 @@ services:
       - 9874:9874
     environment:
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
+      KERBEROS_KEYTABS: om HTTP testuser
     env_file:
       - docker-config
     command: ["/opt/hadoop/bin/ozone","om"]
@@ -71,6 +74,8 @@ services:
       - 9878:9878
     env_file:
       - ./docker-config
+    environment:
+      KERBEROS_KEYTABS: s3g HTTP
     command: ["/opt/hadoop/bin/ozone","s3g"]
   scm:
     image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
@@ -86,6 +91,7 @@ services:
     environment:
       ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "${OZONE_SAFEMODE_MIN_DATANODES:-1}"
+      KERBEROS_KEYTABS: scm HTTP
     command: ["/opt/hadoop/bin/ozone","scm"]
   rm:
     image: apache/hadoop:${HADOOP_VERSION}
@@ -100,6 +106,7 @@ services:
       - ./docker-config
     environment:
       HADOOP_CLASSPATH: /opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-lib-current-@project.version@.jar
+      KERBEROS_KEYTABS: rm HTTP hadoop
     command: ["yarn", "resourcemanager"]
   nm:
     image: apache/hadoop:${HADOOP_VERSION}
@@ -113,6 +120,7 @@ services:
     environment:
       HADOOP_CLASSPATH: /opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-lib-current-@project.version@.jar
       WAIT_FOR: rm:8088
+      KERBEROS_KEYTABS: nm HTTP
     command: ["yarn","nodemanager"]
   jhs:
     image: apache/hadoop:${HADOOP_VERSION}
@@ -127,6 +135,7 @@ services:
     env_file:
       - ./docker-config
     environment:
+      KERBEROS_KEYTABS: jhs HTTP
       HADOOP_CLASSPATH: /opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-lib-current-@project.version@.jar
       WAIT_FOR: rm:8088
     command: ["yarn","timelineserver"]

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
@@ -123,7 +123,6 @@ CAPACITY-SCHEDULER.XML_yarn.scheduler.capacity.queue-mappings-override.enable=fa
 
 OZONE_DATANODE_SECURE_USER=root
 KEYTAB_DIR=/etc/security/keytabs
-KERBEROS_KEYTABS=dn om scm HTTP testuser s3g rm nm yarn jhs hadoop spark
 KERBEROS_KEYSTORES=hadoop
 KERBEROS_SERVER=kdc
 JAVA_HOME=/usr/lib/jvm/jre

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -24,7 +24,6 @@ services:
     hostname: kdc
     volumes:
       - ../..:/opt/hadoop
-  
   kms:
       image: apache/hadoop:${HADOOP_VERSION}
       ports:
@@ -42,6 +41,8 @@ services:
     command: ["/opt/hadoop/bin/ozone","datanode"]
     env_file:
       - docker-config
+    environment:
+      KERBEROS_KEYTABS: dn
   om:
     image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
     hostname: om
@@ -51,9 +52,11 @@ services:
       - 9874:9874
     environment:
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
+      KERBEROS_KEYTABS: om HTTP
     env_file:
       - docker-config
     command: ["/opt/hadoop/bin/ozone","om"]
+
   s3g:
     image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
     hostname: s3g
@@ -64,6 +67,8 @@ services:
     env_file:
       - ./docker-config
     command: ["/opt/hadoop/bin/ozone","s3g"]
+    environment:
+      KERBEROS_KEYTABS: s3g HTTP
   recon:
     image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
     hostname: recon
@@ -75,6 +80,7 @@ services:
       - ./docker-config
     environment:
       WAITFOR: om:9874
+      KERBEROS_KEYTABS: recon HTTP
     command: ["/opt/hadoop/bin/ozone","recon"]
   scm:
     image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
@@ -86,6 +92,7 @@ services:
     env_file:
       - docker-config
     environment:
+      KERBEROS_KEYTABS: scm HTTP testuser
       ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "${OZONE_SAFEMODE_MIN_DATANODES:-1}"
     command: ["/opt/hadoop/bin/ozone","scm"]

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
     env_file:
       - docker-config
     environment:
-      KERBEROS_KEYTABS: dn
+      KERBEROS_KEYTABS: dn HTTP
   om:
     image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
     hostname: om

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -92,7 +92,7 @@ services:
     env_file:
       - docker-config
     environment:
-      KERBEROS_KEYTABS: scm HTTP testuser
+      KERBEROS_KEYTABS: scm HTTP testuser testuser2
       ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "${OZONE_SAFEMODE_MIN_DATANODES:-1}"
     command: ["/opt/hadoop/bin/ozone","scm"]

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -68,7 +68,7 @@ services:
       - ./docker-config
     command: ["/opt/hadoop/bin/ozone","s3g"]
     environment:
-      KERBEROS_KEYTABS: s3g HTTP
+      KERBEROS_KEYTABS: s3g HTTP testuser
   recon:
     image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
     hostname: recon

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -80,7 +80,6 @@ HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300
 OZONE_DATANODE_SECURE_USER=root
 SECURITY_ENABLED=true
 KEYTAB_DIR=/etc/security/keytabs
-KERBEROS_KEYTABS=dn om scm HTTP testuser testuser2 s3g
 KERBEROS_KEYSTORES=hadoop
 KERBEROS_SERVER=kdc
 JAVA_HOME=/usr/lib/jvm/jre


### PR DESCRIPTION
## What changes were proposed in this pull request?

We have acceptance tests with the help of docker/docker-compose where we generate the keytab files on the fly with the help of a lightweight (unsecure) REST endpoint.

But this generation can be very slow especially when the DNS is slow. When I start a VPN the secure cluster can't be started in the 90 sec period. (>100 keytabs are generated and one keytab generation is ~5 sec).

The solutions is to generate only the required keystabs in each of the containers.

Instead of request all the possible keytabs in the generic `docker-config`:

```
KERBEROS_KEYTABS=dn om scm HTTP testuser testuser2 s3g 
```

We can defined the required keytabs per service (in `docker-compose.yaml`)

```
environment:
  KERBEROS_KEYTABS=scm HTTP
```

With this approach ~20 keytab file will be generated instead of >100 and the secure tests will be significant faster.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2895

## How was this patch tested?

This is an acceptance test improvements. If they are passed, it should be fine...