### PR TITLE
HDDS-2997. Support github comment based commands

### DIFF
--- a/.github/comment-commands/debug.sh
+++ b/.github/comment-commands/debug.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#doc: Show current event json to debug problems
+
+echo "\`\`\`"
+cat "$GITHUB_EVENT_PATH"
+echo "\`\`\`"

--- a/.github/comment-commands/help.sh
+++ b/.github/comment-commands/help.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#doc: Show all the available comment commands
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+echo "Available commands:"
+DOCTAG="#"
+DOCTAG="${DOCTAG}doc"
+for command in "$DIR"/*.sh; do
+  COMMAND_NAME="$(basename "$command" | sed 's/.sh//g')"
+  if [ "$COMMAND_NAME" != "debug" ]; then
+    printf " * /**%s** %s\n" "$COMMAND_NAME" "$(grep $DOCTAG "$command" | sed "s/$DOCTAG//g")"
+  fi
+done

--- a/.github/comment-commands/help.sh
+++ b/.github/comment-commands/help.sh
@@ -20,7 +20,7 @@ echo "Available commands:"
 DOCTAG="#"
 DOCTAG="${DOCTAG}doc"
 for command in "$DIR"/*.sh; do
-  COMMAND_NAME="$(basename "$command" | sed 's/.sh//g')"
+  COMMAND_NAME="$(basename "$command" | sed 's/\.sh$//')"
   if [ "$COMMAND_NAME" != "debug" ]; then
     printf " * /**%s** %s\n" "$COMMAND_NAME" "$(grep $DOCTAG "$command" | sed "s/$DOCTAG//g")"
   fi

--- a/.github/comment-commands/label.sh
+++ b/.github/comment-commands/label.sh
@@ -17,6 +17,7 @@
 #doc: add new label to the issue: `/label <label>`
 LABEL="$1"
 URL="$(jq -r '.issue.url' "$GITHUB_EVENT_PATH")/labels"
+set +x #GITHUB_TOKEN
 curl -s -o /dev/null \
   -X POST \
   --data "$(jq --arg value "$LABEL" -n '{labels: [ $value ]}')" \

--- a/.github/comment-commands/label.sh
+++ b/.github/comment-commands/label.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#doc: add new label to the issue: `/label <label>`
+LABEL="$1"
+URL="$(jq -r '.issue.url' "$GITHUB_EVENT_PATH")/labels"
+curl -s -o /dev/null \
+  -X POST \
+  --data "$(jq --arg value "$LABEL" -n '{labels: [ $value ]}')" \
+  --header "authorization: Bearer $GITHUB_TOKEN" \
+  "$URL"

--- a/.github/comment-commands/pending.sh
+++ b/.github/comment-commands/pending.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#doc: Add a REQUESTED_CHANGE type review to mark issue non-mergeable: `/pending <reason>`
+# shellcheck disable=SC2124
+MESSAGE="Marking this issue as un-mergeable as requested.
+
+Please use \`/ready\` comment when it's resolved.
+
+> $@"
+
+URL="$(jq -r '.issue.pull_request.url' "$GITHUB_EVENT_PATH")/reviews"
+set +x #GITHUB_TOKEN
+curl -s -o /dev/null \
+  --data "$(jq --arg body "$MESSAGE" -n '{event: "REQUEST_CHANGES", body: $body}')" \
+  --header "authorization: Bearer $GITHUB_TOKEN" \
+  --header 'content-type: application/json' \
+  "$URL"

--- a/.github/comment-commands/ready.sh
+++ b/.github/comment-commands/ready.sh
@@ -17,6 +17,7 @@
 #doc: Dismiss all the blocking reviews by github-actions bot
 MESSAGE="Blocking review request is removed."
 URL="$(jq -r '.issue.pull_request.url' "$GITHUB_EVENT_PATH")/reviews"
+set +x #GITHUB_TOKEN
 curl -s "$URL" |
   jq -r '.[] | [.user.login, .id] | @tsv' |
   grep github-actions |

--- a/.github/comment-commands/ready.sh
+++ b/.github/comment-commands/ready.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#doc: Dismiss all the blocking reviews by github-actions bot
+MESSAGE="Blocking review request is removed."
+URL="$(jq -r '.issue.pull_request.url' "$GITHUB_EVENT_PATH")/reviews"
+curl -s "$URL" |
+  jq -r '.[] | [.user.login, .id] | @tsv' |
+  grep github-actions |
+  awk '{print $2}' |
+  xargs -n1 -IISSUE_ID curl -s -o /dev/null \
+    -X PUT \
+    --data "$(jq --arg message "$MESSAGE" -n '{message: $message}')" \
+    --header "authorization: Bearer $GITHUB_TOKEN" \
+    "$URL"/ISSUE_ID/dismissals

--- a/.github/comment-commands/retest.sh
+++ b/.github/comment-commands/retest.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 #doc: add new empty commit to trigger new CI build
+set +x #GITHUB_TOKEN
 
 PR_URL=$(jq -r '.issue.pull_request.url' "$GITHUB_EVENT_PATH")
 read -r REPO_URL BRANCH <<<"$(curl "$PR_URL" | jq -r '.head.repo.clone_url + " " + .head.ref' | sed "s/github.com/$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/g")"

--- a/.github/comment-commands/retest.sh
+++ b/.github/comment-commands/retest.sh
@@ -1,4 +1,4 @@
-!/usr/bin/env bash
+#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.

--- a/.github/comment-commands/retest.sh
+++ b/.github/comment-commands/retest.sh
@@ -29,5 +29,5 @@ export GIT_COMMITTER_NAME="GitHub actions"
 export GIT_AUTHOR_EMAIL="noreply@github.com"
 export GIT_AUTHOR_NAME="GitHub actions"
 
-git commit --allow-empty -m "empty commit to retest build"
+git commit --allow-empty -m "empty commit to retest build" > /dev/null
 git push $REPO_URL HEAD:$BRANCH

--- a/.github/comment-commands/retest.sh
+++ b/.github/comment-commands/retest.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -17,14 +17,16 @@
 #doc: add new empty commit to trigger new CI build
 
 PR_URL=$(jq -r '.issue.pull_request.url' "$GITHUB_EVENT_PATH")
-read -r REPO_URL BRANCH <<<"$(curl "$PR_URL" | jq -r '.head.repo.ssh_url + " " + .head.ref')"
+read -r REPO_URL BRANCH <<<"$(curl "$PR_URL" | jq -r '.head.repo.clone_url + " " + .head.ref' | sed "s/github.com/$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/g")"
 
 git fetch "$REPO_URL" "$BRANCH"
 git checkout FETCH_HEAD
 
-git config --global user.email "noreply@github.com"
-git config --global user.name "GitHub"
+export GIT_COMMITTER_EMAIL="noreply@github.com"
+export GIT_COMMITTER_NAME="GitHub actions"
 
-git commit --allow-empty -m "retest build"
-git push origin
-git push $REPO_URL HEAD:$BRANCH
+export GIT_AUTHOR_EMAIL="noreply@github.com"
+export GIT_AUTHOR_NAME="GitHub actions"
+
+echo git commit --allow-empty -m "empty commit to retest build"
+echo git push $REPO_URL HEAD:$BRANCH

--- a/.github/comment-commands/retest.sh
+++ b/.github/comment-commands/retest.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#doc: add new empty commit to trigger new CI build
+
+PR_URL=$(jq -r '.issue.pull_request.url' "$GITHUB_EVENT_PATH")
+read -r REPO_URL BRANCH <<<"$(curl "$PR_URL" | jq -r '.head.repo.ssh_url + " " + .head.ref')"
+
+git fetch "$REPO_URL" "$BRANCH"
+git checkout FETCH_HEAD
+
+git config --global user.email "noreply@github.com"
+git config --global user.name "GitHub"
+
+git commit --allow-empty -m "retest build"
+git push origin
+git push $REPO_URL HEAD:$BRANCH

--- a/.github/comment-commands/retest.sh
+++ b/.github/comment-commands/retest.sh
@@ -29,5 +29,5 @@ export GIT_COMMITTER_NAME="GitHub actions"
 export GIT_AUTHOR_EMAIL="noreply@github.com"
 export GIT_AUTHOR_NAME="GitHub actions"
 
-echo git commit --allow-empty -m "empty commit to retest build"
-echo git push $REPO_URL HEAD:$BRANCH
+git commit --allow-empty -m "empty commit to retest build"
+git push $REPO_URL HEAD:$BRANCH

--- a/.github/process-comment.sh
+++ b/.github/process-comment.sh
@@ -13,6 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+set +x #don't show GITHUB_TOKEN
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 BODY=$(jq -r .comment.body "$GITHUB_EVENT_PATH")
 LINES=$(printf "%s" "$BODY" | wc -l)

--- a/.github/process-comment.sh
+++ b/.github/process-comment.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+BODY=$(jq -r .comment.body "$GITHUB_EVENT_PATH")
+LINES=$(printf "%s" "$BODY" | wc -l)
+if [ "$LINES" == "0" ]; then
+  if [[ "$BODY" == /* ]]; then
+    echo "Command $BODY is received"
+    COMMAND=$(echo "$BODY" | awk '{print $1}' | sed 's/\///')
+    ARGS=$(echo "$BODY" | cut -d ' ' -f2-)
+    if [ -f "$SCRIPT_DIR/comment-commands/$COMMAND.sh" ]; then
+      RESPONSE=$("$SCRIPT_DIR/comment-commands/$COMMAND.sh" "${ARGS[@]}")
+      EXIT_CODE=$?
+      if [[ $EXIT_CODE != 0 ]]; then
+        # shellcheck disable=SC2124
+        RESPONSE="> $BODY
+        
+Script execution has been failed with exit code $EXIT_CODE. Please check the output of the github action run to get more information.
+
+\`\`\`
+$RESPONSE
+\`\`\`
+"
+      fi
+    else
+      RESPONSE="No such command. \`$COMMAND\` $("$SCRIPT_DIR/comment-commands/help.sh")"
+    fi
+    if [ "$GITHUB_TOKEN" ]; then
+      set +x #do not display the GITHUB_TOKEN
+      COMMENTS_URL=$(jq -r .issue.comments_url "$GITHUB_EVENT_PATH")
+      curl -s \
+        --data "$(jq --arg body "$RESPONSE" -n '{body: $body}')" \
+        --header "authorization: Bearer $GITHUB_TOKEN" \
+        --header 'content-type: application/json' \
+        "$COMMENTS_URL"
+    else
+      echo "$RESPONSE"
+    fi
+  fi
+fi

--- a/.github/workflows/comments.yaml
+++ b/.github/workflows/comments.yaml
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: comment-commands
+
+on:
+  issue_comment:
+    types:
+      - created
+      - edited
+
+jobs:
+  process-comment:
+    name: check-comment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - run: ./.github/process-comment.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Before we started to use github actions we had the opportunity to use some "commands" in github comments. For example when a `/label xxx` comment has been added to a PR, a bot added the label (by default just the committers can use labels, but with this approach it was possible for everyone).

Since the move to use github actions I got multiple question about re-triggering the test. Even it it's possible to do with pushing an empty commit (only by the owner or committer) I think it would be better to restore the support of comment commands.

This patch follows a very simple approach. The available commands are store in a separated subdirectory as shell scripts and they are called by a lightweight wrapper.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2997

## How was this patch tested?

As it works only if merged to the master I tested it in my own fork:

Feel free to use this example PR to test it:

https://github.com/elek/hadoop-ozone/pull/9