### PR TITLE
HDDS-2896. Use regex to match with ratis properties when creating ratis client

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -98,7 +98,7 @@ public final class XceiverClientRatis extends XceiverClientSpi {
         SecurityConfig(ozoneConf), caCert);
     return new XceiverClientRatis(pipeline,
         SupportedRpcType.valueOfIgnoreCase(rpcType), maxOutstandingRequests,
-        retryPolicy, tlsConfig, clientRequestTimeout);
+        retryPolicy, tlsConfig, clientRequestTimeout, ozoneConf);
   }
 
   private final Pipeline pipeline;
@@ -108,6 +108,7 @@ public final class XceiverClientRatis extends XceiverClientSpi {
   private final RetryPolicy retryPolicy;
   private final GrpcTlsConfig tlsConfig;
   private final TimeDuration clientRequestTimeout;
+  private final Configuration ozoneConfiguration;
 
   // Map to track commit index at every server
   private final ConcurrentHashMap<UUID, Long> commitInfoMap;
@@ -119,7 +120,8 @@ public final class XceiverClientRatis extends XceiverClientSpi {
    */
   private XceiverClientRatis(Pipeline pipeline, RpcType rpcType,
       int maxOutStandingChunks, RetryPolicy retryPolicy,
-      GrpcTlsConfig tlsConfig, TimeDuration timeout) {
+      GrpcTlsConfig tlsConfig, TimeDuration timeout,
+      Configuration configuration) {
     super();
     this.pipeline = pipeline;
     this.rpcType = rpcType;
@@ -129,6 +131,7 @@ public final class XceiverClientRatis extends XceiverClientSpi {
     this.tlsConfig = tlsConfig;
     this.clientRequestTimeout = timeout;
     metrics = XceiverClientManager.getXceiverClientMetrics();
+    this.ozoneConfiguration = configuration;
   }
 
   private void updateCommitInfosMap(
@@ -178,7 +181,8 @@ public final class XceiverClientRatis extends XceiverClientSpi {
 
     if (!client.compareAndSet(null,
         RatisHelper.newRaftClient(rpcType, getPipeline(), retryPolicy,
-            maxOutstandingRequests, tlsConfig, clientRequestTimeout))) {
+            maxOutstandingRequests, tlsConfig, clientRequestTimeout,
+            ozoneConfiguration))) {
       throw new IllegalStateException("Client is already connected.");
     }
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestRatisHelper.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestRatisHelper.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.ratis;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.ratis.conf.RaftProperties;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test RatisHelper class.
+ */
+public class TestRatisHelper {
+
+  @Test
+  public void testCreateRaftClientProperties() {
+
+    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
+    ozoneConfiguration.set("raft.client.rpc.watch.request.timeout", "30s");
+    ozoneConfiguration.set("raft.client.rpc.request.timeout", "30s");
+
+    RaftProperties raftProperties = new RaftProperties();
+    RatisHelper.createRaftClientProperties(ozoneConfiguration, raftProperties);
+
+    Assert.assertEquals("30s",
+        raftProperties.get("raft.client.rpc.watch.request.timeout"));
+    Assert.assertEquals("30s",
+        raftProperties.get("raft.client.rpc.request.timeout"));
+
+  }
+
+  @Test
+  public void testCreateRaftGrpcProperties() {
+
+    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
+    ozoneConfiguration.set("raft.grpc.message.size.max", "30MB");
+    ozoneConfiguration.set("raft.grpc.flow.control.window", "1MB");
+    ozoneConfiguration.set("raft.grpc.tls.enabled", "true");
+    ozoneConfiguration.set("raft.grpc.tls.mutual_authn.enabled", "true");
+    ozoneConfiguration.set("raft.grpc.server.port", "100");
+
+    RaftProperties raftProperties = new RaftProperties();
+    RatisHelper.createRaftGrpcProperties(ozoneConfiguration, raftProperties);
+
+    Assert.assertEquals("30MB",
+        raftProperties.get("raft.grpc.message.size.max"));
+    Assert.assertEquals("1MB",
+        raftProperties.get("raft.grpc.flow.control.window"));
+
+    // As we dont match tls and server raft.grpc properties. So they should
+    // be null.
+    Assert.assertNull(raftProperties.get("raft.grpc.tls.set"));
+    Assert.assertNull(raftProperties.get("raft.grpc.tls.mutual_authn.enabled"));
+    Assert.assertNull(raftProperties.get("raft.grpc.server.port"));
+
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/RatisTestHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/RatisTestHelper.java
@@ -129,7 +129,7 @@ public interface RatisTestHelper {
         RatisHelper.getClientRequestTimeout(conf);
     final RaftClient client =
         newRaftClient(rpc, p, RatisHelper.createRetryPolicy(conf),
-            maxOutstandingRequests, requestTimeout);
+            maxOutstandingRequests, requestTimeout, conf);
     client.groupAdd(RatisHelper.newRaftGroup(pipeline), p.getId());
   }
 }


### PR DESCRIPTION

## What changes were proposed in this pull request?

Use directly ratis client configuration, match them with regex, and set them to raft properties when creating ratis client.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2896


## How was this patch tested?

Added UT to test the new methods.
