### PR TITLE
HDDS-2953. Handle replay of S3 requests

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -453,11 +453,6 @@ public final class OmUtils {
     return dirFile;
   }
 
-  public static RepeatedOmKeyInfo prepareKeyForDelete(OmKeyInfo keyInfo,
-      RepeatedOmKeyInfo repeatedOmKeyInfo) throws IOException {
-    return prepareKeyForDelete(keyInfo, repeatedOmKeyInfo, 0L);
-  }
-
   /**
    * Prepares key info to be moved to deletedTable.
    * 1. It strips GDPR metadata from key info
@@ -465,14 +460,14 @@ public final class OmUtils {
    * implies that no entry for the object key exists in deletedTable so we
    * create a new instance to include this key, else we update the existing
    * repeatedOmKeyInfo instance.
-   * 3. Set the updateID to the transactionLogIndex
+   * 3. Set the updateID to the transactionLogIndex.
    * @param keyInfo args supplied by client
    * @param repeatedOmKeyInfo key details from deletedTable
    * @param trxnLogIndex For Multipart keys, this is the transactionLogIndex
    *                     of the MultipartUploadAbort request which needs to
    *                     be set as the updateID of the partKeyInfos.
-   *                     For regular Key deletes, this value should be passed
-   *                     as 0 as the updateID is already set.
+   *                     For regular Key deletes, this value should be set to
+   *                     the same updaeID as is in keyInfo.
    * @return {@link RepeatedOmKeyInfo}
    * @throws IOException if I/O Errors when checking for key
    */
@@ -489,10 +484,8 @@ public final class OmUtils {
       keyInfo.clearFileEncryptionInfo();
     }
 
