### PR TITLE
HDDS-2959. Handle replay of OM Key ACL requests

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/WithObjectID.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/WithObjectID.java
@@ -76,7 +76,7 @@ public class WithObjectID extends WithMetadata {
    * @param updateId  long
    */
   public void setUpdateID(long updateId) {
-    Preconditions.checkArgument(updateId > this.updateID, String.format(
+    Preconditions.checkArgument(updateId >= this.updateID, String.format(
         "Trying to set updateID to %d which is not greater than the current " +
             "value of %d for %s", updateId, this.updateID, getObjectInfo()));
     this.updateID = updateId;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -58,6 +58,18 @@ public abstract class OMClientRequest implements RequestAuditor {
 
   private OMRequest omRequest;
 
+  /**
+   * Stores the result of request execution in
+   * OMClientRequest#validateAndUpdateCache.
+   */
+  public enum Result {
+    SUCCESS, // The request was executed successfully
+
+    REPLAY, // The request is a replay and was ignored
+
+    FAILURE // The request failed and exception was thrown
+  }
+
   public OMClientRequest(OMRequest omRequest) {
     Preconditions.checkNotNull(omRequest);
     this.omRequest = omRequest;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
@@ -24,11 +24,13 @@ import com.google.common.base.Optional;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.exceptions.OMReplayException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.request.util.ObjectParser;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.key.acl.OMKeyAclResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneObj.ObjectType;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
@@ -51,8 +53,7 @@ public abstract class OMKeyAclRequest extends OMClientRequest {
 
   @Override
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
-      long transactionLogIndex,
-      OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper) {
+      long trxnLogIndex, OzoneManagerDoubleBufferHelper omDoubleBufferHelper) {
 
     OmKeyInfo omKeyInfo = null;
 
@@ -66,6 +67,7 @@ public abstract class OMKeyAclRequest extends OMClientRequest {
     String bucket = null;
     String key = null;
     boolean operationResult = false;
+    Result result = null;
     try {
       ObjectParser objectParser = new ObjectParser(getPath(),
           ObjectType.KEY);
@@ -91,25 +93,39 @@ public abstract class OMKeyAclRequest extends OMClientRequest {
         throw new OMException(OMException.ResultCodes.KEY_NOT_FOUND);
       }
 
+      // Check if this transaction is a replay of ratis logs.
+      // If this is a replay, then the response has already been returned to
+      // the client. So take no further action and return a dummy
+      // OMClientResponse.
+      if (isReplay(ozoneManager, omKeyInfo.getUpdateID(), trxnLogIndex)) {
+        throw new OMReplayException();
+      }
+
       operationResult = apply(omKeyInfo);
 
       if (operationResult) {
         // update cache.
         omMetadataManager.getKeyTable().addCacheEntry(
             new CacheKey<>(dbKey),
-            new CacheValue<>(Optional.of(omKeyInfo), transactionLogIndex));
+            new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
       }
 
       omClientResponse = onSuccess(omResponse, omKeyInfo, operationResult);
-
+      result = Result.SUCCESS;
     } catch (IOException ex) {
-      exception = ex;
-      omClientResponse = onFailure(omResponse, ex);
+      if (ex instanceof OMReplayException) {
+        result = Result.REPLAY;
+        omClientResponse = onReplay(omResponse);
+      } else {
+        result = Result.FAILURE;
+        exception = ex;
+        omClientResponse = onFailure(omResponse, ex);
+      }
     } finally {
       if (omClientResponse != null) {
         omClientResponse.setFlushFuture(
-            ozoneManagerDoubleBufferHelper.add(omClientResponse,
-                transactionLogIndex));
+            omDoubleBufferHelper.add(omClientResponse,
+                trxnLogIndex));
       }
       if (lockAcquired) {
         omMetadataManager.getLock().releaseWriteLock(BUCKET_LOCK, volume,
@@ -117,8 +133,7 @@ public abstract class OMKeyAclRequest extends OMClientRequest {
       }
     }
 
-
-    onComplete(operationResult, exception);
+    onComplete(result, operationResult, exception, trxnLogIndex);
 
     return omClientResponse;
   }
@@ -154,8 +169,14 @@ public abstract class OMKeyAclRequest extends OMClientRequest {
    * @param exception
    * @return OMClientResponse
    */
-  abstract OMClientResponse onFailure(OMResponse.Builder omResponse,
-      IOException exception);
+  OMClientResponse onFailure(OMResponse.Builder omResponse,
+      IOException exception) {
+    return new OMKeyAclResponse(createErrorOMResponse(omResponse, exception));
+  }
+
+  OMClientResponse onReplay(OMResponse.Builder omResponse) {
+    return new OMKeyAclResponse(createReplayOMResponse(omResponse));
+  }
 
   /**
    * Completion hook for final processing before return without lock.
@@ -163,7 +184,8 @@ public abstract class OMKeyAclRequest extends OMClientRequest {
    * @param operationResult
    * @param exception
    */
-  abstract void onComplete(boolean operationResult, IOException exception);
+  abstract void onComplete(Result result, boolean operationResult,
+      IOException exception, long trxnLogIndex);
 
   /**
    * Apply the acl operation, if successfully completed returns true,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
@@ -101,7 +101,7 @@ public abstract class OMKeyAclRequest extends OMClientRequest {
         throw new OMReplayException();
       }
 
-      operationResult = apply(omKeyInfo);
+      operationResult = apply(omKeyInfo, trxnLogIndex);
 
       if (operationResult) {
         // update cache.
@@ -192,6 +192,6 @@ public abstract class OMKeyAclRequest extends OMClientRequest {
    * else false.
    * @param omKeyInfo
    */
-  abstract boolean apply(OmKeyInfo omKeyInfo);
+  abstract boolean apply(OmKeyInfo omKeyInfo, long trxnLogIndex);
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
@@ -102,13 +102,12 @@ public abstract class OMKeyAclRequest extends OMClientRequest {
       }
 
       operationResult = apply(omKeyInfo, trxnLogIndex);
+      omKeyInfo.setUpdateID(trxnLogIndex);
 
-      if (operationResult) {
-        // update cache.
-        omMetadataManager.getKeyTable().addCacheEntry(
-            new CacheKey<>(dbKey),
-            new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
-      }
+      // update cache.
+      omMetadataManager.getKeyTable().addCacheEntry(
+          new CacheKey<>(dbKey),
+          new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
 
       omClientResponse = onSuccess(omResponse, omKeyInfo, operationResult);
       result = Result.SUCCESS;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
@@ -97,7 +97,7 @@ public abstract class OMKeyAclRequest extends OMClientRequest {
       // If this is a replay, then the response has already been returned to
       // the client. So take no further action and return a dummy
       // OMClientResponse.
-      if (isReplay(ozoneManager, omKeyInfo.getUpdateID(), trxnLogIndex)) {
+      if (isReplay(ozoneManager, omKeyInfo, trxnLogIndex)) {
         throw new OMReplayException();
       }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
@@ -81,16 +81,20 @@ public class OMKeyAddAclRequest extends OMKeyAclRequest {
       IOException exception, long trxnLogIndex) {
     switch (result) {
     case SUCCESS:
-      if (operationResult) {
-        LOG.debug("Add acl: {} to path: {} success!", ozoneAcls, path);
-      } else {
-        LOG.debug("Add acl {} to path {} failed because acl already exists",
-            ozoneAcls, path);
+      if (LOG.isDebugEnabled()) {
+        if (operationResult) {
+          LOG.debug("Add acl: {} to path: {} success!", ozoneAcls, path);
+        } else {
+          LOG.debug("Add acl {} to path {} failed because acl already exists",
+              ozoneAcls, path);
+        }
       }
       break;
     case REPLAY:
-      LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
-          getOmRequest());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
+            getOmRequest());
+      }
       break;
     case FAILURE:
       LOG.error("Add acl {} to path {} failed!", ozoneAcls, path, exception);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
@@ -102,10 +102,13 @@ public class OMKeyAddAclRequest extends OMKeyAclRequest {
   }
 
   @Override
-  boolean apply(OmKeyInfo omKeyInfo) {
+  boolean apply(OmKeyInfo omKeyInfo, long trxnLogIndex) {
     // No need to check not null here, this will be never called with null.
-    return omKeyInfo.addAcl(ozoneAcls.get(0));
+    boolean operationResult = omKeyInfo.addAcl(ozoneAcls.get(0));
+    if (operationResult) {
+      omKeyInfo.setUpdateID(trxnLogIndex);
+    }
+    return operationResult;
   }
-
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
@@ -73,28 +73,31 @@ public class OMKeyAddAclRequest extends OMKeyAclRequest {
     omResponse.setSuccess(operationResult);
     omResponse.setAddAclResponse(AddAclResponse.newBuilder()
         .setResponse(operationResult));
-    return new OMKeyAclResponse(omKeyInfo,
-        omResponse.build());
+    return new OMKeyAclResponse(omResponse.build(), omKeyInfo);
   }
 
   @Override
-  OMClientResponse onFailure(OMResponse.Builder omResponse,
-      IOException exception) {
-    return new OMKeyAclResponse(null,
-        createErrorOMResponse(omResponse, exception));
-  }
-
-  @Override
-  void onComplete(boolean operationResult, IOException exception) {
-    if (operationResult) {
-      LOG.debug("Add acl: {} to path: {} success!", ozoneAcls, path);
-    } else {
-      if (exception == null) {
-        LOG.debug("Add acl {} to path {} failed, because acl already exist",
-            ozoneAcls, path);
+  void onComplete(Result result, boolean operationResult,
+      IOException exception, long trxnLogIndex) {
+    switch (result) {
+    case SUCCESS:
+      if (operationResult) {
+        LOG.debug("Add acl: {} to path: {} success!", ozoneAcls, path);
       } else {
-        LOG.error("Add acl {} to path {} failed!", ozoneAcls, path, exception);
+        LOG.debug("Add acl {} to path {} failed because acl already exists",
+            ozoneAcls, path);
       }
+      break;
+    case REPLAY:
+      LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
+          getOmRequest());
+      break;
+    case FAILURE:
+      LOG.error("Add acl {} to path {} failed!", ozoneAcls, path, exception);
+      break;
+    default:
+      LOG.error("Unrecognized Result for OMKeyAddAclRequest: {}",
+          getOmRequest());
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
@@ -85,8 +85,7 @@ public class OMKeyAddAclRequest extends OMKeyAclRequest {
         if (operationResult) {
           LOG.debug("Add acl: {} to path: {} success!", ozoneAcls, path);
         } else {
-          LOG.debug("Add acl {} to path {} failed because acl already exists",
-              ozoneAcls, path);
+          LOG.debug("Acl {} already exists in path {}", ozoneAcls, path);
         }
       }
       break;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
@@ -81,16 +81,21 @@ public class OMKeyRemoveAclRequest extends OMKeyAclRequest {
       IOException exception, long trxnLogIndex) {
     switch (result) {
     case SUCCESS:
-      if (operationResult) {
-        LOG.debug("Remove acl: {} to path: {} success!", ozoneAcls, path);
-      } else {
-        LOG.debug("Remove acl {} to path {} failed because acl already exists",
-            ozoneAcls, path);
+      if (LOG.isDebugEnabled()) {
+        if (operationResult) {
+          LOG.debug("Remove acl: {} to path: {} success!", ozoneAcls, path);
+        } else {
+          LOG.debug(
+              "Remove acl {} to path {} failed because acl already exists",
+              ozoneAcls, path);
+        }
       }
       break;
     case REPLAY:
-      LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
-          getOmRequest());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
+            getOmRequest());
+      }
       break;
     case FAILURE:
       LOG.error("Remove acl {} to path {} failed!", ozoneAcls, path, exception);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
@@ -102,10 +102,13 @@ public class OMKeyRemoveAclRequest extends OMKeyAclRequest {
   }
 
   @Override
-  boolean apply(OmKeyInfo omKeyInfo) {
+  boolean apply(OmKeyInfo omKeyInfo, long trxnLogIndex) {
     // No need to check not null here, this will be never called with null.
-    return omKeyInfo.removeAcl(ozoneAcls.get(0));
+    boolean operationResult = omKeyInfo.removeAcl(ozoneAcls.get(0));
+    if (operationResult) {
+      omKeyInfo.setUpdateID(trxnLogIndex);
+    }
+    return operationResult;
   }
-
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
@@ -85,8 +85,7 @@ public class OMKeyRemoveAclRequest extends OMKeyAclRequest {
         if (operationResult) {
           LOG.debug("Remove acl: {} to path: {} success!", ozoneAcls, path);
         } else {
-          LOG.debug(
-              "Remove acl {} to path {} failed because acl already exists",
+          LOG.debug("Acl {} not removed from path {} as it does not exist",
               ozoneAcls, path);
         }
       }
@@ -109,11 +108,7 @@ public class OMKeyRemoveAclRequest extends OMKeyAclRequest {
   @Override
   boolean apply(OmKeyInfo omKeyInfo, long trxnLogIndex) {
     // No need to check not null here, this will be never called with null.
-    boolean operationResult = omKeyInfo.removeAcl(ozoneAcls.get(0));
-    if (operationResult) {
-      omKeyInfo.setUpdateID(trxnLogIndex);
-    }
-    return operationResult;
+    return omKeyInfo.removeAcl(ozoneAcls.get(0));
   }
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
@@ -83,12 +83,7 @@ public class OMKeySetAclRequest extends OMKeyAclRequest {
     switch (result) {
     case SUCCESS:
       if (LOG.isDebugEnabled()) {
-        if (operationResult) {
-          LOG.debug("Set acl: {} to path: {} success!", ozoneAcls, path);
-        } else {
-          LOG.debug("Set acl {} to path {} failed because acl already exists",
-              ozoneAcls, path);
-        }
+        LOG.debug("Set acl: {} to path: {} success!", ozoneAcls, path);
       }
       break;
     case REPLAY:
@@ -109,11 +104,7 @@ public class OMKeySetAclRequest extends OMKeyAclRequest {
   @Override
   boolean apply(OmKeyInfo omKeyInfo, long trxnLogIndex) {
     // No need to check not null here, this will be never called with null.
-    boolean operationResult = omKeyInfo.setAcls(ozoneAcls);
-    if (operationResult) {
-      omKeyInfo.setUpdateID(trxnLogIndex);
-    }
-    return operationResult;
+    return omKeyInfo.setAcls(ozoneAcls);
   }
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
@@ -82,16 +82,20 @@ public class OMKeySetAclRequest extends OMKeyAclRequest {
       IOException exception, long trxnLogIndex) {
     switch (result) {
     case SUCCESS:
-      if (operationResult) {
-        LOG.debug("Set acl: {} to path: {} success!", ozoneAcls, path);
-      } else {
-        LOG.debug("Set acl {} to path {} failed because acl already exists",
-            ozoneAcls, path);
+      if (LOG.isDebugEnabled()) {
+        if (operationResult) {
+          LOG.debug("Set acl: {} to path: {} success!", ozoneAcls, path);
+        } else {
+          LOG.debug("Set acl {} to path {} failed because acl already exists",
+              ozoneAcls, path);
+        }
       }
       break;
     case REPLAY:
-      LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
-          getOmRequest());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
+            getOmRequest());
+      }
       break;
     case FAILURE:
       LOG.error("Set acl {} to path {} failed!", ozoneAcls, path, exception);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
@@ -103,10 +103,13 @@ public class OMKeySetAclRequest extends OMKeyAclRequest {
   }
 
   @Override
-  boolean apply(OmKeyInfo omKeyInfo) {
+  boolean apply(OmKeyInfo omKeyInfo, long trxnLogIndex) {
     // No need to check not null here, this will be never called with null.
-    return omKeyInfo.setAcls(ozoneAcls);
+    boolean operationResult = omKeyInfo.setAcls(ozoneAcls);
+    if (operationResult) {
+      omKeyInfo.setUpdateID(trxnLogIndex);
+    }
+    return operationResult;
   }
-
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
@@ -74,27 +74,31 @@ public class OMKeySetAclRequest extends OMKeyAclRequest {
     omResponse.setSuccess(operationResult);
     omResponse.setSetAclResponse(SetAclResponse.newBuilder()
         .setResponse(operationResult));
-    return new OMKeyAclResponse(omKeyInfo,
-        omResponse.build());
+    return new OMKeyAclResponse(omResponse.build(), omKeyInfo);
   }
 
   @Override
-  OMClientResponse onFailure(OMResponse.Builder omResponse,
-      IOException exception) {
-    return new OMKeyAclResponse(null,
-        createErrorOMResponse(omResponse, exception));
-  }
-
-  @Override
-  void onComplete(boolean operationResult, IOException exception) {
-    if (operationResult) {
-      LOG.debug("Set acl: {} to path: {} success!", ozoneAcls, path);
-    } else {
-      if (exception == null) {
-        LOG.debug("Set acl {} to path {} failed!", ozoneAcls, path);
+  void onComplete(Result result, boolean operationResult,
+      IOException exception, long trxnLogIndex) {
+    switch (result) {
+    case SUCCESS:
+      if (operationResult) {
+        LOG.debug("Set acl: {} to path: {} success!", ozoneAcls, path);
       } else {
-        LOG.error("Set acl {} to path {} failed!", ozoneAcls, path, exception);
+        LOG.debug("Set acl {} to path {} failed because acl already exists",
+            ozoneAcls, path);
       }
+      break;
+    case REPLAY:
+      LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
+          getOmRequest());
+      break;
+    case FAILURE:
+      LOG.error("Set acl {} to path {} failed!", ozoneAcls, path, exception);
+      break;
+    default:
+      LOG.error("Unrecognized Result for OMKeySetAclRequest: {}",
+          getOmRequest());
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/acl/OMKeyAclResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/acl/OMKeyAclResponse.java
@@ -21,12 +21,10 @@ package org.apache.hadoop.ozone.om.response.key.acl;
 import java.io.IOException;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
@@ -36,27 +34,30 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
  */
 public class OMKeyAclResponse extends OMClientResponse {
 
-  private final OmKeyInfo omKeyInfo;
+  private OmKeyInfo omKeyInfo;
 
-  public OMKeyAclResponse(@Nullable OmKeyInfo omKeyInfo,
-      @Nonnull OMResponse omResponse) {
+  public OMKeyAclResponse(@Nonnull OMResponse omResponse,
+      @Nonnull OmKeyInfo omKeyInfo) {
     super(omResponse);
     this.omKeyInfo = omKeyInfo;
+  }
+
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
+  public OMKeyAclResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
   }
 
   @Override
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    // If response status is OK and success is true, add to DB batch.
-    if (getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK &&
-        getOMResponse().getSuccess()) {
-      String dbKey =
-          omMetadataManager.getOzoneKey(omKeyInfo.getVolumeName(),
-              omKeyInfo.getBucketName(), omKeyInfo.getKeyName());
-      omMetadataManager.getKeyTable().putWithBatch(batchOperation,
-          dbKey, omKeyInfo);
-    }
+    String dbKey = omMetadataManager.getOzoneKey(omKeyInfo.getVolumeName(),
+        omKeyInfo.getBucketName(), omKeyInfo.getKeyName());
+    omMetadataManager.getKeyTable().putWithBatch(batchOperation, dbKey,
+        omKeyInfo);
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequest.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.request.key;
+
+import java.util.UUID;
+import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
+import org.apache.hadoop.ozone.om.request.key.acl.OMKeyAddAclRequest;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AddAclRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.security.acl.OzoneObj;
+import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test Key ACL requests.
+ */
+public class TestOMKeyAclRequest extends TestOMKeyRequest {
+
+  @Test
+  public void testReplayRequest() throws Exception {
+    // Manually add volume, bucket and key to DB
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
+    TestOMRequestUtils.addKeyToTable(false, false, volumeName, bucketName,
+        keyName, clientID, replicationType, replicationFactor, 1L,
+        omMetadataManager);
+
+    OzoneAcl acl = OzoneAcl.parseAcl("user:bilbo:rwdlncxy[ACCESS]");
+
+    // Create KeyAddAcl request
+    OMRequest originalRequest = createAddAclkeyRequest(acl);
+    OMKeyAddAclRequest omKeyAddAclRequest = new OMKeyAddAclRequest(
+        originalRequest);
+    omKeyAddAclRequest.preExecute(ozoneManager);
+
+    // Execute original request
+    OMClientResponse omClientResponse = omKeyAddAclRequest
+        .validateAndUpdateCache(ozoneManager, 2,
+            ozoneManagerDoubleBufferHelper);
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omClientResponse.getOMResponse().getStatus());
+
+    // Replay the original request
+    OMClientResponse replayResponse = omKeyAddAclRequest
+        .validateAndUpdateCache(ozoneManager, 2,
+            ozoneManagerDoubleBufferHelper);
+
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.REPLAY,
+        replayResponse.getOMResponse().getStatus());
+  }
+
+  /**
+   * Create OMRequest which encapsulates OMKeyAddAclRequest.
+   */
+  private OMRequest createAddAclkeyRequest(OzoneAcl acl) {
+    OzoneObj obj = OzoneObjInfo.Builder.newBuilder()
+        .setBucketName(bucketName)
+        .setVolumeName(volumeName)
+        .setKeyName(keyName)
+        .setResType(OzoneObj.ResourceType.KEY)
+        .setStoreType(OzoneObj.StoreType.OZONE)
+        .build();
+    AddAclRequest addAclRequest = AddAclRequest.newBuilder()
+        .setObj(OzoneObj.toProtobuf(obj))
+        .setAcl(OzoneAcl.toProtobuf(acl))
+        .build();
+
+    return OMRequest.newBuilder().setClientId(UUID.randomUUID().toString())
+        .setCmdType(OzoneManagerProtocolProtos.Type.AddAcl)
+        .setAddAclRequest(addAclRequest)
+        .build();
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

To ensure that Key acl operations are idempotent, compare the transactionID with the objectID and updateID to make sure that the transaction is not a replay. If the transactionID <= updateID, then it implies that the transaction is a replay and hence it should be skipped.

OMKeyAclRequests (Add, Remove and Set ACL requests) are made idempotent in this Jira.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2959

## How was this patch tested?

Unit tests are added
