### PR TITLE
HDDS-2902. execute_robot_test on unknown/unavailable container should fail acceptance test

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -29,8 +29,6 @@ execute_robot_test scm kinit.robot
 
 execute_robot_test scm basic
 
-execute_robot_test recon basic/basic.robot
-
 execute_robot_test scm security
 
 execute_robot_test scm ozonefs/ozonefs.robot

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -29,6 +29,8 @@ execute_robot_test scm kinit.robot
 
 execute_robot_test scm basic
 
+execute_robot_test recon basic/basic.robot
+
 execute_robot_test scm security
 
 execute_robot_test scm ozonefs/ozonefs.robot

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -99,14 +99,20 @@ execute_robot_test(){
   set +e
   OUTPUT_NAME="$COMPOSE_ENV_NAME-$TEST_NAME-$CONTAINER"
   OUTPUT_PATH="$RESULT_DIR_INSIDE/robot-$OUTPUT_NAME.xml"
-  docker-compose -f "$COMPOSE_FILE" exec -T "$CONTAINER" mkdir -p "$RESULT_DIR_INSIDE"
   # shellcheck disable=SC2068
-  docker-compose -f "$COMPOSE_FILE" exec -T -e  SECURITY_ENABLED="${SECURITY_ENABLED}" "$CONTAINER" python -m robot ${ARGUMENTS[@]} --log NONE -N "$TEST_NAME" --report NONE "${OZONE_ROBOT_OPTS[@]}" --output "$OUTPUT_PATH" "$SMOKETEST_DIR_INSIDE/$TEST"
+  docker-compose -f "$COMPOSE_FILE" exec -T "$CONTAINER" mkdir -p "$RESULT_DIR_INSIDE" \
+    && docker-compose -f "$COMPOSE_FILE" exec -T -e  SECURITY_ENABLED="${SECURITY_ENABLED}" "$CONTAINER" python -m robot ${ARGUMENTS[@]} --log NONE -N "$TEST_NAME" --report NONE "${OZONE_ROBOT_OPTS[@]}" --output "$OUTPUT_PATH" "$SMOKETEST_DIR_INSIDE/$TEST"
+  local -i rc=$?
 
   FULL_CONTAINER_NAME=$(docker-compose -f "$COMPOSE_FILE" ps | grep "_${CONTAINER}_" | head -n 1 | awk '{print $1}')
   docker cp "$FULL_CONTAINER_NAME:$OUTPUT_PATH" "$RESULT_DIR/"
   set -e
 
+  if [[ ${rc} -gt 0 ]]; then
+    stop_docker_env
+  fi
+
+  return ${rc}
 }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make acceptance test fail if the command to run tests fails.  This is necessary because acceptance test result is normally determined by test result analysis (via `rebot` command).  But `rebot` only encounters results for tests that were actually run, does not know about tests that failed to be run.

https://issues.apache.org/jira/browse/HDDS-2902

## How was this patch tested?

1. Temporarily added a test execution on `recon` container in `ozonesecure` environment to reproduce the problem.  Since this branch does not have the fix for HDDS-2897, it should fail, but without this fix (for HDDS-2902) it actually passes despite the container being down:

```
2020-01-17T20:02:29.8256065Z No container found for recon_1
```

https://github.com/adoroszlai/hadoop-ozone/runs/395850452


2. Implemented the fix for HDDS-2902.  Verified that it makes acceptance test fail at the right point:

```
2020-01-20T09:41:34.9813929Z No container found for recon_1
2020-01-20T09:41:35.5724622Z Error: No such container:path: ozonesecure_recon_1:/tmp/smoketest/ozonesecure/result/robot-ozonesecure-ozonesecure-basic-recon.xml
2020-01-20T09:41:37.8846612Z Stopping ozonesecure_kdc_1      ... done
...
2020-01-20T09:41:39.4007426Z Removing ozonesecure_s3g_1      ... done
2020-01-20T09:41:39.4007632Z Removing network ozonesecure_default
2020-01-20T09:41:39.5108890Z ERROR: Test execution of /home/runner/work/hadoop-ozone/hadoop-ozone/hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonesecure is FAILED!!!!
...
2020-01-20T09:41:41.0464403Z ##[error]Process completed with exit code 1.
```

https://github.com/adoroszlai/hadoop-ozone/runs/398565843

3. Reverted the "repro" change.  Verified that acceptance test passes:

https://github.com/adoroszlai/hadoop-ozone/runs/398666218