### PR TITLE
HDDS-2901. List Trash - Fix Cluster Max Keys Check

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -868,9 +868,9 @@ public class KeyManagerImpl implements KeyManager {
 
     Preconditions.checkNotNull(volumeName);
     Preconditions.checkNotNull(bucketName);
-    Preconditions.checkArgument(maxKeys < listTrashKeysMax,
+    Preconditions.checkArgument(maxKeys <= listTrashKeysMax,
         "The max keys limit specified is not less than the cluster " +
-          "allowed limit.");
+          "allowed maximum limit.");
 
     return metadataManager.listTrash(volumeName, bucketName,
      startKeyName, keyPrefix, maxKeys);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Small fix to the cluster max keys check for list trash.  This should account for users requesting up to the max cluster allowed limit and not just less than it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2901

## How was this patch tested?

Caught in the list trash core logic tests, I will add those in the next PR.  
