### PR TITLE
HDDS-2988. Use getPropertiesByPrefix instead of regex in matching ratis client and server properties.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/conf/RatisClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/conf/RatisClientConfig.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.hdds.conf;
 
+import org.apache.hadoop.hdds.ratis.RatisHelper;
+import org.apache.ratis.client.RaftClientConfigKeys;
+
 import static org.apache.hadoop.hdds.conf.ConfigTag.CLIENT;
 import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
 import static org.apache.hadoop.hdds.conf.ConfigTag.PERFORMANCE;
@@ -26,9 +29,9 @@ import static org.apache.hadoop.hdds.conf.ConfigTag.PERFORMANCE;
  * RaftClient creation.
  *
  */
-@ConfigGroup(prefix = "raft.client")
+@ConfigGroup(prefix = RatisHelper.HDDS_DATANODE_RATIS_CLIENT_PREFIX_KEY)
 public class RatisClientConfig {
-  @Config(key = "async.outstanding-requests.max",
+  @Config(key = RaftClientConfigKeys.Async.MAX_OUTSTANDING_REQUESTS_KEY,
       defaultValue = "32",
       type = ConfigType.INT,
       tags = {OZONE, CLIENT, PERFORMANCE},
@@ -46,7 +49,7 @@ public class RatisClientConfig {
     this.maxOutstandingRequests = maxOutstandingRequests;
   }
 
-  @Config(key = "rpc.request.timeout",
+  @Config(key = RaftClientConfigKeys.Rpc.REQUEST_TIMEOUT_KEY,
       defaultValue = "60s",
       type = ConfigType.TIME,
       tags = {OZONE, CLIENT, PERFORMANCE},
@@ -64,7 +67,7 @@ public class RatisClientConfig {
     this.requestTimeOut = requestTimeOut;
   }
 
-  @Config(key = "watch.request.timeout",
+  @Config(key = RaftClientConfigKeys.Rpc.WATCH_REQUEST_TIMEOUT_KEY,
       defaultValue = "180s",
       type = ConfigType.TIME,
       tags = {OZONE, CLIENT, PERFORMANCE},

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/conf/RatisClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/conf/RatisClientConfig.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdds.conf;
 
 import org.apache.hadoop.hdds.ratis.RatisHelper;
-import org.apache.ratis.client.RaftClientConfigKeys;
 
 import static org.apache.hadoop.hdds.conf.ConfigTag.CLIENT;
 import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
@@ -31,7 +30,7 @@ import static org.apache.hadoop.hdds.conf.ConfigTag.PERFORMANCE;
  */
 @ConfigGroup(prefix = RatisHelper.HDDS_DATANODE_RATIS_CLIENT_PREFIX_KEY)
 public class RatisClientConfig {
-  @Config(key = RaftClientConfigKeys.Async.MAX_OUTSTANDING_REQUESTS_KEY,
+  @Config(key = "async.outstanding-requests.max",
       defaultValue = "32",
       type = ConfigType.INT,
       tags = {OZONE, CLIENT, PERFORMANCE},
@@ -49,7 +48,7 @@ public class RatisClientConfig {
     this.maxOutstandingRequests = maxOutstandingRequests;
   }
 
-  @Config(key = RaftClientConfigKeys.Rpc.REQUEST_TIMEOUT_KEY,
+  @Config(key = "rpc.request.timeout",
       defaultValue = "60s",
       type = ConfigType.TIME,
       tags = {OZONE, CLIENT, PERFORMANCE},
@@ -67,7 +66,7 @@ public class RatisClientConfig {
     this.requestTimeOut = requestTimeOut;
   }
 
-  @Config(key = RaftClientConfigKeys.Rpc.WATCH_REQUEST_TIMEOUT_KEY,
+  @Config(key = "rpc.watch.request.timeout",
       defaultValue = "180s",
       type = ConfigType.TIME,
       tags = {OZONE, CLIENT, PERFORMANCE},

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.hdds.conf;
 
-import org.apache.ratis.grpc.GrpcConfigKeys;
-
 import static org.apache.hadoop.hdds.conf.ConfigTag.CLIENT;
 import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
 import static org.apache.hadoop.hdds.conf.ConfigTag.PERFORMANCE;
@@ -30,7 +28,7 @@ import static org.apache.hadoop.hdds.ratis.RatisHelper.HDDS_DATANODE_RATIS_GRPC_
  */
 @ConfigGroup(prefix = HDDS_DATANODE_RATIS_GRPC_PREFIX_KEY)
 public class DatanodeRatisGrpcConfig {
-  @Config(key = GrpcConfigKeys.MESSAGE_SIZE_MAX_KEY,
+  @Config(key = "message.size.max",
       defaultValue = "32MB",
       type = ConfigType.INT,
       tags = {OZONE, CLIENT, PERFORMANCE},

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
@@ -18,16 +18,19 @@
 
 package org.apache.hadoop.hdds.conf;
 
+import org.apache.ratis.grpc.GrpcConfigKeys;
+
 import static org.apache.hadoop.hdds.conf.ConfigTag.CLIENT;
 import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
 import static org.apache.hadoop.hdds.conf.ConfigTag.PERFORMANCE;
+import static org.apache.hadoop.hdds.ratis.RatisHelper.HDDS_DATANODE_RATIS_GRPC_PREFIX_KEY;
 
 /**
  * Ratis Grpc Config Keys.
  */
-@ConfigGroup(prefix = "raft.grpc")
-public class RatisGrpcConfig {
-  @Config(key = "message.size.max",
+@ConfigGroup(prefix = HDDS_DATANODE_RATIS_GRPC_PREFIX_KEY)
+public class DatanodeRatisGrpcConfig {
+  @Config(key = GrpcConfigKeys.MESSAGE_SIZE_MAX_KEY,
       defaultValue = "32MB",
       type = ConfigType.INT,
       tags = {OZONE, CLIENT, PERFORMANCE},

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisServerConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisServerConfig.java
@@ -17,7 +17,6 @@
  */
 
 package org.apache.hadoop.hdds.conf;
-import org.apache.ratis.server.RaftServerConfigKeys;
 
 import static org.apache.hadoop.hdds.conf.ConfigTag.DATANODE;
 import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
@@ -32,19 +31,19 @@ import static org.apache.hadoop.hdds.ratis.RatisHelper.HDDS_DATANODE_RATIS_SERVE
 public class DatanodeRatisServerConfig {
 
   public static final String RATIS_SERVER_REQUEST_TIMEOUT_KEY =
-      RaftServerConfigKeys.Rpc.REQUEST_TIMEOUT_KEY;
+      "rpc.request.timeout";
 
   public static final String RATIS_SERVER_WATCH_REQUEST_TIMEOUT_KEY =
-      RaftServerConfigKeys.Watch.TIMEOUT_KEY;
+      "watch.timeout";
 
   public static final String RATIS_SERVER_NO_LEADER_TIMEOUT_KEY =
-      "raft.server.Notification.no-leader.timeout";
+      "Notification.no-leader.timeout";
 
   public static final String RATIS_FOLLOWER_SLOWNESS_TIMEOUT_KEY =
-      RaftServerConfigKeys.Rpc.SLOWNESS_TIMEOUT_KEY;
+      "rpcslowness.timeout";
 
   public static final String RATIS_LEADER_NUM_PENDING_REQUESTS_KEY =
-      RaftServerConfigKeys.Write.ELEMENT_LIMIT_KEY;
+      "write.element-limit";
 
   @Config(key = RATIS_SERVER_REQUEST_TIMEOUT_KEY,
       defaultValue = "60s",

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisServerConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisServerConfig.java
@@ -16,40 +16,35 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.ozone.conf;
-
-import org.apache.hadoop.hdds.conf.Config;
-import org.apache.hadoop.hdds.conf.ConfigGroup;
-import org.apache.hadoop.hdds.conf.ConfigType;
+package org.apache.hadoop.hdds.conf;
+import org.apache.ratis.server.RaftServerConfigKeys;
 
 import static org.apache.hadoop.hdds.conf.ConfigTag.DATANODE;
 import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
 import static org.apache.hadoop.hdds.conf.ConfigTag.PERFORMANCE;
 import static org.apache.hadoop.hdds.conf.ConfigTag.RATIS;
+import static org.apache.hadoop.hdds.ratis.RatisHelper.HDDS_DATANODE_RATIS_SERVER_PREFIX_KEY;
 
 /**
  * Datanode Ratis server Configuration.
  */
-@ConfigGroup(prefix = "datanode.ratis")
+@ConfigGroup(prefix = HDDS_DATANODE_RATIS_SERVER_PREFIX_KEY)
 public class DatanodeRatisServerConfig {
 
-  public static final String DATANODE_RATIS_SERVER_CONFIG_PREFIX = "datanode" +
-      ".ratis.";
-
   public static final String RATIS_SERVER_REQUEST_TIMEOUT_KEY =
-      "raft.server.rpc.request.timeout";
+      RaftServerConfigKeys.Rpc.REQUEST_TIMEOUT_KEY;
 
   public static final String RATIS_SERVER_WATCH_REQUEST_TIMEOUT_KEY =
-      "raft.server.watch.timeout";
+      RaftServerConfigKeys.Watch.TIMEOUT_KEY;
 
   public static final String RATIS_SERVER_NO_LEADER_TIMEOUT_KEY =
-      "raft.server.no-leader.timeout";
+      "raft.server.Notification.no-leader.timeout";
 
   public static final String RATIS_FOLLOWER_SLOWNESS_TIMEOUT_KEY =
-      "raft.server.rpcslowness.timeout";
+      RaftServerConfigKeys.Rpc.SLOWNESS_TIMEOUT_KEY;
 
   public static final String RATIS_LEADER_NUM_PENDING_REQUESTS_KEY =
-      "raft.server.write.element-limit";
+      RaftServerConfigKeys.Write.ELEMENT_LIMIT_KEY;
 
   @Config(key = RATIS_SERVER_REQUEST_TIMEOUT_KEY,
       defaultValue = "60s",

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
@@ -33,7 +33,9 @@ import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import com.google.common.base.Preconditions;
@@ -375,5 +377,19 @@ public class OzoneConfiguration extends Configuration {
       }
     }
     return props;
+  }
+
+  @Override
+  public Map<String, String> getPropsWithPrefix(String confPrefix) {
+    Properties props = getProps();
+    Map<String, String> configMap = new HashMap<>();
+    for (String name : props.stringPropertyNames()) {
+      if (name.startsWith(confPrefix)) {
+        String value = get(name);
+        String keyName = name.substring(confPrefix.length());
+        configMap.put(keyName, value);
+      }
+    }
+    return configMap;
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestRatisHelper.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestRatisHelper.java
@@ -32,8 +32,10 @@ public class TestRatisHelper {
   public void testCreateRaftClientProperties() {
 
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
-    ozoneConfiguration.set("raft.client.rpc.watch.request.timeout", "30s");
-    ozoneConfiguration.set("raft.client.rpc.request.timeout", "30s");
+    ozoneConfiguration.set("datanode.ratis.client.raft.client.rpc.watch" +
+        ".request.timeout", "30s");
+    ozoneConfiguration.set("datanode.ratis.client.raft.client.rpc.request" +
+        ".timeout", "30s");
 
     RaftProperties raftProperties = new RaftProperties();
     RatisHelper.createRaftClientProperties(ozoneConfiguration, raftProperties);
@@ -46,17 +48,20 @@ public class TestRatisHelper {
   }
 
   @Test
-  public void testCreateRaftGrpcProperties() {
+  public void testCreateRaftGrpcPropertiesForClient() {
 
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
-    ozoneConfiguration.set("raft.grpc.message.size.max", "30MB");
-    ozoneConfiguration.set("raft.grpc.flow.control.window", "1MB");
-    ozoneConfiguration.set("raft.grpc.tls.enabled", "true");
-    ozoneConfiguration.set("raft.grpc.tls.mutual_authn.enabled", "true");
-    ozoneConfiguration.set("raft.grpc.server.port", "100");
+    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.message.size.max",
+        "30MB");
+    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.flow.control" +
+        ".window", "1MB");
+    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.tls.enabled", "true");
+    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.tls.mutual_authn" +
+        ".enabled", "true");
+    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.server.port", "100");
 
     RaftProperties raftProperties = new RaftProperties();
-    RatisHelper.createRaftGrpcProperties(ozoneConfiguration, raftProperties);
+    RatisHelper.createRaftClientProperties(ozoneConfiguration, raftProperties);
 
     Assert.assertEquals("30MB",
         raftProperties.get("raft.grpc.message.size.max"));
@@ -73,19 +78,22 @@ public class TestRatisHelper {
 
 
   @Test
-  public void testCreateRaftServerGrpcProperties() {
+  public void testCreateRaftGrpcPropertiesForServer() {
 
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
-    ozoneConfiguration.set("datanode.ratis.raft.grpc.message.size.max", "30MB");
-    ozoneConfiguration.set("datanode.ratis.raft.grpc.flow.control.window",
-        "1MB");
-    ozoneConfiguration.set("datanode.ratis.raft.grpc.tls.enabled", "true");
-    ozoneConfiguration.set("datanode.ratis.raft.grpc.tls.mutual_authn" +
+    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.message.size.max",
+        "30MB");
+    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.flow.control" +
+        ".window", "1MB");
+    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.tls.enabled",
+        "true");
+    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.tls.mutual_authn" +
         ".enabled", "true");
-    ozoneConfiguration.set("datanode.ratis.raft.grpc.server.port", "100");
+    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.server.port",
+        "100");
 
     RaftProperties raftProperties = new RaftProperties();
-    RatisHelper.createRaftServerGrpcProperties(ozoneConfiguration,
+    RatisHelper.createRaftServerProperties(ozoneConfiguration,
         raftProperties);
 
     Assert.assertEquals("30MB",
@@ -106,9 +114,9 @@ public class TestRatisHelper {
 
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(
-        "datanode.ratis.raft.server.rpc.watch.request.timeout", "30s");
+        "datanode.ratis.server.raft.server.rpc.watch.request.timeout", "30s");
     ozoneConfiguration.set(
-        "datanode.ratis.raft.server.rpc.request.timeout", "30s");
+        "datanode.ratis.server.raft.server.rpc.request.timeout", "30s");
 
     RaftProperties raftProperties = new RaftProperties();
     RatisHelper.createRaftServerProperties(ozoneConfiguration, raftProperties);

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestRatisHelper.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestRatisHelper.java
@@ -32,10 +32,12 @@ public class TestRatisHelper {
   public void testCreateRaftClientProperties() {
 
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
-    ozoneConfiguration.set("datanode.ratis.client.raft.client.rpc.watch" +
+    ozoneConfiguration.set("hdds.ratis.raft.client.rpc.watch" +
         ".request.timeout", "30s");
-    ozoneConfiguration.set("datanode.ratis.client.raft.client.rpc.request" +
+    ozoneConfiguration.set("hdds.ratis.raft.client.rpc.request" +
         ".timeout", "30s");
+    ozoneConfiguration.set(
+        "hdds.ratis.raft.server.rpc.watch.request.timeout", "30s");
 
     RaftProperties raftProperties = new RaftProperties();
     RatisHelper.createRaftClientProperties(ozoneConfiguration, raftProperties);
@@ -44,6 +46,8 @@ public class TestRatisHelper {
         raftProperties.get("raft.client.rpc.watch.request.timeout"));
     Assert.assertEquals("30s",
         raftProperties.get("raft.client.rpc.request.timeout"));
+    Assert.assertNull(
+        raftProperties.get("raft.server.rpc.watch.request.timeout"));
 
   }
 
@@ -51,14 +55,14 @@ public class TestRatisHelper {
   public void testCreateRaftGrpcPropertiesForClient() {
 
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
-    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.message.size.max",
+    ozoneConfiguration.set("hdds.ratis.raft.grpc.message.size.max",
         "30MB");
-    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.flow.control" +
+    ozoneConfiguration.set("hdds.ratis.raft.grpc.flow.control" +
         ".window", "1MB");
-    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.tls.enabled", "true");
-    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.tls.mutual_authn" +
+    ozoneConfiguration.set("hdds.ratis.raft.grpc.tls.enabled", "true");
+    ozoneConfiguration.set("hdds.ratis.raft.grpc.tls.mutual_authn" +
         ".enabled", "true");
-    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.server.port", "100");
+    ozoneConfiguration.set("hdds.ratis.raft.grpc.server.port", "100");
 
     RaftProperties raftProperties = new RaftProperties();
     RatisHelper.createRaftClientProperties(ozoneConfiguration, raftProperties);
@@ -81,15 +85,15 @@ public class TestRatisHelper {
   public void testCreateRaftGrpcPropertiesForServer() {
 
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
-    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.message.size.max",
+    ozoneConfiguration.set("hdds.ratis.raft.grpc.message.size.max",
         "30MB");
-    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.flow.control" +
+    ozoneConfiguration.set("hdds.ratis.raft.grpc.flow.control" +
         ".window", "1MB");
-    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.tls.enabled",
+    ozoneConfiguration.set("hdds.ratis.raft.grpc.tls.enabled",
         "true");
-    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.tls.mutual_authn" +
+    ozoneConfiguration.set("hdds.ratis.raft.grpc.tls.mutual_authn" +
         ".enabled", "true");
-    ozoneConfiguration.set("datanode.ratis.grpc.raft.grpc.server.port",
+    ozoneConfiguration.set("hdds.ratis.raft.grpc.server.port",
         "100");
 
     RaftProperties raftProperties = new RaftProperties();
@@ -114,9 +118,11 @@ public class TestRatisHelper {
 
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(
-        "datanode.ratis.server.raft.server.rpc.watch.request.timeout", "30s");
+        "hdds.ratis.raft.server.rpc.watch.request.timeout", "30s");
     ozoneConfiguration.set(
-        "datanode.ratis.server.raft.server.rpc.request.timeout", "30s");
+        "hdds.ratis.raft.server.rpc.request.timeout", "30s");
+    ozoneConfiguration.set(
+        "hdds.ratis.raft.client.rpc.request.timeout", "30s");
 
     RaftProperties raftProperties = new RaftProperties();
     RatisHelper.createRaftServerProperties(ozoneConfiguration, raftProperties);
@@ -125,6 +131,7 @@ public class TestRatisHelper {
         raftProperties.get("raft.server.rpc.watch.request.timeout"));
     Assert.assertEquals("30s",
         raftProperties.get("raft.server.rpc.request.timeout"));
+    Assert.assertNull(raftProperties.get("raft.client.rpc.request.timeout"));
 
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerExcep
 import org.apache.hadoop.hdds.utils.Cache;
 import org.apache.hadoop.hdds.utils.ResourceLimitCache;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.apache.hadoop.ozone.conf.DatanodeRatisServerConfig;
+import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.proto.RaftProtos.StateMachineLogEntryProto;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -37,7 +37,7 @@ import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 
 import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.hadoop.ozone.conf.DatanodeRatisServerConfig;
+import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerDispatcher;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 
@@ -263,9 +263,6 @@ public final class XceiverServerRatis implements XceiverServerSpi {
 
     // Set properties starting with prefix raft.server
     RatisHelper.createRaftServerProperties(conf, properties);
-
-    // Set properties starting with prefix raft.grpc
-    RatisHelper.createRaftServerGrpcProperties(conf, properties);
 
     return properties;
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNodeFailure.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNodeFailure.java
@@ -20,11 +20,12 @@ package org.apache.hadoop.hdds.scm.pipeline;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.conf.DatanodeRatisServerConfig;
+import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -63,10 +64,11 @@ public class TestNodeFailure {
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
     conf.setTimeDuration(
+        RatisHelper.HDDS_DATANODE_RATIS_SERVER_PREFIX_KEY + "." +
         DatanodeRatisServerConfig.RATIS_FOLLOWER_SLOWNESS_TIMEOUT_KEY,
         10, TimeUnit.SECONDS);
     conf.setTimeDuration(
-        DatanodeRatisServerConfig.DATANODE_RATIS_SERVER_CONFIG_PREFIX +
+        RatisHelper.HDDS_DATANODE_RATIS_SERVER_PREFIX_KEY + "." +
         DatanodeRatisServerConfig.RATIS_SERVER_NO_LEADER_TIMEOUT_KEY,
         10, TimeUnit.SECONDS);
     conf.setTimeDuration(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerReplicationEndToEnd.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerReplicationEndToEnd.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
@@ -36,7 +37,7 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.io.KeyOutputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
-import org.apache.hadoop.ozone.conf.DatanodeRatisServerConfig;
+import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
 import org.apache.hadoop.ozone.container.TestHelper;
 
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -98,11 +99,11 @@ public class TestContainerReplicationEndToEnd {
     conf.setTimeDuration(OZONE_SCM_PIPELINE_DESTROY_TIMEOUT, 1000,
         TimeUnit.SECONDS);
     conf.setTimeDuration(
-        DatanodeRatisServerConfig.DATANODE_RATIS_SERVER_CONFIG_PREFIX +
+        RatisHelper.HDDS_DATANODE_RATIS_SERVER_PREFIX_KEY + "." +
         DatanodeRatisServerConfig.RATIS_FOLLOWER_SLOWNESS_TIMEOUT_KEY,
         1000, TimeUnit.SECONDS);
     conf.setTimeDuration(
-        DatanodeRatisServerConfig.DATANODE_RATIS_SERVER_CONFIG_PREFIX +
+        RatisHelper.HDDS_DATANODE_RATIS_SERVER_PREFIX_KEY + "." +
         DatanodeRatisServerConfig.RATIS_SERVER_NO_LEADER_TIMEOUT_KEY,
         1000, TimeUnit.SECONDS);
     conf.setLong("hdds.scm.replication.thread.interval",

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithSlowFollower.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithSlowFollower.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
@@ -36,7 +37,7 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.io.KeyOutputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
-import org.apache.hadoop.ozone.conf.DatanodeRatisServerConfig;
+import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
@@ -111,11 +112,11 @@ public class TestDeleteWithSlowFollower {
     conf.setTimeDuration(OZONE_SCM_PIPELINE_DESTROY_TIMEOUT, 1000,
         TimeUnit.SECONDS);
     conf.setTimeDuration(
-        DatanodeRatisServerConfig.DATANODE_RATIS_SERVER_CONFIG_PREFIX +
+        RatisHelper.HDDS_DATANODE_RATIS_SERVER_PREFIX_KEY + "." +
             DatanodeRatisServerConfig.RATIS_FOLLOWER_SLOWNESS_TIMEOUT_KEY,
         1000, TimeUnit.SECONDS);
     conf.setTimeDuration(
-        DatanodeRatisServerConfig.DATANODE_RATIS_SERVER_CONFIG_PREFIX +
+        RatisHelper.HDDS_DATANODE_RATIS_SERVER_PREFIX_KEY + "." +
         DatanodeRatisServerConfig.RATIS_SERVER_NO_LEADER_TIMEOUT_KEY,
         1000, TimeUnit.SECONDS);
     conf.setTimeDuration(OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL,


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Remove getValByRegex usage and regex usage.
2. Use getByPrefix.
3. Use prefix for Ratis Client, GRPC and Serve Conf.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2988

## How was this patch tested?

UT's are modified to test the behavior.
