### PR TITLE
HDDS-2928. Implement ofs://: listStatus

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -334,8 +334,8 @@ public class TestRootedOzoneFileSystem {
     Assert.assertNotNull(fileStatus);
     Assert.assertEquals(new Path(rootPath), fileStatus.getPath());
     Assert.assertTrue(fileStatus.isDirectory());
-    Assert.assertEquals(
-        new FsPermission((short)00755), fileStatus.getPermission());
+    Assert.assertEquals(FsPermission.getDirDefault(),
+        fileStatus.getPermission());
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -51,6 +51,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.fs.ozone.Constants.LISTING_PAGE_SIZE;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 
 /**
@@ -86,7 +87,8 @@ public class TestRootedOzoneFileSystem {
     OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
     volumeName = bucket.getVolumeName();
     bucketName = bucket.getName();
-    String testBucketStr = "/" + volumeName + "/" + bucketName;
+    String testBucketStr =
+        OZONE_URI_DELIMITER + volumeName + OZONE_URI_DELIMITER + bucketName;
     testBucketPath = new Path(testBucketStr);
 
     rootPath = String.format("%s://%s/",
@@ -469,7 +471,8 @@ public class TestRootedOzoneFileSystem {
     fs.mkdirs(leafInsideInterimPath);
 
     // Attempt to rename the key to a different bucket
-    Path bucket2 = new Path("/" + volumeName + "/" + bucketName + "test");
+    Path bucket2 = new Path(OZONE_URI_DELIMITER + volumeName +
+        OZONE_URI_DELIMITER + bucketName + "test");
     Path leafInTargetInAnotherBucket = new Path(bucket2, "leaf");
     try {
       fs.rename(leafInsideInterimPath, leafInTargetInAnotherBucket);
@@ -484,7 +487,7 @@ public class TestRootedOzoneFileSystem {
       throws IOException {
     String key = ofs.pathToKey(keyPath);
     if (isDirectory) {
-      key = key + "/";
+      key = key + OZONE_URI_DELIMITER;
     }
     OFSPath ofsPath = new OFSPath(key);
     String keyInBucket = ofsPath.getKeyName();
@@ -502,7 +505,8 @@ public class TestRootedOzoneFileSystem {
   private Path createRandomVolumeBucketWithDirs() throws IOException {
     String volume1 = getRandomNonExistVolumeName();
     String bucket1 = "bucket-" + RandomStringUtils.randomNumeric(5);
-    Path bucketPath1 = new Path("/" + volume1 + "/" + bucket1);
+    Path bucketPath1 = new Path(
+        OZONE_URI_DELIMITER + volume1 + OZONE_URI_DELIMITER + bucket1);
 
     Path dir1 = new Path(bucketPath1, "dir1");
     fs.mkdirs(dir1);  // Intentionally creating this "in-the-middle" dir key
@@ -521,15 +525,16 @@ public class TestRootedOzoneFileSystem {
   public void testListStatusRootAndVolumeNonRecursive() throws Exception {
     Path bucketPath1 = createRandomVolumeBucketWithDirs();
     createRandomVolumeBucketWithDirs();
-    // listStatus(/volume/bucket)
+    // listStatus("/volume/bucket")
     FileStatus[] fileStatusBucket = ofs.listStatus(bucketPath1);
     Assert.assertEquals(2, fileStatusBucket.length);
-    // listStatus(volume)
-    Path volume = new Path("/" + new OFSPath(bucketPath1).getVolumeName());
+    // listStatus("/volume")
+    Path volume = new Path(
+        OZONE_URI_DELIMITER + new OFSPath(bucketPath1).getVolumeName());
     FileStatus[] fileStatusVolume = ofs.listStatus(volume);
     Assert.assertEquals(1, fileStatusVolume.length);
-    // listStatus(/)
-    Path root = new Path("/");
+    // listStatus("/")
+    Path root = new Path(OZONE_URI_DELIMITER);
     FileStatus[] fileStatusRoot = ofs.listStatus(root);
     Assert.assertEquals(2, fileStatusRoot.length);
   }
@@ -600,13 +605,14 @@ public class TestRootedOzoneFileSystem {
   public void testListStatusRootAndVolumeRecursive() throws Exception {
     Path bucketPath1 = createRandomVolumeBucketWithDirs();
     createRandomVolumeBucketWithDirs();
-    // listStatus(/volume/bucket)
+    // listStatus("/volume/bucket")
     listStatusCheckHelper(bucketPath1);
-    // listStatus(volume)
-    Path volume = new Path("/" + new OFSPath(bucketPath1).getVolumeName());
+    // listStatus("/volume")
+    Path volume = new Path(
+        OZONE_URI_DELIMITER + new OFSPath(bucketPath1).getVolumeName());
     listStatusCheckHelper(volume);
-    // listStatus(/)
-    Path root = new Path("/");
+    // listStatus("/")
+    Path root = new Path(OZONE_URI_DELIMITER);
     listStatusCheckHelper(root);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -68,6 +68,7 @@ public class TestRootedOzoneFileSystem {
   private String bucketName;
   // Store path commonly used by tests that test functionality within a bucket
   private Path testBucketPath;
+  private String rootPath;
 
   @Before
   public void init() throws Exception {
@@ -85,7 +86,7 @@ public class TestRootedOzoneFileSystem {
     String testBucketStr = "/" + volumeName + "/" + bucketName;
     testBucketPath = new Path(testBucketStr);
 
-    String rootPath = String.format("%s://%s/",
+    rootPath = String.format("%s://%s/",
         OzoneConsts.OZONE_OFS_URI_SCHEME, conf.get(OZONE_OM_ADDRESS_KEY));
 
     // Set the fs.defaultFS and start the filesystem
@@ -328,7 +329,7 @@ public class TestRootedOzoneFileSystem {
     Path root = new Path("/");
     FileStatus fileStatus = fs.getFileStatus(root);
     Assert.assertNotNull(fileStatus);
-    Assert.assertNull(fileStatus.getPath());
+    Assert.assertEquals(new Path(rootPath), fileStatus.getPath());
     Assert.assertTrue(fileStatus.isDirectory());
     Assert.assertEquals(
         new FsPermission((short)00755), fileStatus.getPermission());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -493,4 +493,42 @@ public class TestRootedOzoneFileSystem {
     GenericTestUtils.assertExceptionContains("KEY_NOT_FOUND", ex);
   }
 
+  /**
+   * OFS: Test recursive listStatus on root.
+   */
+  @Test
+  public void testListStatusRootAndVolumeNonRecursive() throws Exception {
+    String volume1 = getRandomNonExistVolumeName();
+    String bucket1 = "bucket-" + RandomStringUtils.randomNumeric(5);
+    Path bucketPath1 = new Path("/" + volume1 + "/" + bucket1);
+    Path dir1 = new Path(bucketPath1, "dir1");
+    Path subdir1 = new Path(dir1, "subdir1");
+    fs.mkdirs(subdir1);
+    Path dir2 = new Path(bucketPath1, "dir2");
+    fs.mkdirs(dir2);
+
+    String volume2 = getRandomNonExistVolumeName();
+    String bucket2 = "bucket-" + RandomStringUtils.randomNumeric(5);
+    Path bucketPath2 = new Path("/" + volume2 + "/" + bucket2);
+    Path dir3 = new Path(bucketPath2, "dir3");
+    Path subdir2 = new Path(dir3, "subdir2");
+    fs.mkdirs(subdir2);
+    Path dir4 = new Path(bucketPath2, "dir4");
+    fs.mkdirs(dir4);
+
+    // bucket
+    FileStatus[] fileStatuses = ofs.listStatus(bucketPath1);
+    Assert.assertEquals(2, fileStatuses.length);
+
+    // volume
+    Path volume = new Path("/" + volume1);
+    FileStatus[] fileStatusesVolume = ofs.listStatus(volume);
+    Assert.assertEquals(1, fileStatusesVolume.length);
+
+    // root
+    Path root = new Path("/");
+    FileStatus[] fileStatusesRoot = ofs.listStatus(root);
+    Assert.assertEquals(2, fileStatusesRoot.length);
+  }
+
 }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -564,15 +564,11 @@ public class BasicRootedOzoneClientAdapterImpl
 
     incrementCounter(Statistic.OBJECTS_LIST);
     OFSPath ofsPath = new OFSPath(pathStr);