-    // If trxnLogIndex is 0, then the updateID has already been set.
-    if (trxnLogIndex != 0) {
-      keyInfo.setUpdateID(trxnLogIndex);
-    }
+    // Set the updateID
+    keyInfo.setUpdateID(trxnLogIndex);
 
     if(repeatedOmKeyInfo == null) {
       //The key doesn't exist in deletedTable, so create a new instance.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/WithObjectID.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/WithObjectID.java
@@ -76,7 +76,7 @@ public class WithObjectID extends WithMetadata {
    * @param updateId  long
    */
   public void setUpdateID(long updateId) {
-    Preconditions.checkArgument(updateId > this.updateID, String.format(
+    Preconditions.checkArgument(updateId >= this.updateID, String.format(
         "Trying to set updateID to %d which is not greater than the current " +
             "value of %d for %s", updateId, this.updateID, getObjectInfo()));
     this.updateID = updateId;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -815,7 +815,7 @@ public class KeyManagerImpl implements KeyManager {
       RepeatedOmKeyInfo repeatedOmKeyInfo =
           metadataManager.getDeletedTable().get(objectKey);
       repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(keyInfo,
-          repeatedOmKeyInfo);
+          repeatedOmKeyInfo, 0L);
       metadataManager.getKeyTable().delete(objectKey);
       metadataManager.getDeletedTable().put(objectKey, repeatedOmKeyInfo);
     } catch (OMException ex) {
@@ -1060,7 +1060,7 @@ public class KeyManagerImpl implements KeyManager {
         RepeatedOmKeyInfo repeatedOmKeyInfo =
             metadataManager.getDeletedTable().get(partName);
         repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-            keyInfo, repeatedOmKeyInfo);
+            keyInfo, repeatedOmKeyInfo, 0L);
         metadataManager.getDeletedTable().put(partName, repeatedOmKeyInfo);
         throw new OMException("No such Multipart upload is with specified " +
             "uploadId " + uploadID, ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR);
@@ -1097,7 +1097,7 @@ public class KeyManagerImpl implements KeyManager {
                     .get(oldPartKeyInfo.getPartName());
 
             repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-                partKey, repeatedOmKeyInfo);
+                partKey, repeatedOmKeyInfo, 0L);
 
             metadataManager.getDeletedTable().put(partName, repeatedOmKeyInfo);
             metadataManager.getDeletedTable().putWithBatch(batch,
@@ -1215,7 +1215,7 @@ public class KeyManagerImpl implements KeyManager {
                     .get(partKeyInfo.getPartName());
 
             repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-                currentKeyPartInfo, repeatedOmKeyInfo);
+                currentKeyPartInfo, repeatedOmKeyInfo, 0L);
 
             metadataManager.getDeletedTable().putWithBatch(batch,
                 partKeyInfo.getPartName(), repeatedOmKeyInfo);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.exceptions.OMReplayException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
@@ -82,9 +83,9 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
   }
 
   @Override
+  @SuppressWarnings("methodlength")
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
-      long transactionLogIndex,
-      OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper) {
+      long trxnLogIndex, OzoneManagerDoubleBufferHelper omDoubleBufferHelper) {
     MultipartCommitUploadPartRequest multipartCommitUploadPartRequest =
         getOmRequest().getCommitMultiPartUploadRequest();
 
@@ -111,11 +112,11 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
     OmKeyInfo omKeyInfo = null;
     String multipartKey = null;
     OmMultipartKeyInfo multipartKeyInfo = null;
+    Result result = null;
     try {
       // TODO to support S3 ACL later.
-      acquiredLock =
-          omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK, volumeName,
-              bucketName);
+      acquiredLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
+          volumeName, bucketName);
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
 
@@ -123,19 +124,34 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
       multipartKey = omMetadataManager.getMultipartKey(volumeName,
           bucketName, keyName, uploadID);
 
-      multipartKeyInfo =
-          omMetadataManager.getMultipartInfoTable().get(multipartKey);
+      multipartKeyInfo = omMetadataManager.getMultipartInfoTable()
+          .get(multipartKey);
 
       long clientID = multipartCommitUploadPartRequest.getClientID();
 
-      openKey = omMetadataManager.getOpenKey(
-          volumeName, bucketName, keyName, clientID);
+      openKey = omMetadataManager.getOpenKey(volumeName, bucketName, keyName,
+          clientID);
 
       omKeyInfo = omMetadataManager.getOpenKeyTable().get(openKey);
 
       if (omKeyInfo == null) {
+        // Check the KeyTable if this transaction is a replay of ratis logs.
+        String ozoneKey = omMetadataManager.getOzoneKey(volumeName,
+            bucketName, keyName);
+        OmKeyInfo dbKeyInfo = omMetadataManager.getKeyTable().get(ozoneKey);
+        if (dbKeyInfo != null) {
+          if (isReplay(ozoneManager, dbKeyInfo.getUpdateID(), trxnLogIndex)) {
+            throw new OMReplayException();
+          }
+        }
         throw new OMException("Failed to commit Multipart Upload key, as " +
-            openKey + "entry is not found in the openKey table", KEY_NOT_FOUND);
+            openKey + "entry is not found in the openKey table",
+            KEY_NOT_FOUND);
+      } else {
+        // Check the OpenKeyTable if this transaction is a replay of ratis logs.
+        if (isReplay(ozoneManager, omKeyInfo.getUpdateID(), trxnLogIndex)) {
+          throw new OMReplayException();
+        }
       }
 
       // set the data size and location info list
@@ -146,7 +162,7 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
       // Set Modification time
       omKeyInfo.setModificationTime(keyArgs.getModificationTime());
       // Set the UpdateID to current transactionLogIndex
-      omKeyInfo.setUpdateID(transactionLogIndex);
+      omKeyInfo.setUpdateID(trxnLogIndex);
 
       partName = omMetadataManager.getOzoneKey(volumeName, bucketName,
           keyName) + clientID;
@@ -176,7 +192,7 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
         multipartKeyInfo.addPartKeyInfo(partNumber, partKeyInfo.build());
 
         // Set the UpdateID to current transactionLogIndex
-        multipartKeyInfo.setUpdateID(transactionLogIndex);
+        multipartKeyInfo.setUpdateID(trxnLogIndex);
 
         // Add to cache.
 
