### PR TITLE
HDDS-2962. Handle replay of OM Prefix ACL requests

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmPrefixInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmPrefixInfo.java
@@ -35,12 +35,10 @@ import java.util.stream.Collectors;
  * can be extended for other OzFS optimizations in future.
  */
 // TODO: support Auditable interface
-public final class OmPrefixInfo extends WithMetadata {
+public final class OmPrefixInfo extends WithObjectID {
 
   private String name;
   private List<OzoneAcl> acls;
-  private long objectID;
-  private long updateID;
 
   public OmPrefixInfo(String name, List<OzoneAcl> acls,
       Map<String, String> metadata, long objectId, long updateId) {
@@ -77,50 +75,6 @@ public final class OmPrefixInfo extends WithMetadata {
    */
   public String getName() {
     return name;
-  }
-
-  /**
-   * Set the Object ID. If this value is already set then this function throws.
-   * There is a reason why we cannot use the final here. The OMKeyInfo is
-   * deserialized from the protobuf in many places in code. We need to set
-   * this object ID, after it is deserialized.
-   *
-   * @param obId - long
-   */
-  public void setObjectID(long obId) {
-    if(this.objectID != 0) {
-      throw new UnsupportedOperationException("Attempt to modify object ID " +
-          "which is not zero. Current Object ID is " + this.objectID);
-    }
-    this.objectID = obId;
-  }
-
-  /**
-   * Sets the update ID. For each modification of this object, we will set
-   * this to a value greater than the current value.
-   * @param updateId  long
-   */
-  public void setUpdateID(long updateId) {
-    Preconditions.checkArgument(updateId >= this.updateID,
-        "Trying to set updateID to a value ({}) which is less than the " +
-            "current value ({}) for ()", updateId, this.updateID, this);
-    this.updateID = updateId;
-  }
-
-  /**
-   * Returns objectID.
-   * @return long
-   */
-  public long getObjectID() {
-    return objectID;
-  }
-
-  /**
-   * Returns updateID.
-   * @return long
-   */
-  public long getUpdateID() {
-    return updateID;
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmPrefixInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmPrefixInfo.java
@@ -101,7 +101,7 @@ public final class OmPrefixInfo extends WithMetadata {
    * @param updateId  long
    */
   public void setUpdateID(long updateId) {
-    Preconditions.checkArgument(updateId > this.updateID,
+    Preconditions.checkArgument(updateId >= this.updateID,
         "Trying to set updateID to a value ({}) which is less than the " +
             "current value ({}) for ()", updateId, this.updateID, this);
     this.updateID = updateId;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmPrefixInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmPrefixInfo.java
@@ -39,12 +39,16 @@ public final class OmPrefixInfo extends WithMetadata {
 
   private String name;
   private List<OzoneAcl> acls;
+  private long objectID;
+  private long updateID;
 
   public OmPrefixInfo(String name, List<OzoneAcl> acls,
-      Map<String, String> metadata) {
+      Map<String, String> metadata, long objectId, long updateId) {
     this.name = name;
     this.acls = acls;
     this.metadata = metadata;
+    this.objectID = objectId;
+    this.updateID = updateId;
   }
 
   /**
@@ -76,6 +80,50 @@ public final class OmPrefixInfo extends WithMetadata {
   }
 
   /**
+   * Set the Object ID. If this value is already set then this function throws.
+   * There is a reason why we cannot use the final here. The OMKeyInfo is
+   * deserialized from the protobuf in many places in code. We need to set
+   * this object ID, after it is deserialized.
+   *
+   * @param obId - long
+   */
+  public void setObjectID(long obId) {
+    if(this.objectID != 0) {
+      throw new UnsupportedOperationException("Attempt to modify object ID " +
+          "which is not zero. Current Object ID is " + this.objectID);
+    }
+    this.objectID = obId;
+  }
+
+  /**
+   * Sets the update ID. For each modification of this object, we will set
+   * this to a value greater than the current value.
+   * @param updateId  long
+   */
+  public void setUpdateID(long updateId) {
+    Preconditions.checkArgument(updateId > this.updateID,
+        "Trying to set updateID to a value ({}) which is less than the " +
+            "current value ({}) for ()", updateId, this.updateID, this);
+    this.updateID = updateId;
+  }
+
+  /**
+   * Returns objectID.
+   * @return long
+   */
+  public long getObjectID() {
+    return objectID;
+  }
+
+  /**
+   * Returns updateID.
+   * @return long
+   */
+  public long getUpdateID() {
+    return updateID;
+  }
+
+  /**
    * Returns new builder class that builds a OmPrefixInfo.
    *
    * @return Builder
@@ -91,6 +139,8 @@ public final class OmPrefixInfo extends WithMetadata {
     private String name;
     private List<OzoneAcl> acls;
     private Map<String, String> metadata;
+    private long objectID;
+    private long updateID;
 
     public Builder() {
       //Default values
@@ -123,13 +173,23 @@ public final class OmPrefixInfo extends WithMetadata {
       return this;
     }
 
+    public Builder setObjectID(long obId) {
+      this.objectID = obId;
+      return this;
+    }
+
+    public Builder setUpdateID(long id) {
+      this.updateID = id;
+      return this;
+    }
+
     /**
      * Constructs the OmPrefixInfo.
      * @return instance of OmPrefixInfo.
      */
     public OmPrefixInfo build() {
       Preconditions.checkNotNull(name);
-      return new OmPrefixInfo(name, acls, metadata);
+      return new OmPrefixInfo(name, acls, metadata, objectID, updateID);
     }
   }
 
@@ -195,7 +255,7 @@ public final class OmPrefixInfo extends WithMetadata {
     if (metadata != null) {
       metadata.forEach((k, v) -> metadataList.put(k, v));
     }
-    return new OmPrefixInfo(name, aclList, metadataList);
+    return new OmPrefixInfo(name, aclList, metadataList, objectID, updateID);
   }
 }
 

--- a/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
+++ b/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
@@ -564,6 +564,8 @@ message PrefixInfo {
     required string name = 1;
     repeated OzoneAclInfo acls = 2;
     repeated hadoop.hdds.KeyValue metadata = 3;
+    optional uint64 objectID = 4;
+    optional uint64 updateID = 5;
 }
 
 message OzoneObj {

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmPrefixInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmPrefixInfo.java
@@ -38,7 +38,7 @@ public class TestOmPrefixInfo {
     OmPrefixInfo omPrefixInfo = new OmPrefixInfo("/path",
         Collections.singletonList(new OzoneAcl(
         IAccessAuthorizer.ACLIdentityType.USER, "user1",
-        IAccessAuthorizer.ACLType.WRITE, ACCESS)), new HashMap<>());
+        IAccessAuthorizer.ACLType.WRITE, ACCESS)), new HashMap<>(), 10, 100);
 
     OmPrefixInfo clonePrefixInfo = omPrefixInfo.copyObject();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PrefixManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PrefixManagerImpl.java
@@ -108,7 +108,7 @@ public class PrefixManagerImpl implements PrefixManager {
 
       OMPrefixAclOpResult omPrefixAclOpResult = addAcl(obj, acl, prefixInfo);
 
-      return omPrefixAclOpResult.isOperationsResult();
+      return omPrefixAclOpResult.isSuccess();
     } catch (IOException ex) {
       if (!(ex instanceof OMException)) {
         LOG.error("Add acl operation failed for prefix path:{} acl:{}",
@@ -138,7 +138,7 @@ public class PrefixManagerImpl implements PrefixManager {
           metadataManager.getPrefixTable().get(prefixPath);
       OMPrefixAclOpResult omPrefixAclOpResult = removeAcl(obj, acl, prefixInfo);
 
-      if (!omPrefixAclOpResult.isOperationsResult()) {
+      if (!omPrefixAclOpResult.isSuccess()) {
         if (LOG.isDebugEnabled()) {
           LOG.debug("acl {} does not exist for prefix path {} ",
               acl, prefixPath);
@@ -146,7 +146,7 @@ public class PrefixManagerImpl implements PrefixManager {
         return false;
       }
 
-      return omPrefixAclOpResult.isOperationsResult();
+      return omPrefixAclOpResult.isSuccess();
 
     } catch (IOException ex) {
       if (!(ex instanceof OMException)) {
@@ -178,7 +178,7 @@ public class PrefixManagerImpl implements PrefixManager {
 
       OMPrefixAclOpResult omPrefixAclOpResult = setAcl(obj, acls, prefixInfo);
 
-      return omPrefixAclOpResult.isOperationsResult();
+      return omPrefixAclOpResult.isSuccess();
     } catch (IOException ex) {
       if (!(ex instanceof OMException)) {
         LOG.error("Set prefix acl operation failed for prefix path:{} acls:{}",
@@ -410,7 +410,7 @@ public class PrefixManagerImpl implements PrefixManager {
       return omPrefixInfo;
     }
 
-    public boolean isOperationsResult() {
+    public boolean isSuccess() {
       return operationsResult;
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PrefixManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PrefixManagerImpl.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.RequestContext;
 import org.apache.hadoop.ozone.util.RadixNode;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
@@ -26,10 +26,12 @@ import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.PrefixManagerImpl;
 import org.apache.hadoop.ozone.om.PrefixManagerImpl.OMPrefixAclOpResult;
+import org.apache.hadoop.ozone.om.exceptions.OMReplayException;
 import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.key.acl.prefix.OMPrefixAclResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
@@ -50,9 +52,7 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
 
   @Override
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
-      long transactionLogIndex,
-      OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper) {
-
+      long trxnLogIndex, OzoneManagerDoubleBufferHelper omDoubleBufferHelper) {
 
     OmPrefixInfo omPrefixInfo = null;
 
@@ -66,7 +66,8 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
     String bucket = null;
     String key = null;
     OMPrefixAclOpResult operationResult = null;
-    boolean result = false;
+    boolean opResult = false;
+    Result result = null;
 
     PrefixManagerImpl prefixManager =
         (PrefixManagerImpl) ozoneManager.getPrefixManager();
@@ -85,6 +86,14 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
 
       omPrefixInfo = omMetadataManager.getPrefixTable().get(prefixPath);
 
+      // Check if this transaction is a replay of ratis logs.
+      if (omPrefixInfo != null) {
+        if (isReplay(ozoneManager, omPrefixInfo.getUpdateID(), trxnLogIndex)) {
+          // This is a replayed transaction. Return dummy response.
+          throw new OMReplayException();
+        }
+      }
+
       try {
         operationResult = apply(prefixManager, omPrefixInfo);
       } catch (IOException ex) {
@@ -96,7 +105,7 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
         operationResult = new OMPrefixAclOpResult(null, false);
       }
 
-      if (operationResult.isOperationsResult()) {
+      if (operationResult.isSuccess()) {
         // As for remove acl list, for a prefix if after removing acl from
         // the existing acl list, if list size becomes zero, delete the
         // prefix from prefix table.
@@ -104,28 +113,35 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
             operationResult.getOmPrefixInfo().getAcls().size() == 0) {
           omMetadataManager.getPrefixTable().addCacheEntry(
               new CacheKey<>(prefixPath),
-              new CacheValue<>(Optional.absent(), transactionLogIndex));
+              new CacheValue<>(Optional.absent(), trxnLogIndex));
         } else {
           // update cache.
           omMetadataManager.getPrefixTable().addCacheEntry(
               new CacheKey<>(prefixPath),
               new CacheValue<>(Optional.of(operationResult.getOmPrefixInfo()),
-                  transactionLogIndex));
+                  trxnLogIndex));
         }
       }
 
-      result  = operationResult.isOperationsResult();
+      opResult  = operationResult.isSuccess();
       omClientResponse = onSuccess(omResponse,
-          operationResult.getOmPrefixInfo(), result);
+          operationResult.getOmPrefixInfo(), opResult);
+      result = Result.SUCCESS;
 
     } catch (IOException ex) {
-      exception = ex;
-      omClientResponse = onFailure(omResponse, ex);
+      if (ex instanceof OMReplayException) {
+        result = Result.REPLAY;
+        omClientResponse = onReplay(omResponse);
+      } else {
+        result = Result.FAILURE;
+        exception = ex;
+        omClientResponse = onFailure(omResponse, ex);
+      }
     } finally {
       if (omClientResponse != null) {
         omClientResponse.setFlushFuture(
-            ozoneManagerDoubleBufferHelper.add(omClientResponse,
-                transactionLogIndex));
+            omDoubleBufferHelper.add(omClientResponse,
+                trxnLogIndex));
       }
       if (lockAcquired) {
         omMetadataManager.getLock().releaseWriteLock(PREFIX_LOCK,
@@ -133,7 +149,8 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
       }
     }
 
-    onComplete(result, exception, ozoneManager.getMetrics());
+    onComplete(opResult, exception, ozoneManager.getMetrics(), result,
+        trxnLogIndex);
 
     return omClientResponse;
   }
@@ -173,6 +190,15 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
       IOException exception);
 
   /**
+   * Get the OM Client Response on replayed transactions
+   * @param omResonse
+   * @return OMClientResponse
+   */
+  OMClientResponse onReplay(OMResponse.Builder omResonse) {
+    return new OMPrefixAclResponse(createReplayOMResponse(omResonse));
+  }
+
+  /**
    * Completion hook for final processing before return without lock.
    * Usually used for logging without lock and metric update.
    * @param operationResult
@@ -180,7 +206,7 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
    * @param omMetrics
    */
   abstract void onComplete(boolean operationResult, IOException exception,
-      OMMetrics omMetrics);
+      OMMetrics omMetrics, Result result, long trxnLogIndex);
 
   /**
    * Apply the acl operation, if successfully completed returns true,
@@ -191,7 +217,5 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
    */
   abstract OMPrefixAclOpResult apply(PrefixManagerImpl prefixManager,
       OmPrefixInfo omPrefixInfo) throws IOException;
-
-
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
@@ -95,7 +95,7 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
       }
 
       try {
-        operationResult = apply(prefixManager, omPrefixInfo);
+        operationResult = apply(prefixManager, omPrefixInfo, trxnLogIndex);
       } catch (IOException ex) {
         // In HA case this will never happen.
         // As in add/remove/setAcl method we have logic to update database,
@@ -190,7 +190,7 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
       IOException exception);
 
   /**
-   * Get the OM Client Response on replayed transactions
+   * Get the OM Client Response on replayed transactions.
    * @param omResonse
    * @return OMClientResponse
    */
@@ -213,9 +213,10 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
    * else false.
    * @param prefixManager
    * @param omPrefixInfo
+   * @param trxnLogIndex
    * @throws IOException
    */
   abstract OMPrefixAclOpResult apply(PrefixManagerImpl prefixManager,
-      OmPrefixInfo omPrefixInfo) throws IOException;
+      OmPrefixInfo omPrefixInfo, long trxnLogIndex) throws IOException;
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
@@ -88,7 +88,7 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
 
       // Check if this transaction is a replay of ratis logs.
       if (omPrefixInfo != null) {
-        if (isReplay(ozoneManager, omPrefixInfo.getUpdateID(), trxnLogIndex)) {
+        if (isReplay(ozoneManager, omPrefixInfo, trxnLogIndex)) {
           // This is a replayed transaction. Return dummy response.
           throw new OMReplayException();
         }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
@@ -105,27 +105,27 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
         operationResult = new OMPrefixAclOpResult(null, false);
       }
 
-      if (operationResult.isSuccess()) {
-        // As for remove acl list, for a prefix if after removing acl from
-        // the existing acl list, if list size becomes zero, delete the
-        // prefix from prefix table.
-        if (getOmRequest().hasRemoveAclRequest() &&
-            operationResult.getOmPrefixInfo().getAcls().size() == 0) {
-          omMetadataManager.getPrefixTable().addCacheEntry(
-              new CacheKey<>(prefixPath),
-              new CacheValue<>(Optional.absent(), trxnLogIndex));
-        } else {
-          // update cache.
-          omMetadataManager.getPrefixTable().addCacheEntry(
-              new CacheKey<>(prefixPath),
-              new CacheValue<>(Optional.of(operationResult.getOmPrefixInfo()),
-                  trxnLogIndex));
-        }
+      omPrefixInfo = operationResult.getOmPrefixInfo();
+      omPrefixInfo.setUpdateID(trxnLogIndex);
+
+      // As for remove acl list, for a prefix if after removing acl from
+      // the existing acl list, if list size becomes zero, delete the
+      // prefix from prefix table.
+      if (getOmRequest().hasRemoveAclRequest() &&
+          omPrefixInfo.getAcls().size() == 0) {
+        omMetadataManager.getPrefixTable().addCacheEntry(
+            new CacheKey<>(prefixPath),
+            new CacheValue<>(Optional.absent(), trxnLogIndex));
+      } else {
+        // update cache.
+        omMetadataManager.getPrefixTable().addCacheEntry(
+            new CacheKey<>(prefixPath),
+            new CacheValue<>(Optional.of(omPrefixInfo),
+                trxnLogIndex));
       }
 
       opResult  = operationResult.isSuccess();
-      omClientResponse = onSuccess(omResponse,
-          operationResult.getOmPrefixInfo(), opResult);
+      omClientResponse = onSuccess(omResponse, omPrefixInfo, opResult);
       result = Result.SUCCESS;
 
     } catch (IOException ex) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAddAclRequest.java
@@ -103,7 +103,7 @@ public class OMPrefixAddAclRequest extends OMPrefixAclRequest {
           LOG.debug("Add acl: {} to path: {} success!", ozoneAcls,
               ozoneObj.getPath());
         } else {
-          LOG.debug("Add acl {} to path {} failed because acl already exists",
+          LOG.debug("Acl {} already exists in path {}",
               ozoneAcls, ozoneObj.getPath());
         }
       }
@@ -128,12 +128,8 @@ public class OMPrefixAddAclRequest extends OMPrefixAclRequest {
   @Override
   OMPrefixAclOpResult apply(PrefixManagerImpl prefixManager,
       OmPrefixInfo omPrefixInfo, long trxnLogIndex) throws IOException {
-    OMPrefixAclOpResult operationResult = prefixManager.addAcl(ozoneObj,
-        ozoneAcls.get(0), omPrefixInfo, trxnLogIndex);
-    if (operationResult.isSuccess()) {
-      operationResult.getOmPrefixInfo().setUpdateID(trxnLogIndex);
-    }
-    return operationResult;
+    return prefixManager.addAcl(ozoneObj, ozoneAcls.get(0), omPrefixInfo,
+        trxnLogIndex);
   }
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixRemoveAclRequest.java
@@ -95,17 +95,22 @@ public class OMPrefixRemoveAclRequest extends OMPrefixAclRequest {
       OMMetrics omMetrics, Result result, long trxnLogIndex) {
     switch (result) {
     case SUCCESS:
-      if (operationResult) {
-        LOG.debug("Remove acl: {} to path: {} success!", ozoneAcls,
-            ozoneObj.getPath());
-      } else {
-        LOG.debug("Remove acl {} to path {} failed because acl does not exist",
-            ozoneAcls, ozoneObj.getPath());
+      if (LOG.isDebugEnabled()) {
+        if (operationResult) {
+          LOG.debug("Remove acl: {} to path: {} success!", ozoneAcls,
+              ozoneObj.getPath());
+        } else {
+          LOG.debug(
+              "Remove acl {} to path {} failed because acl does not exist",
+              ozoneAcls, ozoneObj.getPath());
+        }
       }
       break;
     case REPLAY:
-      LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
-          getOmRequest());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
+            getOmRequest());
+      }
       break;
     case FAILURE:
       omMetrics.incNumBucketUpdateFails();
@@ -120,9 +125,13 @@ public class OMPrefixRemoveAclRequest extends OMPrefixAclRequest {
 
   @Override
   OMPrefixAclOpResult apply(PrefixManagerImpl prefixManager,
-      OmPrefixInfo omPrefixInfo) throws IOException {
-    return prefixManager.removeAcl(ozoneObj, ozoneAcls.get(0), omPrefixInfo);
+      OmPrefixInfo omPrefixInfo, long trxnLogIndex) throws IOException {
+    OMPrefixAclOpResult operationResult = prefixManager.removeAcl(ozoneObj,
+        ozoneAcls.get(0), omPrefixInfo);
+    if (operationResult.isSuccess()) {
+      operationResult.getOmPrefixInfo().setUpdateID(trxnLogIndex);
+    }
+    return operationResult;
   }
-
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixRemoveAclRequest.java
@@ -100,8 +100,7 @@ public class OMPrefixRemoveAclRequest extends OMPrefixAclRequest {
           LOG.debug("Remove acl: {} to path: {} success!", ozoneAcls,
               ozoneObj.getPath());
         } else {
-          LOG.debug(
-              "Remove acl {} to path {} failed because acl does not exist",
+          LOG.debug("Acl {} not removed from path {} as it does not exist",
               ozoneAcls, ozoneObj.getPath());
         }
       }
@@ -126,12 +125,7 @@ public class OMPrefixRemoveAclRequest extends OMPrefixAclRequest {
   @Override
   OMPrefixAclOpResult apply(PrefixManagerImpl prefixManager,
       OmPrefixInfo omPrefixInfo, long trxnLogIndex) throws IOException {
-    OMPrefixAclOpResult operationResult = prefixManager.removeAcl(ozoneObj,
-        ozoneAcls.get(0), omPrefixInfo);
-    if (operationResult.isSuccess()) {
-      operationResult.getOmPrefixInfo().setUpdateID(trxnLogIndex);
-    }
-    return operationResult;
+    return prefixManager.removeAcl(ozoneObj, ozoneAcls.get(0), omPrefixInfo);
   }
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixSetAclRequest.java
@@ -96,17 +96,21 @@ public class OMPrefixSetAclRequest extends OMPrefixAclRequest {
       OMMetrics omMetrics, Result result, long trxnLogIndex) {
     switch (result) {
     case SUCCESS:
-      if (operationResult) {
-        LOG.debug("Set acl: {} to path: {} success!", ozoneAcls,
-            ozoneObj.getPath());
-      } else {
-        LOG.debug("Set acl {} to path {} failed", ozoneAcls,
-            ozoneObj.getPath());
+      if (LOG.isDebugEnabled()) {
+        if (operationResult) {
+          LOG.debug("Set acl: {} to path: {} success!", ozoneAcls,
+              ozoneObj.getPath());
+        } else {
+          LOG.debug("Set acl {} to path {} failed", ozoneAcls,
+              ozoneObj.getPath());
+        }
       }
       break;
     case REPLAY:
-      LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
-          getOmRequest());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
+            getOmRequest());
+      }
       break;
     case FAILURE:
       omMetrics.incNumBucketUpdateFails();
@@ -121,9 +125,13 @@ public class OMPrefixSetAclRequest extends OMPrefixAclRequest {
 
   @Override
   OMPrefixAclOpResult apply(PrefixManagerImpl prefixManager,
-      OmPrefixInfo omPrefixInfo) throws IOException {
-    return prefixManager.setAcl(ozoneObj, ozoneAcls, omPrefixInfo);
+      OmPrefixInfo omPrefixInfo, long trxnLogIndex) throws IOException {
+    OMPrefixAclOpResult operationResult = prefixManager.setAcl(ozoneObj,
+        ozoneAcls, omPrefixInfo, trxnLogIndex);
+    if (operationResult.isSuccess()) {
+      operationResult.getOmPrefixInfo().setUpdateID(trxnLogIndex);
+    }
+    return operationResult;
   }
-
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixSetAclRequest.java
@@ -97,13 +97,8 @@ public class OMPrefixSetAclRequest extends OMPrefixAclRequest {
     switch (result) {
     case SUCCESS:
       if (LOG.isDebugEnabled()) {
-        if (operationResult) {
-          LOG.debug("Set acl: {} to path: {} success!", ozoneAcls,
-              ozoneObj.getPath());
-        } else {
-          LOG.debug("Set acl {} to path {} failed", ozoneAcls,
-              ozoneObj.getPath());
-        }
+        LOG.debug("Set acl: {} to path: {} success!", ozoneAcls,
+            ozoneObj.getPath());
       }
       break;
     case REPLAY:
@@ -126,12 +121,8 @@ public class OMPrefixSetAclRequest extends OMPrefixAclRequest {
   @Override
   OMPrefixAclOpResult apply(PrefixManagerImpl prefixManager,
       OmPrefixInfo omPrefixInfo, long trxnLogIndex) throws IOException {
-    OMPrefixAclOpResult operationResult = prefixManager.setAcl(ozoneObj,
-        ozoneAcls, omPrefixInfo, trxnLogIndex);
-    if (operationResult.isSuccess()) {
-      operationResult.getOmPrefixInfo().setUpdateID(trxnLogIndex);
-    }
-    return operationResult;
+    return prefixManager.setAcl(ozoneObj, ozoneAcls, omPrefixInfo,
+        trxnLogIndex);
   }
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixSetAclRequest.java
@@ -81,32 +81,41 @@ public class OMPrefixSetAclRequest extends OMPrefixAclRequest {
     omResponse.setSuccess(operationResult);
     omResponse.setSetAclResponse(SetAclResponse.newBuilder()
         .setResponse(operationResult));
-    return new OMPrefixAclResponse(omPrefixInfo,
-        omResponse.build());
+    return new OMPrefixAclResponse(omResponse.build(), omPrefixInfo);
   }
 
   @Override
   OMClientResponse onFailure(OMResponse.Builder omResponse,
       IOException exception) {
-    return new OMPrefixAclResponse(null,
-        createErrorOMResponse(omResponse, exception));
+    return new OMPrefixAclResponse(createErrorOMResponse(omResponse,
+        exception));
   }
 
   @Override
   void onComplete(boolean operationResult, IOException exception,
-      OMMetrics omMetrics) {
-    if (operationResult) {
-      LOG.debug("Set acl: {} to path: {} success!", ozoneAcls,
-          ozoneObj.getPath());
-    } else {
-      omMetrics.incNumBucketUpdateFails();
-      if (exception == null) {
-        LOG.debug("Set acl {} to path {} failed", ozoneAcls,
+      OMMetrics omMetrics, Result result, long trxnLogIndex) {
+    switch (result) {
+    case SUCCESS:
+      if (operationResult) {
+        LOG.debug("Set acl: {} to path: {} success!", ozoneAcls,
             ozoneObj.getPath());
       } else {
-        LOG.error("Set acl {} to path {} failed!", ozoneAcls,
-            ozoneObj.getPath(), exception);
+        LOG.debug("Set acl {} to path {} failed", ozoneAcls,
+            ozoneObj.getPath());
       }
+      break;
+    case REPLAY:
+      LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
+          getOmRequest());
+      break;
+    case FAILURE:
+      omMetrics.incNumBucketUpdateFails();
+      LOG.error("Set acl {} to path {} failed!", ozoneAcls,
+          ozoneObj.getPath(), exception);
+      break;
+    default:
+      LOG.error("Unrecognized Result for OMPrefixSetAclRequest: {}",
+          getOmRequest());
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/acl/prefix/OMPrefixAclResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/acl/prefix/OMPrefixAclResponse.java
@@ -21,47 +21,52 @@ package org.apache.hadoop.ozone.om.response.key.acl.prefix;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 
 /**
  * Response for Prefix Acl request.
  */
 public class OMPrefixAclResponse extends OMClientResponse {
-  private final OmPrefixInfo prefixInfo;
 
-  public OMPrefixAclResponse(@Nullable OmPrefixInfo omPrefixInfo,
-      @Nonnull OzoneManagerProtocolProtos.OMResponse omResponse) {
+  private OmPrefixInfo prefixInfo;
+
+  public OMPrefixAclResponse(@Nonnull OMResponse omResponse,
+      @Nonnull OmPrefixInfo omPrefixInfo) {
     super(omResponse);
     this.prefixInfo = omPrefixInfo;
+  }
+
+  /**
+   * For when the request is not successful or it is a replay transaction.
+   * For a successful request, the other constructor should be used.
+   */
+  public OMPrefixAclResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
   }
 
   @Override
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    // If response status is OK and success is true, add to DB batch.
-    if (getOMResponse().getSuccess()) {
-      if ((getOMResponse().hasAddAclResponse()
-          && getOMResponse().getAddAclResponse().getResponse()) ||
-          (getOMResponse().hasSetAclResponse()
-              && getOMResponse().getSetAclResponse().getResponse())) {
+    if ((getOMResponse().hasAddAclResponse()
+        && getOMResponse().getAddAclResponse().getResponse()) ||
+        (getOMResponse().hasSetAclResponse()
+            && getOMResponse().getSetAclResponse().getResponse())) {
+      omMetadataManager.getPrefixTable().putWithBatch(batchOperation,
+          prefixInfo.getName(), prefixInfo);
+    } else if ((getOMResponse().hasRemoveAclResponse()
+        && getOMResponse().getRemoveAclResponse().getResponse())) {
+      if (prefixInfo.getAcls().size() == 0) {
+        // if acl list size is zero delete.
+        omMetadataManager.getPrefixTable().deleteWithBatch(batchOperation,
+            prefixInfo.getName());
+      } else {
         omMetadataManager.getPrefixTable().putWithBatch(batchOperation,
             prefixInfo.getName(), prefixInfo);
-      } else if ((getOMResponse().hasRemoveAclResponse()
-          && getOMResponse().getRemoveAclResponse().getResponse())) {
-        if (prefixInfo.getAcls().size() == 0) {
-          // if acl list size is zero delete.
-          omMetadataManager.getPrefixTable().deleteWithBatch(batchOperation,
-              prefixInfo.getName());
-        } else {
-          omMetadataManager.getPrefixTable().putWithBatch(batchOperation,
-              prefixInfo.getName(), prefixInfo);
-        }
       }
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/acl/prefix/OMPrefixAclResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/acl/prefix/OMPrefixAclResponse.java
@@ -52,25 +52,16 @@ public class OMPrefixAclResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    if ((getOMResponse().hasAddAclResponse()
-        && getOMResponse().getAddAclResponse().getResponse()) ||
-        (getOMResponse().hasSetAclResponse()
-            && getOMResponse().getSetAclResponse().getResponse())) {
+    if (getOMResponse().hasRemoveAclResponse() &&
+        prefixInfo.getAcls().size() == 0) {
+      // if acl list size is zero, delete the entry.
+      omMetadataManager.getPrefixTable().deleteWithBatch(batchOperation,
+          prefixInfo.getName());
+    } else {
       omMetadataManager.getPrefixTable().putWithBatch(batchOperation,
           prefixInfo.getName(), prefixInfo);
-    } else if ((getOMResponse().hasRemoveAclResponse()
-        && getOMResponse().getRemoveAclResponse().getResponse())) {
-      if (prefixInfo.getAcls().size() == 0) {
-        // if acl list size is zero delete.
-        omMetadataManager.getPrefixTable().deleteWithBatch(batchOperation,
-            prefixInfo.getName());
-      } else {
-        omMetadataManager.getPrefixTable().putWithBatch(batchOperation,
-            prefixInfo.getName(), prefixInfo);
-      }
     }
   }
-
 }
 
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMPrefixAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMPrefixAclRequest.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.request.key;
+
+import java.util.UUID;
+import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.om.PrefixManager;
+import org.apache.hadoop.ozone.om.PrefixManagerImpl;
+import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
+import org.apache.hadoop.ozone.om.request.key.acl.prefix.OMPrefixAddAclRequest;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AddAclRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.security.acl.OzoneObj;
+import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests Prefix ACL requests.
+ */
+public class TestOMPrefixAclRequest extends TestOMKeyRequest {
+
+  @Test
+  public void testReplayRequest() throws Exception {
+    PrefixManager prefixManager = new PrefixManagerImpl(
+        ozoneManager.getMetadataManager(), true);
+    when(ozoneManager.getPrefixManager()).thenReturn(prefixManager);
+
+    // Manually add volume, bucket and key to DB
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
+    TestOMRequestUtils.addKeyToTable(false, false, volumeName, bucketName,
+        keyName, clientID, replicationType, replicationFactor, 1L,
+        omMetadataManager);
+
+    OzoneAcl acl = OzoneAcl.parseAcl("user:bilbo:rwdlncxy[ACCESS]");
+
+    // Create KeyAddAcl request
+    OMRequest originalRequest = createAddAclkeyRequest(acl);
+    OMPrefixAddAclRequest omKeyPrefixAclRequest = new OMPrefixAddAclRequest(
+        originalRequest);
+    omKeyPrefixAclRequest.preExecute(ozoneManager);
+
+    // Execute original request
+    OMClientResponse omClientResponse = omKeyPrefixAclRequest
+        .validateAndUpdateCache(ozoneManager, 2,
+            ozoneManagerDoubleBufferHelper);
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omClientResponse.getOMResponse().getStatus());
+
+    // Replay the original request
+    OMClientResponse replayResponse = omKeyPrefixAclRequest
+        .validateAndUpdateCache(ozoneManager, 2,
+            ozoneManagerDoubleBufferHelper);
+
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.REPLAY,
+        replayResponse.getOMResponse().getStatus());
+  }
+
+  /**
+   * Create OMRequest which encapsulates OMKeyAddAclRequest.
+   */
+  private OMRequest createAddAclkeyRequest(OzoneAcl acl) {
+    OzoneObj obj = OzoneObjInfo.Builder.newBuilder()
+        .setBucketName(bucketName)
+        .setVolumeName(volumeName)
+        .setKeyName(keyName)
+        .setResType(OzoneObj.ResourceType.PREFIX)
+        .setStoreType(OzoneObj.StoreType.OZONE)
+        .build();
+    AddAclRequest addAclRequest = AddAclRequest.newBuilder()
+        .setObj(OzoneObj.toProtobuf(obj))
+        .setAcl(OzoneAcl.toProtobuf(acl))
+        .build();
+
+    return OMRequest.newBuilder().setClientId(UUID.randomUUID().toString())
+        .setCmdType(OzoneManagerProtocolProtos.Type.AddAcl)
+        .setAddAclRequest(addAclRequest)
+        .build();
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

To ensure that Prefix acl operations are idempotent, compare the transactionID with the objectID and updateID to make sure that the transaction is not a replay. If the transactionID <= updateID, then it implies that the transaction is a replay and hence it should be skipped.

OMPrefixAclRequests (Add, Remove and Set ACL requests) are made idempotent in this Jira.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2962

## How was this patch tested?

Unit tests added.
