### PR TITLE
HDDS-2990. Set the default value of grpc flow control window for ratis client and ratis server

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.hdds.conf;
 
+import org.apache.ratis.grpc.GrpcConfigKeys;
+
 import static org.apache.hadoop.hdds.conf.ConfigTag.CLIENT;
 import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
 import static org.apache.hadoop.hdds.conf.ConfigTag.PERFORMANCE;
@@ -43,5 +45,26 @@ public class DatanodeRatisGrpcConfig {
 
   public void setMaximumMessageSize(int maximumMessageSize) {
     this.maximumMessageSize = maximumMessageSize;
+  }
+
+  @Config(key = "flow.control.window",
+      defaultValue = "5MB",
+      type = ConfigType.INT,
+      tags =  {OZONE, CLIENT, PERFORMANCE},
+      description = "This parameter tells how much data grpc client can send " +
+          "to grpc server with out receiving any ack(WINDOW_UPDATE) packet " +
+          "from server. This parameter should be set in accordance with " +
+          "chunk size. Example: If Chunk size is 4MB, considering some header" +
+          " size in to consideration, this can be set 5MB or greater. " +
+          "Tune this parameter accordingly, as when it is set with a value " +
+          "lesser than chunk size it degrades the ozone client performance.")
+  private int flowControlWindow = 5 * 1024 * 1024;
+
+  public int getFlowControlWindow() {
+    return flowControlWindow;
+  }
+
+  public void setFlowControlWindow(int flowControlWindow) {
+    this.flowControlWindow = flowControlWindow;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/DatanodeRatisGrpcConfig.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.hdds.conf;
 
-import org.apache.ratis.grpc.GrpcConfigKeys;
-
 import static org.apache.hadoop.hdds.conf.ConfigTag.CLIENT;
 import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
 import static org.apache.hadoop.hdds.conf.ConfigTag.PERFORMANCE;

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -707,10 +707,14 @@
     <description>
       The chunk size for reading/writing chunk operations in bytes.
 
-      The chunk size defaults to 8MB. If the value configured is more than the
-      maximum size (16MB), it will be reset to the maximum size. This maps to
-      the network packet sizes and file write operations in the client to
-      datanode protocol.
+      The chunk size defaults to 4MB. If the value configured is more than the
+      maximum size (32MB), it will be reset to the maximum size (32MB). This
+      maps to the network packet sizes and file write operations in the
+      client to datanode protocol.
+
+      When this parameter is tuned flow control window parameter should be
+      tuned accordingly. Refer to
+      hdds.ratis.raft.grpc.flow.control.window for more information.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -712,7 +712,7 @@
       maps to the network packet sizes and file write operations in the
       client to datanode protocol.
 
-      When this parameter is tuned flow control window parameter should be
+      When tuning this parameter, flow control window parameter should be
       tuned accordingly. Refer to
       hdds.ratis.raft.grpc.flow.control.window for more information.
     </description>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The grpc flow control window by default is set to 1Mb by default. During performance tests, it was observed that the flow control window has to be greater than the chunk size for optimum performance.

This PR is dependent on #536. For the ease of review refer only 2nd commit, which are the changes for this PR.

https://issues.apache.org/jira/browse/HDDS-2990

## How was this patch tested?

Deployed on physical cluster and ran multiple teragen tests.
