### PR TITLE
HDDS-2977. ozonesecure acceptance test fails due to unexpected error message

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
@@ -39,7 +39,7 @@ Create volume bucket with wrong credentials
 Create volume with non-admin user
     Run Keyword         Kinit test user     testuser2     testuser2.keytab
     ${rc}               ${output} =          Run And Return Rc And Output       ozone sh volume create o3://om/fstest
-    Should contain      ${output}       Client cannot authenticate via
+    Should contain      ${output}       Only admin users are authorized to create
 
 Create volume bucket with credentials
                         # Authenticate testuser


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix expected error message in `Create volume with non-admin user` acceptance test.  Volume creation is rejected because `testuser2` is not an admin, not due to authentication failure.

https://issues.apache.org/jira/browse/HDDS-2977

## How was this patch tested?

Ran acceptance test (specific test locally, all tests in CI):

https://github.com/adoroszlai/hadoop-ozone/runs/425107849