### PR TITLE
HDDS-2956. Handle Replay of AllocateBlock request

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -197,7 +197,8 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
             throw new OMReplayException();
           }
         }
-        throw new OMException("Open Key not found " + openKeyName, KEY_NOT_FOUND);
+        throw new OMException("Open Key not found " + openKeyName,
+            KEY_NOT_FOUND);
       }
 
       // Check if this transaction is a replay of ratis logs.
@@ -220,8 +221,8 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
 
       // Add to cache.
       omMetadataManager.getOpenKeyTable().addCacheEntry(
-          new CacheKey<>(openKeyName), new CacheValue<>(Optional.of(openKeyInfo),
-              trxnLogIndex));
+          new CacheKey<>(openKeyName),
+          new CacheValue<>(Optional.of(openKeyInfo), trxnLogIndex));
 
       omResponse.setAllocateBlockResponse(AllocateBlockResponse.newBuilder()
           .setKeyLocation(blockLocation).build());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.ozone.om.exceptions.OMReplayException;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.util.Time;
@@ -134,8 +135,7 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
 
   @Override
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
-      long transactionLogIndex,
-      OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper) {
+      long trxnLogIndex, OzoneManagerDoubleBufferHelper omDoubleBufferHelper) {
 
     OzoneManagerProtocolProtos.AllocateBlockRequest allocateBlockRequest =
         getOmRequest().getAllocateBlockRequest();
@@ -160,71 +160,97 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
     Map<String, String> auditMap = buildKeyArgsAuditMap(keyArgs);
     auditMap.put(OzoneConsts.CLIENT_ID, String.valueOf(clientID));
 
+    OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
+    String openKeyName = omMetadataManager.getOpenKey(volumeName, bucketName,
+        keyName, clientID);
+
     OMResponse.Builder omResponse = OMResponse.newBuilder().setCmdType(
         OzoneManagerProtocolProtos.Type.AllocateBlock).setStatus(
         OzoneManagerProtocolProtos.Status.OK).setSuccess(true);
+    OMClientResponse omClientResponse = null;
 
+    OmKeyInfo openKeyInfo = null;
     IOException exception = null;
-    OmKeyInfo omKeyInfo = null;
+
     try {
       // check Acl
       checkKeyAclsInOpenKeyTable(ozoneManager, volumeName, bucketName, keyName,
           IAccessAuthorizer.ACLType.WRITE, allocateBlockRequest.getClientID());
 
-      OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
       validateBucketAndVolume(omMetadataManager, volumeName,
           bucketName);
-
-      String openKey = omMetadataManager.getOpenKey(
-          volumeName, bucketName, keyName, clientID);
 
       // Here we don't acquire bucket/volume lock because for a single client
       // allocateBlock is called in serial fashion.
 
-      omKeyInfo = omMetadataManager.getOpenKeyTable().get(openKey);
-      if (omKeyInfo == null) {
-        throw new OMException("Open Key not found " + openKey, KEY_NOT_FOUND);
+      openKeyInfo = omMetadataManager.getOpenKeyTable().get(openKeyName);
+      if (openKeyInfo == null) {
+        // Check if this transaction is a replay of ratis logs.
+        // If the Key was already committed and this transaction is being
+        // replayed, we should ignore this transaction.
+        String ozoneKey = omMetadataManager.getOzoneKey(volumeName,
+            bucketName, keyName);
+        OmKeyInfo dbKeyInfo = omMetadataManager.getKeyTable().get(ozoneKey);
+        if (dbKeyInfo != null) {
+          if (isReplay(ozoneManager, dbKeyInfo.getUpdateID(), trxnLogIndex)) {
+            // This transaction is a replay. Send replay response.
+            throw new OMReplayException();
+          }
+        }
+        throw new OMException("Open Key not found " + openKeyName, KEY_NOT_FOUND);
+      }
+
+      // Check if this transaction is a replay of ratis logs.
+      // Check the updateID of the openKey to verify that it is not greater
+      // than the current transactionLogIndex
+      if (isReplay(ozoneManager, openKeyInfo.getUpdateID(), trxnLogIndex)) {
+        // This transaction is a replay. Send replay response.
+        throw new OMReplayException();
       }
 
       // Append new block
-      omKeyInfo.appendNewBlocks(Collections.singletonList(
+      openKeyInfo.appendNewBlocks(Collections.singletonList(
           OmKeyLocationInfo.getFromProtobuf(blockLocation)), false);
 
       // Set modification time.
-      omKeyInfo.setModificationTime(keyArgs.getModificationTime());
+      openKeyInfo.setModificationTime(keyArgs.getModificationTime());
 
       // Set the UpdateID to current transactionLogIndex
-      omKeyInfo.setUpdateID(transactionLogIndex);
+      openKeyInfo.setUpdateID(trxnLogIndex);
 
       // Add to cache.
       omMetadataManager.getOpenKeyTable().addCacheEntry(
-          new CacheKey<>(openKey), new CacheValue<>(Optional.of(omKeyInfo),
-              transactionLogIndex));
+          new CacheKey<>(openKeyName), new CacheValue<>(Optional.of(openKeyInfo),
+              trxnLogIndex));
 
+      omResponse.setAllocateBlockResponse(AllocateBlockResponse.newBuilder()
+          .setKeyLocation(blockLocation).build());
+      omClientResponse = new OMAllocateBlockResponse(omResponse.build(),
+          openKeyInfo, clientID);
+      LOG.debug("Allocated block for Volume:{}, Bucket:{}, OpenKey:{}",
+          volumeName, bucketName, openKeyName);
     } catch (IOException ex) {
-      exception = ex;
+      if (ex instanceof OMReplayException) {
+        omClientResponse = new OMAllocateBlockResponse(createReplayOMResponse(
+            omResponse));
+        LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
+            allocateBlockRequest);
+      } else {
+        omMetrics.incNumBlockAllocateCallFails();
+        exception = ex;
+        omClientResponse = new OMAllocateBlockResponse(createErrorOMResponse(
+            omResponse, exception));
+        LOG.error("Allocate Block failed. Volume:{}, Bucket:{}, OpenKey:{}. " +
+            "Exception:{}", volumeName, bucketName, openKeyName, exception);
+      }
     }
 
     auditLog(auditLogger, buildAuditMessage(OMAction.ALLOCATE_BLOCK, auditMap,
         exception, getOmRequest().getUserInfo()));
 
-    OMClientResponse omClientResponse = null;
-    if (exception == null) {
-      omResponse.setAllocateBlockResponse(AllocateBlockResponse.newBuilder()
-          .setKeyLocation(blockLocation).build());
-      omClientResponse = new OMAllocateBlockResponse(omKeyInfo,
-          clientID, omResponse.build());
-    } else {
-      omMetrics.incNumBlockAllocateCallFails();
-      omClientResponse = new OMAllocateBlockResponse(null, -1L,
-          createErrorOMResponse(omResponse, exception));
-    }
+    omClientResponse.setFlushFuture(omDoubleBufferHelper.add(omClientResponse,
+        trxnLogIndex));
 
-    omClientResponse.setFlushFuture(
-        ozoneManagerDoubleBufferHelper.add(omClientResponse,
-            transactionLogIndex));
     return omClientResponse;
-
   }
-
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponse.java
@@ -47,7 +47,7 @@ public class TestOMAllocateBlockResponse extends TestOMKeyResponse {
         .setCmdType(OzoneManagerProtocolProtos.Type.AllocateBlock)
         .build();
     OMAllocateBlockResponse omAllocateBlockResponse =
-        new OMAllocateBlockResponse(omKeyInfo, clientID, omResponse);
+        new OMAllocateBlockResponse(omResponse, omKeyInfo, clientID);
 
     String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,
         keyName, clientID);
@@ -74,7 +74,7 @@ public class TestOMAllocateBlockResponse extends TestOMKeyResponse {
         .setCmdType(OzoneManagerProtocolProtos.Type.AllocateBlock)
         .build();
     OMAllocateBlockResponse omAllocateBlockResponse =
-        new OMAllocateBlockResponse(omKeyInfo, clientID, omResponse);
+        new OMAllocateBlockResponse(omResponse, omKeyInfo, clientID);
 
     // Before calling addToDBBatch
     String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponse.java
@@ -81,7 +81,7 @@ public class TestOMAllocateBlockResponse extends TestOMKeyResponse {
         keyName, clientID);
     Assert.assertFalse(omMetadataManager.getOpenKeyTable().isExist(openKey));
 
-    omAllocateBlockResponse.addToDBBatch(omMetadataManager, batchOperation);
+    omAllocateBlockResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
 
     // Do manual commit and see whether addToBatch is successful or not.
     omMetadataManager.getStore().commitBatchOperation(batchOperation);


### PR DESCRIPTION
## What changes were proposed in this pull request?

To ensure that allocate block operations are idempotent, compare the transactionID with the objectID and updateID to make sure that the transaction is not a replay. If the transactionID <= updateID, then it implies that the transaction is a replay and hence it should be skipped.

OMAllocateBlockRequest is made idempotent in this Jira.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2956

## How was this patch tested?

Unit test added.
