### PR TITLE
HDDS-2898. build failure due to hadoop-hdds-client test

### DIFF
--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyBlockInputStream.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.storage;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChunkInfo;
+import org.apache.hadoop.hdds.scm.XceiverClientManager;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
+import org.apache.hadoop.security.token.Token;
+
+/**
+ * A dummy BlockInputStream to mock read block call to DN.
+ */
+class DummyBlockInputStream extends BlockInputStream {
+
+  private List<ChunkInfo> chunks;
+
+  private Map<String, byte[]> chunkDataMap;
+
+  @SuppressWarnings("parameternumber")
+  DummyBlockInputStream(
+      BlockID blockId,
+      long blockLen,
+      Pipeline pipeline,
+      Token<OzoneBlockTokenIdentifier> token,
+      boolean verifyChecksum,
+      XceiverClientManager xceiverClientManager,
+      List<ChunkInfo> chunkList,
+      Map<String, byte[]> chunkMap) {
+    super(blockId, blockLen, pipeline, token, verifyChecksum,
+        xceiverClientManager);
+    this.chunks = chunkList;
+    this.chunkDataMap = chunkMap;
+  }
+
+  @SuppressWarnings("parameternumber")
+  DummyBlockInputStream(
+      BlockID blockId,
+      long blockLen,
+      Pipeline pipeline,
+      Token<OzoneBlockTokenIdentifier> token,
+      boolean verifyChecksum,
+      XceiverClientManager xceiverClientManager,
+      Function<BlockID, Pipeline> refreshFunction,
+      List<ChunkInfo> chunkList,
+      Map<String, byte[]> chunks) {
+    super(blockId, blockLen, pipeline, token, verifyChecksum,
+        xceiverClientManager, refreshFunction);
+    this.chunkDataMap = chunks;
+    this.chunks = chunkList;
+
+  }
+
+  @Override
+  protected List<ChunkInfo> getChunkInfos() throws IOException {
+    return chunks;
+  }
+
+  @Override
+  protected void addStream(ChunkInfo chunkInfo) {
+    TestChunkInputStream testChunkInputStream = new TestChunkInputStream();
+    getChunkStreams().add(new DummyChunkInputStream(testChunkInputStream,
+        chunkInfo, null, null, false,
+        chunkDataMap.get(chunkInfo.getChunkName()).clone()));
+  }
+
+  @Override
+  protected synchronized void checkOpen() throws IOException {
+    // No action needed
+  }
+}

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyBlockInputStreamWithRetry.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyBlockInputStreamWithRetry.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.storage;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChunkInfo;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.XceiverClientManager;
+import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
+import org.apache.hadoop.security.token.Token;
+
+/**
+ * A dummy BlockInputStream with pipeline refresh function to mock read
+ * block call to DN.
+ */
+final class DummyBlockInputStreamWithRetry
+    extends DummyBlockInputStream {
+
+  private int getChunkInfoCount = 0;
+
+  @SuppressWarnings("parameternumber")
+  DummyBlockInputStreamWithRetry(
+      BlockID blockId,
+      long blockLen,
+      Pipeline pipeline,
+      Token<OzoneBlockTokenIdentifier> token,
+      boolean verifyChecksum,
+      XceiverClientManager xceiverClientManager,
+      List<ChunkInfo> chunkList,
+      Map<String, byte[]> chunkMap,
+      AtomicBoolean isRerfreshed) {
+    super(blockId, blockLen, pipeline, token, verifyChecksum,
+        xceiverClientManager, blockID -> {
+          isRerfreshed.set(true);
+          return Pipeline.newBuilder()
+              .setState(Pipeline.PipelineState.OPEN)
+              .setId(PipelineID.randomId())
+              .setType(HddsProtos.ReplicationType.STAND_ALONE)
+              .setFactor(HddsProtos.ReplicationFactor.ONE)
+              .setNodes(Collections.emptyList())
+              .build();
+        }, chunkList, chunkMap);
+  }
+
+  @Override
+  protected List<ChunkInfo> getChunkInfos() throws IOException {
+    if (getChunkInfoCount == 0) {
+      getChunkInfoCount++;
+      throw new ContainerNotFoundException("Exception encountered");
+    } else {
+      return super.getChunkInfos();
+    }
+  }
+}

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyChunkInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyChunkInputStream.java
@@ -51,12 +51,16 @@ public class DummyChunkInputStream extends ChunkInputStream {
     ByteString byteString = ByteString.copyFrom(chunkData,
         (int) readChunkInfo.getOffset(),
         (int) readChunkInfo.getLen());
-    readByteBuffers.add(byteString);
+    getReadByteBuffers().add(byteString);
     return byteString;
   }
 
   @Override
   protected void checkOpen() {
     // No action needed
+  }
+
+  public List<ByteString> getReadByteBuffers() {
+    return readByteBuffers;
   }
 }

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyChunkInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyChunkInputStream.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.storage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChunkInfo;
+import org.apache.hadoop.hdds.scm.XceiverClientSpi;
+
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+
+/**
+ * A dummy ChunkInputStream to mock read chunk calls to DN.
+ */
+public class DummyChunkInputStream extends ChunkInputStream {
+
+  private byte[] chunkData;
+
+  // Stores the read chunk data in each readChunk call
+  private List<ByteString> readByteBuffers = new ArrayList<>();
+
+  public DummyChunkInputStream(TestChunkInputStream testChunkInputStream,
+      ChunkInfo chunkInfo,
+      BlockID blockId,
+      XceiverClientSpi xceiverClient,
+      boolean verifyChecksum,
+      byte[] data) {
+    super(chunkInfo, blockId, xceiverClient, verifyChecksum);
+    this.chunkData = data;
+  }
+
+  @Override
+  protected ByteString readChunk(ChunkInfo readChunkInfo) {
+    ByteString byteString = ByteString.copyFrom(chunkData,
+        (int) readChunkInfo.getOffset(),
+        (int) readChunkInfo.getLen());
+    readByteBuffers.add(byteString);
+    return byteString;
+  }
+
+  @Override
+  protected void checkOpen() {
+    // No action needed
+  }
+}

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestBlockInputStream.java
@@ -23,27 +23,19 @@ import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChunkInfo;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.scm.XceiverClientManager;
-import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
-import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
-import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
-import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
 import org.apache.hadoop.ozone.common.Checksum;
