### PR TITLE
HDDS-2972. Any container replication error can terminate SCM service.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -330,6 +330,8 @@ public class ReplicationManager implements MetricsSource {
 
     } catch (ContainerNotFoundException ex) {
       LOG.warn("Missing container {}.", id);
+    } catch (Exception ex) {
+      LOG.warn("Process container {} error: ", id, ex);
     } finally {
       lockManager.unlock(id);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Catch the exception thrown in processing container under class ReplicationManage.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2972

## How was this patch tested?
Will be added.