@@ -186,29 +202,38 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
         omMetadataManager.getMultipartInfoTable().addCacheEntry(
             new CacheKey<>(multipartKey),
             new CacheValue<>(Optional.of(multipartKeyInfo),
-                transactionLogIndex));
+                trxnLogIndex));
 
         omMetadataManager.getOpenKeyTable().addCacheEntry(
             new CacheKey<>(openKey),
-            new CacheValue<>(Optional.absent(), transactionLogIndex));
+            new CacheValue<>(Optional.absent(), trxnLogIndex));
       }
 
       omResponse.setCommitMultiPartUploadResponse(
-          MultipartCommitUploadPartResponse.newBuilder().setPartName(partName));
-      omClientResponse = new S3MultipartUploadCommitPartResponse(multipartKey,
-        openKey, omKeyInfo, multipartKeyInfo,
-          oldPartKeyInfo, omResponse.build());
+          MultipartCommitUploadPartResponse.newBuilder()
+              .setPartName(partName));
+      omClientResponse = new S3MultipartUploadCommitPartResponse(
+          omResponse.build(), multipartKey, openKey, omKeyInfo,
+          multipartKeyInfo, oldPartKeyInfo);
 
+      result = Result.SUCCESS;
     } catch (IOException ex) {
-      exception = ex;
-      omClientResponse = new S3MultipartUploadCommitPartResponse(multipartKey,
-          openKey, omKeyInfo, multipartKeyInfo,
-          oldPartKeyInfo, createErrorOMResponse(omResponse, exception));
+      if (ex instanceof OMReplayException) {
+        result = Result.REPLAY;
+        omClientResponse = new S3MultipartUploadCommitPartResponse(
+            createReplayOMResponse(omResponse));
+      } else {
+        result = Result.FAILURE;
+        exception = ex;
+        omClientResponse = new S3MultipartUploadCommitPartResponse(
+            createErrorOMResponse(omResponse, exception), multipartKey,
+            openKey, omKeyInfo, multipartKeyInfo, oldPartKeyInfo);
+      }
     } finally {
       if (omClientResponse != null) {
         omClientResponse.setFlushFuture(
-            ozoneManagerDoubleBufferHelper.add(omClientResponse,
-                transactionLogIndex));
+            omDoubleBufferHelper.add(omClientResponse,
+                trxnLogIndex));
       }
       if (acquiredLock) {
         omMetadataManager.getLock().releaseWriteLock(BUCKET_LOCK, volumeName,
@@ -222,15 +247,25 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
         buildAuditMap(keyArgs, partName), exception,
         getOmRequest().getUserInfo()));
 
