### PR TITLE
HDDS-2979. Implement ofs://: Fix getFileStatus for mkdir volume

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -329,6 +330,8 @@ public class TestRootedOzoneFileSystem {
     Assert.assertNotNull(fileStatus);
     Assert.assertNull(fileStatus.getPath());
     Assert.assertTrue(fileStatus.isDirectory());
+    Assert.assertEquals(
+        new FsPermission((short)00755), fileStatus.getPermission());
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,6 +51,7 @@ import static org.apache.hadoop.fs.ozone.Constants.LISTING_PAGE_SIZE;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -280,7 +282,7 @@ public class TestRootedOzoneFileSystem {
   }
 
   /**
-   * OFS: Tests mkdir on a volume and bucket that doesn't exist.
+   * OFS: Test mkdir on a volume and bucket that doesn't exist.
    */
   @Test
   public void testMkdirNonExistentVolumeBucket() throws Exception {
@@ -307,7 +309,7 @@ public class TestRootedOzoneFileSystem {
   }
 
   /**
-   * OFS: Tests mkdir on a volume that doesn't exist.
+   * OFS: Test mkdir on a volume that doesn't exist.
    */
   @Test
   public void testMkdirNonExistentVolume() throws Exception {
@@ -326,10 +328,22 @@ public class TestRootedOzoneFileSystem {
   }
 
   /**
-   * Tests listStatus operation in a bucket.
+   * OFS: Test getListStatus on root.
    */
   @Test
-  public void testListStatusOnRoot() throws Exception {
+  public void testGetListStatusRoot() throws Exception {
+    Path root = new Path("/");
+    FileStatus fileStatus = fs.getFileStatus(root);
+    Assert.assertNotNull(fileStatus);
+    Assert.assertNull(fileStatus.getPath());
+    Assert.assertTrue(fileStatus.isDirectory());
+  }
+
+  /**
+   * Test listStatus operation in a bucket.
+   */
+  @Test
+  public void testListStatusInBucket() throws Exception {
     Path root = new Path("/" + volumeName + "/" + bucketName);
     Path dir1 = new Path(root, "dir1");
     Path dir12 = new Path(dir1, "dir12");
@@ -347,8 +361,8 @@ public class TestRootedOzoneFileSystem {
     // Verify that dir12 is not included in the result of the listStatus on root
     String fileStatus1 = fileStatuses[0].getPath().toUri().getPath();
     String fileStatus2 = fileStatuses[1].getPath().toUri().getPath();
-    assertFalse(fileStatus1.equals(dir12.toString()));
-    assertFalse(fileStatus2.equals(dir12.toString()));
+    assertNotEquals(fileStatus1, dir12.toString());
+    assertNotEquals(fileStatus2, dir12.toString());
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -320,7 +320,7 @@ public class TestRootedOzoneFileSystem {
   }
 
   /**
-   * OFS: Test getListStatus on root.
+   * OFS: Test getFileStatus on root.
    */
   @Test
   public void testGetFileStatusRoot() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -323,7 +323,7 @@ public class TestRootedOzoneFileSystem {
    * OFS: Test getListStatus on root.
    */
   @Test
-  public void testGetListStatusRoot() throws Exception {
+  public void testGetFileStatusRoot() throws Exception {
     Path root = new Path("/");
     FileStatus fileStatus = fs.getFileStatus(root);
     Assert.assertNotNull(fileStatus);

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -439,6 +439,12 @@ public class BasicRootedOzoneClientAdapterImpl
     incrementCounter(Statistic.OBJECTS_QUERY);
     OFSPath ofsPath = new OFSPath(path);
     String key = ofsPath.getKeyName();
+    // getFileStatus is called for root
+    if (ofsPath.getVolumeName().isEmpty() &&
+        ofsPath.getBucketName().isEmpty()) {
+      // Generate a FileStatusAdapter for root
+      return rootFileStatusAdapter();
+    }
     try {
       OzoneBucket bucket = getBucket(ofsPath, false);
       OzoneFileStatus status = bucket.getFileStatus(key);
@@ -655,6 +661,22 @@ public class BasicRootedOzoneClientAdapterImpl
         status.getOwner(),
         status.getGroup(),
         status.getPath()
+    );
+  }
+
+  private FileStatusAdapter rootFileStatusAdapter() {
+    return new FileStatusAdapter(
+        0L,
+        null,
+        true,
+        (short)0,
+        0L,
+        0L,
+        0L,
+        (short)0,
+        null,
+        null,
+        null
     );
   }
 }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -81,8 +81,8 @@ public class BasicRootedOzoneClientAdapterImpl
       LoggerFactory.getLogger(BasicRootedOzoneClientAdapterImpl.class);
 
   private OzoneClient ozoneClient;
-  private ClientProtocol proxy;
   private ObjectStore objectStore;
+  private ClientProtocol proxy;
   private ReplicationType replicationType;
   private ReplicationFactor replicationFactor;
   private boolean securityEnabled;

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -199,11 +199,11 @@ public class BasicRootedOzoneClientAdapterImpl
       boolean createIfNotExist) throws IOException {
     Preconditions.checkNotNull(volumeStr);
     Preconditions.checkNotNull(bucketStr);
-
-    if (!createIfNotExist && bucketStr.isEmpty()) {
-      // Make Hadoop common happy by throwing FileNotFoundException in this case
-      throw new FileNotFoundException("getBucket: Invalid arguments: "
-          + "bucket is empty string while create flag is not set.");
+    
+    if (bucketStr.isEmpty()) {
+      // Make Hadoop common happy by throwing FileNotFoundException in this case.
+      throw new FileNotFoundException(
+          "getBucket: Invalid argument: given bucket string is empty.");
     }
 
     OzoneBucket bucket;
@@ -357,11 +357,11 @@ public class BasicRootedOzoneClientAdapterImpl
     LOG.trace("creating dir for path: {}", pathStr);
     incrementCounter(Statistic.OBJECTS_CREATED);
     OFSPath ofsPath = new OFSPath(pathStr);
-    if (ofsPath.getVolumeName().length() == 0) {
+    if (ofsPath.getVolumeName().isEmpty()) {
       // Volume name unspecified, invalid param, return failure
       return false;
     }
-    if (ofsPath.getBucketName().length() == 0) {
+    if (ofsPath.getBucketName().isEmpty()) {
       // Create volume only
       objectStore.createVolume(ofsPath.getVolumeName());
       return true;

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -664,7 +664,14 @@ public class BasicRootedOzoneClientAdapterImpl
     );
   }
 
+  /**
+   * Generate a FileStatusAdapter for OFS root.
+   * @return FileStatusAdapter for root.
+   */
   private FileStatusAdapter rootFileStatusAdapter() {
+    // Note that most fields are mimicked from HDFS FileStatus for root,
+    //  except modification time, permission, owner and group.
+    // TODO: Revisit the return value.
     return new FileStatusAdapter(
         0L,
         null,

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -680,7 +680,7 @@ public class BasicRootedOzoneClientAdapterImpl
         0L,
         0L,
         0L,
-        (short)0,
+        (short)00755,
         null,
         null,
         null

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -668,7 +668,7 @@ public class BasicRootedOzoneClientAdapterImpl
    * Generate a FileStatusAdapter for OFS root.
    * @return FileStatusAdapter for root.
    */
-  private FileStatusAdapter rootFileStatusAdapter() {
+  private static FileStatusAdapter rootFileStatusAdapter() {
     // Note that most fields are mimicked from HDFS FileStatus for root,
     //  except modification time, permission, owner and group.
     // TODO: Revisit the return value.

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -201,7 +201,7 @@ public class BasicRootedOzoneClientAdapterImpl
     Preconditions.checkNotNull(bucketStr);
     
     if (bucketStr.isEmpty()) {
-      // Make Hadoop common happy by throwing FileNotFoundException in this case.
+      // throw FileNotFoundException in this case to make Hadoop common happy
       throw new FileNotFoundException(
           "getBucket: Invalid argument: given bucket string is empty.");
     }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import com.google.common.base.Preconditions;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.crypto.key.KeyProvider;
@@ -196,6 +197,14 @@ public class BasicRootedOzoneClientAdapterImpl
    */
   private OzoneBucket getBucket(String volumeStr, String bucketStr,
       boolean createIfNotExist) throws IOException {
+    Preconditions.checkNotNull(volumeStr);
+    Preconditions.checkNotNull(bucketStr);
+
+    if (!createIfNotExist && bucketStr.isEmpty()) {
+      // Make Hadoop common happy by throwing FileNotFoundException in this case
+      throw new FileNotFoundException("getBucket: Invalid arguments: "
+          + "bucket is empty string while create flag is not set.");
+    }
 
     OzoneBucket bucket;
     try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Xiaoyu Yao discovered that when running ozone fs -mkdir -p ofs://om/vol1/ (only volume name is given, no bucket name or key path), the command would fail in getFileStatus (before reaching createDirectory()) in Hadoop common code:
```
bash-4.2$ ozone fs -mkdir -p ofs://om/vol1/
-mkdir: Bucket or Volume length is illegal, valid length is 3-63 characters

# Same w/o -p
bash-4.2$ ozone fs -mkdir ofs://om/vol1/
-mkdir: Bucket or Volume length is illegal, valid length is 3-63 characters
And we discovered with debugger attached that the root cause is that getFileStatus() is not behaving as expected.
```
Solution: Patch existing OFS code, throw proper exception in getBucket() code to make Hadoop common happy.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2979

## How was this patch tested?

Manually ran `ozone fs -mkdir -p ofs://om/vol1/` in `docker-compose` cluster:

```
bash-4.2$ ozone fs -mkdir -p ofs://om/vol1/
2020-02-04 20:58:25,828 [main] INFO rpc.RpcClient: Creating Volume: vol1, with hadoop as owner.
```

Will add a new unit test for this case.