### PR TITLE
HDDS-3021. Ozone S3 CLI path command not working on HA cluster.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/ozShell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/ozShell/TestOzoneShellHA.java
@@ -27,6 +27,9 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.web.ozShell.OzoneShell;
+import org.apache.hadoop.ozone.web.ozShell.Shell;
+import org.apache.hadoop.ozone.web.ozShell.s3.S3Shell;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -152,7 +155,7 @@ public class TestOzoneShellHA {
     System.setErr(OLD_ERR);
   }
 
-  private void execute(OzoneShell shell, String[] args) {
+  private void execute(Shell shell, String[] args) {
     LOG.info("Executing OzoneShell command with args {}", Arrays.asList(args));
     CommandLine cmd = shell.getCmd();
 
@@ -393,4 +396,32 @@ public class TestOzoneShellHA {
     Assert.assertEquals(0, out.size());
     Assert.assertEquals(0, getNumOfKeys());
   }
+
+
+  @Test
+  public void testS3PathCommand() throws Exception {
+
+    String s3Bucket = "b12345";
+    cluster.getClient().getObjectStore().createS3Bucket(
+        UserGroupInformation.getCurrentUser().getUserName(), s3Bucket);
+
+    String[] args = new String[] {"path", s3Bucket,
+        "--om-service-id="+omServiceId};
+
+    S3Shell s3Shell = new S3Shell();
+    execute(s3Shell, args);
+
+
+    String volumeName =
+        cluster.getClient().getObjectStore().getOzoneVolumeName(s3Bucket);
+
+    String ozoneFsUri = String.format("%s://%s.%s", OzoneConsts
+        .OZONE_URI_SCHEME, s3Bucket, volumeName);
+
+    Assert.assertTrue(out.toString().contains(volumeName));
+    Assert.assertTrue(out.toString().contains(ozoneFsUri));
+
+    out.reset();
+  }
+
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/ozShell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/ozShell/TestOzoneShellHA.java
@@ -402,7 +402,7 @@ public class TestOzoneShellHA {
   public void testS3PathCommand() throws Exception {
 
     String s3Bucket = "b12345";
-    cluster.getClient().getObjectStore().createS3Bucket(
+    cluster.getRpcClient().getObjectStore().createS3Bucket(
         UserGroupInformation.getCurrentUser().getUserName(), s3Bucket);
 
     String[] args = new String[] {"path", s3Bucket,
@@ -413,7 +413,7 @@ public class TestOzoneShellHA {
 
 
     String volumeName =
-        cluster.getClient().getObjectStore().getOzoneVolumeName(s3Bucket);
+        cluster.getRpcClient().getObjectStore().getOzoneVolumeName(s3Bucket);
 
     String ozoneFsUri = String.format("%s://%s.%s", OzoneConsts
         .OZONE_URI_SCHEME, s3Bucket, volumeName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/GetS3SecretHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/GetS3SecretHandler.java
@@ -19,10 +19,8 @@ package org.apache.hadoop.ozone.web.ozShell.s3;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.web.ozShell.Handler;
 import org.apache.hadoop.ozone.web.ozShell.OzoneAddress;
 import org.apache.hadoop.security.UserGroupInformation;
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
@@ -32,16 +30,11 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY
  */
 @Command(name = "getsecret",
     description = "Returns s3 secret for current user")
-public class GetS3SecretHandler extends Handler {
+public class GetS3SecretHandler extends S3Handler {
 
   public static final String OZONE_GETS3SECRET_ERROR = "This command is not" +
       " supported in unsecure clusters.";
 
-  @CommandLine.Option(names = {"--om-service-id"},
-      required = false,
-      description = "OM Service ID is required to be specified for OM HA" +
-          " cluster")
-  private String omServiceID;
   /**
    * Executes getS3Secret.
    */
@@ -50,7 +43,7 @@ public class GetS3SecretHandler extends Handler {
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
     try (OzoneClient client =
         new OzoneAddress().createClientForS3Commands(ozoneConfiguration,
-            omServiceID)) {
+            getOmServiceID())) {
 
       // getS3Secret works only with secured clusters
       if (ozoneConfiguration.getBoolean(OZONE_SECURITY_ENABLED_KEY, false)) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/S3BucketMapping.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/S3BucketMapping.java
@@ -15,11 +15,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.apache.hadoop.ozone.web.ozShell.bucket;
+package org.apache.hadoop.ozone.web.ozShell.s3;
 
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.web.ozShell.Handler;
 import org.apache.hadoop.ozone.web.ozShell.OzoneAddress;
 
 import picocli.CommandLine.Command;
@@ -31,7 +30,7 @@ import picocli.CommandLine.Parameters;
  */
 @Command(name = "path",
     description = "Returns the ozone path for S3Bucket")
-public class S3BucketMapping extends Handler {
+public class S3BucketMapping extends S3Handler {
 
   @Parameters(arity = "1..1", description = "Name of the s3 bucket.")
   private String s3BucketName;
@@ -44,7 +43,8 @@ public class S3BucketMapping extends Handler {
 
     OzoneAddress ozoneAddress = new OzoneAddress();
     try (OzoneClient client =
-        ozoneAddress.createClient(createOzoneConfiguration())) {
+        ozoneAddress.createClientForS3Commands(
+            createOzoneConfiguration(), getOmServiceID())) {
 
       String mapping =
           client.getObjectStore().getOzoneBucketMapping(s3BucketName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/S3Handler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/S3Handler.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.apache.hadoop.ozone.web.ozShell.s3;
 
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/S3Handler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/S3Handler.java
@@ -1,0 +1,26 @@
+package org.apache.hadoop.ozone.web.ozShell.s3;
+
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.ozone.web.ozShell.Handler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+/**
+ * Common interface for S3 command handling.
+ */
+@CommandLine.Command(mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class)
+public class S3Handler extends Handler {
+  protected static final Logger LOG = LoggerFactory.getLogger(S3Handler.class);
+
+  @CommandLine.Option(names = {"--om-service-id"},
+      required = false,
+      description = "OM Service ID is required to be specified for OM HA" +
+          " cluster")
+  private String omServiceID;
+
+  public String getOmServiceID() {
+    return omServiceID;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/S3Shell.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/s3/S3Shell.java
@@ -21,7 +21,6 @@ import io.opentracing.Scope;
 import io.opentracing.util.GlobalTracer;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.web.ozShell.Shell;
-import org.apache.hadoop.ozone.web.ozShell.bucket.S3BucketMapping;
 import picocli.CommandLine.Command;
 
 /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

ozone s3 path <<bucketname>>

ozone s3 path are not working on OM HA cluster

Fix these commands to work on OM HA cluster.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3021

## How was this patch tested?

Added UT and also tested on the docker-compose om-ha-s3 cluster.
```
bash-4.2$ ozone s3 path b12345 --om-service-id=id1
Volume name for S3Bucket is : s34124bc0a9335c27f086f24ba207a4912
Ozone FileSystem Uri is : o3fs://b12345.s34124bc0a9335c27f086f24ba207a4912
```
