### PR TITLE
HDDS-2982. Recon server start failed with CNF exception in a cluster …

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -82,7 +82,13 @@ public class ReconServer extends GenericCli {
       LOG.info("Creating Recon Schema.");
       reconSchemaManager.createReconSchema();
 
-      httpServer = injector.getInstance(ReconHttpServer.class);
+      // TODO Remove try-catch block after HDDS-2041 is fixed.
+      // Allowing Recon server start even if HTTP server start failed
+      try {
+        httpServer = injector.getInstance(ReconHttpServer.class);
+      } catch (Exception ex) {
+        LOG.error("Error trying to start HTTP Server. ", ex);
+      }
       this.ozoneManagerServiceProvider =
           injector.getInstance(OzoneManagerServiceProvider.class);
       this.reconStorageContainerManager =
@@ -114,7 +120,10 @@ public class ReconServer extends GenericCli {
     if (!isStarted) {
       LOG.info("Starting Recon server");
       isStarted = true;
-      httpServer.start();
+      // TODO Remove null check after HDDS-2041 is fixed.
+      if (httpServer != null) {
+        httpServer.start();
+      }
       ozoneManagerServiceProvider.start();
       reconStorageContainerManager.start();
     }


### PR DESCRIPTION
…with Auto TLS enabled.

## What changes were proposed in this pull request?
Recon server crashes on a cluster with Auto TLS enabled due to CNF error while starting up its HTTP server. Recon's Httpserver is inherited from BaseHttpServer that is used by all the other components in Ozone. The underlying problem is being fixed in HDDS-2041. Since the other components like the SCM, OM start successfully even if their HTTP Server is not up, this patch relaxes the start for Recon as well. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2982

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?
Manually tested.