### PR TITLE
HDDS-2938. Use regex to match with ratis grpc properties when creating ratis server.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
@@ -76,6 +76,8 @@ public interface RatisHelper {
 
   // Ratis Server header regex filter.
   String RATIS_SERVER_HEADER_REGEX = "raft\\.server\\.([a-z\\.]+)";
+  String RATIS_SERVER_GRPC_HEADER_REGEX = "datanode\\.ratis\\.raft\\.grpc\\" +
+      ".([a-z\\.]+)";
 
   static String toRaftPeerIdString(DatanodeDetails id) {
     return id.getUuidString();
@@ -269,6 +271,19 @@ public interface RatisHelper {
         ozoneConf.getValByRegex(RATIS_GRPC_CLIENT_HEADER_REGEX);
     ratisClientConf.forEach((key, val) -> raftProperties.set(key, val));
   }
+
+  static void createRaftServerGrpcProperties(Configuration ozoneConf,
+      RaftProperties raftProperties) {
+    Map<String, String> ratisClientConf =
+        ozoneConf.getValByRegex(RATIS_SERVER_GRPC_HEADER_REGEX);
+    ratisClientConf.forEach((key, val) -> raftProperties.set(
+        removeDatanodePrefix(key), val));
+  }
+
+  static String removeDatanodePrefix(String key) {
+    return key.replaceFirst("datanode.ratis.", "");
+  }
+
 
   /**
    * Set all the properties matching with regex

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestRatisHelper.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestRatisHelper.java
@@ -71,6 +71,36 @@ public class TestRatisHelper {
 
   }
 
+
+  @Test
+  public void testCreateRaftServerGrpcProperties() {
+
+    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
+    ozoneConfiguration.set("datanode.ratis.raft.grpc.message.size.max", "30MB");
+    ozoneConfiguration.set("datanode.ratis.raft.grpc.flow.control.window",
+        "1MB");
+    ozoneConfiguration.set("datanode.ratis.raft.grpc.tls.enabled", "true");
+    ozoneConfiguration.set("datanode.ratis.raft.grpc.tls.mutual_authn" +
+        ".enabled", "true");
+    ozoneConfiguration.set("datanode.ratis.raft.grpc.server.port", "100");
+
+    RaftProperties raftProperties = new RaftProperties();
+    RatisHelper.createRaftServerGrpcProperties(ozoneConfiguration,
+        raftProperties);
+
+    Assert.assertEquals("30MB",
+        raftProperties.get("raft.grpc.message.size.max"));
+    Assert.assertEquals("1MB",
+        raftProperties.get("raft.grpc.flow.control.window"));
+    Assert.assertEquals("true",
+        raftProperties.get("raft.grpc.tls.enabled"));
+    Assert.assertEquals("true",
+        raftProperties.get("raft.grpc.tls.mutual_authn.enabled"));
+    Assert.assertEquals("100",
+        raftProperties.get("raft.grpc.server.port"));
+
+  }
+
   @Test
   public void testCreateRaftServerProperties() {
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -265,8 +265,12 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     RaftServerConfigKeys.Snapshot.setRetentionFileNum(properties,
         numSnapshotsRetained);
 
-    // Set headers starting with prefix raft.server
+    // Set properties starting with prefix raft.server
     RatisHelper.createRaftServerProperties(conf, properties);
+
+    // Set properties starting with prefix raft.grpc
+    RatisHelper.createRaftServerGrpcProperties(conf, properties);
+
     return properties;
   }
 


### PR DESCRIPTION

## What changes were proposed in this pull request?

This Jira is to use regex which are matching with ratis grpc properties and set them when creating ratis server. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2938

## How was this patch tested?

Added UT for the new method.