-    if (exception == null) {
+    switch (result) {
+    case REPLAY:
+      LOG.debug("Replayed Transaction {} ignored. Request: {}",
+          trxnLogIndex, multipartCommitUploadPartRequest);
+      break;
+    case SUCCESS:
       LOG.debug("MultipartUpload Commit is successfully for Key:{} in " +
           "Volume/Bucket {}/{}", keyName, volumeName, bucketName);
-
-    } else {
+      break;
+    case FAILURE:
+      ozoneManager.getMetrics().incNumCommitMultipartUploadPartFails();
       LOG.error("MultipartUpload Commit is failed for Key:{} in " +
           "Volume/Bucket {}/{}", keyName, volumeName, bucketName, exception);
-      ozoneManager.getMetrics().incNumCommitMultipartUploadPartFails();
+      break;
+    default:
+      LOG.error("Unrecognized Result for S3MultipartUploadCommitPartRequest: " +
+          "{}", multipartCommitUploadPartRequest);
     }
+
     return omClientResponse;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -194,6 +194,10 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
         // Set the UpdateID to current transactionLogIndex
         multipartKeyInfo.setUpdateID(trxnLogIndex);
 
+        // OldPartKeyInfo will be deleted. Its updateID will be set in
+        // S3MultipartUplodaCommitPartResponse before being added to
+        // DeletedKeyTable.
+
         // Add to cache.
 
         // Delete from open key table and add it to multipart info table.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -140,7 +140,7 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
             bucketName, keyName);
         OmKeyInfo dbKeyInfo = omMetadataManager.getKeyTable().get(ozoneKey);
         if (dbKeyInfo != null) {
-          if (isReplay(ozoneManager, dbKeyInfo.getUpdateID(), trxnLogIndex)) {
+          if (isReplay(ozoneManager, dbKeyInfo, trxnLogIndex)) {
             throw new OMReplayException();
           }
         }
@@ -149,7 +149,7 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
             KEY_NOT_FOUND);
       } else {
         // Check the OpenKeyTable if this transaction is a replay of ratis logs.
-        if (isReplay(ozoneManager, omKeyInfo.getUpdateID(), trxnLogIndex)) {
+        if (isReplay(ozoneManager, omKeyInfo, trxnLogIndex)) {
           throw new OMReplayException();
         }
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -129,11 +129,14 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
 
       if (omKeyInfo != null) {
         // Check if this transaction is a replay of ratis logs.
-        if (isReplay(ozoneManager, omKeyInfo.getUpdateID(), trxnLogIndex)) {
+        if (isReplay(ozoneManager, omKeyInfo, trxnLogIndex)) {
           // Replay implies the response has already been returned to
           // the client. So take no further action and return a dummy
           // OMClientResponse.
           throw new OMReplayException();
+          // TODO: Check if corresponding key exists in OpenKey table as we
+          //  do not check for replay while creating Keys. If it exists,
+          //  delete the key from OpenKey table.
         }
       }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.exceptions.OMReplayException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
@@ -82,14 +83,12 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
             .toBuilder().setKeyArgs(keyArgs.toBuilder()
                 .setModificationTime(Time.now())))
         .setUserInfo(getUserInfo()).build();
-
   }
 
   @Override
   @SuppressWarnings("methodlength")
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
-      long transactionLogIndex,
-      OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper) {
+      long trxnLogIndex, OzoneManagerDoubleBufferHelper omDoubleBufferHelper) {
     MultipartUploadCompleteRequest multipartUploadCompleteRequest =
         getOmRequest().getCompleteMultiPartUploadRequest();
 
@@ -113,6 +112,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         .setSuccess(true);
     OMClientResponse omClientResponse = null;
     IOException exception = null;
+    Result result = null;
     try {
       // TODO to support S3 ACL later.
 
@@ -126,6 +126,16 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
       String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
           keyName);
       OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable().get(ozoneKey);
+
+      if (omKeyInfo != null) {
+        // Check if this transaction is a replay of ratis logs.
+        if (isReplay(ozoneManager, omKeyInfo.getUpdateID(), trxnLogIndex)) {
+          // Replay implies the response has already been returned to
+          // the client. So take no further action and return a dummy
+          // OMClientResponse.
+          throw new OMReplayException();
+        }
+      }
 
       OmMultipartKeyInfo multipartKeyInfo = omMetadataManager
           .getMultipartInfoTable().get(multipartKey);
@@ -147,7 +157,6 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
               volumeName + "bucket: " + bucketName + "key: " + keyName,
               OMException.ResultCodes.INVALID_PART);
         }
-
 
         // First Check for Invalid Part Order.
         int prevPartNumber = partsList.get(0).getPartNumber();
@@ -261,7 +270,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
           omKeyInfo.setModificationTime(keyArgs.getModificationTime());
           omKeyInfo.setDataSize(dataSize);
         }
-        omKeyInfo.setUpdateID(transactionLogIndex);
+        omKeyInfo.setUpdateID(trxnLogIndex);
 
         //Find all unused parts.
 
@@ -275,7 +284,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         }
 
         updateCache(omMetadataManager, ozoneKey, multipartKey, omKeyInfo,
-            transactionLogIndex);
+            trxnLogIndex);
 
         omResponse.setCompleteMultiPartUploadResponse(
             MultipartUploadCompleteResponse.newBuilder()
@@ -284,8 +293,10 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
                 .setKey(keyName)
                 .setHash(DigestUtils.sha256Hex(keyName)));
 