-import org.apache.hadoop.security.token.Token;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.EOFException;
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.function.Function;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.hadoop.hdds.scm.storage.TestChunkInputStream.generateRandomData;
 
@@ -60,7 +52,7 @@ public class TestBlockInputStream {
   private int blockSize;
   private List<ChunkInfo> chunks;
   private Map<String, byte[]> chunkDataMap;
-  private boolean refreshFunctionFlag = false;
+  private AtomicBoolean isRefreshed = new AtomicBoolean();
 
   @Before
   public void setup() throws Exception {
@@ -69,7 +61,7 @@ public class TestBlockInputStream {
     createChunkList(5);
 
     blockStream = new DummyBlockInputStream(blockID, blockSize, null, null,
-        false, null);
+        false, null, chunks, chunkDataMap);
   }
 
   /**
@@ -106,51 +98,6 @@ public class TestBlockInputStream {
 
       blockSize += chunkLen;
       blockData = Bytes.concat(blockData, byteData);
-    }
-  }
-
-  /**
-   * A dummy BlockInputStream to mock read block call to DN.
-   */
-  private class DummyBlockInputStream extends BlockInputStream {
-
-    DummyBlockInputStream(BlockID blockId,
-        long blockLen,
-        Pipeline pipeline,
-        Token<OzoneBlockTokenIdentifier> token,
-        boolean verifyChecksum,
-        XceiverClientManager xceiverClientManager) {
-      super(blockId, blockLen, pipeline, token, verifyChecksum,
-          xceiverClientManager);
-    }
-
-    DummyBlockInputStream(BlockID blockId,
-                          long blockLen,
-                          Pipeline pipeline,
-                          Token<OzoneBlockTokenIdentifier> token,
-                          boolean verifyChecksum,
-                          XceiverClientManager xceiverClientManager,
-                          Function<BlockID, Pipeline> refreshFunction) {
-      super(blockId, blockLen, pipeline, token, verifyChecksum,
-          xceiverClientManager, refreshFunction);
-    }
-
-    @Override
-    protected List<ChunkInfo> getChunkInfos() throws IOException {
-      return chunks;
-    }
-
-    @Override
-    protected void addStream(ChunkInfo chunkInfo) {
-      TestChunkInputStream testChunkInputStream = new TestChunkInputStream();
-      getChunkStreams().add(testChunkInputStream.new DummyChunkInputStream(
-          chunkInfo, null, null, false,
-          chunkDataMap.get(chunkInfo.getChunkName()).clone()));
-    }
-
-    @Override
-    protected synchronized void checkOpen() throws IOException {
-      // No action needed
     }
   }
 
@@ -249,57 +196,18 @@ public class TestBlockInputStream {
     matchWithInputData(b2, 150, 100);
   }
 
-  /**
-   * A dummy BlockInputStream with pipeline refresh function to mock read
-   * block call to DN.
-   */
-  private final class DummyBlockInputStreamWithRetry
-      extends DummyBlockInputStream {
-
-    private int getChunkInfoCount = 0;
-
-    private DummyBlockInputStreamWithRetry(BlockID blockId,
-                                   long blockLen,
-                                   Pipeline pipeline,
-                                   Token<OzoneBlockTokenIdentifier> token,
-                                   boolean verifyChecksum,
-                                   XceiverClientManager xceiverClientManager) {
-      super(blockId, blockLen, pipeline, token, verifyChecksum,
-          xceiverClientManager, blockID -> {
-            refreshFunctionFlag = true;
-            return Pipeline.newBuilder()
-                .setState(Pipeline.PipelineState.OPEN)
-                .setId(PipelineID.randomId())
-                .setType(HddsProtos.ReplicationType.STAND_ALONE)
-                .setFactor(HddsProtos.ReplicationFactor.ONE)
-                .setNodes(Collections.emptyList())
-                .build();
-          });
-    }
-
-    @Override
-    protected List<ChunkInfo> getChunkInfos() throws IOException {
-      if (getChunkInfoCount == 0) {
-        getChunkInfoCount++;
-        throw new ContainerNotFoundException("Exception encountered");
-      } else {
-        return super.getChunkInfos();
-      }
-    }
-  }
-
   @Test
   public void testRefreshPipelineFunction() throws Exception {
     BlockID blockID = new BlockID(new ContainerBlockID(1, 1));
     createChunkList(5);
     BlockInputStream blockInputStreamWithRetry =
         new DummyBlockInputStreamWithRetry(blockID, blockSize, null, null,
-        false, null);
+            false, null, chunks, chunkDataMap, isRefreshed);
 
-    Assert.assertFalse(refreshFunctionFlag);
+    Assert.assertFalse(isRefreshed.get());
     seekAndVerify(50);
     byte[] b = new byte[200];
     blockInputStreamWithRetry.read(b, 0, 200);
-    Assert.assertTrue(refreshFunctionFlag);
+    Assert.assertTrue(isRefreshed.get());
   }
 }

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
@@ -18,21 +18,17 @@
 
 package org.apache.hadoop.hdds.scm.storage;
 
