### PR TITLE
HDDS-2903. Use regex to match with ratis properties when creating ratis server.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
@@ -74,6 +74,9 @@ public interface RatisHelper {
   String RATIS_GRPC_CLIENT_HEADER_REGEX = "raft\\.grpc\\.(?!server|tls)" +
       "([a-z\\.]+)";
 
+  // Ratis Server header regex filter.
+  String RATIS_SERVER_HEADER_REGEX = "raft\\.server\\.([a-z\\.]+)";
+
   static String toRaftPeerIdString(DatanodeDetails id) {
     return id.getUuidString();
   }
@@ -265,6 +268,20 @@ public interface RatisHelper {
     Map<String, String> ratisClientConf =
         ozoneConf.getValByRegex(RATIS_GRPC_CLIENT_HEADER_REGEX);
     ratisClientConf.forEach((key, val) -> raftProperties.set(key, val));
+  }
+
+  /**
+   * Set all the properties matching with regex
+   * {@link RatisHelper#RATIS_SERVER_HEADER_REGEX} in ozone configuration
+   * object and configure it to RaftProperties.
+   * @param ozoneConf
+   * @param raftProperties
+   */
+  static void createRaftServerProperties(Configuration ozoneConf,
+       RaftProperties raftProperties) {
+    Map<String, String> ratisServerConf =
+        ozoneConf.getValByRegex(RATIS_SERVER_HEADER_REGEX);
+    ratisServerConf.forEach((key, val) -> raftProperties.set(key, val));
   }
 
   // For External gRPC client to server with gRPC TLS.

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestRatisHelper.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestRatisHelper.java
@@ -70,4 +70,21 @@ public class TestRatisHelper {
     Assert.assertNull(raftProperties.get("raft.grpc.server.port"));
 
   }
+
+  @Test
+  public void testCreateRaftServerProperties() {
+
+    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
+    ozoneConfiguration.set("raft.server.rpc.watch.request.timeout", "30s");
+    ozoneConfiguration.set("raft.server.rpc.request.timeout", "30s");
+
+    RaftProperties raftProperties = new RaftProperties();
+    RatisHelper.createRaftServerProperties(ozoneConfiguration, raftProperties);
+
+    Assert.assertEquals("30s",
+        raftProperties.get("raft.server.rpc.watch.request.timeout"));
+    Assert.assertEquals("30s",
+        raftProperties.get("raft.server.rpc.request.timeout"));
+
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -264,6 +264,9 @@ public final class XceiverServerRatis implements XceiverServerSpi {
         ratisServerConfiguration.getNumSnapshotsRetained();
     RaftServerConfigKeys.Snapshot.setRetentionFileNum(properties,
         numSnapshotsRetained);
+
+    // Set headers starting with prefix raft.server
+    RatisHelper.createRaftServerProperties(conf, properties);
     return properties;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use directly ratis server configuration, match them with regex, and set them to raft properties when creating ratis server.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2903


## How was this patch tested?

Added UT for the new method.

This PR combines both HDDS-2896 and HDDS-2903.

