### PR TITLE
HDDS-2041. Don't depend on DFSUtil to check HTTP policy.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -708,8 +708,8 @@ public final class HddsUtils {
       }
     }
 
-    boolean requireClientAuth = conf.getBoolean(OZONE_CLIENT_HTTPS_NEED_AUTH_KEY,
-        OZONE_CLIENT_HTTPS_NEED_AUTH_DEFAULT);
+    boolean requireClientAuth = conf.getBoolean(
+        OZONE_CLIENT_HTTPS_NEED_AUTH_KEY, OZONE_CLIENT_HTTPS_NEED_AUTH_DEFAULT);
     sslConf.setBoolean(OZONE_CLIENT_HTTPS_NEED_AUTH_KEY, requireClientAuth);
     return sslConf;
   }
@@ -746,8 +746,7 @@ public final class HddsUtils {
       if (passchars != null) {
         password = new String(passchars);
       }
-    }
-    catch (IOException ioe) {
+    } catch (IOException ioe) {
       LOG.warn("Setting password to null since IOException is caught"
           + " when getting password", ioe);
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.net.UnknownHostException;
 import java.nio.file.Path;
 import java.util.Calendar;
@@ -34,6 +35,7 @@ import java.util.OptionalInt;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
@@ -48,6 +50,8 @@ import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslator
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolPB;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.protocolPB.ScmBlockLocationProtocolPB;
+import org.apache.hadoop.http.HttpConfig;
+import org.apache.hadoop.http.HttpServer2;
 import org.apache.hadoop.io.retry.RetryPolicies;
 import org.apache.hadoop.io.retry.RetryPolicy;
 import org.apache.hadoop.ipc.Client;
@@ -60,6 +64,8 @@ import org.apache.hadoop.metrics2.source.JvmMetrics;
 import org.apache.hadoop.metrics2.util.MBeans;
 import org.apache.hadoop.net.DNS;
 import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 
 import com.google.common.base.Preconditions;
@@ -70,6 +76,14 @@ import static org.apache.hadoop.hdds.DFSConfigKeysLegacy.DFS_DATANODE_DNS_NAMESE
 import static org.apache.hadoop.hdds.DFSConfigKeysLegacy.DFS_DATANODE_HOST_NAME_KEY;
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_ADDRESS_KEY;
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_DATANODE_PORT_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_HTTPS_NEED_AUTH_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_HTTPS_NEED_AUTH_KEY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SERVER_HTTPS_KEYPASSWORD_KEY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SERVER_HTTPS_KEYSTORE_PASSWORD_KEY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SERVER_HTTPS_TRUSTSTORE_PASSWORD_KEY;
+
+import org.apache.hadoop.security.authorize.AccessControlList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -605,5 +619,140 @@ public final class HddsUtils {
     builder.append(location);
 
     return builder.toString();
+  }
+
+  public static HttpConfig.Policy getHttpPolicy(Configuration conf) {
+    String policyStr = conf.get(OzoneConfigKeys.OZONE_HTTP_POLICY_KEY,
+        OzoneConfigKeys.OZONE_HTTP_POLICY_DEFAULT);
+    HttpConfig.Policy policy = HttpConfig.Policy.fromString(policyStr);
+    if (policy == null) {
+      throw new HadoopIllegalArgumentException("Unregonized value '"
+          + policyStr + "' for " + OzoneConfigKeys.OZONE_HTTP_POLICY_KEY);
+    }
+    conf.set(OzoneConfigKeys.OZONE_HTTP_POLICY_KEY, policy.name());
+    return policy;
+  }
+
+  /**
+   * Return a HttpServer.Builder that the OzoneManager/SCM/Datanode/S3Gateway/
+   * Recon to initialize their HTTP / HTTPS server.
+   */
+  public static HttpServer2.Builder newHttpServer2BuilderForOzone(
+      Configuration conf, final InetSocketAddress httpAddr,
+      final InetSocketAddress httpsAddr, String name, String spnegoUserNameKey,
+      String spnegoKeytabFileKey) throws IOException {
+    HttpConfig.Policy policy = getHttpPolicy(conf);
+
+    HttpServer2.Builder builder = new HttpServer2.Builder().setName(name)
+        .setConf(conf).setACL(new AccessControlList(conf.get(
+            OZONE_ADMINISTRATORS, " ")))
+        .setSecurityEnabled(UserGroupInformation.isSecurityEnabled())
+        .setUsernameConfKey(spnegoUserNameKey)
+        .setKeytabConfKey(spnegoKeytabFileKey);
+
+    // initialize the webserver for uploading/downloading files.
+    if (UserGroupInformation.isSecurityEnabled()) {
+      LOG.info("Starting web server as: "
+          + SecurityUtil.getServerPrincipal(conf.get(spnegoUserNameKey),
+          httpAddr.getHostName()));
+    }
+
+    if (policy.isHttpEnabled()) {
+      if (httpAddr.getPort() == 0) {
+        builder.setFindPort(true);
+      }
+
+      URI uri = URI.create("http://" + NetUtils.getHostPortString(httpAddr));
+      builder.addEndpoint(uri);
+      LOG.info("Starting Web-server for " + name + " at: " + uri);
+    }
+
+    if (policy.isHttpsEnabled() && httpsAddr != null) {
+      Configuration sslConf = loadSslConfiguration(conf);
+      loadSslConfToHttpServerBuilder(builder, sslConf);
+
+      if (httpsAddr.getPort() == 0) {
+        builder.setFindPort(true);
+      }
+
+      URI uri = URI.create("https://" + NetUtils.getHostPortString(httpsAddr));
+      builder.addEndpoint(uri);
+      LOG.info("Starting Web-server for " + name + " at: " + uri);
+    }
+    return builder;
+  }
+
+  /**
+   * Load HTTPS-related configuration.
+   */
+  public static Configuration loadSslConfiguration(Configuration conf) {
+    Configuration sslConf = new Configuration(false);
+
+    sslConf.addResource(conf.get(
+        OzoneConfigKeys.OZONE_SERVER_HTTPS_KEYSTORE_RESOURCE_KEY,
+        OzoneConfigKeys.OZONE_SERVER_HTTPS_KEYSTORE_RESOURCE_DEFAULT));
+
+    final String[] reqSslProps = {
+        OzoneConfigKeys.OZONE_SERVER_HTTPS_TRUSTSTORE_LOCATION_KEY,
+        OzoneConfigKeys.OZONE_SERVER_HTTPS_KEYSTORE_LOCATION_KEY,
+        OzoneConfigKeys.OZONE_SERVER_HTTPS_KEYSTORE_PASSWORD_KEY,
+        OzoneConfigKeys.OZONE_SERVER_HTTPS_KEYPASSWORD_KEY
+    };
+
+    // Check if the required properties are included
+    for (String sslProp : reqSslProps) {
+      if (sslConf.get(sslProp) == null) {
+        LOG.warn("SSL config " + sslProp + " is missing. If " +
+            OzoneConfigKeys.OZONE_SERVER_HTTPS_KEYSTORE_RESOURCE_KEY +
+            " is specified, make sure it is a relative path");
+      }
+    }
+
+    boolean requireClientAuth = conf.getBoolean(OZONE_CLIENT_HTTPS_NEED_AUTH_KEY,
+        OZONE_CLIENT_HTTPS_NEED_AUTH_DEFAULT);
+    sslConf.setBoolean(OZONE_CLIENT_HTTPS_NEED_AUTH_KEY, requireClientAuth);
+    return sslConf;
+  }
+
+  public static HttpServer2.Builder loadSslConfToHttpServerBuilder(
+      HttpServer2.Builder builder, Configuration sslConf) {
+    return builder
+        .needsClientAuth(
+            sslConf.getBoolean(OZONE_CLIENT_HTTPS_NEED_AUTH_KEY,
+                OZONE_CLIENT_HTTPS_NEED_AUTH_DEFAULT))
+        .keyPassword(getPassword(sslConf, OZONE_SERVER_HTTPS_KEYPASSWORD_KEY))
+        .keyStore(sslConf.get("ssl.server.keystore.location"),
+            getPassword(sslConf, OZONE_SERVER_HTTPS_KEYSTORE_PASSWORD_KEY),
+            sslConf.get("ssl.server.keystore.type", "jks"))
+        .trustStore(sslConf.get("ssl.server.truststore.location"),
+            getPassword(sslConf, OZONE_SERVER_HTTPS_TRUSTSTORE_PASSWORD_KEY),
+            sslConf.get("ssl.server.truststore.type", "jks"))
+        .excludeCiphers(
+            sslConf.get("ssl.server.exclude.cipher.list"));
+  }
+
+  /**
+   * Leverages the Configuration.getPassword method to attempt to get
+   * passwords from the CredentialProvider API before falling back to
+   * clear text in config - if falling back is allowed.
+   * @param conf Configuration instance
+   * @param alias name of the credential to retreive
+   * @return String credential value or null
+   */
+  static String getPassword(Configuration conf, String alias) {
+    String password = null;
+    try {
+      char[] passchars = conf.getPassword(alias);
+      if (passchars != null) {
+        password = new String(passchars);
+      }
+    }
+    catch (IOException ioe) {
+      LOG.warn("Setting password to null since IOException is caught"
+          + " when getting password", ioe);
+
+      password = null;
+    }
+    return password;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -429,7 +429,6 @@ public final class OzoneConfigKeys {
       "ozone.http.policy";
   public static final String OZONE_HTTP_POLICY_DEFAULT =
       HttpConfig.Policy.HTTP_ONLY.name();
-
   public static final String  OZONE_SERVER_HTTPS_KEYSTORE_RESOURCE_KEY =
       "ozone.https.server.keystore.resource";
   public static final String  OZONE_SERVER_HTTPS_KEYSTORE_RESOURCE_DEFAULT =
@@ -444,15 +443,13 @@ public final class OzoneConfigKeys {
       "ssl.server.truststore.location";
   public static final String  OZONE_SERVER_HTTPS_TRUSTSTORE_PASSWORD_KEY =
       "ssl.server.truststore.password";
-
-  public static final String  OZONE_CLIENT_HTTPS_NEED_AUTH_KEY =
-      "ozone.https.client.need.auth";
-  public static final boolean OZONE_CLIENT_HTTPS_NEED_AUTH_DEFAULT = false;
-
   public static final String  OZONE_CLIENT_HTTPS_KEYSTORE_RESOURCE_KEY =
       "ozone.https.client.keystore.resource";
   public static final String  OZONE_CLIENT_HTTPS_KEYSTORE_RESOURCE_DEFAULT =
       "ssl-client.xml";
+  public static final String  OZONE_CLIENT_HTTPS_NEED_AUTH_KEY =
+      "ozone.https.client.need-auth";
+  public static final boolean OZONE_CLIENT_HTTPS_NEED_AUTH_DEFAULT = false;
   /**
    * There is no need to instantiate this class.
    */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 
+import org.apache.hadoop.http.HttpConfig;
 import org.apache.ratis.proto.RaftProtos.ReplicationLevel;
 import org.apache.ratis.util.TimeDuration;
 
@@ -424,6 +425,34 @@ public final class OzoneConfigKeys {
 
   public static final String OZONE_HTTP_BASEDIR = "ozone.http.basedir";
 
+  public static final String OZONE_HTTP_POLICY_KEY =
+      "ozone.http.policy";
+  public static final String OZONE_HTTP_POLICY_DEFAULT =
+      HttpConfig.Policy.HTTP_ONLY.name();
+
+  public static final String  OZONE_SERVER_HTTPS_KEYSTORE_RESOURCE_KEY =
+      "ozone.https.server.keystore.resource";
+  public static final String  OZONE_SERVER_HTTPS_KEYSTORE_RESOURCE_DEFAULT =
+      "ssl-server.xml";
+  public static final String  OZONE_SERVER_HTTPS_KEYPASSWORD_KEY =
+      "ssl.server.keystore.keypassword";
+  public static final String  OZONE_SERVER_HTTPS_KEYSTORE_PASSWORD_KEY =
+      "ssl.server.keystore.password";
+  public static final String  OZONE_SERVER_HTTPS_KEYSTORE_LOCATION_KEY =
+      "ssl.server.keystore.location";
+  public static final String  OZONE_SERVER_HTTPS_TRUSTSTORE_LOCATION_KEY =
+      "ssl.server.truststore.location";
+  public static final String  OZONE_SERVER_HTTPS_TRUSTSTORE_PASSWORD_KEY =
+      "ssl.server.truststore.password";
+
+  public static final String  OZONE_CLIENT_HTTPS_NEED_AUTH_KEY =
+      "ozone.https.client.need.auth";
+  public static final boolean OZONE_CLIENT_HTTPS_NEED_AUTH_DEFAULT = false;
+
+  public static final String  OZONE_CLIENT_HTTPS_KEYSTORE_RESOURCE_KEY =
+      "ozone.https.client.keystore.resource";
+  public static final String  OZONE_CLIENT_HTTPS_KEYSTORE_RESOURCE_DEFAULT =
+      "ssl-client.xml";
   /**
    * There is no need to instantiate this class.
    */

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2433,4 +2433,80 @@
       The directory named by this property must exist and be writeable.
     </description>
   </property>
+  <property>
+    <name>ozone.http.policy</name>
+    <value>HTTP_ONLY</value>
+    <tag>OZONE, SECURITY, MANAGEMENT</tag>
+    <description>Decide if HTTPS(SSL) is supported on Ozone
+      This configures the HTTP endpoint for Ozone daemons:
+      The following values are supported:
+      - HTTP_ONLY : Service is provided only on http
+      - HTTPS_ONLY : Service is provided only on https
+      - HTTP_AND_HTTPS : Service is provided both on http and https
+    </description>
+  </property>
+  <property>
+    <name>ozone.https.client.need-auth</name>
+    <tag>OZONE, SECURITY, MANAGEMENT</tag>
+    <value>false</value>
+    <description>
+      Whether SSL client certificate authentication is required
+    </description>
+  </property>
+  <property>
+    <name>ozone.https.client.keystore.resource</name>
+    <tag>OZONE, SECURITY, MANAGEMENT</tag>
+    <value>ssl-client.xml</value>
+    <description>
+      Resource file from which ssl client keystore
+      information will be extracted
+    </description>
+  </property>
+  <property>
+    <name>ozone.https.server.keystore.resource</name>
+    <tag>OZONE, SECURITY, MANAGEMENT</tag>
+    <value>ssl-server.xml</value>
+    <description>Resource file from which ssl server keystore
+      information will be extracted
+    </description>
+  </property>
+  <property>
+    <name>ssl.server.keystore.keypassword</name>
+    <tag>OZONE, SECURITY, MANAGEMENT</tag>
+    <value></value>
+    <description>Keystore key password for HTTPS SSL configuration
+    </description>
+  </property>
+  <property>
+    <name>ssl.server.keystore.location</name>
+    <tag>OZONE, SECURITY, MANAGEMENT</tag>
+    <value></value>
+    <description>
+      Keystore location for HTTPS SSL configuration
+    </description>
+  </property>
+  <property>
+    <name>ssl.server.keystore.password</name>
+    <tag>OZONE, SECURITY, MANAGEMENT</tag>
+    <value></value>
+    <description>
+      Keystore password for HTTPS SSL configuration
+    </description>
+  </property>
+  <property>
+    <name>ssl.server.truststore.location</name>
+    <tag>OZONE, SECURITY, MANAGEMENT</tag>
+    <value></value>
+    <description>
+      Truststore location for HTTPS SSL configuration
+    </description>
+  </property>
+  <property>
+    <name>ssl.server.truststore.password</name>
+    <tag>OZONE, SECURITY, MANAGEMENT</tag>
+    <value></value>
+    <description>
+      Truststore password for HTTPS SSL configuration
+    </description>
+  </property>
 </configuration>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/BaseHttpServer.java
@@ -80,8 +80,8 @@ public abstract class BaseHttpServer {
       // CommonConfigurationKeysPublic.HADOOP_PROMETHEUS_ENABLED when possible.
       conf.setBoolean("hadoop.prometheus.endpoint.enabled", false);
 
-      HttpServer2.Builder builder = HddsUtils.newHttpServer2BuilderForOzone(conf,
-          httpAddress, httpsAddress,
+      HttpServer2.Builder builder = HddsUtils.newHttpServer2BuilderForOzone(
+          conf, httpAddress, httpsAddress,
           name, getSpnegoPrincipal(), getKeytabFile());
 
       final boolean xFrameEnabled = conf.getBoolean(

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/BaseHttpServer.java
@@ -26,8 +26,8 @@ import java.util.OptionalInt;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.HddsConfServlet;
-import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.http.HttpConfig;
 import org.apache.hadoop.http.HttpServer2;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
@@ -70,7 +70,7 @@ public abstract class BaseHttpServer {
   public BaseHttpServer(Configuration conf, String name) throws IOException {
     this.name = name;
     this.conf = conf;
-    policy = DFSUtil.getHttpPolicy(conf);
+    policy = HddsUtils.getHttpPolicy(conf);
     if (isEnabled()) {
       this.httpAddress = getHttpBindAddress();
       this.httpsAddress = getHttpsBindAddress();
@@ -80,7 +80,7 @@ public abstract class BaseHttpServer {
       // CommonConfigurationKeysPublic.HADOOP_PROMETHEUS_ENABLED when possible.
       conf.setBoolean("hadoop.prometheus.endpoint.enabled", false);
 
-      HttpServer2.Builder builder = DFSUtil.httpServerTemplateForNNAndJN(conf,
+      HttpServer2.Builder builder = HddsUtils.newHttpServer2BuilderForOzone(conf,
           httpAddress, httpsAddress,
           name, getSpnegoPrincipal(), getKeytabFile());
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHttpServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHttpServer.java
@@ -28,12 +28,12 @@ import java.util.Collection;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
-import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManagerHttpServer;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import org.apache.hadoop.http.HttpConfig;
 import org.apache.hadoop.http.HttpConfig.Policy;
 import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.test.GenericTestUtils;
 
@@ -83,9 +83,9 @@ public class TestStorageContainerManagerHttpServer {
     KeyStoreTestUtil.setupSSLConfig(keystoresDir, sslConfDir, conf, false);
     connectionFactory =
         URLConnectionFactory.newDefaultURLConnectionFactory(conf);
-    conf.set(DFSConfigKeysLegacy.DFS_CLIENT_HTTPS_KEYSTORE_RESOURCE_KEY,
+    conf.set(OzoneConfigKeys.OZONE_CLIENT_HTTPS_KEYSTORE_RESOURCE_KEY,
         KeyStoreTestUtil.getClientSSLConfigFileName());
-    conf.set(DFSConfigKeysLegacy.DFS_SERVER_HTTPS_KEYSTORE_RESOURCE_KEY,
+    conf.set(OzoneConfigKeys.OZONE_SERVER_HTTPS_KEYSTORE_RESOURCE_KEY,
         KeyStoreTestUtil.getServerSSLConfigFileName());
   }
 
@@ -95,7 +95,7 @@ public class TestStorageContainerManagerHttpServer {
   }
 
   @Test public void testHttpPolicy() throws Exception {
-    conf.set(DFSConfigKeysLegacy.DFS_HTTP_POLICY_KEY, policy.name());
+    conf.set(OzoneConfigKeys.OZONE_HTTP_POLICY_KEY, policy.name());
     conf.set(ScmConfigKeys.OZONE_SCM_HTTP_ADDRESS_KEY, "localhost:0");
     conf.set(ScmConfigKeys.OZONE_SCM_HTTPS_ADDRESS_KEY, "localhost:0");
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OzoneManagerSnapshotProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OzoneManagerSnapshotProvider.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.ozone.om.snapshot;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
-import org.apache.hadoop.hdfs.DFSUtil;
+import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.http.HttpConfig;
 import org.apache.hadoop.ozone.om.ha.OMNodeDetails;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
@@ -87,7 +87,7 @@ public class OzoneManagerSnapshotProvider {
       this.peerNodesMap.put(peerNode.getOMNodeId(), peerNode);
     }
 
-    this.httpPolicy = DFSUtil.getHttpPolicy(conf);
+    this.httpPolicy = HddsUtils.getHttpPolicy(conf);
     this.httpRequestConfig = getHttpRequestConfig(conf);
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHttpServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHttpServer.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import org.apache.hadoop.http.HttpConfig;
 import org.apache.hadoop.http.HttpConfig.Policy;
 import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.AfterClass;
@@ -80,9 +81,9 @@ public class TestOzoneManagerHttpServer {
     KeyStoreTestUtil.setupSSLConfig(keystoresDir, sslConfDir, conf, false);
     connectionFactory =
         URLConnectionFactory.newDefaultURLConnectionFactory(conf);
-    conf.set(DFSConfigKeysLegacy.DFS_CLIENT_HTTPS_KEYSTORE_RESOURCE_KEY,
+    conf.set(OzoneConfigKeys.OZONE_CLIENT_HTTPS_KEYSTORE_RESOURCE_KEY,
         KeyStoreTestUtil.getClientSSLConfigFileName());
-    conf.set(DFSConfigKeysLegacy.DFS_SERVER_HTTPS_KEYSTORE_RESOURCE_KEY,
+    conf.set(OzoneConfigKeys.OZONE_SERVER_HTTPS_KEYSTORE_RESOURCE_KEY,
         KeyStoreTestUtil.getServerSSLConfigFileName());
   }
 
@@ -92,7 +93,7 @@ public class TestOzoneManagerHttpServer {
   }
 
   @Test public void testHttpPolicy() throws Exception {
-    conf.set(DFSConfigKeysLegacy.DFS_HTTP_POLICY_KEY, policy.name());
+    conf.set(OzoneConfigKeys.OZONE_HTTP_POLICY_KEY, policy.name());
     conf.set(OMConfigKeys.OZONE_OM_HTTP_ADDRESS_KEY, "localhost:0");
     conf.set(OMConfigKeys.OZONE_OM_HTTPS_ADDRESS_KEY, "localhost:0");
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHttpServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHttpServer.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.om;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
-import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import org.apache.hadoop.http.HttpConfig;
 import org.apache.hadoop.http.HttpConfig.Policy;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -47,8 +47,8 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.http.HttpConfig;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -123,7 +123,7 @@ public class OzoneManagerServiceProviderImpl
     omSnapshotDBParentDir = reconUtils.getReconDbDir(configuration,
         OZONE_RECON_OM_SNAPSHOT_DB_DIR);
 
-    HttpConfig.Policy policy = DFSUtil.getHttpPolicy(configuration);
+    HttpConfig.Policy policy = HddsUtils.getHttpPolicy(configuration);
 
     int socketTimeout = (int) configuration.getTimeDuration(
         RECON_OM_SOCKET_TIMEOUT, RECON_OM_SOCKET_TIMEOUT_DEFAULT,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove dependency on dfs.* keys for ozone related HTTPS configuration for web console.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2041

## How was this patch tested?

unit test.