-        omClientResponse = new S3MultipartUploadCompleteResponse(multipartKey,
-            omKeyInfo, unUsedParts, omResponse.build());
+        omClientResponse = new S3MultipartUploadCompleteResponse(
+            omResponse.build(), multipartKey, omKeyInfo, unUsedParts);
+
+        result = Result.SUCCESS;
       } else {
         throw new OMException("Complete Multipart Upload Failed: volume: " +
             volumeName + "bucket: " + bucketName + "key: " + keyName +
@@ -294,14 +305,21 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
       }
 
     } catch (IOException ex) {
-      exception = ex;
-      omClientResponse = new S3MultipartUploadCompleteResponse(null, null, null,
-          createErrorOMResponse(omResponse, exception));
+      if (ex instanceof OMReplayException) {
+        result = Result.REPLAY;
+        omClientResponse = new S3MultipartUploadCompleteResponse(
+            createReplayOMResponse(omResponse));
+      } else {
+        result = Result.FAILURE;
+        exception = ex;
+        omClientResponse = new S3MultipartUploadCompleteResponse(
+            createErrorOMResponse(omResponse, exception));
+      }
     } finally {
       if (omClientResponse != null) {
         omClientResponse.setFlushFuture(
-            ozoneManagerDoubleBufferHelper.add(omClientResponse,
-                transactionLogIndex));
+            omDoubleBufferHelper.add(omClientResponse,
+                trxnLogIndex));
       }
       if (acquiredLock) {
         omMetadataManager.getLock().releaseWriteLock(BUCKET_LOCK, volumeName,
@@ -312,19 +330,27 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
     Map<String, String> auditMap = buildKeyArgsAuditMap(keyArgs);
     auditMap.put(OzoneConsts.MULTIPART_LIST, partsList.toString());
 
-
     // audit log
     auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
         OMAction.COMPLETE_MULTIPART_UPLOAD, auditMap, exception,
         getOmRequest().getUserInfo()));
 
-    if (exception == null) {
+    switch (result) {
+    case SUCCESS:
       LOG.debug("MultipartUpload Complete request is successfull for Key: {} " +
           "in Volume/Bucket {}/{}", keyName, volumeName, bucketName);
-    } else {
+      break;
+    case REPLAY:
+      LOG.debug("Replayed Transaction {} ignored. Request: {}",
+          trxnLogIndex, multipartUploadCompleteRequest);
+      break;
+    case FAILURE:
+      ozoneManager.getMetrics().incNumCompleteMultipartUploadFails();
       LOG.error("MultipartUpload Complete request failed for Key: {} " +
           "in Volume/Bucket {}/{}", keyName, volumeName, bucketName, exception);
-      ozoneManager.getMetrics().incNumCompleteMultipartUploadFails();
+    default:
+      LOG.error("Unrecognized Result for S3MultipartUploadCommitRequest: {}",
+          multipartUploadCompleteRequest);
     }
 
     return omClientResponse;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponse.java
@@ -80,7 +80,7 @@ public class OMKeyDeleteResponse extends OMClientResponse {
         RepeatedOmKeyInfo repeatedOmKeyInfo =
             omMetadataManager.getDeletedTable().get(ozoneKey);
         repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-            omKeyInfo, repeatedOmKeyInfo);
+            omKeyInfo, repeatedOmKeyInfo, omKeyInfo.getUpdateID());
         omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
             ozoneKey, repeatedOmKeyInfo);
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponse.java
@@ -82,12 +82,11 @@ public class S3MultipartUploadAbortResponse extends OMClientResponse {
       RepeatedOmKeyInfo repeatedOmKeyInfo =
           omMetadataManager.getDeletedTable().get(partKeyInfo.getPartName());
 
-      repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-          currentKeyPartInfo, repeatedOmKeyInfo);
+      repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(currentKeyPartInfo,
+          repeatedOmKeyInfo, omMultipartKeyInfo.getUpdateID());
 
       omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
