### PR TITLE
HDDS-2946. Rename audit log should contain both srcKey and dstKey not just key

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -237,6 +237,8 @@ public final class OzoneConsts {
   public static final String VOLUME = "volume";
   public static final String BUCKET = "bucket";
   public static final String KEY = "key";
+  public static final String SRC_KEY = "srcKey";
+  public static final String DST_KEY = "dstKey";
   public static final String QUOTA = "quota";
   public static final String QUOTA_IN_BYTES = "quotaInBytes";
   public static final String OBJECT_ID = "objectID";

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
@@ -111,7 +112,8 @@ public class OMKeyRenameRequest extends OMKeyRequest {
 
     AuditLogger auditLogger = ozoneManager.getAuditLogger();
 
-    Map<String, String> auditMap = buildKeyArgsAuditMap(renameKeyArgs);
+    Map<String, String> auditMap =
+        buildAuditMap(renameKeyArgs, renameKeyRequest);
 
     OzoneManagerProtocolProtos.OMResponse.Builder omResponse =
         OzoneManagerProtocolProtos.OMResponse.newBuilder().setCmdType(
@@ -284,5 +286,14 @@ public class OMKeyRenameRequest extends OMKeyRequest {
           renameKeyRequest);
     }
     return omClientResponse;
+  }
+
+  private Map<String, String> buildAuditMap(
+      KeyArgs keyArgs, RenameKeyRequest renameKeyRequest) {
+    Map<String, String> auditMap = buildKeyArgsAuditMap(keyArgs);
+    auditMap.remove(OzoneConsts.KEY);
+    auditMap.put(OzoneConsts.SRC_KEY, keyArgs.getKeyName());
+    auditMap.put(OzoneConsts.DST_KEY, renameKeyRequest.getToKeyName());
+    return auditMap;
   }
 }


### PR DESCRIPTION
#478  What changes were proposed in this pull request?
In the audit log of a rename request we just log the key to be renamed. The purpose of this PR is to replace key to srcKey and dstKey in the audit log message in case of a rename.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2946

## How was this patch tested?
I haven't find any particular junit test that tests actual audit log messages, and I haven't added one, though I have this patch applied on a cluster, and used the new type of audit log to trace down multiple renames properly. I am happy to discuss how to add a junit test if there is any place for it, and if there is any reason to test the particular queries audit contents, I don't see it necessary as the general facilities we are using for audit log message creation are already tested.