### PR TITLE
HDDS-1335. Add basic UI for showing missing containers and keys

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -271,5 +271,90 @@
         "leaderElections": 5
       }
     ]
+  },
+  "missingContainers": {
+    "totalCount": 2,
+    "containers": [
+      {
+        "id": 1,
+        "keys": 3876,
+        "datanodes": [
+          "localhost1.storage.enterprise.com",
+          "localhost3.storage.enterprise.com",
+          "localhost5.storage.enterprise.com"
+        ]
+      },
+      {
+        "id": 2,
+        "keys": 5943,
+        "datanodes": [
+          "localhost1.storage.enterprise.com",
+          "localhost3.storage.enterprise.com",
+          "localhost5.storage.enterprise.com"
+        ]
+      }
+    ]
+  },
+  "keys": {
+    "totalCount": 534,
+    "keys": [
+      {
+        "Volume": "vol-0-20448",
+        "Bucket": "bucket-0-12811",
+        "Key": "key-0-77505",
+        "DataSize": 10240,
+        "Versions": [
+          0
+        ],
+        "Blocks": {
+          "0": [
+            {
+              "containerID": 1,
+              "localID": 103206297511460860
+            }
+          ]
+        },
+        "CreationTime": "2019-11-26T21:18:43.688Z",
+        "ModificationTime": "2019-11-26T21:18:46.062Z"
+      },
+      {
+        "Volume": "vol-0-20448",
+        "Bucket": "bucket-0-12811",
+        "Key": "key-21-64511",
+        "DataSize": 5692407,
+        "Versions": [
+          0
+        ],
+        "Blocks": {
+          "0": [
+            {
+              "containerID": 1,
+              "localID": 103206299949795380
+            }
+          ]
+        },
+        "CreationTime": "2019-11-26T21:19:20.855Z",
+        "ModificationTime": "2019-11-26T21:19:20.991Z"
+      },
+      {
+        "Volume": "vol-0-20448",
+        "Bucket": "bucket-0-12811",
+        "Key": "key-22-69104",
+        "DataSize": 189407,
+        "Versions": [
+          0
+        ],
+        "Blocks": {
+          "0": [
+            {
+              "containerID": 1,
+              "localID": 103206300033091740
+            }
+          ]
+        },
+        "CreationTime": "2019-11-26T21:19:22.126Z",
+        "ModificationTime": "2019-11-26T21:19:22.251Z"
+      }
+    ]
   }
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/routes.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/routes.json
@@ -1,3 +1,4 @@
 {
-  "/api/v1/*": "/$1"
+  "/api/v1/*": "/$1",
+  "/containers/:id/keys": "/keys"
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/App.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/App.less
@@ -51,10 +51,10 @@
 
         .ant-table-tbody {
           tr.ant-table-row:hover {
-            background: rgba(60, 90, 100, 0.04);
+            background: rgba(60, 90, 100, 0.01);
 
             & > td {
-              background: rgba(60, 90, 100, 0.04);
+              background: rgba(60, 90, 100, 0.01);
             }
           }
         }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/OverviewCard/OverviewCard.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/OverviewCard/OverviewCard.tsx
@@ -32,13 +32,15 @@ interface OverviewCardProps extends RouteComponentProps<any> {
   loading?: boolean;
   linkToUrl?: string;
   capacityPercent?: number;
+  error?: boolean;
 }
 
 const defaultProps = {
   hoverable: false,
   loading: false,
   capacityPercent: -1,
-  linkToUrl: ''
+  linkToUrl: '',
+  error: false
 };
 
 interface OverviewCardWrapperProps {
@@ -62,8 +64,9 @@ class OverviewCard extends React.Component<OverviewCardProps> {
   static defaultProps = defaultProps;
 
   render() {
-    let {icon, data, title, loading, hoverable, capacityPercent, linkToUrl} = this.props;
+    let {icon, data, title, loading, hoverable, capacityPercent, linkToUrl, error} = this.props;
     let meta = <Meta title={data} description={title}/>;
+    const errorClass = error ? 'card-error' : '';
     if (capacityPercent && capacityPercent > -1) {
       meta = <div className="ant-card-percentage">
         {meta}
@@ -74,7 +77,7 @@ class OverviewCard extends React.Component<OverviewCardProps> {
 
     return (
         <OverviewCardWrapper linkToUrl={linkToUrl}>
-          <Card className="overview-card" loading={loading} hoverable={hoverable}>
+          <Card className={`overview-card ${errorClass}`} loading={loading} hoverable={hoverable}>
             <Row type="flex" justify="space-between">
               <Col span={18}>
                 <Row>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/constants/breadcrumbs.constants.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/constants/breadcrumbs.constants.tsx
@@ -23,5 +23,6 @@ interface IBreadcrumbNameMap {
 export const breadcrumbNameMap: IBreadcrumbNameMap = {
   '/Overview': 'Overview',
   '/Datanodes': 'Datanodes',
-  '/Pipelines': 'Pipelines'
+  '/Pipelines': 'Pipelines',
+  '/MissingContainers': 'Missing Containers'
 };

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/routes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/routes.tsx
@@ -21,6 +21,7 @@ import {Datanodes} from './views/Datanodes/Datanodes';
 import {Pipelines} from "./views/Pipelines/Pipelines";
 import {NotFound} from './views/NotFound/NotFound';
 import {IRoute} from "./routes.types";
+import {MissingContainers} from "./views/MissingContainers/MissingContainers";
 
 export const routes: IRoute[] = [
   {
@@ -34,6 +35,10 @@ export const routes: IRoute[] = [
   {
     path: "/Pipelines",
     component: Pipelines
+  },
+  {
+    path: "/MissingContainers",
+    component: MissingContainers
   },
   {
     path: "/:NotFound",

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/MissingContainers/MissingContainers.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/MissingContainers/MissingContainers.less
@@ -15,28 +15,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-.overview-card {
-  .ant-card-meta-detail {
-    .ant-card-meta-title {
-      margin-bottom: 0;
-      font-size: 24px;
-    }
-  }
-  .ant-card-percentage {
-    .capacity-bar {
-      position: absolute;
-      top: 18px;
-      .ant-progress-inner {
-        background-color: #d0d0d0;
-      }
-    }
-    .ant-progress {
-      margin-bottom: 0;
-    }
-  }
-}
-
-.card-error {
-  border-color: #f5222d;
-}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/MissingContainers/MissingContainers.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/MissingContainers/MissingContainers.tsx
@@ -1,0 +1,218 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import axios from 'axios';
+import {Table} from 'antd';
+import './MissingContainers.less';
+import {PaginationConfig} from "antd/lib/pagination";
+import prettyBytes from "pretty-bytes";
+import moment from "moment";
+
+interface MissingContainerResponse {
+  id: number;
+  keys: number;
+  datanodes: string[];
+}
+
+interface MissingContainersResponse  {
+  totalCount: number;
+  containers: MissingContainerResponse[];
+}
+
+interface KeyResponse {
+  Volume: string;
+  Bucket: string;
+  Key: string;
+  DataSize: number;
+  Versions: number[];
+  Blocks: any;
+  CreationTime: string;
+  ModificationTime: string;
+}
+
+interface ContainerKeysResponse {
+  totalCount: number;
+  keys: KeyResponse[];
+}
+
+const COLUMNS = [
+  {
+    title: 'Container ID',
+    dataIndex: 'id',
+    key: 'id'
+  },
+  {
+    title: 'No. of Keys',
+    dataIndex: 'keys',
+    key: 'keys'
+  },
+  {
+    title: 'Datanodes',
+    dataIndex: 'datanodes',
+    key: 'datanodes',
+    render: (datanodes: string[]) => <div>{datanodes.map(datanode => <div key={datanode}>{datanode}</div>)}</div>
+  }
+];
+
+const KEY_TABLE_COLUMNS = [
+  {
+    title: 'Volume',
+    dataIndex: 'Volume',
+    key: 'Volume'
+  },
+  {
+    title: 'Bucket',
+    dataIndex: 'Bucket',
+    key: 'Bucket'
+  },
+  {
+    title: 'Key',
+    dataIndex: 'Key',
+    key: 'Key'
+  },
+  {
+    title: 'Size',
+    dataIndex: 'DataSize',
+    key: 'DataSize',
+    render: (dataSize: number) => <div>{prettyBytes(dataSize)}</div>
+  },
+  {
+    title: 'Date Created',
+    dataIndex: 'CreationTime',
+    key: 'CreationTime',
+    render: (date: number) => moment(date).format('lll')
+  },
+  {
+    title: 'Date Modified',
+    dataIndex: 'ModificationTime',
+    key: 'ModificationTime',
+    render: (date: number) => moment(date).format('lll')
+  }
+];
+
+interface ExpandedRow {
+  [key: number]: ExpandedRowState
+}
+
+interface ExpandedRowState {
+  containerId: number;
+  loading: boolean;
+  dataSource: KeyResponse[];
+  totalCount: number;
+}
+
+interface MissingContainersState {
+  loading: boolean;
+  dataSource: MissingContainerResponse[];
+  totalCount: number;
+  expandedRowData: ExpandedRow
+}
+
+export class MissingContainers extends React.Component<any, MissingContainersState> {
+
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      loading: false,
+      dataSource: [],
+      totalCount: 0,
+      expandedRowData: {}
+    }
+  }
+
+  componentDidMount(): void {
+    // Fetch missing containers on component mount
+    this.setState({
+      loading: true
+    });
+    axios.get('/api/v1/missingContainers').then(response => {
+      const missingContainersResponse: MissingContainersResponse = response.data;
+      const totalCount = missingContainersResponse.totalCount;
+      const missingContainers: MissingContainerResponse[] = missingContainersResponse.containers;
+      this.setState({
+        loading: false,
+        dataSource: missingContainers,
+        totalCount: totalCount
+      });
+    });
+  }
+
+  onShowSizeChange = (current: number, pageSize: number) => {
+    // TODO: Implement this method once server side pagination is enabled
+    console.log(current, pageSize);
+  };
+
+  onRowExpandClick = (expanded: boolean, record: MissingContainerResponse) => {
+    if (expanded) {
+      this.setState(({expandedRowData}) => {
+        const expandedRowState: ExpandedRowState = expandedRowData[record.id] ?
+            Object.assign({}, expandedRowData[record.id], {loading: true}) :
+            {containerId: record.id, loading: true, dataSource: [], totalCount: 0};
+        return {
+          expandedRowData: Object.assign({}, expandedRowData, {[record.id]: expandedRowState})
+        }
+      });
+      axios.get(`/api/v1/containers/${record.id}/keys`).then(response => {
+        const containerKeysResponse: ContainerKeysResponse = response.data;
+        this.setState(({expandedRowData}) => {
+          const expandedRowState: ExpandedRowState =
+              Object.assign({}, expandedRowData[record.id],
+                  {loading: false, dataSource: containerKeysResponse.keys, totalCount: containerKeysResponse.totalCount});
+          return {
+            expandedRowData: Object.assign({}, expandedRowData, {[record.id]: expandedRowState})
+          }
+        });
+      });
+    }
+  };
+
+  expandedRowRender = (record: MissingContainerResponse) => {
+    const {expandedRowData} = this.state;
+    const containerId = record.id;
+    if (expandedRowData[containerId]) {
+      const containerKeys: ExpandedRowState = expandedRowData[containerId];
+      const paginationConfig: PaginationConfig = {
+        showTotal: (total: number, range) => `${range[0]}-${range[1]} of ${total} keys`
+      };
+      return <Table loading={containerKeys.loading} dataSource={containerKeys.dataSource}
+                    columns={KEY_TABLE_COLUMNS} pagination={paginationConfig}/>
+    }
+    return <div>Loading...</div>;
+  };
+
+  render () {
+    const {dataSource, loading, totalCount} = this.state;
+    const paginationConfig: PaginationConfig = {
+      showTotal: (total: number, range) => `${range[0]}-${range[1]} of ${total} missing containers`,
+      showSizeChanger: true,
+      onShowSizeChange: this.onShowSizeChange
+    };
+    return (
+        <div className="missing-containers-container">
+          <div className="page-header">
+            Missing Containers ({totalCount})
+          </div>
+          <div className="content-div">
+            <Table dataSource={dataSource} columns={COLUMNS} loading={loading} pagination={paginationConfig}
+                   rowKey="id" expandedRowRender={this.expandedRowRender} expandRowByClick={true} onExpand={this.onRowExpandClick}/>
+          </div>
+        </div>
+    );
+  }
+}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/Overview/Overview.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/Overview/Overview.less
@@ -24,4 +24,7 @@
   .meta {
     font-size: 12px;
   }
+  .padded-text {
+    padding-left: 5px;
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds a new page to look at all the missing containers and the keys present within those containers. Also, the Overview page is modified to indicate the missing containers, if there is at-least one missing container. Clicking on the Containers card will take the users to a new "Missing Containers" page with more detailed view.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-1335

## How was this patch tested?

This patch was tested by running the react app with mock api server.
```
cd hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web
yarn install
yarn run dev
```
A screen-shot of Overview page with indication of missing containers is attached below:
<img width="1680" alt="Screen Shot 2020-01-25 at 1 29 35 PM" src="https://user-images.githubusercontent.com/1051198/73127823-21ded380-3f7b-11ea-9020-6d5cc4895ba8.png">

A screen-shot of the new Missing Containers page is attached below:
<img width="1680" alt="Screen Shot 2020-01-25 at 1 29 15 PM" src="https://user-images.githubusercontent.com/1051198/73127827-2905e180-3f7b-11ea-8723-96a6caa52f58.png">
