### PR TITLE
HDDS-2940. mkdir : create key table entries for intermediate directories in the path

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -228,4 +228,10 @@ public final class OMConfigKeys {
   // hadoop-policy.xml, "*" allows all users/groups to access.
   public static final String OZONE_OM_SECURITY_CLIENT_PROTOCOL_ACL =
       "ozone.om.security.client.protocol.acl";
+
+  //Ozone FS Config parameters.
+  public static final String OZONE_FS_CREATE_PREFIX_DIRECTORIES =
+      "ozone.fs.prefix.create";
+  public static final Boolean OZONE_FS_CREATE_PREFIX_DIRECTORIES_DEFAULT =
+      Boolean.TRUE;
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -231,7 +231,7 @@ public final class OMConfigKeys {
 
   //Ozone FS Config parameters.
   public static final String OZONE_FS_CREATE_PREFIX_DIRECTORIES =
-      "ozone.fs.prefix.create";
+      "ozone.manager.fs.prefix.create";
   public static final Boolean OZONE_FS_CREATE_PREFIX_DIRECTORIES_DEFAULT =
       Boolean.TRUE;
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
@@ -197,6 +197,8 @@ public class OMException extends IOException {
 
     NOT_A_FILE,
 
+    PATH_TOO_LONG,
+
     PERMISSION_DENIED, // Error codes used during acl validation
 
     TIMEOUT, // Error codes used during acl validation

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
@@ -197,8 +197,6 @@ public class OMException extends IOException {
 
     NOT_A_FILE,
 
-    PATH_TOO_LONG,
-
     PERMISSION_DENIED, // Error codes used during acl validation
 
     TIMEOUT, // Error codes used during acl validation

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
@@ -262,8 +262,6 @@ public class TestOzoneFileInterfaces {
       FileStatus lev2status;
 
       // verify prefix directories got created when creating the leaf directory.
-      String kn = metadataManager.getKeyTable().get(lev2key).getKeyName();
-      assertTrue(kn.equals("abc/def/"));
       assertTrue(metadataManager
           .getKeyTable()
           .get(lev1key)
@@ -456,7 +454,6 @@ public class TestOzoneFileInterfaces {
     }
     assertTrue("The created path is not directory.", status.isDirectory());
 
-    assertTrue(status.isDirectory());
     assertEquals(FsPermission.getDirDefault(), status.getPermission());
     verifyOwnerGroup(status);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -56,6 +56,7 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         HddsConfigKeys.HDDS_X509_CRL_NAME, // HDDS-2873
         OMConfigKeys.OZONE_OM_NODES_KEY,
         OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS_NATIVE,
+        OMConfigKeys.OZONE_FS_CREATE_PREFIX_DIRECTORIES,
         OzoneConfigKeys.OZONE_S3_AUTHINFO_MAX_LIFETIME_KEY,
         ReconServerConfigKeys.OZONE_RECON_SCM_DB_DIR
         // TODO HDDS-2856

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -202,6 +202,8 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_METRICS_SAVE_INTE
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_METRICS_SAVE_INTERVAL_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_USER_MAX_VOLUME;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_USER_MAX_VOLUME_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_FS_CREATE_PREFIX_DIRECTORIES;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_FS_CREATE_PREFIX_DIRECTORIES_DEFAULT;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_AUTH_METHOD;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
@@ -304,6 +306,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   private boolean isNativeAuthorizerEnabled;
 
+  private boolean createPrefixDirectories;
+
   private OzoneManager(OzoneConfiguration conf) throws IOException,
       AuthenticationException {
     super(OzoneVersionInfo.OZONE_VERSION_INFO);
@@ -366,6 +370,14 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY,
         OMConfigKeys.OZONE_OM_RATIS_ENABLE_DEFAULT);
 
+    createPrefixDirectories = conf.getBoolean(
+        OZONE_FS_CREATE_PREFIX_DIRECTORIES,
+        OZONE_FS_CREATE_PREFIX_DIRECTORIES_DEFAULT);
+    if (createPrefixDirectories) {
+      LOG.info("OzoneFS will create entries for parent directories in path.");
+    } else {
+      LOG.info("OzoneFS will not create entries for parent directories in path.");
+    }
 
     InetSocketAddress omNodeRpcAddr = omNodeDetails.getRpcAddress();
     omRpcAddressTxt = new Text(omNodeDetails.getRpcAddressString());
@@ -452,6 +464,14 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     };
     ShutdownHookManager.get().addShutdownHook(shutdownHook,
         SHUTDOWN_HOOK_PRIORITY);
+  }
+
+  /**
+   * Create separate entries for prefix directories in the object path.
+   * @return create directory entries if true
+   */
+  public boolean createPrefixEntries() {
+    return createPrefixDirectories;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2787,14 +2787,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       checkAcls(getResourceType(args), StoreType.OZONE, ACLType.READ,
           args.getVolumeName(), args.getBucketName(), args.getKeyName());
     }
-    LOG.trace("getFileStatus initiated for " + args.getKeyName());
     boolean auditSuccess = true;
     try {
       metrics.incNumGetFileStatus();
       return keyManager.getFileStatus(args);
     } catch (IOException ex) {
-      LOG.trace("getFileStatus for " + args.getKeyName()
-          + " caught exception : " + ex);
       metrics.incNumGetFileStatusFails();
       auditSuccess = false;
       AUDIT.logReadFailure(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1627,8 +1627,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         .setAclRights(aclType)
         .build();
     if (!accessAuthorizer.checkAccess(obj, context)) {
-      LOG.warn("User {} doesn't have {} permission to access {}",
-          ugi.getUserName(), aclType, resType);
+      LOG.warn("User {} doesn't have {} permission to access {} /{}/{}/{}",
+          ugi.getUserName(), aclType, resType, vol, bucket, key);
       throw new OMException("User " + ugi.getUserName() + " doesn't " +
           "have " + aclType + " permission to access " + resType,
           ResultCodes.PERMISSION_DENIED);
@@ -2787,11 +2787,14 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       checkAcls(getResourceType(args), StoreType.OZONE, ACLType.READ,
           args.getVolumeName(), args.getBucketName(), args.getKeyName());
     }
+    LOG.trace("getFileStatus initiated for " + args.getKeyName());
     boolean auditSuccess = true;
     try {
       metrics.incNumGetFileStatus();
       return keyManager.getFileStatus(args);
     } catch (IOException ex) {
+      LOG.trace("getFileStatus for " + args.getKeyName()
+          + " caught exception : " + ex);
       metrics.incNumGetFileStatusFails();
       auditSuccess = false;
       AUDIT.logReadFailure(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -185,8 +185,7 @@ public class OMBucketCreateRequest extends OMClientRequest {
       }
 
       // Add objectID and updateID
-      long objectId = OMFileRequest.getObjIdRangeFromTxId(transactionLogIndex)
-          .getLeft();
+      long objectId = OMFileRequest.getObjIDFromTxId(transactionLogIndex);
       omBucketInfo.setObjectID(objectId);
       omBucketInfo.setUpdateID(transactionLogIndex);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
+import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -184,7 +185,9 @@ public class OMBucketCreateRequest extends OMClientRequest {
       }
 
       // Add objectID and updateID
-      omBucketInfo.setObjectID(transactionLogIndex);
+      long objectId = OMFileRequest.getObjIdRangeFromTxId(transactionLogIndex)
+          .getLeft();
+      omBucketInfo.setObjectID(objectId);
       omBucketInfo.setUpdateID(transactionLogIndex);
 
       // Add default acls from volume.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -177,8 +177,7 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
       OMFileRequest.OMDirectoryResult omDirectoryResult =
           omPathInfo.getDirectoryResult();
       List<String> missingParents = omPathInfo.getMissingParents();
-      long baseObjId = OMFileRequest.getObjIdRangeFromTxId(trxnLogIndex)
-          .getLeft();
+      long baseObjId = OMFileRequest.getObjIDFromTxId(trxnLogIndex);
 
       OmKeyInfo dirKeyInfo = null;
       if (omDirectoryResult == FILE_EXISTS ||

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -176,8 +176,6 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
               bucketName, keyName, keyPath);
       OMFileRequest.OMDirectoryResult omDirectoryResult =
           omPathInfo.getDirectoryResult();
-      List<String> missingParents = omPathInfo.getMissingParents();
-      long baseObjId = OMFileRequest.getObjIDFromTxId(trxnLogIndex);
 
       OmKeyInfo dirKeyInfo = null;
       if (omDirectoryResult == FILE_EXISTS ||
@@ -187,6 +185,9 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
             FILE_ALREADY_EXISTS);
       } else if (omDirectoryResult == DIRECTORY_EXISTS_IN_GIVENPATH ||
           omDirectoryResult == NONE) {
+        List<String> missingParents = omPathInfo.getMissingParents();
+        long baseObjId = OMFileRequest.getObjIDFromTxId(trxnLogIndex);
+
         dirKeyInfo = createDirectoryKeyInfo(ozoneManager, keyName, keyArgs,
             baseObjId, trxnLogIndex);
 
@@ -272,7 +273,7 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
             INVALID_KEY_NAME);
       }
 
-      LOG.debug("missing parent {}", missingKey);
+      LOG.debug("missing parent {} getting added to KeyTable", missingKey);
       // what about keyArgs for parent directories? TODO
       OmKeyInfo parentKeyInfo = createDirectoryKeyInfoNoACL(ozoneManager,
           missingKey, keyArgs, nextObjId, trxnLogIndex);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -235,7 +235,7 @@ public class OMFileCreateRequest extends OMKeyRequest {
 
       OMFileRequest.OMDirectoryResult omDirectoryResult =
           OMFileRequest.verifyFilesInPath(omMetadataManager, volumeName,
-              bucketName, keyName, Paths.get(keyName));
+              bucketName, keyName, Paths.get(keyName)).getDirectoryResult();
 
       // Check if a file or directory exists with same key name.
       if (omDirectoryResult == FILE_EXISTS) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -175,6 +175,8 @@ public class OMFileCreateRequest extends OMKeyRequest {
     // if isRecursive is true, file would be created even if parent
     // directories does not exist.
     boolean isRecursive = createFileRequest.getIsRecursive();
+    LOG.info("File create for : " + volumeName + "/" + bucketName + "/"
+        + keyName + ":" + isRecursive);
 
     // if isOverWrite is true, file would be over written.
     boolean isOverWrite = createFileRequest.getIsOverwrite();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -108,9 +108,14 @@ public final class OMFileRequest {
   public static ImmutablePair<Long, Long> getObjIdRangeFromTxId(long id) {
     long baseId = id << TRANSACTION_ID_SHIFT;
     long maxId = baseId + ((1 << TRANSACTION_ID_SHIFT) - 1);
-    return new ImmutablePair<>(new Long(baseId), new Long(maxId));
+    return new ImmutablePair<>(baseId, maxId);
   }
 
+  /**
+   * Class to return the results from verifyFilesInPath.
+   * Includes the list of missing intermediate directories and
+   * the directory search result code.
+   */
   public static class OMPathInfo {
     private OMDirectoryResult directoryResult;
     private List<String> missingParents;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -23,13 +23,10 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 
 import javax.annotation.Nonnull;
 
-import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_NOT_FOUND;
 
 /**
  * Base class for file requests.
@@ -110,6 +107,7 @@ public final class OMFileRequest {
    * @return List of keys representing non-existent parent dirs
    * @throws IOException
    */
+  @Nonnull
   public static List<String> getMissingParents(
       @Nonnull OMMetadataManager omMetadataManager,
       @Nonnull String volumeName,
@@ -141,19 +139,6 @@ public final class OMFileRequest {
     }
 
     return missing;
-  }
-
-  private static OmKeyInfo getKeyInfo(
-      @Nonnull OMMetadataManager omMetadataManager,
-      @Nonnull String volumeName,
-      @Nonnull String bucketName,
-      @Nonnull String keyName) throws IOException {
-
-    if (omMetadataManager.getKeyTable().isExist(keyName)) {
-      return omMetadataManager.getKeyTable().get(keyName);
-    } else {
-      return null;
-    }
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -158,7 +158,7 @@ public final class OMFileRequest {
   public static class OMPathInfo {
     private OMDirectoryResult directoryResult;
     private List<String> missingParents;
-    List<OzoneAcl> acls;
+    private List<OzoneAcl> acls;
 
     public OMPathInfo(List missingParents, OMDirectoryResult result,
         List<OzoneAcl> aclList) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -101,7 +101,20 @@ public final class OMFileRequest {
   }
 
   /**
-   * generate the valid object id range from the transaction id.
+   * Get the valid base object id given the transaction id.
+   * @param id of the transaction
+   * @return base object id allocated against the transaction
+   */
+  public static long getObjIDFromTxId(long id) {
+    return getObjIdRangeFromTxId(id).getLeft();
+  }
+
+  /**
+   * Generate the valid object id range for the transaction id.
+   * The transaction id is left shifted by 8 bits -
+   * creating space to create (2^8 - 1) object ids in every request.
+   * maxId (right element of Immutable pair) represents the largest
+   * object id allocation possible inside the transaction.
    * @param id
    * @return object id range
    */

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
+import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.slf4j.Logger;
@@ -240,6 +241,8 @@ public abstract class OMKeyRequest extends OMClientRequest {
       @Nonnull PrefixManager prefixManager,
       @Nullable OmBucketInfo omBucketInfo,
         long transactionLogIndex) {
+    long objectID = OMFileRequest.getObjIdFromTxId(transactionLogIndex);
+
     return new OmKeyInfo.Builder()
         .setVolumeName(keyArgs.getVolumeName())
         .setBucketName(keyArgs.getBucketName())
@@ -254,7 +257,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
         .setFileEncryptionInfo(encInfo)
         .setAcls(getAclsForKey(keyArgs, omBucketInfo, prefixManager))
         .addAllMetadata(KeyValueUtil.getFromProtobuf(keyArgs.getMetadataList()))
-        .setObjectID(transactionLogIndex)
+        .setObjectID(objectID)
         .setUpdateID(transactionLogIndex)
         .build();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -241,8 +241,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
       @Nonnull PrefixManager prefixManager,
       @Nullable OmBucketInfo omBucketInfo,
         long transactionLogIndex) {
-    long objectID = OMFileRequest.getObjIdRangeFromTxId(transactionLogIndex)
-        .getLeft();
+    long objectID = OMFileRequest.getObjIDFromTxId(transactionLogIndex);
 
     return new OmKeyInfo.Builder()
         .setVolumeName(keyArgs.getVolumeName())

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -241,7 +241,8 @@ public abstract class OMKeyRequest extends OMClientRequest {
       @Nonnull PrefixManager prefixManager,
       @Nullable OmBucketInfo omBucketInfo,
         long transactionLogIndex) {
-    long objectID = OMFileRequest.getObjIdFromTxId(transactionLogIndex);
+    long objectID = OMFileRequest.getObjIdRangeFromTxId(transactionLogIndex)
+        .getLeft();
 
     return new OmKeyInfo.Builder()
         .setVolumeName(keyArgs.getVolumeName())

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/bucket/S3BucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/bucket/S3BucketCreateRequest.java
@@ -28,6 +28,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
+import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -340,12 +341,14 @@ public class S3BucketCreateRequest extends OMVolumeRequest {
    */
   private OmVolumeArgs createOmVolumeArgs(String volumeName, String userName,
       long creationTime, long transactionLogIndex) throws IOException {
+    long objectID = OMFileRequest.getObjIdRangeFromTxId(transactionLogIndex)
+        .getLeft();
     OmVolumeArgs.Builder builder = OmVolumeArgs.newBuilder()
         .setAdminName(S3_ADMIN_NAME).setVolume(volumeName)
         .setQuotaInBytes(OzoneConsts.MAX_QUOTA_IN_BYTES)
         .setOwnerName(userName)
         .setCreationTime(creationTime)
-        .setObjectID(transactionLogIndex)
+        .setObjectID(objectID)
         .setUpdateID(transactionLogIndex);
 
     // Set default acls.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/bucket/S3BucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/bucket/S3BucketCreateRequest.java
@@ -341,8 +341,7 @@ public class S3BucketCreateRequest extends OMVolumeRequest {
    */
   private OmVolumeArgs createOmVolumeArgs(String volumeName, String userName,
       long creationTime, long transactionLogIndex) throws IOException {
-    long objectID = OMFileRequest.getObjIdRangeFromTxId(transactionLogIndex)
-        .getLeft();
+    long objectID = OMFileRequest.getObjIDFromTxId(transactionLogIndex);
     OmVolumeArgs.Builder builder = OmVolumeArgs.newBuilder()
         .setAdminName(S3_ADMIN_NAME).setVolume(volumeName)
         .setQuotaInBytes(OzoneConsts.MAX_QUOTA_IN_BYTES)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
+import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.s3.multipart.S3InitiateMultipartUploadResponse;
@@ -112,6 +113,7 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
     OmMultipartKeyInfo multipartKeyInfo = null;
     OmKeyInfo omKeyInfo = null;
     Result result = null;
+    long objectID = OMFileRequest.getObjIdFromTxId(transactionLogIndex);
 
     OMResponse.Builder omResponse = OMResponse.newBuilder()
         .setCmdType(OzoneManagerProtocolProtos.Type.InitiateMultiPartUpload)
@@ -159,7 +161,7 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
           .setCreationTime(keyArgs.getModificationTime())
           .setReplicationType(keyArgs.getType())
           .setReplicationFactor(keyArgs.getFactor())
-          .setObjectID(transactionLogIndex)
+          .setObjectID(objectID)
           .setUpdateID(transactionLogIndex)
           .build();
 
@@ -174,7 +176,7 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
           .setOmKeyLocationInfos(Collections.singletonList(
               new OmKeyLocationInfoGroup(0, new ArrayList<>())))
           .setAcls(OzoneAclUtil.fromProtobuf(keyArgs.getAclsList()))
-          .setObjectID(transactionLogIndex)
+          .setObjectID(objectID)
           .setUpdateID(transactionLogIndex)
           .build();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -113,7 +113,8 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
     OmMultipartKeyInfo multipartKeyInfo = null;
     OmKeyInfo omKeyInfo = null;
     Result result = null;
-    long objectID = OMFileRequest.getObjIdFromTxId(transactionLogIndex);
+    long objectID = OMFileRequest.getObjIdRangeFromTxId(transactionLogIndex)
+        .getLeft();
 
     OMResponse.Builder omResponse = OMResponse.newBuilder()
         .setCmdType(OzoneManagerProtocolProtos.Type.InitiateMultiPartUpload)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -113,8 +113,7 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
     OmMultipartKeyInfo multipartKeyInfo = null;
     OmKeyInfo omKeyInfo = null;
     Result result = null;
-    long objectID = OMFileRequest.getObjIdRangeFromTxId(transactionLogIndex)
-        .getLeft();
+    long objectID = OMFileRequest.getObjIDFromTxId(transactionLogIndex);
 
     OMResponse.Builder omResponse = OMResponse.newBuilder()
         .setCmdType(OzoneManagerProtocolProtos.Type.InitiateMultiPartUpload)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
@@ -115,8 +115,7 @@ public class OMVolumeCreateRequest extends OMVolumeRequest {
     Map<String, String> auditMap = new HashMap<>();
     Collection<String> ozAdmins = ozoneManager.getOzoneAdmins();
     try {
-      long objectID = OMFileRequest.getObjIdRangeFromTxId(transactionLogIndex)
-          .getLeft();
+      long objectID = OMFileRequest.getObjIDFromTxId(transactionLogIndex);
       omVolumeArgs = OmVolumeArgs.getFromProtobuf(volumeInfo);
       // when you create a volume, we set both Object ID and update ID to the
       // same ratis transaction ID. The Object ID will never change, but update

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
+import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,12 +115,14 @@ public class OMVolumeCreateRequest extends OMVolumeRequest {
     Map<String, String> auditMap = new HashMap<>();
     Collection<String> ozAdmins = ozoneManager.getOzoneAdmins();
     try {
+      long objectID = OMFileRequest.getObjIdRangeFromTxId(transactionLogIndex)
+          .getLeft();
       omVolumeArgs = OmVolumeArgs.getFromProtobuf(volumeInfo);
       // when you create a volume, we set both Object ID and update ID to the
       // same ratis transaction ID. The Object ID will never change, but update
       // ID will be set to transactionID each time we update the object.
       omVolumeArgs.setUpdateID(transactionLogIndex);
-      omVolumeArgs.setObjectID(transactionLogIndex);
+      omVolumeArgs.setObjectID(objectID);
       auditMap = omVolumeArgs.toAuditMap();
 
       // check Acl

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponse.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Response for create directory request.
@@ -39,11 +40,18 @@ public class OMDirectoryCreateResponse extends OMClientResponse {
   public static final Logger LOG =
       LoggerFactory.getLogger(OMDirectoryCreateResponse.class);
   private OmKeyInfo dirKeyInfo;
+  private List<OmKeyInfo> parentKeyInfos;
+  private boolean createPrefix;
 
   public OMDirectoryCreateResponse(@Nonnull OMResponse omResponse,
-      @Nullable OmKeyInfo dirKeyInfo) {
+      @Nullable OmKeyInfo dirKeyInfo,
+      @Nullable List<OmKeyInfo> parentKeyInfos,
+      boolean createPrefix) {
+
     super(omResponse);
     this.dirKeyInfo = dirKeyInfo;
+    this.parentKeyInfos = parentKeyInfos;
+    this.createPrefix = createPrefix;
   }
 
   /**
@@ -63,6 +71,24 @@ public class OMDirectoryCreateResponse extends OMClientResponse {
           dirKeyInfo.getBucketName(), dirKeyInfo.getKeyName());
       omMetadataManager.getKeyTable().putWithBatch(batchOperation, dirKey,
           dirKeyInfo);
+      if (createPrefix) {
+        if (parentKeyInfos != null) {
+          for (OmKeyInfo parentKeyInfo : parentKeyInfos) {
+            String parentKey = omMetadataManager
+                .getOzoneDirKey(parentKeyInfo.getVolumeName(), parentKeyInfo.getBucketName(),
+                    parentKeyInfo.getKeyName());
+            LOG.debug("putWithBatch parent : key {} info : {}", parentKey,
+                parentKeyInfo);
+            omMetadataManager.getKeyTable()
+                .putWithBatch(batchOperation, parentKey, parentKeyInfo);
+          }
+        }
+      }
+    } else {
+      // When directory already exists, we don't add it to cache. And it is
+      // not an error, in this case dirKeyInfo will be null.
+      LOG.debug("Response Status is OK, dirKeyInfo is null in " +
+          "OMDirectoryCreateResponse");
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponse.java
@@ -75,8 +75,8 @@ public class OMDirectoryCreateResponse extends OMClientResponse {
         if (parentKeyInfos != null) {
           for (OmKeyInfo parentKeyInfo : parentKeyInfos) {
             String parentKey = omMetadataManager
-                .getOzoneDirKey(parentKeyInfo.getVolumeName(), parentKeyInfo.getBucketName(),
-                    parentKeyInfo.getKeyName());
+                .getOzoneDirKey(parentKeyInfo.getVolumeName(),
+                    parentKeyInfo.getBucketName(), parentKeyInfo.getKeyName());
             LOG.debug("putWithBatch parent : key {} info : {}", parentKey,
                 parentKeyInfo);
             omMetadataManager.getKeyTable()

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
@@ -59,8 +59,7 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
     String adminName = "user1";
     String ownerName = "user1";
     long txLogIndex = 1;
-    long expectedObjId = OMFileRequest.getObjIdRangeFromTxId(txLogIndex)
-        .getLeft();
+    long expectedObjId = OMFileRequest.getObjIDFromTxId(txLogIndex);
 
     OMRequest originalRequest = createVolumeRequest(volumeName, adminName,
         ownerName);
@@ -111,8 +110,7 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
 
     omVolumeCreateRequest = new OMVolumeCreateRequest(modifiedRequest);
     long txLogIndex = 2;
-    long expectedObjId = OMFileRequest.getObjIdRangeFromTxId(txLogIndex)
-        .getLeft();
+    long expectedObjId = OMFileRequest.getObjIDFromTxId(txLogIndex);
 
     OMClientResponse omClientResponse =
         omVolumeCreateRequest.validateAndUpdateCache(ozoneManager, txLogIndex,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
@@ -77,7 +77,8 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
       Assert.assertTrue(omClientResponse instanceof OMVolumeCreateResponse);
       OMVolumeCreateResponse respone =
           (OMVolumeCreateResponse) omClientResponse;
-      Assert.assertEquals(expectedObjId, respone.getOmVolumeArgs().getObjectID());
+      Assert.assertEquals(expectedObjId, respone.getOmVolumeArgs()
+          .getObjectID());
       Assert.assertEquals(txLogIndex, respone.getOmVolumeArgs().getUpdateID());
     } catch (IllegalArgumentException ex){
       GenericTestUtils.assertExceptionContains("should be greater than zero",

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.request.volume;
 
 import java.util.UUID;
 
+import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.response.volume.OMVolumeCreateResponse;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assert;
@@ -57,6 +58,9 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
     String volumeName = UUID.randomUUID().toString();
     String adminName = "user1";
     String ownerName = "user1";
+    long txLogIndex = 1;
+    long expectedObjId = OMFileRequest.getObjIdRangeFromTxId(txLogIndex)
+        .getLeft();
 
     OMRequest originalRequest = createVolumeRequest(volumeName, adminName,
         ownerName);
@@ -68,13 +72,13 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
 
     try {
       OMClientResponse omClientResponse =
-          omVolumeCreateRequest.validateAndUpdateCache(ozoneManager, 1,
-              ozoneManagerDoubleBufferHelper);
+          omVolumeCreateRequest.validateAndUpdateCache(ozoneManager,
+              txLogIndex, ozoneManagerDoubleBufferHelper);
       Assert.assertTrue(omClientResponse instanceof OMVolumeCreateResponse);
       OMVolumeCreateResponse respone =
           (OMVolumeCreateResponse) omClientResponse;
-      Assert.assertEquals(1, respone.getOmVolumeArgs().getObjectID());
-      Assert.assertEquals(1, respone.getOmVolumeArgs().getUpdateID());
+      Assert.assertEquals(expectedObjId, respone.getOmVolumeArgs().getObjectID());
+      Assert.assertEquals(txLogIndex, respone.getOmVolumeArgs().getUpdateID());
     } catch (IllegalArgumentException ex){
       GenericTestUtils.assertExceptionContains("should be greater than zero",
           ex);
@@ -105,9 +109,12 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
     Assert.assertNull(omMetadataManager.getUserTable().get(ownerKey));
 
     omVolumeCreateRequest = new OMVolumeCreateRequest(modifiedRequest);
+    long txLogIndex = 2;
+    long expectedObjId = OMFileRequest.getObjIdRangeFromTxId(txLogIndex)
+        .getLeft();
 
     OMClientResponse omClientResponse =
-        omVolumeCreateRequest.validateAndUpdateCache(ozoneManager, 2,
+        omVolumeCreateRequest.validateAndUpdateCache(ozoneManager, txLogIndex,
             ozoneManagerDoubleBufferHelper);
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
@@ -125,8 +132,8 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
         omMetadataManager.getVolumeTable().get(volumeKey);
     // As request is valid volume table should not have entry.
     Assert.assertNotNull(omVolumeArgs);
-    Assert.assertEquals(2, omVolumeArgs.getObjectID());
-    Assert.assertEquals(2, omVolumeArgs.getUpdateID());
+    Assert.assertEquals(expectedObjId, omVolumeArgs.getObjectID());
+    Assert.assertEquals(txLogIndex, omVolumeArgs.getUpdateID());
 
     // Check data from table and request.
     Assert.assertEquals(volumeInfo.getVolume(), omVolumeArgs.getVolume());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponse.java
@@ -75,7 +75,7 @@ public class TestOMDirectoryCreateResponse {
             .build();
 
     OMDirectoryCreateResponse omDirectoryCreateResponse =
-        new OMDirectoryCreateResponse(omResponse, omKeyInfo);
+        new OMDirectoryCreateResponse(omResponse, omKeyInfo, null, false);
 
     omDirectoryCreateResponse.addToDBBatch(omMetadataManager, batchOperation);
 


### PR DESCRIPTION

## What changes were proposed in this pull request?

for MKDIR operation - add separate directory entry in OM key table for each directory that appears in the path passed to mkdir.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2940

## How was this patch tested?

unit tests.
TestOzoneFileInterfaces#testDirectory is modified to assert that prefix directories get created.