### PR TITLE
HDDS-2883. Change the default client settings accordingly with change in default chunk size.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -136,8 +136,8 @@ public final class ScmConfigKeys {
 
   // TODO : this is copied from OzoneConsts, may need to move to a better place
   public static final String OZONE_SCM_CHUNK_SIZE_KEY = "ozone.scm.chunk.size";
-  // 16 MB by default
-  public static final String OZONE_SCM_CHUNK_SIZE_DEFAULT = "16MB";
+  // 4 MB by default
+  public static final String OZONE_SCM_CHUNK_SIZE_DEFAULT = "4MB";
 
   public static final String OZONE_SCM_CLIENT_PORT_KEY =
       "ozone.scm.client.port";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -126,13 +126,13 @@ public final class OzoneConfigKeys {
       "ozone.client.stream.buffer.flush.size";
 
   public static final String OZONE_CLIENT_STREAM_BUFFER_FLUSH_SIZE_DEFAULT =
-      "64MB";
+      "16MB";
 
   public static final String OZONE_CLIENT_STREAM_BUFFER_MAX_SIZE =
       "ozone.client.stream.buffer.max.size";
 
   public static final String OZONE_CLIENT_STREAM_BUFFER_MAX_SIZE_DEFAULT =
-      "128MB";
+      "32MB";
 
   public static final String OZONE_CLIENT_MAX_RETRIES =
       "ozone.client.max.retries";

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -388,7 +388,7 @@
   </property>
   <property>
     <name>ozone.client.stream.buffer.flush.size</name>
-    <value>64MB</value>
+    <value>16MB</value>
     <tag>OZONE, CLIENT</tag>
     <description>Size which determines at what buffer position , a partial
       flush will be initiated during write. It should be ideally a multiple
@@ -397,7 +397,7 @@
   </property>
   <property>
     <name>ozone.client.stream.buffer.max.size</name>
-    <value>128MB</value>
+    <value>32MB</value>
     <tag>OZONE, CLIENT</tag>
     <description>Size which determines at what buffer position,
       write call be blocked till acknowledgement of the first partial flush
@@ -702,7 +702,7 @@
   </property>
   <property>
     <name>ozone.scm.chunk.size</name>
-    <value>16MB</value>
+    <value>4MB</value>
     <tag>OZONE, SCM, CONTAINER, PERFORMANCE</tag>
     <description>
       The chunk size for reading/writing chunk operations in bytes.


### PR DESCRIPTION

## What changes were proposed in this pull request?

This Jira proposes to change the following values

ozone.client.stream.buffer.flush.size - 64MB -> 16MB

ozone.client.stream.buffer.max.size - 128 MB -> 32MB

ozone.scm.chunk.size - 16MB -> 4MB

 

In this way, the client-side holding buffer size will be reduced, and data is transferred at smaller size intervals.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2883

## How was this patch tested?

Multiple teragen tests are run on a 6 node cluster with these values and along changes from HDDS-2920 and HDDS-2921 we have seen teragen completed successfully.
