### PR TITLE
HDDS-2987. Add metrics to OM DoubleBuffer.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -145,7 +146,10 @@ public class OzoneManagerDoubleBuffer {
               }
             });
 
+            long startTime = Time.monotonicNowNanos();
             omMetadataManager.getStore().commitBatchOperation(batchOperation);
+            ozoneManagerDoubleBufferMetrics.updateFlushTime(
+                Time.monotonicNowNanos() - startTime);
           }
 
           // Complete futures first and then do other things. So, that
@@ -248,6 +252,9 @@ public class OzoneManagerDoubleBuffer {
     ozoneManagerDoubleBufferMetrics.incrTotalNumOfFlushOperations();
     ozoneManagerDoubleBufferMetrics.incrTotalSizeOfFlushedTransactions(
         flushedTransactionsSize);
+    ozoneManagerDoubleBufferMetrics.setAvgFlushTransactionsInOneIteration(
+        ozoneManagerDoubleBufferMetrics.getTotalNumOfFlushedTransactions()
+            / ozoneManagerDoubleBufferMetrics.getTotalNumOfFlushOperations());
     if (maxFlushedTransactionsInOneIteration < flushedTransactionsSize) {
       maxFlushedTransactionsInOneIteration = flushedTransactionsSize;
       ozoneManagerDoubleBufferMetrics

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -253,8 +253,9 @@ public class OzoneManagerDoubleBuffer {
     ozoneManagerDoubleBufferMetrics.incrTotalSizeOfFlushedTransactions(
         flushedTransactionsSize);
     ozoneManagerDoubleBufferMetrics.setAvgFlushTransactionsInOneIteration(
-        ozoneManagerDoubleBufferMetrics.getTotalNumOfFlushedTransactions()
-            / ozoneManagerDoubleBufferMetrics.getTotalNumOfFlushOperations());
+        (float) ozoneManagerDoubleBufferMetrics
+            .getTotalNumOfFlushedTransactions() /
+            ozoneManagerDoubleBufferMetrics.getTotalNumOfFlushOperations());
     if (maxFlushedTransactionsInOneIteration < flushedTransactionsSize) {
       maxFlushedTransactionsInOneIteration = flushedTransactionsSize;
       ozoneManagerDoubleBufferMetrics

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/metrics/OzoneManagerDoubleBufferMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/metrics/OzoneManagerDoubleBufferMetrics.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+import org.apache.hadoop.metrics2.lib.MutableGaugeFloat;
 import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 import org.apache.hadoop.metrics2.lib.MutableRate;
 
@@ -53,7 +54,7 @@ public class OzoneManagerDoubleBufferMetrics {
 
   @Metric(about = "Average number of transactions flushed in a single " +
       "iteration")
-  private MutableGaugeLong avgFlushTransactionsInOneIteration;
+  private MutableGaugeFloat avgFlushTransactionsInOneIteration;
 
 
 
@@ -103,11 +104,11 @@ public class OzoneManagerDoubleBufferMetrics {
     return flushTime;
   }
 
-  public long getAvgFlushTransactionsInOneIteration() {
+  public float getAvgFlushTransactionsInOneIteration() {
     return avgFlushTransactionsInOneIteration.value();
   }
 
-  public void setAvgFlushTransactionsInOneIteration(long count) {
+  public void setAvgFlushTransactionsInOneIteration(float count) {
     this.avgFlushTransactionsInOneIteration.set(count);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/metrics/OzoneManagerDoubleBufferMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/metrics/OzoneManagerDoubleBufferMetrics.java
@@ -18,10 +18,13 @@
 
 package org.apache.hadoop.ozone.om.ratis.metrics;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
+import org.apache.hadoop.metrics2.lib.MutableRate;
 
 /**
  * Class which maintains metrics related to OzoneManager DoubleBuffer.
@@ -43,6 +46,15 @@ public class OzoneManagerDoubleBufferMetrics {
       "OzoneManagerDoubleBuffer. This will provide a value which is maximum " +
       "number of transactions flushed in a single flush iteration till now.")
   private MutableCounterLong maxNumberOfTransactionsFlushedInOneIteration;
+
+  @Metric(about = "DoubleBuffer flushTime. This metrics particularly captures" +
+      " rocksdb batch commit time.")
+  private MutableRate flushTime;
+
+  @Metric(about = "Average number of transactions flushed in a single " +
+      "iteration")
+  private MutableGaugeLong avgFlushTransactionsInOneIteration;
+
 
 
   public static OzoneManagerDoubleBufferMetrics create() {
@@ -80,6 +92,23 @@ public class OzoneManagerDoubleBufferMetrics {
 
   public long getMaxNumberOfTransactionsFlushedInOneIteration() {
     return maxNumberOfTransactionsFlushedInOneIteration.value();
+  }
+
+  public void updateFlushTime(long time) {
+    flushTime.add(time);
+  }
+
+  @VisibleForTesting
+  public MutableRate getFlushTime() {
+    return flushTime;
+  }
+
+  public long getAvgFlushTransactionsInOneIteration() {
+    return avgFlushTransactionsInOneIteration.value();
+  }
+
+  public void setAvgFlushTransactionsInOneIteration(long count) {
+    this.avgFlushTransactionsInOneIteration.set(count);
   }
 
   public void unRegister() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/metrics/OzoneManagerDoubleBufferMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/metrics/OzoneManagerDoubleBufferMetrics.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableGaugeFloat;
-import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 import org.apache.hadoop.metrics2.lib.MutableRate;
 
 /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
@@ -111,6 +111,8 @@ public class TestOzoneManagerDoubleBufferWithDummyResponse {
     assertEquals(bucketCount, omMetadataManager.countRowsInTable(
         omMetadataManager.getBucketTable()));
     assertTrue(doubleBuffer.getFlushIterations() > 0);
+    assertTrue(metrics.getFlushTime().lastStat().mean() > 0);
+    assertTrue(metrics.getAvgFlushTransactionsInOneIteration() > 0);
 
     // Check lastAppliedIndex is updated correctly or not.
     assertEquals(bucketCount, lastAppliedIndex);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a metric that will help in understanding the Average flush time which will help in understanding how the flush time increases over time.

Add another metric to show the average number of flush transactions in an iteration. This will show how many transactions are flushed in a single iteration over time.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2987

## How was this patch tested?

Added a UT and also deployed cluster to look into these new metrics.