-
-    // listStatus root
-    if (ofsPath.getVolumeName().isEmpty()
-        && ofsPath.getBucketName().isEmpty()) {
+    if (ofsPath.isRoot()) {
       return listStatusRoot(
           recursive, startPath, numEntries, uri, workingDir, username);
     }
-    // listStatus volume
-    if (ofsPath.getBucketName().isEmpty()) {
+    if (ofsPath.isVolume()) {
       return listStatusVolume(ofsPath.getVolumeName(),
           recursive, startPath, numEntries, uri, workingDir, username);
     }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -739,20 +739,16 @@ public class BasicRootedOzoneClientAdapterImpl
       OzoneVolume ozoneVolume, URI uri) {
     String pathStr = uri.toString() +
         OZONE_URI_DELIMITER + ozoneVolume.getName();
-    LOG.debug("getFileStatusAdapterForVolume(pathStr=" + pathStr);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("getFileStatusAdapterForVolume: ozoneVolume={}, pathStr={}",
+          ozoneVolume.getName(), pathStr);
+    }
     Path path = new Path(pathStr);
-    return new FileStatusAdapter(
-        0L,
-        path,
-        true,
-        (short)0,
-        0L,
-        ozoneVolume.getCreationTime().getEpochSecond() * 1000,
-        0L,
-        (short)00755,  // Default directory permission, derive from ACLs later?
-        ozoneVolume.getOwner(),
-        ozoneVolume.getAdmin(),  // TODO: Get group of whom?
-        path
+    return new FileStatusAdapter(0L, path, true, (short)0, 0L,
+        ozoneVolume.getCreationTime().getEpochSecond() * 1000, 0L,
+        FsPermission.getDirDefault().toShort(),
+        // TODO: Revisit owner and admin
+        ozoneVolume.getOwner(), ozoneVolume.getAdmin(), path
     );
   }
 

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -674,7 +674,7 @@ public class BasicRootedOzoneClientAdapterImpl
     // TODO: Revisit the return value.
     return new FileStatusAdapter(
         0L,
-        null,
+        new Path("/"),
         true,
         (short)0,
         0L,

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -767,6 +767,11 @@ public class BasicRootedOzoneClientAdapterImpl
     String pathStr = uri.toString() +
         OZONE_URI_DELIMITER + ozoneBucket.getVolumeName() +
         OZONE_URI_DELIMITER + ozoneBucket.getName();
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("getFileStatusAdapterForBucket: ozoneBucket={}, pathStr={}, "
+              + "username={}", ozoneBucket.getVolumeName() + OZONE_URI_DELIMITER
+              + ozoneBucket.getName(), pathStr, username);
+    }
     Path path = new Path(pathStr);
     return new FileStatusAdapter(0L, path, true, (short)0, 0L,
         ozoneBucket.getCreationTime().getEpochSecond() * 1000, 0L,

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -496,16 +496,16 @@ public class BasicRootedOzoneClientAdapterImpl
     OFSPath ofsStartPath = new OFSPath(startPath);
     // list volumes
     Iterator<? extends OzoneVolume> iter = objectStore.listVolumesByUser(
-        username, null, ofsStartPath.getVolumeName());
+        username, ofsStartPath.getVolumeName(), null);
     List<FileStatusAdapter> res = new ArrayList<>();
     // TODO: Test continuation
     while (iter.hasNext() && res.size() <= numEntries) {
       OzoneVolume volume = iter.next();
       res.add(getFileStatusAdapterForVolume(volume, uri));
       if (recursive) {
-        String next = volume.getName();
+        String pathStrNextVolume = volume.getName();
         // TODO: Check startPath
-        res.addAll(listStatus(next, recursive, startPath,
+        res.addAll(listStatus(pathStrNextVolume, recursive, startPath,
             numEntries - res.size(), uri, workingDir, username));
       }
     }
@@ -516,22 +516,23 @@ public class BasicRootedOzoneClientAdapterImpl
    * Helper for OFS listStatus on a volume.
    */
   private List<FileStatusAdapter> listStatusVolume(String volumeStr,
-      boolean recursive, String startBucket, long numEntries,
+      boolean recursive, String startPath, long numEntries,
       URI uri, Path workingDir, String username) throws IOException {
 
+    OFSPath ofsStartPath = new OFSPath(startPath);
     // list buckets in the volume
     OzoneVolume volume = objectStore.getVolume(volumeStr);
     Iterator<? extends OzoneBucket> iter =
-        volume.listBuckets(null, startBucket);
+        volume.listBuckets(null, ofsStartPath.getBucketName());
     List<FileStatusAdapter> res = new ArrayList<>();
     // TODO: Test continuation
     while (iter.hasNext() && res.size() <= numEntries) {
       OzoneBucket bucket = iter.next();
       res.add(getFileStatusAdapterForBucket(bucket, uri, username));
       if (recursive) {
-        String next = volumeStr + OZONE_URI_DELIMITER + bucket.getName();
+        String pathStrNext = volumeStr + OZONE_URI_DELIMITER + bucket.getName();
         // TODO: Check startPath
-        res.addAll(listStatus(next, recursive, startBucket,
+        res.addAll(listStatus(pathStrNext, recursive, startPath,
             numEntries - res.size(), uri, workingDir, username));
       }
     }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -58,6 +58,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes
     .BUCKET_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes
@@ -439,11 +440,11 @@ public class BasicRootedOzoneClientAdapterImpl
     incrementCounter(Statistic.OBJECTS_QUERY);
     OFSPath ofsPath = new OFSPath(path);
     String key = ofsPath.getKeyName();
-    // getFileStatus is called for root
+    // path is root
     if (ofsPath.getVolumeName().isEmpty() &&
         ofsPath.getBucketName().isEmpty()) {
-      // Generate a FileStatusAdapter for root
-      return rootFileStatusAdapter();
+      return getFileStatusAdapterForRoot(uri);
+    }
     }
     try {
       OzoneBucket bucket = getBucket(ofsPath, false);
@@ -666,15 +667,16 @@ public class BasicRootedOzoneClientAdapterImpl
 
   /**
    * Generate a FileStatusAdapter for OFS root.
+   * @param uri Full URI to OFS root.
    * @return FileStatusAdapter for root.
    */
-  private static FileStatusAdapter rootFileStatusAdapter() {
+  private static FileStatusAdapter getFileStatusAdapterForRoot(URI uri) {
     // Note that most fields are mimicked from HDFS FileStatus for root,
     //  except modification time, permission, owner and group.
-    // TODO: Revisit the return value.
+    Path path = new Path(uri.toString() + OZONE_URI_DELIMITER);
     return new FileStatusAdapter(
         0L,
-        new Path("/"),
+        path,
         true,
         (short)0,
         0L,

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -440,13 +440,10 @@ public class BasicRootedOzoneClientAdapterImpl
     incrementCounter(Statistic.OBJECTS_QUERY);
     OFSPath ofsPath = new OFSPath(path);
     String key = ofsPath.getKeyName();
-    // path is root
-    if (ofsPath.getVolumeName().isEmpty() &&
-        ofsPath.getBucketName().isEmpty()) {
+    if (ofsPath.isRoot()) {
       return getFileStatusAdapterForRoot(uri);
     }
-    // path is a volume
-    if (ofsPath.getBucketName().isEmpty()) {
+    if (ofsPath.isVolume()) {
       OzoneVolume volume = objectStore.getVolume(ofsPath.getVolumeName());
       return getFileStatusAdapterForVolume(volume, uri);
     }
@@ -497,8 +494,9 @@ public class BasicRootedOzoneClientAdapterImpl
   private List<FileStatusAdapter> listStatusRoot(
       boolean recursive, String startPath, long numEntries,
       URI uri, Path workingDir, String username) throws IOException {
+
     OFSPath ofsStartPath = new OFSPath(startPath);
-    // list volumes for user
+    // list volumes
     Iterator<? extends OzoneVolume> iter = objectStore.listVolumesByUser(
         username, null, ofsStartPath.getVolumeName());
     List<FileStatusAdapter> res = new ArrayList<>();
@@ -522,8 +520,9 @@ public class BasicRootedOzoneClientAdapterImpl
   private List<FileStatusAdapter> listStatusVolume(String volumeStr,
       boolean recursive, String startPath, long numEntries,
       URI uri, Path workingDir, String username) throws IOException {
+
     OFSPath ofsStartPath = new OFSPath(startPath);
-    // list buckets in volume
+    // list buckets in the volume
     OzoneVolume volume = objectStore.getVolume(volumeStr);
     Iterator<? extends OzoneBucket> iter = volume.listBuckets(
         null, ofsStartPath.getBucketName());

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.fs.ozone;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
@@ -763,9 +764,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     return true;
   }
 
-  private FileStatus convertFileStatus(
-      FileStatusAdapter fileStatusAdapter) {
-
+  @VisibleForTesting
+  FileStatus convertFileStatus(FileStatusAdapter fileStatusAdapter) {
     Path symLink = null;
     try {
       fileStatusAdapter.getSymlink();

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
@@ -142,4 +142,20 @@ class OFSPath {
   public boolean isInSameBucketAs(OFSPath p2) {
     return isInSameBucketAsInternal(this, p2);
   }
+
+  /**
+   * If both volume and bucket names are empty, the given path is root.
+   * i.e. /
+   */
+  public boolean isRoot() {
+    return this.getVolumeName().isEmpty() && this.getBucketName().isEmpty();
+  }
+
+  /**
+   * If bucket name is empty but volume name is not, the given path is volume.
+   * e.g. /volume1
+   */
+  public boolean isVolume() {
+    return this.getBucketName().isEmpty() && !this.getVolumeName().isEmpty();
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

ofs:// should be able to handle list (recursive or not) under "root" and under each volume "directory", as if it is a flat filesystem (if the user has permissions to see the volumes).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2928

## How was this patch tested?

So far manually tested in CLI. See commit message for instructions.
Adding unit tests.