### PR TITLE
HDDS-2957. listBuckets result should include the exact match of bucketPrefix

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1432,6 +1432,32 @@ public abstract class TestOzoneRpcClientAbstract {
   }
 
   @Test
+  public void testListBucketWithPrefixAsExactBucketName()
+      throws IOException {
+    // Create a volume
+    String volumeName = "vol-a-" + RandomStringUtils.randomNumeric(5);
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    // Create a bucket
+    String bucketName = "bucket-a-" + "-" + RandomStringUtils.randomNumeric(5);
+    volume.createBucket(bucketName);
+
+    // Test listBuckets: bucketPrefix is PART of bucketName
+    Iterator<? extends OzoneBucket> volABucketIter =
+        volume.listBuckets("bucket-");
+    Assert.assertTrue(volABucketIter.hasNext());
+    OzoneBucket ozoneBucket = volABucketIter.next();
+    Assert.assertEquals(bucketName, ozoneBucket.getName());
+
+    // Test listBuckets: bucketPrefix is EXACTLY bucketName
+    volABucketIter = volume.listBuckets(bucketName);
+    // Should match the bucket
+    Assert.assertTrue(volABucketIter.hasNext());
+    ozoneBucket = volABucketIter.next();
+    Assert.assertEquals(bucketName, ozoneBucket.getName());
+  }
+
+  @Test
   public void testListKey()
       throws IOException {
     String volumeA = "vol-a-" + RandomStringUtils.randomNumeric(5);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -661,7 +661,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
 
         // We should return only the keys, whose keys match with prefix and
         // the keys after the startBucket.
-        if (key.startsWith(seekPrefix) && key.compareTo(startKey) > 0) {
+        if (key.startsWith(seekPrefix) && key.compareTo(startKey) >= 0) {
           result.add(omBucketInfo);
           currentCount++;
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

I noticed that `OzoneVolume.listBuckets(String bucketPrefix)` behaves differently than `ObjectStore.listVolumes(String volumePrefix)` with a given prefix: `listBuckets` ignores the `bucketPrefix` in the result if it is an exact match; `listVolumes` doesn't.

e.g. If we have a bucket named `bucket-12345`, currently `OzoneVolume.listBuckets("bucket-12345")` will NOT return bucket-12345 in its result.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2957

## How was this patch tested?

Added unit test `testListBucketWithPrefixAsExactBucketName` and passed.

Undoing the fix in `OmMetadataManagerImpl` will cause the last step in the unit test to fail.