### PR TITLE
HDDS-2936. Hive queries fail at readFully

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -75,7 +75,13 @@ public class KeyOutputStream extends OutputStream {
   private FileEncryptionInfo feInfo;
   private final Map<Class<? extends Throwable>, RetryPolicy> retryPolicyMap;
   private int retryCount;
+  // how much of data is actually written yet to underlying stream
   private long offset;
+  // how much data has been ingested into the stream
+  private long writeOffset;
+  // whether an exception is encountered while write and whole write could
+  // not succeed
+  private boolean isException;
   private final BlockOutputStreamEntryPool blockOutputStreamEntryPool;
 
   /**
@@ -134,6 +140,8 @@ public class KeyOutputStream extends OutputStream {
     this.retryPolicyMap = HddsClientUtils.getRetryPolicyByException(
         maxRetryCount, retryInterval);
     this.retryCount = 0;
+    this.isException = false;
+    this.writeOffset = 0;
   }
 
   /**
@@ -188,6 +196,7 @@ public class KeyOutputStream extends OutputStream {
       return;
     }
     handleWrite(b, off, len, false);
+    writeOffset += len;
   }
 
   private void handleWrite(byte[] b, int off, long len, boolean retry)
@@ -199,15 +208,21 @@ public class KeyOutputStream extends OutputStream {
         // length(len) will be in int range if the call is happening through
         // write API of blockOutputStream. Length can be in long range if it
         // comes via Exception path.
-        int writeLen = Math.min((int) len, (int) current.getRemaining());
+        int expectedWriteLen = Math.min((int) len,
+                (int) current.getRemaining());
         long currentPos = current.getWrittenDataLength();
-        writeToOutputStream(current, retry, len, b, writeLen, off, currentPos);
+        // writeLen will be updated based on whether the write was succeeded
+        // or if it sees an exception, how much the actual write was
+        // acknowledged.
+        int writtenLength =
+                writeToOutputStream(current, retry, len, b, expectedWriteLen,
+                off, currentPos);
         if (current.getRemaining() <= 0) {
           // since the current block is already written close the stream.
           handleFlushOrClose(StreamAction.FULL);
         }
-        len -= writeLen;
-        off += writeLen;
+        len -= writtenLength;
+        off += writtenLength;
       } catch (Exception e) {
         markStreamClosed();
         throw new IOException("Allocate any more blocks for write failed", e);
@@ -215,7 +230,7 @@ public class KeyOutputStream extends OutputStream {
     }
   }
 
-  private void writeToOutputStream(BlockOutputStreamEntry current,
+  private int writeToOutputStream(BlockOutputStreamEntry current,
       boolean retry, long len, byte[] b, int writeLen, int off, long currentPos)
       throws IOException {
     try {
@@ -234,7 +249,7 @@ public class KeyOutputStream extends OutputStream {
       // The len specified here is the combined sum of the data length of
       // the buffers
       Preconditions.checkState(!retry || len <= blockOutputStreamEntryPool
-          .getStreamBufferMaxSize());
+              .getStreamBufferMaxSize());
       int dataWritten = (int) (current.getWrittenDataLength() - currentPos);
       writeLen = retry ? (int) len : dataWritten;
       // In retry path, the data written is already accounted in offset.
@@ -244,6 +259,7 @@ public class KeyOutputStream extends OutputStream {
       LOG.debug("writeLen {}, total len {}", writeLen, len);
       handleException(current, ioe);
     }
+    return writeLen;
   }
 
   /**
@@ -344,11 +360,11 @@ public class KeyOutputStream extends OutputStream {
     if (retryPolicy == null) {
       retryPolicy = retryPolicyMap.get(Exception.class);
     }
-    RetryPolicy.RetryAction action;
+    RetryPolicy.RetryAction action = null;
     try {
       action = retryPolicy.shouldRetry(exception, retryCount, 0, true);
     } catch (Exception e) {
-      throw new IOException(e);
+      setExceptionAndThrow(new IOException(e));
     }
     if (action.action == RetryPolicy.RetryAction.RetryDecision.FAIL) {
       String msg = "";
@@ -356,13 +372,13 @@ public class KeyOutputStream extends OutputStream {
         msg = "Retry request failed. " + action.reason;
         LOG.error(msg, exception);
       }
-      throw new IOException(msg, exception);
+      setExceptionAndThrow(new IOException(msg, exception));
     }
 
     // Throw the exception if the thread is interrupted
     if (Thread.currentThread().isInterrupted()) {
       LOG.warn("Interrupted while trying for retry");
-      throw exception;
+      setExceptionAndThrow(exception);
     }
     Preconditions.checkArgument(
         action.action == RetryPolicy.RetryAction.RetryDecision.RETRY);
@@ -371,9 +387,10 @@ public class KeyOutputStream extends OutputStream {
         Thread.sleep(action.delayMillis);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
-        throw (IOException) new InterruptedIOException(
+        IOException ioe =  (IOException) new InterruptedIOException(
             "Interrupted: action=" + action + ", retry policy=" + retryPolicy)
             .initCause(e);
+        setExceptionAndThrow(ioe);
       }
     }
     retryCount++;
@@ -382,6 +399,11 @@ public class KeyOutputStream extends OutputStream {
           "retry policy is {} ", retryCount, retryPolicy);
     }
     handleWrite(null, 0, len, true);
+  }
+
+  private void setExceptionAndThrow(IOException ioe) throws IOException {
+    isException = true;
+    throw ioe;
   }
 
   /**
@@ -484,6 +506,9 @@ public class KeyOutputStream extends OutputStream {
     closed = true;
     try {
       handleFlushOrClose(StreamAction.CLOSE);
+      if (!isException) {
+        Preconditions.checkArgument(writeOffset == offset);
+      }
       blockOutputStreamEntryPool.commitKey(offset);
     } finally {
       blockOutputStreamEntryPool.cleanup();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCloseContainerHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCloseContainerHandlingByClient.java
@@ -62,7 +62,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 /**
  * Tests Close Container Exception handling by Ozone Client.
  */
-@Ignore
 public class TestCloseContainerHandlingByClient {
 
   private static MiniOzoneCluster cluster;


### PR DESCRIPTION
## What changes were proposed in this pull request?

It fixes in the retry path of ozone client where length of data written was getting updated incorrectly while write in KeyouputStream.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2936


## How was this patch tested?
The existing test "TestCloseContainerHandlingByClient" was failing because the issue. All these tests are executing successfully with the fix. The patch also tested in a real deployment where HIve workload was run and all hive queries succeed now.
