### PR TITLE
HDDS-2916. OM HA cli getserviceroles not working.

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -467,10 +467,8 @@
     <value></value>
     <tag>OM, HA</tag>
     <description>
-      Comma-separated list of OM service Ids.
-
-      If not set, the default value of "omServiceIdDefault" is assigned as the
-      OM service ID.
+      Comma-separated list of OM service Ids. This property allows the client
+      to figure out quorum of OzoneManager address.
     </description>
   </property>
   <property>

--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -40,6 +40,8 @@ execute_robot_test scm s3
 
 execute_robot_test scm recon
 
+execute_robot_test scm om-ratis
+
 stop_docker_env
 
 generate_report

--- a/hadoop-ozone/dist/src/main/smoketest/om-ratis/testOMAdminCmd.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/om-ratis/testOMAdminCmd.robot
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Smoketest ozone cluster startup
+Library             OperatingSystem
+Resource            ../commonlib.robot
+
+
+*** Test Cases ***
+
+Check om admin command
+    ${result} =        Execute and checkrc              ozone admin om getserviceroles -id=omServiceIdDefault  0
+                       Should Contain                   ${result}  This command works only on OzoneManager HA cluster.

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.ozone.admin.om;
 
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.client.OzoneClientException;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.ozone.admin.om;
 
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.client.OzoneClientException;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import picocli.CommandLine;
@@ -46,8 +48,12 @@ public class GetServiceRolesSubcommand implements Callable<Void> {
 
   @Override
   public Void call() throws Exception {
-    ClientProtocol client = parent.createClient(omServiceId);
-    getOmServerRoles(client.getOmRoleInfos());
+    try {
+      ClientProtocol client = parent.createClient(omServiceId);
+      getOmServerRoles(client.getOmRoleInfos());
+    } catch (OzoneClientException ex) {
+      System.out.printf("Error: %s", ex.getMessage());
+    }
     return null;
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
@@ -21,12 +21,16 @@ import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.MissingSubcommandException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.admin.OzoneAdmin;
+import org.apache.hadoop.ozone.client.OzoneClientException;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import picocli.CommandLine;
 
 import java.io.IOException;
+
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 
 /**
  * Subcommand for admin operations related to OM.
@@ -54,10 +58,17 @@ public class OMAdmin extends GenericCli {
         this.parent.getCmd().getSubcommands().get("om"));
   }
 
-  public ClientProtocol createClient(String omServiceId) throws IOException {
+  public ClientProtocol createClient(String omServiceId) throws Exception {
     OzoneConfiguration conf = parent.getOzoneConf();
-    return OzoneClientFactory.getRpcClient(omServiceId, conf).getObjectStore()
+    if (OmUtils.isOmHAServiceId(conf, omServiceId)) {
+      return OzoneClientFactory.getRpcClient(omServiceId, conf).getObjectStore()
         .getClientProxy();
-
+    } else {
+      throw new OzoneClientException("This command works only on OzoneManager" +
+          " HA cluster. Service ID specified does not match" +
+          " with " + OZONE_OM_SERVICE_IDS_KEY + " defined in the " +
+              "configuration. Configured " + OZONE_OM_SERVICE_IDS_KEY + " are" +
+              conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY));
+    }
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
@@ -28,8 +28,6 @@ import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import picocli.CommandLine;
 
-import java.io.IOException;
-
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 
 /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

When om admin commands are run on a non-HA cluster, return error message to client.

**Reason for this change:**
1. ozone.om.ratis.enable is a temporary config, once OM starts using by default ratis this config will be gone. So, if ozone.om.service.ids is not defined then technically it is not an HA cluster, so returned an error message. If the user passed service id is matching with service ID in the config, the command will work as usual.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2916

## How was this patch tested?

Added smoke test.