-          partKeyInfo.getPartName(),
-          repeatedOmKeyInfo);
+          partKeyInfo.getPartName(), repeatedOmKeyInfo);
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponse.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import java.io.IOException;
 import java.util.Map;
 import java.util.TreeMap;
-import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
 
 /**
@@ -45,46 +44,51 @@ public class S3MultipartUploadAbortResponse extends OMClientResponse {
   private String multipartKey;
   private OmMultipartKeyInfo omMultipartKeyInfo;
 
-  public S3MultipartUploadAbortResponse(String multipartKey,
-      @Nullable OmMultipartKeyInfo omMultipartKeyInfo,
-      @Nonnull OMResponse omResponse) {
+  public S3MultipartUploadAbortResponse(@Nonnull OMResponse omResponse,
+      String multipartKey,
+      @Nonnull OmMultipartKeyInfo omMultipartKeyInfo) {
     super(omResponse);
     this.multipartKey = multipartKey;
     this.omMultipartKeyInfo = omMultipartKeyInfo;
+  }
+
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
+  public S3MultipartUploadAbortResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+    checkStatusNotOK();
   }
 
   @Override
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    if (getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK) {
+    // Delete from openKey table and multipart info table.
+    omMetadataManager.getOpenKeyTable().deleteWithBatch(batchOperation,
+        multipartKey);
+    omMetadataManager.getMultipartInfoTable().deleteWithBatch(batchOperation,
+        multipartKey);
 
-      // Delete from openKey table and multipart info table.
-      omMetadataManager.getOpenKeyTable().deleteWithBatch(batchOperation,
-          multipartKey);
-      omMetadataManager.getMultipartInfoTable().deleteWithBatch(batchOperation,
-          multipartKey);
+    // Move all the parts to delete table
+    TreeMap<Integer, PartKeyInfo > partKeyInfoMap =
+        omMultipartKeyInfo.getPartKeyInfoMap();
+    for (Map.Entry<Integer, PartKeyInfo > partKeyInfoEntry :
+        partKeyInfoMap.entrySet()) {
+      PartKeyInfo partKeyInfo = partKeyInfoEntry.getValue();
+      OmKeyInfo currentKeyPartInfo =
+          OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
 
-      // Move all the parts to delete table
-      TreeMap<Integer, PartKeyInfo > partKeyInfoMap =
-          omMultipartKeyInfo.getPartKeyInfoMap();
-      for (Map.Entry<Integer, PartKeyInfo > partKeyInfoEntry :
-          partKeyInfoMap.entrySet()) {
-        PartKeyInfo partKeyInfo = partKeyInfoEntry.getValue();
-        OmKeyInfo currentKeyPartInfo =
-            OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+      RepeatedOmKeyInfo repeatedOmKeyInfo =
+          omMetadataManager.getDeletedTable().get(partKeyInfo.getPartName());
 
-        RepeatedOmKeyInfo repeatedOmKeyInfo =
-            omMetadataManager.getDeletedTable().get(partKeyInfo.getPartName());
+      repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
+          currentKeyPartInfo, repeatedOmKeyInfo);
 
-        repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-            currentKeyPartInfo, repeatedOmKeyInfo);
-
-        omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
-            partKeyInfo.getPartName(),
-            repeatedOmKeyInfo);
-      }
-
+      omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
+          partKeyInfo.getPartName(),
+          repeatedOmKeyInfo);
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponse.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
@@ -117,11 +117,10 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
               .get(oldMultipartKeyInfo.getPartName());
 
       repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(partKey,
-          repeatedOmKeyInfo);
+          repeatedOmKeyInfo, omMultipartKeyInfo.getUpdateID());
 
       omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
-          oldMultipartKeyInfo.getPartName(),
-          repeatedOmKeyInfo);
+          oldMultipartKeyInfo.getPartName(), repeatedOmKeyInfo);
     }
 
     omMetadataManager.getMultipartInfoTable().putWithBatch(batchOperation,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
@@ -35,7 +35,6 @@ import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .Status.OK;
 
-import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
 
 /**
@@ -50,17 +49,26 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
   private OzoneManagerProtocolProtos.PartKeyInfo oldMultipartKeyInfo;
 
 
-  public S3MultipartUploadCommitPartResponse(String multipartKey,
-      String openKey, @Nullable OmKeyInfo deletePartKeyInfo,
-      @Nullable OmMultipartKeyInfo omMultipartKeyInfo,
-      @Nullable OzoneManagerProtocolProtos.PartKeyInfo oldPartKeyInfo,
-      @Nonnull OMResponse omResponse) {
+  public S3MultipartUploadCommitPartResponse(@Nonnull OMResponse omResponse,
+      String multipartKey,
+      String openKey, @Nonnull OmKeyInfo deletePartKeyInfo,
+      @Nonnull OmMultipartKeyInfo omMultipartKeyInfo,
+      @Nonnull OzoneManagerProtocolProtos.PartKeyInfo oldPartKeyInfo) {
     super(omResponse);
     this.multipartKey = multipartKey;
     this.openKey = openKey;
     this.deletePartKeyInfo = deletePartKeyInfo;
     this.omMultipartKeyInfo = omMultipartKeyInfo;
     this.oldMultipartKeyInfo = oldPartKeyInfo;
+  }
+
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
+  public S3MultipartUploadCommitPartResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+    checkStatusNotOK();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
@@ -81,13 +81,12 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
       RepeatedOmKeyInfo repeatedOmKeyInfo =
           omMetadataManager.getDeletedTable().get(openKey);
 
-      repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-          deletePartKeyInfo, repeatedOmKeyInfo);
+      repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(deletePartKeyInfo,
+          repeatedOmKeyInfo, deletePartKeyInfo.getUpdateID());
 
 
       omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
-          openKey,
-          repeatedOmKeyInfo);
+          openKey, repeatedOmKeyInfo);
     }
 
     if (getOMResponse().getStatus() == OK) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
@@ -25,12 +25,10 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
-import javax.annotation.Nullable;
 import javax.annotation.Nonnull;
 
 /**
@@ -41,46 +39,54 @@ public class S3MultipartUploadCompleteResponse extends OMClientResponse {
   private OmKeyInfo omKeyInfo;
   private List<OmKeyInfo> partsUnusedList;
 
-
-  public S3MultipartUploadCompleteResponse(@Nullable String multipartKey,
-      @Nullable OmKeyInfo omKeyInfo,
-      @Nullable List<OmKeyInfo> unUsedParts, @Nonnull OMResponse omResponse) {
+  public S3MultipartUploadCompleteResponse(
+      @Nonnull OMResponse omResponse,
+      @Nonnull String multipartKey,
+      @Nonnull OmKeyInfo omKeyInfo,
+      @Nonnull List<OmKeyInfo> unUsedParts) {
     super(omResponse);
     this.partsUnusedList = unUsedParts;
     this.multipartKey = multipartKey;
     this.omKeyInfo = omKeyInfo;
   }
 
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
+  public S3MultipartUploadCompleteResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+    checkStatusNotOK();
+  }
+
   @Override
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    if (getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK) {
-      omMetadataManager.getKeyTable().putWithBatch(batchOperation,
-          omMetadataManager.getOzoneKey(omKeyInfo.getVolumeName(),
-              omKeyInfo.getBucketName(), omKeyInfo.getKeyName()), omKeyInfo);
-      omMetadataManager.getOpenKeyTable().deleteWithBatch(batchOperation,
-          multipartKey);
-      omMetadataManager.getMultipartInfoTable().deleteWithBatch(batchOperation,
-          multipartKey);
+    omMetadataManager.getKeyTable().putWithBatch(batchOperation,
+        omMetadataManager.getOzoneKey(omKeyInfo.getVolumeName(),
+            omKeyInfo.getBucketName(), omKeyInfo.getKeyName()), omKeyInfo);
+    omMetadataManager.getOpenKeyTable().deleteWithBatch(batchOperation,
+        multipartKey);
+    omMetadataManager.getMultipartInfoTable().deleteWithBatch(batchOperation,
+        multipartKey);
 
-      // Add unused parts to deleted key table.
-      String keyName =
-          omMetadataManager.getOzoneKey(omKeyInfo.getVolumeName(),
-              omKeyInfo.getBucketName(), omKeyInfo.getKeyName());
+    // Add unused parts to deleted key table.
+    String keyName =
+        omMetadataManager.getOzoneKey(omKeyInfo.getVolumeName(),
+            omKeyInfo.getBucketName(), omKeyInfo.getKeyName());
 
-      RepeatedOmKeyInfo repeatedOmKeyInfo =
-          omMetadataManager.getDeletedTable().get(keyName);
+    RepeatedOmKeyInfo repeatedOmKeyInfo =
+        omMetadataManager.getDeletedTable().get(keyName);
 
-      if (repeatedOmKeyInfo == null) {
-        repeatedOmKeyInfo =
-            new RepeatedOmKeyInfo(partsUnusedList);
-      } else {
-        repeatedOmKeyInfo.addOmKeyInfo(omKeyInfo);
-      }
-
-      omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
-          keyName, repeatedOmKeyInfo);
+    if (repeatedOmKeyInfo == null) {
+      repeatedOmKeyInfo =
+          new RepeatedOmKeyInfo(partsUnusedList);
+    } else {
+      repeatedOmKeyInfo.addOmKeyInfo(omKeyInfo);
     }
+
+    omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
+        keyName, repeatedOmKeyInfo);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -470,7 +470,6 @@ public final class TestOMRequestUtils {
       throws IOException {
     // Retrieve the keyInfo
     OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable().get(ozoneKey);
-    omKeyInfo.setUpdateID(trxnLogIndex);
 
     // Delete key from KeyTable and put in DeletedKeyTable
     omMetadataManager.getKeyTable().delete(ozoneKey);
@@ -479,7 +478,7 @@ public final class TestOMRequestUtils {
         omMetadataManager.getDeletedTable().get(ozoneKey);
 
     repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(omKeyInfo,
-        repeatedOmKeyInfo);
+        repeatedOmKeyInfo, trxnLogIndex);
 
     omMetadataManager.getDeletedTable().put(ozoneKey, repeatedOmKeyInfo);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
@@ -102,8 +102,8 @@ public class TestS3MultipartResponse {
                 .setKeyName(keyName)
                 .setMultipartUploadID(multipartUploadID)).build();
 
-    return new S3InitiateMultipartUploadResponse(multipartKeyInfo, omKeyInfo,
-            omResponse);
+    return new S3InitiateMultipartUploadResponse(omResponse, multipartKeyInfo,
+        omKeyInfo);
   }
 
   public S3MultipartUploadAbortResponse createS3AbortMPUResponse(
@@ -116,8 +116,8 @@ public class TestS3MultipartResponse {
         .setAbortMultiPartUploadResponse(
             MultipartUploadAbortResponse.newBuilder().build()).build();
 
-    return new S3MultipartUploadAbortResponse(multipartKey, omMultipartKeyInfo,
-            omResponse);
+    return new S3MultipartUploadAbortResponse(omResponse, multipartKey,
+        omMultipartKeyInfo);
   }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

To ensure that S3 operations is idempotent, compare the transactionID with the objectID and updateID to make sure that the transaction is not a replay. If the transactionID <= updateID, then it implies that the transaction is a replay and hence it should be skipped.

In this Jira, the following requests are made idempotent:

S3InitiateMultipartUploadRequest
S3MultipartUploadCommitPartRequest
S3MultipartUploadCompleteRequest
S3MultipartUploadAbortRequest

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2953

## How was this patch tested?

Will add unit tests in next commit