### PR TITLE
HDDS-2958. Handle replay of OM Volume ACL requests

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -58,6 +58,18 @@ public abstract class OMClientRequest implements RequestAuditor {
 
   private OMRequest omRequest;
 
+  /**
+   * Stores the result of request execution in
+   * OMClientRequest#validateAndUpdateCache.
+   */
+  public enum Result {
+    SUCCESS, // The request was executed successfully
+
+    REPLAY, // The request is a replay and was ignored
+
+    FAILURE // The request failed and exception was thrown
+  }
+
   public OMClientRequest(OMRequest omRequest) {
     Preconditions.checkNotNull(omRequest);
     this.omRequest = omRequest;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -82,18 +82,6 @@ public abstract class OMKeyRequest extends OMClientRequest {
 
   private static final Logger LOG = LoggerFactory.getLogger(OMKeyRequest.class);
 
-  /**
-   * Stores the result of request execution in
-   * OMClientRequest#validateAndUpdateCache.
-   */
-  public enum Result {
-    SUCCESS, // The request was executed successfully
-
-    REPLAY, // The request is a replay and was ignored
-
-    FAILURE // The request failed and exception was thrown
-  }
-
   public OMKeyRequest(OMRequest omRequest) {
     super(omRequest);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java
@@ -25,10 +25,12 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.exceptions.OMReplayException;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.volume.OMVolumeAclOpResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
@@ -57,8 +59,7 @@ public abstract class OMVolumeAclRequest extends OMClientRequest {
 
   @Override
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
-      long transactionLogIndex,
-      OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper) {
+      long trxnLogIndex, OzoneManagerDoubleBufferHelper omDoubleBufferHelper) {
     // protobuf guarantees volume and acls are non-null.
     String volume = getVolumeName();
     List<OzoneAcl> ozoneAcls = getAcls();
@@ -73,6 +74,7 @@ public abstract class OMVolumeAclRequest extends OMClientRequest {
 
     OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
     boolean lockAcquired = false;
+    Result result = null;
     try {
       // check Acl
       if (ozoneManager.getAclsEnabled()) {
@@ -80,46 +82,63 @@ public abstract class OMVolumeAclRequest extends OMClientRequest {
             OzoneObj.StoreType.OZONE, IAccessAuthorizer.ACLType.WRITE_ACL,
             volume, null, null);
       }
-      lockAcquired =
-          omMetadataManager.getLock().acquireWriteLock(VOLUME_LOCK, volume);
+      lockAcquired = omMetadataManager.getLock().acquireWriteLock(
+          VOLUME_LOCK, volume);
       String dbVolumeKey = omMetadataManager.getVolumeKey(volume);
       omVolumeArgs = omMetadataManager.getVolumeTable().get(dbVolumeKey);
       if (omVolumeArgs == null) {
         throw new OMException(OMException.ResultCodes.VOLUME_NOT_FOUND);
       }
 
+      // Check if this transaction is a replay of ratis logs.
+      // If this is a replay, then the response has already been returned to
+      // the client. So take no further action and return a dummy
+      // OMClientResponse.
+      if (isReplay(ozoneManager, omVolumeArgs.getUpdateID(),
+          trxnLogIndex)) {
+        throw new OMReplayException();
+      }
+
       // result is false upon add existing acl or remove non-existing acl
-      boolean result = true;
+      boolean applyAcl = true;
       try {
         omVolumeAclOp.apply(ozoneAcls, omVolumeArgs);
       } catch (OMException ex) {
-        result = false;
+        applyAcl = false;
       }
 
-      if (result) {
+      if (applyAcl) {
+        omVolumeArgs.setUpdateID(trxnLogIndex);
         // update cache.
         omMetadataManager.getVolumeTable().addCacheEntry(
             new CacheKey<>(dbVolumeKey),
-            new CacheValue<>(Optional.of(omVolumeArgs), transactionLogIndex));
+            new CacheValue<>(Optional.of(omVolumeArgs), trxnLogIndex));
       }
 
-      omClientResponse = onSuccess(omResponse, omVolumeArgs, result);
+      omClientResponse = onSuccess(omResponse, omVolumeArgs, applyAcl);
+      result = Result.SUCCESS;
     } catch (IOException ex) {
-      exception = ex;
-      omMetrics.incNumVolumeUpdateFails();
-      omClientResponse = onFailure(omResponse, ex);
+      if (ex instanceof OMReplayException) {
+        result = Result.REPLAY;
+        omClientResponse = onReplay(omResponse);
+      } else {
+        result = Result.FAILURE;
+        exception = ex;
+        omMetrics.incNumVolumeUpdateFails();
+        omClientResponse = onFailure(omResponse, ex);
+      }
     } finally {
       if (omClientResponse != null) {
         omClientResponse.setFlushFuture(
-            ozoneManagerDoubleBufferHelper.add(omClientResponse,
-                transactionLogIndex));
+            omDoubleBufferHelper.add(omClientResponse,
+                trxnLogIndex));
       }
       if (lockAcquired) {
         omMetadataManager.getLock().releaseWriteLock(VOLUME_LOCK, volume);
       }
     }
 
-    onComplete(exception);
+    onComplete(result, exception, trxnLogIndex);
 
     return omClientResponse;
   }
@@ -151,11 +170,12 @@ public abstract class OMVolumeAclRequest extends OMClientRequest {
    * Get the om client response on success case with lock.
    * @param omResponse
    * @param omVolumeArgs
-   * @param result
+   * @param aclApplied
    * @return OMClientResponse
    */
   abstract OMClientResponse onSuccess(
-      OMResponse.Builder omResponse, OmVolumeArgs omVolumeArgs, boolean result);
+      OMResponse.Builder omResponse, OmVolumeArgs omVolumeArgs,
+      boolean aclApplied);
 
   /**
    * Get the om client response on failure case with lock.
@@ -166,10 +186,14 @@ public abstract class OMVolumeAclRequest extends OMClientRequest {
   abstract OMClientResponse onFailure(OMResponse.Builder omResponse,
       IOException ex);
 
+  OMClientResponse onReplay(OMResponse.Builder omResonse) {
+    return new OMVolumeAclOpResponse(createReplayOMResponse(omResonse));
+  }
+
   /**
    * Completion hook for final processing before return without lock.
    * Usually used for logging without lock.
    * @param ex
    */
-  abstract void onComplete(IOException ex);
+  abstract void onComplete(Result result, IOException ex, long trxnLogIndex);
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java
@@ -94,8 +94,7 @@ public abstract class OMVolumeAclRequest extends OMClientRequest {
       // If this is a replay, then the response has already been returned to
       // the client. So take no further action and return a dummy
       // OMClientResponse.
-      if (isReplay(ozoneManager, omVolumeArgs.getUpdateID(),
-          trxnLogIndex)) {
+      if (isReplay(ozoneManager, omVolumeArgs, trxnLogIndex)) {
         throw new OMReplayException();
       }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java
@@ -107,13 +107,14 @@ public abstract class OMVolumeAclRequest extends OMClientRequest {
         applyAcl = false;
       }
 
-      if (applyAcl) {
-        omVolumeArgs.setUpdateID(trxnLogIndex);
-        // update cache.
-        omMetadataManager.getVolumeTable().addCacheEntry(
-            new CacheKey<>(dbVolumeKey),
-            new CacheValue<>(Optional.of(omVolumeArgs), trxnLogIndex));
-      }
+      // We set the updateID even if applyAcl = false to catch the replay
+      // transactions.
+      omVolumeArgs.setUpdateID(trxnLogIndex);
+
+      // update cache.
+      omMetadataManager.getVolumeTable().addCacheEntry(
+          new CacheKey<>(dbVolumeKey),
+          new CacheValue<>(Optional.of(omVolumeArgs), trxnLogIndex));
 
       omClientResponse = onSuccess(omResponse, omVolumeArgs, applyAcl);
       result = Result.SUCCESS;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAddAclRequest.java
@@ -84,27 +84,36 @@ public class OMVolumeAddAclRequest extends OMVolumeAclRequest {
 
   @Override
   OMClientResponse onSuccess(OMResponse.Builder omResponse,
-      OmVolumeArgs omVolumeArgs, boolean result){
+      OmVolumeArgs omVolumeArgs, boolean aclApplied){
     omResponse.setAddAclResponse(OzoneManagerProtocolProtos.AddAclResponse
-        .newBuilder().setResponse(result).build());
-    return new OMVolumeAclOpResponse(omVolumeArgs, omResponse.build());
+        .newBuilder().setResponse(aclApplied).build());
+    return new OMVolumeAclOpResponse(omResponse.build(), omVolumeArgs);
   }
 
   @Override
   OMClientResponse onFailure(OMResponse.Builder omResponse,
       IOException ex) {
-    return new OMVolumeAclOpResponse(null,
-        createErrorOMResponse(omResponse, ex));
+    return new OMVolumeAclOpResponse(createErrorOMResponse(omResponse, ex));
   }
 
   @Override
-  void onComplete(IOException ex) {
-    if (ex == null) {
-      LOG.debug("Add acl: {} to volume: {} success!",
-          getAcl(), getVolumeName());
-    } else {
-      LOG.error("Add acl {} to volume {} failed!",
-          getAcl(), getVolumeName(), ex);
+  void onComplete(Result result, IOException ex, long trxnLogIndex) {
+    switch (result) {
+    case SUCCESS:
+      LOG.debug("Add acl: {} to volume: {} success!", getAcl(),
+          getVolumeName());
+      break;
+    case REPLAY:
+      LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
+          getOmRequest());
+      break;
+    case FAILURE:
+      LOG.error("Add acl {} to volume {} failed!", getAcl(), getVolumeName(),
+          ex);
+      break;
+    default:
+      LOG.error("Unrecognized Result for OMVolumeAddAclRequest: {}",
+          getOmRequest());
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAddAclRequest.java
@@ -100,12 +100,16 @@ public class OMVolumeAddAclRequest extends OMVolumeAclRequest {
   void onComplete(Result result, IOException ex, long trxnLogIndex) {
     switch (result) {
     case SUCCESS:
-      LOG.debug("Add acl: {} to volume: {} success!", getAcl(),
-          getVolumeName());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Add acl: {} to volume: {} success!", getAcl(),
+            getVolumeName());
+      }
       break;
     case REPLAY:
-      LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
-          getOmRequest());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
+            getOmRequest());
+      }
       break;
     case FAILURE:
       LOG.error("Add acl {} to volume {} failed!", getAcl(), getVolumeName(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeRemoveAclRequest.java
@@ -83,27 +83,36 @@ public class OMVolumeRemoveAclRequest extends OMVolumeAclRequest {
 
   @Override
   OMClientResponse onSuccess(OMResponse.Builder omResponse,
-      OmVolumeArgs omVolumeArgs, boolean result){
+      OmVolumeArgs omVolumeArgs, boolean aclApplied){
     omResponse.setRemoveAclResponse(OzoneManagerProtocolProtos.RemoveAclResponse
-        .newBuilder().setResponse(result).build());
-    return new OMVolumeAclOpResponse(omVolumeArgs, omResponse.build());
+        .newBuilder().setResponse(aclApplied).build());
+    return new OMVolumeAclOpResponse(omResponse.build(), omVolumeArgs);
   }
 
   @Override
   OMClientResponse onFailure(OMResponse.Builder omResponse,
       IOException ex) {
-    return new OMVolumeAclOpResponse(null,
-        createErrorOMResponse(omResponse, ex));
+    return new OMVolumeAclOpResponse(createErrorOMResponse(omResponse, ex));
   }
 
   @Override
-  void onComplete(IOException ex) {
-    if (ex == null) {
-      LOG.debug("Remove acl: {} from volume: {} success!",
-          getAcl(), getVolumeName());
-    } else {
-      LOG.error("Remove acl {} from volume {} failed!",
-          getAcl(), getVolumeName(), ex);
+  void onComplete(Result result, IOException ex, long trxnLogIndex) {
+    switch (result) {
+    case SUCCESS:
+      LOG.debug("Remove acl: {} from volume: {} success!", getAcl(),
+          getVolumeName());
+      break;
+    case REPLAY:
+      LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
+          getOmRequest());
+      break;
+    case FAILURE:
+      LOG.error("Remove acl {} from volume {} failed!", getAcl(),
+          getVolumeName(), ex);
+      break;
+    default:
+      LOG.error("Unrecognized Result for OMVolumeRemoveAclRequest: {}",
+          getOmRequest());
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeRemoveAclRequest.java
@@ -99,12 +99,16 @@ public class OMVolumeRemoveAclRequest extends OMVolumeAclRequest {
   void onComplete(Result result, IOException ex, long trxnLogIndex) {
     switch (result) {
     case SUCCESS:
-      LOG.debug("Remove acl: {} from volume: {} success!", getAcl(),
-          getVolumeName());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Remove acl: {} from volume: {} success!", getAcl(),
+            getVolumeName());
+      }
       break;
     case REPLAY:
-      LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
-          getOmRequest());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
+            getOmRequest());
+      }
       break;
     case FAILURE:
       LOG.error("Remove acl {} from volume {} failed!", getAcl(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeSetAclRequest.java
@@ -96,12 +96,16 @@ public class OMVolumeSetAclRequest extends OMVolumeAclRequest {
   void onComplete(Result result, IOException ex, long trxnLogIndex) {
     switch (result) {
     case SUCCESS:
-      LOG.debug("Set acls: {} to volume: {} success!", getAcls(),
-          getVolumeName());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Set acls: {} to volume: {} success!", getAcls(),
+            getVolumeName());
+      }
       break;
     case REPLAY:
-      LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
-          getOmRequest());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
+            getOmRequest());
+      }
       break;
     case FAILURE:
       LOG.error("Set acls {} to volume {} failed!", getAcls(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeSetAclRequest.java
@@ -80,29 +80,36 @@ public class OMVolumeSetAclRequest extends OMVolumeAclRequest {
 
   @Override
   OMClientResponse onSuccess(OMResponse.Builder omResponse,
-      OmVolumeArgs omVolumeArgs, boolean result){
+      OmVolumeArgs omVolumeArgs, boolean aclApplied){
     omResponse.setSetAclResponse(OzoneManagerProtocolProtos.SetAclResponse
-        .newBuilder().setResponse(result).build());
-    return new OMVolumeAclOpResponse(omVolumeArgs, omResponse.build());
+        .newBuilder().setResponse(aclApplied).build());
+    return new OMVolumeAclOpResponse(omResponse.build(), omVolumeArgs);
   }
 
   @Override
   OMClientResponse onFailure(OMResponse.Builder omResponse,
       IOException ex) {
-    return new OMVolumeAclOpResponse(null,
-        createErrorOMResponse(omResponse, ex));
+    return new OMVolumeAclOpResponse(createErrorOMResponse(omResponse, ex));
   }
 
   @Override
-  void onComplete(IOException ex) {
-    if (ex == null) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Set acls: {} to volume: {} success!",
-            getAcls(), getVolumeName());
-      }
-    } else {
-      LOG.error("Set acls {} to volume {} failed!",
-          getAcls(), getVolumeName(), ex);
+  void onComplete(Result result, IOException ex, long trxnLogIndex) {
+    switch (result) {
+    case SUCCESS:
+      LOG.debug("Set acls: {} to volume: {} success!", getAcls(),
+          getVolumeName());
+      break;
+    case REPLAY:
+      LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
+          getOmRequest());
+      break;
+    case FAILURE:
+      LOG.error("Set acls {} to volume {} failed!", getAcls(),
+          getVolumeName(), ex);
+      break;
+    default:
+      LOG.error("Unrecognized Result for OMVolumeSetAclRequest: {}",
+          getOmRequest());
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeAclOpResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeAclOpResponse.java
@@ -35,27 +35,34 @@ public class OMVolumeAclOpResponse extends OMClientResponse {
 
   private OmVolumeArgs omVolumeArgs;
 
-  public OMVolumeAclOpResponse(OmVolumeArgs omVolumeArgs,
-      @Nonnull OMResponse omResponse) {
+  public OMVolumeAclOpResponse(@Nonnull OMResponse omResponse,
+      OmVolumeArgs omVolumeArgs) {
     super(omResponse);
     this.omVolumeArgs = omVolumeArgs;
+  }
+
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
+  public OMVolumeAclOpResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+    checkStatusNotOK();
   }
 
   @Override
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    if (getOMResponse().getSuccess()) {
-      if ((getOMResponse().hasAddAclResponse() &&
-          getOMResponse().getAddAclResponse().getResponse()) ||
-          (getOMResponse().hasRemoveAclResponse() &&
-              getOMResponse().getRemoveAclResponse().getResponse()) ||
-          (getOMResponse().hasSetAclResponse() &&
-              getOMResponse().getSetAclResponse().getResponse())) {
-        omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
-            omMetadataManager.getVolumeKey(omVolumeArgs.getVolume()),
-            omVolumeArgs);
-      }
+    if ((getOMResponse().hasAddAclResponse() &&
+        getOMResponse().getAddAclResponse().getResponse()) ||
+        (getOMResponse().hasRemoveAclResponse() &&
+            getOMResponse().getRemoveAclResponse().getResponse()) ||
+        (getOMResponse().hasSetAclResponse() &&
+            getOMResponse().getSetAclResponse().getResponse())) {
+      omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
+          omMetadataManager.getVolumeKey(omVolumeArgs.getVolume()),
+          omVolumeArgs);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeAclOpResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeAclOpResponse.java
@@ -54,16 +54,9 @@ public class OMVolumeAclOpResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    if ((getOMResponse().hasAddAclResponse() &&
-        getOMResponse().getAddAclResponse().getResponse()) ||
-        (getOMResponse().hasRemoveAclResponse() &&
-            getOMResponse().getRemoveAclResponse().getResponse()) ||
-        (getOMResponse().hasSetAclResponse() &&
-            getOMResponse().getSetAclResponse().getResponse())) {
-      omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
-          omMetadataManager.getVolumeKey(omVolumeArgs.getVolume()),
-          omVolumeArgs);
-    }
+    omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
+        omMetadataManager.getVolumeKey(omVolumeArgs.getVolume()),
+        omVolumeArgs);
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeRemoveAclRequest.java
@@ -75,7 +75,6 @@ public class TestOMVolumeRemoveAclRequest extends TestOMVolumeRequest {
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omAddAclResponse.getStatus());
 
-
     // remove acl
     OMRequest removeAclRequest =
         TestOMRequestUtils.createVolumeRemoveAclRequest(volumeName, acl);
@@ -94,7 +93,7 @@ public class TestOMVolumeRemoveAclRequest extends TestOMVolumeRequest {
     Assert.assertEquals(acl, aclMapBeforeRemove.getAcl().get(0));
 
     OMClientResponse omClientRemoveResponse =
-        omVolumeRemoveAclRequest.validateAndUpdateCache(ozoneManager, 1,
+        omVolumeRemoveAclRequest.validateAndUpdateCache(ozoneManager, 2,
             ozoneManagerDoubleBufferHelper);
 
     OMResponse omRemoveAclResponse = omClientRemoveResponse.getOMResponse();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeRemoveAclRequest.java
@@ -129,4 +129,48 @@ public class TestOMVolumeRemoveAclRequest extends TestOMVolumeRequest {
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
         omResponse.getStatus());
   }
+
+  @Test
+  public void testReplayRequest() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String ownerName = "user1";
+
+    TestOMRequestUtils.addUserToDB(volumeName, ownerName, omMetadataManager);
+    TestOMRequestUtils.addVolumeToDB(volumeName, ownerName, omMetadataManager);
+
+    OzoneAcl acl = OzoneAcl.parseAcl("user:bilbo:rwdlncxy[ACCESS]");
+
+    // add acl first
+    OMRequest addAclRequest = TestOMRequestUtils.createVolumeAddAclRequest(
+        volumeName, acl);
+    OMVolumeAddAclRequest omVolumeAddAclRequest = new OMVolumeAddAclRequest(
+        addAclRequest);
+    omVolumeAddAclRequest.preExecute(ozoneManager);
+    OMClientResponse addAclResponse = omVolumeAddAclRequest
+        .validateAndUpdateCache(ozoneManager, 1,
+            ozoneManagerDoubleBufferHelper);
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        addAclResponse.getOMResponse().getStatus());
+
+    // remove acl
+    OMRequest removeAclRequest = TestOMRequestUtils
+        .createVolumeRemoveAclRequest(volumeName, acl);
+    OMVolumeRemoveAclRequest omVolumeRemoveAclRequest =
+        new OMVolumeRemoveAclRequest(removeAclRequest);
+    omVolumeRemoveAclRequest.preExecute(ozoneManager);
+
+    OMClientResponse omClientResponse = omVolumeRemoveAclRequest
+        .validateAndUpdateCache(ozoneManager, 2,
+            ozoneManagerDoubleBufferHelper);
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omClientResponse.getOMResponse().getStatus());
+
+    // Replay the original request
+    OMClientResponse replayResponse = omVolumeRemoveAclRequest
+        .validateAndUpdateCache(ozoneManager, 2,
+            ozoneManagerDoubleBufferHelper);
+
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.REPLAY,
+        replayResponse.getOMResponse().getStatus());
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

To ensure that volume acl operations are idempotent, compare the transactionID with the objectID and updateID to make sure that the transaction is not a replay. If the transactionID <= updateID, then it implies that the transaction is a replay and hence it should be skipped.

OMVolumeAclRequests (Add, Remove and Set ACL requests) are made idempotent in this Jira.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2958

## How was this patch tested?

Unit test added.
