### PR TITLE
HDDS-2855. Recon getContainers API should return a maximum of 1000 co…

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
@@ -44,7 +44,7 @@ public final class ReconConstants {
       "containerKeyCountTable";
 
   // By default, limit the number of results returned
-  public static final String FETCH_ALL = "1000";
+  public static final String DEFAULT_FETCH_COUNT = "1000";
   public static final String RECON_QUERY_PREVKEY = "prevKey";
   public static final String PREV_CONTAINER_ID_DEFAULT_VALUE = "0";
   public static final String RECON_QUERY_LIMIT = "limit";

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
@@ -43,7 +43,8 @@ public final class ReconConstants {
   public static final String CONTAINER_KEY_COUNT_TABLE =
       "containerKeyCountTable";
 
-  public static final String FETCH_ALL = "-1";
+  // By default, limit the number of results returned
+  public static final String FETCH_ALL = "1000";
   public static final String RECON_QUERY_PREVKEY = "prevKey";
   public static final String PREV_CONTAINER_ID_DEFAULT_VALUE = "0";
   public static final String RECON_QUERY_LIMIT = "limit";

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerKeyService.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerKeyService.java
@@ -49,7 +49,7 @@ import org.apache.hadoop.ozone.recon.api.types.KeysResponse;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.spi.ContainerDBServiceProvider;
 
-import static org.apache.hadoop.ozone.recon.ReconConstants.FETCH_ALL;
+import static org.apache.hadoop.ozone.recon.ReconConstants.DEFAULT_FETCH_COUNT;
 import static org.apache.hadoop.ozone.recon.ReconConstants.PREV_CONTAINER_ID_DEFAULT_VALUE;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_QUERY_LIMIT;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_QUERY_PREVKEY;
@@ -79,7 +79,8 @@ public class ContainerKeyService {
    */
   @GET
   public Response getContainers(
-      @DefaultValue(FETCH_ALL) @QueryParam(RECON_QUERY_LIMIT) int limit,
+      @DefaultValue(DEFAULT_FETCH_COUNT) @QueryParam(RECON_QUERY_LIMIT)
+          int limit,
       @DefaultValue(PREV_CONTAINER_ID_DEFAULT_VALUE)
       @QueryParam(RECON_QUERY_PREVKEY) long prevKey) {
     Map<Long, ContainerMetadata> containersMap;
@@ -111,7 +112,8 @@ public class ContainerKeyService {
   @Path("/{id}/keys")
   public Response getKeysForContainer(
       @PathParam("id") Long containerID,
-      @DefaultValue(FETCH_ALL) @QueryParam(RECON_QUERY_LIMIT) int limit,
+      @DefaultValue(DEFAULT_FETCH_COUNT) @QueryParam(RECON_QUERY_LIMIT)
+          int limit,
       @DefaultValue(StringUtils.EMPTY) @QueryParam(RECON_QUERY_PREVKEY)
           String prevKeyPrefix) {
     Map<String, KeyMetadata> keyMetadataMap = new LinkedHashMap<>();


### PR DESCRIPTION
…ntainers by default.

## What changes were proposed in this pull request?

Change the default limit of Recon API responses to 1000 items for any API request.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2855

## How was this patch tested?

I tested the patch by hitting the API - `http://localhost:9888/api/containers/1/keys` and `http://localhost:9888/api/containers` to check if the response defaults to 1000 items and it did.

<img width="413" alt="Screen Shot 2020-01-27 at 1 21 46 PM" src="https://user-images.githubusercontent.com/1051198/73214958-06ed9a00-4108-11ea-90c3-09f446e68c84.png">