-import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChunkInfo;
-import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.EOFException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Random;
 
 /**
@@ -66,52 +62,14 @@ public class TestChunkInputStream {
             chunkData, 0, CHUNK_SIZE).getProtoBufMessage())
         .build();
 
-    chunkStream = new DummyChunkInputStream(chunkInfo, null, null, true);
+    chunkStream =
+        new DummyChunkInputStream(this, chunkInfo, null, null, true, chunkData);
   }
 
   static byte[] generateRandomData(int length) {
     byte[] bytes = new byte[length];
     RANDOM.nextBytes(bytes);
     return bytes;
-  }
-
-  /**
-   * A dummy ChunkInputStream to mock read chunk calls to DN.
-   */
-  public class DummyChunkInputStream extends ChunkInputStream {
-
-    // Stores the read chunk data in each readChunk call
-    private List<ByteString> readByteBuffers = new ArrayList<>();
-
-    DummyChunkInputStream(ChunkInfo chunkInfo,
-        BlockID blockId,
-        XceiverClientSpi xceiverClient,
-        boolean verifyChecksum) {
-      super(chunkInfo, blockId, xceiverClient, verifyChecksum);
-    }
-
-    public DummyChunkInputStream(ChunkInfo chunkInfo,
-        BlockID blockId,
-        XceiverClientSpi xceiverClient,
-        boolean verifyChecksum,
-        byte[] data) {
-      super(chunkInfo, blockId, xceiverClient, verifyChecksum);
-      chunkData = data;
-    }
-
-    @Override
-    protected ByteString readChunk(ChunkInfo readChunkInfo) {
-      ByteString byteString = ByteString.copyFrom(chunkData,
-          (int) readChunkInfo.getOffset(),
-          (int) readChunkInfo.getLen());
-      readByteBuffers.add(byteString);
-      return byteString;
-    }
-
-    @Override
-    protected void checkOpen() {
-      // No action needed
-    }
   }
 
   /**

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
@@ -117,7 +117,7 @@ public class TestChunkInputStream {
     // chunk from offset 0 to 60 as the checksum boundary is at every 20
     // bytes. Verify that 60 bytes of chunk data are read and stored in the
     // buffers.
-    matchWithInputData(chunkStream.readByteBuffers.get(0).toByteArray(),
+    matchWithInputData(chunkStream.getReadByteBuffers().get(0).toByteArray(),
         0, 60);
 
   }
@@ -145,7 +145,7 @@ public class TestChunkInputStream {
     byte[] b = new byte[30];
     chunkStream.read(b, 0, 30);
     matchWithInputData(b, 25, 30);
-    matchWithInputData(chunkStream.readByteBuffers.get(0).toByteArray(),
+    matchWithInputData(chunkStream.getReadByteBuffers().get(0).toByteArray(),
         20, 40);
 
     // After read, the position of the chunkStream is evaluated from the


### PR DESCRIPTION
## What changes were proposed in this pull request?

Moving out DummyBlock/ChunkInputStream helper classes from the unit test class (inner class) to outer class to avoid a strange error:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M1:test (default-test) on project hadoop-hdds-client:
Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M1:test failed: java.lang.ClassFormatError: Illegal field name "org.apache.hadoop.hdds.scm.storage.TestBlockInputStream$this" in class org/apache/hadoop/hdds/scm/storage/TestBlockInputStream$DummyBlockInputStreamWithRetry -> [Help 1]
``` 

Most probably it's a surefire plugin limitation/bug.

Testing logic has not been changed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2898

## How was this patch tested?

This is a unit test-only changed. The changed unit tests are executed.