### PR TITLE
HDDS-2931. Recon integration test should use ephemeral port for HTTP server.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestRecon.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestRecon.java
@@ -16,8 +16,25 @@
  */
 package org.apache.hadoop.ozone.recon;
 
-import com.google.gson.Gson;
-import com.google.gson.internal.LinkedTreeMap;
+import static java.net.HttpURLConnection.HTTP_CREATED;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_CONNECTION_REQUEST_TIMEOUT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_CONNECTION_TIMEOUT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_CONNECTION_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_SOCKET_TIMEOUT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_SOCKET_TIMEOUT_DEFAULT;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -27,8 +44,8 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.db.RDBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -47,31 +64,8 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
-import static java.net.HttpURLConnection.HTTP_CREATED;
-import static java.net.HttpURLConnection.HTTP_OK;
-import static org.apache.hadoop.ozone.recon.
-    ReconServerConfigKeys.RECON_OM_SOCKET_TIMEOUT;
-import static org.apache.hadoop.ozone.recon.
-    ReconServerConfigKeys.RECON_OM_SOCKET_TIMEOUT_DEFAULT;
-import static org.apache.hadoop.ozone.recon.
-    ReconServerConfigKeys.OZONE_RECON_HTTP_ADDRESS_KEY;
-import static org.apache.hadoop.ozone.recon.
-    ReconServerConfigKeys.RECON_OM_CONNECTION_TIMEOUT;
-import static org.apache.hadoop.ozone.recon.
-    ReconServerConfigKeys.RECON_OM_CONNECTION_TIMEOUT_DEFAULT;
-import static org.apache.hadoop.ozone.recon.
-    ReconServerConfigKeys.RECON_OM_CONNECTION_REQUEST_TIMEOUT;
-import static org.apache.hadoop.ozone.recon.
-    ReconServerConfigKeys.RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT;
+import com.google.gson.Gson;
+import com.google.gson.internal.LinkedTreeMap;
 
 /**
  * Test Ozone Recon.
@@ -80,18 +74,15 @@ public class TestRecon {
   private static MiniOzoneCluster cluster = null;
   private static OzoneConfiguration conf;
   private static OMMetadataManager metadataManager;
-  private static File dir;
   private static CloseableHttpClient httpClient;
-  private static String reconHTTPAddress;
   private static String containerKeyServiceURL;
   private static String taskStatusURL;
 
   @BeforeClass
   public static void init() throws Exception {
-    dir = GenericTestUtils.getRandomizedTestDir();
+    File dir = GenericTestUtils.getRandomizedTestDir();
     conf = new OzoneConfiguration();
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, dir.toString());
-
     int socketTimeout = (int) conf.getTimeDuration(
         RECON_OM_SOCKET_TIMEOUT, RECON_OM_SOCKET_TIMEOUT_DEFAULT,
         TimeUnit.MILLISECONDS);
@@ -106,11 +97,10 @@ public class TestRecon {
         .setConnectionRequestTimeout(connectionTimeout)
         .setSocketTimeout(connectionRequestTimeout).build();
 
-    reconHTTPAddress = conf.get(OZONE_RECON_HTTP_ADDRESS_KEY);
-    containerKeyServiceURL = "http://" + reconHTTPAddress
-        + "/api/containers";
-    taskStatusURL = "http://" + reconHTTPAddress
-        + "/api/task/status";
+    String reconHTTPAddress = "localhost:" + NetUtils.getFreeSocketPort();
+    conf.set(OZONE_RECON_HTTP_ADDRESS_KEY, reconHTTPAddress);
+    containerKeyServiceURL = "http://" + reconHTTPAddress + "/api/containers";
+    taskStatusURL = "http://" + reconHTTPAddress + "/api/task/status";
 
     cluster =  MiniOzoneCluster.newBuilder(conf).setNumDatanodes(1).build();
     cluster.waitForClusterToBeReady();
@@ -161,10 +151,10 @@ public class TestRecon {
 
   @Test
   public void testReconWithOzoneManager() throws Exception {
-    //add a vol, bucket and key
+    // add a vol, bucket and key
     addKeys(0, 1);
 
-    //check if OM metadata has vol0/bucket0/key0 info
+    // check if OM metadata has vol0/bucket0/key0 info
     String ozoneKey = metadataManager.getOzoneKey(
         "vol0", "bucket0", "key0");
     OmKeyInfo keyInfo1 = metadataManager.getKeyTable().get(ozoneKey);
@@ -174,7 +164,7 @@ public class TestRecon {
 
     long omMetadataKeyCount = getTableKeyCount(omKeyValueTableIterator);
 
-    //verify if OM has /vol0/bucket0/key0
+    // verify if OM has /vol0/bucket0/key0
     Assert.assertEquals("vol0", keyInfo1.getVolumeName());
     Assert.assertEquals("bucket0", keyInfo1.getBucketName());
 
@@ -186,10 +176,10 @@ public class TestRecon {
     String containerResponse = makeHttpCall(containerKeyServiceURL);
     long reconMetadataContainerCount =
         getReconContainerCount(containerResponse);
-    //verify count of keys after full snapshot
+    // verify count of keys after full snapshot
     Assert.assertEquals(omMetadataKeyCount, reconMetadataContainerCount);
 
-    //verify if Recon Metadata captures vol0/bucket0/key0 info in container0
+    // verify if Recon Metadata captures vol0/bucket0/key0 info in container0
     LinkedTreeMap containerResponseMap = getContainerResponseMap(
         containerResponse, 0);
     Assert.assertEquals(0,
@@ -205,7 +195,7 @@ public class TestRecon {
     long reconLatestSeqNumber = getReconTaskLastUpdatedSeqNumber(
         taskStatusResponse, 3);
 
-    //verify sequence number after full snapshot
+    // verify sequence number after full snapshot
     Assert.assertEquals(omLatestSeqNumber, reconLatestSeqNumber);
 
     //add 4 keys to check for delta updates
@@ -263,10 +253,10 @@ public class TestRecon {
     containerResponse = makeHttpCall(containerKeyServiceURL);
     reconMetadataContainerCount = getReconContainerCount(containerResponse);
 
-    //verify count of keys
+    // verify count of keys
     Assert.assertEquals(omMetadataKeyCount, reconMetadataContainerCount);
 
-    //verify if Recon Metadata captures vol7/bucket7/key7 info in container7
+    // verify if Recon Metadata captures vol7/bucket7/key7 info in container7
     containerResponseMap = getContainerResponseMap(
         containerResponse, 7);
     Assert.assertEquals(7,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Used ephemeral port for Recon http server used by the integration test.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2931

## How was this patch tested?
Verified with the integration test that an unused ephemeral port was used.