### PR TITLE
HDDS-3023. Create Freon test to test isolated Ratis LEADER

### DIFF
--- a/dev-support/byteman/ratis-mock-followers.btm
+++ b/dev-support/byteman/ratis-mock-followers.btm
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# This script instruments hadoop rpc layer to print out all the request/response messages to the standard output.
+#
+
+RULE mock request vote
+CLASS org.apache.ratis.grpc.server.GrpcServerProtocolClient
+METHOD requestVote
+AT ENTRY
+BIND service:org.apache.ratis.grpc.server.GrpcServerProtocolClient = $0;
+     raftPeerId:org.apache.ratis.protocol.RaftPeerId = service.raftPeerId;
+     result:org.apache.ratis.proto.RaftProtos$RequestVoteReplyProto = org.apache.hadoop.hdds.freon.FakeRatisFollower.requestVote(raftPeerId, $1);
+IF true
+DO return result;
+ENDRULE
+
+
+RULE mock append log
+CLASS org.apache.ratis.grpc.server.GrpcServerProtocolClient
+METHOD appendEntries
+AT ENTRY
+BIND service:org.apache.ratis.grpc.server.GrpcServerProtocolClient = $0;
+     raftPeerId:org.apache.ratis.protocol.RaftPeerId = service.raftPeerId;
+     result:org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver = org.apache.hadoop.hdds.freon.FakeRatisFollower.appendEntries(raftPeerId, $1);
+IF true
+DO return result;
+ENDRULE
+

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/hdds/freon/FakeRatisFollower.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/hdds/freon/FakeRatisFollower.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.hdds.freon;
+
+import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto;
+import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto.AppendResult;
+import org.apache.ratis.proto.RaftProtos.AppendEntriesRequestProto;
+import org.apache.ratis.proto.RaftProtos.CommitInfoProto;
+import org.apache.ratis.proto.RaftProtos.LogEntryProto;
+import org.apache.ratis.proto.RaftProtos.RaftRpcReplyProto;
+import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
+import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+
+/**
+ * Helper class to use it to replace original Ratis GRPC outgoing calls.
+ */
+public final class FakeRatisFollower {
+
+  private static int simulatedLatency = 0;
+
+  static {
+    String ratisSimulatedLatency = System.getenv("RATIS_SIMULATED_LATENCY");
+    if (ratisSimulatedLatency != null) {
+      simulatedLatency = Integer.parseInt(ratisSimulatedLatency);
+    }
+  }
+
+  private FakeRatisFollower() {
+  }
+
+  public static StreamObserver<AppendEntriesRequestProto> appendEntries(
+      RaftPeerId raftPeerId,
+      StreamObserver<AppendEntriesReplyProto> responseHandler) {
+    return new StreamObserver<AppendEntriesRequestProto>() {
+      private long maxIndex = -1L;
+
+      @Override
+      public void onNext(AppendEntriesRequestProto value) {
+
+        for (LogEntryProto entry : value.getEntriesList()) {
+          if (entry.getIndex() > maxIndex) {
+            maxIndex = entry.getIndex();
+          }
+        }
+
+        long maxCommitted = value.getCommitInfosList()
+            .stream()
+            .mapToLong(CommitInfoProto::getCommitIndex)
+            .max().orElseGet(() -> 0L);
+
+        maxCommitted = Math.min(maxCommitted, maxIndex);
+
+        AppendEntriesReplyProto response = AppendEntriesReplyProto.newBuilder()
+            .setNextIndex(maxIndex + 1)
+            .setFollowerCommit(maxCommitted)
+            .setResult(AppendResult.SUCCESS)
+            .setTerm(value.getLeaderTerm())
+            .setMatchIndex(maxIndex)
+            .setServerReply(RaftRpcReplyProto.newBuilder()
+                .setSuccess(true)
+                .setRequestorId(value.getServerRequest().getRequestorId())
+                .setReplyId(raftPeerId.toByteString())
+                .setCallId(value.getServerRequest().getCallId())
+                .setRaftGroupId(value.getServerRequest().getRaftGroupId()))
+            .build();
+        maxCommitted = Math.min(value.getLeaderCommit(), maxIndex);
+        addLatency();
+        responseHandler.onNext(response);
+      }
+
+      @Override
+      public void onError(Throwable t) {
+
+      }
+
+      @Override
+      public void onCompleted() {
+
+      }
+    };
+  }
+
+  public static RequestVoteReplyProto requestVote(RaftPeerId raftPeerId,
+      RequestVoteRequestProto request) {
+    addLatency();
+    System.out.println("Request vote response");
+    return RequestVoteReplyProto.newBuilder()
+        .setServerReply(
+            RaftRpcReplyProto.newBuilder()
+                .setSuccess(true)
+                .setRequestorId(request.getServerRequest().getRequestorId())
+                .setReplyId(raftPeerId.toByteString())
+                .setCallId(request.getServerRequest().getCallId())
+                .setRaftGroupId(request.getServerRequest().getRaftGroupId())
+        )
+        .setTerm(request.getCandidateTerm())
+        .build();
+  }
+
+  private static void addLatency() {
+    if (simulatedLatency > 0) {
+      try {
+        Thread.sleep(simulatedLatency);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/hdds/freon/package-info.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/hdds/freon/package-info.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <p>
+ * Utility classes used in instrumented freon tests like
+ * LeaderAppendLogEntryGenerator.
+ */
+
+/**
+ * Utility classes used in instrumented freon tests like
+ * LeaderAppendLogEntryGenerator.
+ */
+package org.apache.hadoop.hdds.freon;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseAppendLogGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseAppendLogGenerator.java
@@ -18,6 +18,7 @@ package org.apache.hadoop.ozone.freon;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -43,6 +44,15 @@ public class BaseAppendLogGenerator extends BaseFreonGenerator {
       description = "Host:port of the Ratis server",
       defaultValue = "localhost:9858")
   protected String serverAddress = "localhost:9858";
+
+  @SuppressWarnings("checkstyle:VisibilityModifier")
+  @Option(names = {"--inflight-limit"},
+      description = "Maximum in-flight messages",
+      defaultValue = "10")
+  protected int inflightLimit;
+
+  @SuppressWarnings("checkstyle:VisibilityModifier")
+  protected BlockingQueue<Long> inFlightMessages;
 
   protected void setServerIdFromFile(OzoneConfiguration conf) throws
       IOException {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FollowerAppendLogEntryGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FollowerAppendLogEntryGenerator.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import java.util.UUID;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -128,11 +127,6 @@ public class FollowerAppendLogEntryGenerator extends BaseAppendLogGenerator
       defaultValue = "0")
   private int rateLimit;
 
-  @Option(names = {"--inflight-limit"},
-      description = "Maximum in-flight messages",
-      defaultValue = "10")
-  private int inflightLimit;
-
   private TimedSemaphore rateLimiter;
 
   private RaftPeerProto requestor;
@@ -146,8 +140,6 @@ public class FollowerAppendLogEntryGenerator extends BaseAppendLogGenerator
   private ByteString dataToWrite;
 
   private Timer timer;
-
-  private BlockingQueue<Long> inFlightMessages;
 
   private StreamObserver<AppendEntriesRequestProto> sender;
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
@@ -47,7 +47,8 @@ import picocli.CommandLine.Option;
         S3KeyGenerator.class,
         DatanodeChunkGenerator.class,
         FollowerAppendLogEntryGenerator.class,
-        ChunkManagerDiskWrite.class},
+        ChunkManagerDiskWrite.class,
+        LeaderAppendLogEntryGenerator.class},
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true)
 public class Freon extends GenericCli {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/LeaderAppendLogEntryGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/LeaderAppendLogEntryGenerator.java
@@ -1,0 +1,273 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.freon;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumData;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumType;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChunkInfo;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerType;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CreateContainerRequestProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.DatanodeBlockID;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.WriteChunkRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
+import org.apache.hadoop.hdds.scm.XceiverClientRatis;
+import org.apache.hadoop.hdds.scm.XceiverClientReply;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+
+import com.codahale.metrics.Timer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.proto.RaftProtos.RaftPeerProto;
+import org.apache.ratis.proto.grpc.RaftServerProtocolServiceGrpc;
+import org.apache.ratis.proto.grpc.RaftServerProtocolServiceGrpc.RaftServerProtocolServiceStub;
+import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.thirdparty.io.grpc.ManagedChannel;
+import org.apache.ratis.thirdparty.io.grpc.netty.NegotiationType;
+import org.apache.ratis.thirdparty.io.grpc.netty.NettyChannelBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Test isolated LEADER datanodes.
+ * <p>
+ * This test configures a Raft group, in a single standalone datanode and use
+ * it as a leader. To move out followers from the picture
+ * dev-support/byteman/ratis-mock-followers.btm byteman script can be used.
+ */
+@Command(name = "lalg",
+    aliases = "leader-append-log-generator",
+    description = "Generate append log entries to a leader server",
+    versionProvider = HddsVersionProvider.class,
+    mixinStandardHelpOptions = true,
+    showDefaultValues = true)
+public class LeaderAppendLogEntryGenerator extends BaseAppendLogGenerator
+    implements
+    Callable<Void> {
+
+  public static final String FAKE_LEADER_ADDDRESS1 = "localhost:1234";
+  public static final String FAKE_LEADER_ADDDRESS2 = "localhost:1235";
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(LeaderAppendLogEntryGenerator.class);
+
+  private static final String FAKE_FOLLOWER_ID1 =
+      "ffffffff-df33-4a20-8e1f-ffffffff6be5";
+
+  @Option(names = {"-l", "--pipeline"},
+      description = "Pipeline to use. By default the first RATIS/THREE "
+          + "pipeline will be used.",
+      defaultValue = "96714307-4bd7-42b5-a65d-e1b13b4ca5c0")
+  private String pipelineId = "96714307-4bd7-42b5-a65d-e1b13b4ca5c0";
+
+  @Option(names = {"-s", "--size"},
+      description = "Size of the generated chunks (in bytes)",
+      defaultValue = "1024")
+  private int chunkSize;
+
+  @Option(names = {"-i", "--next-index"},
+      description = "The next index in the term 2 to continue a test. (If "
+          + "zero, a new ratis ring will be intialized with configureGroup "
+          + "call and vote)",
+      defaultValue = "0")
+  private long nextIndex;
+
+  private RaftPeerProto requestor;
+
+  private long term = 2L;
+
+  private RaftServerProtocolServiceStub stub;
+
+  private Random callIdRandom = new Random();
+
+  private ByteString dataToWrite;
+
+  private Timer timer;
+
+  @Override
+  public Void call() throws Exception {
+
+    inFlightMessages = new LinkedBlockingQueue<>(inflightLimit);
+
+    OzoneConfiguration conf = createOzoneConfiguration();
+
+    byte[] data = RandomStringUtils.randomAscii(chunkSize)
+        .getBytes(StandardCharsets.UTF_8);
+    dataToWrite = ByteString.copyFrom(data);
+
+    setServerIdFromFile(conf);
+
+    requestor = RaftPeerProto.newBuilder()
+        .setId(RaftPeerId.valueOf(FAKE_FOLLOWER_ID1).toByteString())
+        .setAddress(FAKE_LEADER_ADDDRESS1)
+        .build();
+
+    NettyChannelBuilder channelBuilder =
+        NettyChannelBuilder.forTarget(serverAddress);
+    channelBuilder.negotiationType(NegotiationType.PLAINTEXT);
+    ManagedChannel build = channelBuilder.build();
+    stub = RaftServerProtocolServiceGrpc.newStub(build);
+
+    init();
+
+    if (nextIndex == 0) {
+      configureGroup();
+    }
+
+    Thread.sleep(3000L);
+
+    XceiverClientRatis client = createXceiverClient(conf);
+
+    client.connect();
+
+    long containerId = 1L;
+
+    System.out.println(client.sendCommand(createContainerRequest(containerId)));
+
+    timer = getMetrics().timer("append-entry");
+
+    runTests(step -> timer.time(() -> {
+      inFlightMessages.put(step);
+      XceiverClientReply xceiverClientReply =
+          client.sendCommandAsync(createChunkWriteRequest(containerId, step));
+      xceiverClientReply.getResponse()
+          .thenApply(response -> inFlightMessages.remove(step));
+      return null;
+    }));
+
+    return null;
+  }
+
+  private XceiverClientRatis createXceiverClient(OzoneConfiguration conf) {
+    List<DatanodeDetails> datanodes = new ArrayList<>();
+
+    datanodes.add(DatanodeDetails.newBuilder()
+        .setUuid(serverId)
+        .setHostName("localhost")
+        .setIpAddress("127.0.0.1")
+        .addPort(DatanodeDetails.newPort(Name.RATIS, 9858))
+        .build());
+
+    Pipeline pipeline = Pipeline.newBuilder()
+        .setId(PipelineID.valueOf(UUID.fromString(pipelineId)))
+        .setState(PipelineState.OPEN)
+        .setType(ReplicationType.RATIS)
+        .setFactor(ReplicationFactor.THREE)
+        .setLeaderId(UUID.fromString(serverId))
+        .setNodes(datanodes)
+        .build();
+
+    return XceiverClientRatis
+        .newXceiverClientRatis(pipeline, conf);
+  }
+
+  private ContainerCommandRequestProto createContainerRequest(
+      long containerId) {
+    return ContainerCommandRequestProto.newBuilder()
+        .setContainerID(containerId)
+        .setCmdType(Type.CreateContainer)
+        .setDatanodeUuid(serverId)
+        .setCreateContainer(CreateContainerRequestProto.newBuilder()
+            .setContainerType(ContainerType.KeyValueContainer)
+            .build())
+        .build();
+
+  }
+
+  private ContainerCommandRequestProto createChunkWriteRequest(long containerId,
+      long chunkId) {
+
+    long blockId = getPrefix().hashCode() + chunkId / 1000;
+    return ContainerCommandRequestProto.newBuilder()
+        .setContainerID(containerId)
+        .setCmdType(Type.WriteChunk)
+        .setDatanodeUuid(serverId)
+        .setWriteChunk(WriteChunkRequestProto.newBuilder()
+            .setData(dataToWrite)
+            .setBlockID(DatanodeBlockID.newBuilder()
+                .setContainerID(containerId)
+                .setLocalID(blockId)
+                .build())
+            .setChunkData(ChunkInfo.newBuilder()
+                .setChunkName("chunk" + chunkId)
+                .setLen(dataToWrite.size())
+                .setOffset(0)
+                .setChecksumData(ChecksumData.newBuilder()
+                    .setBytesPerChecksum(0)
+                    .setType(ChecksumType.NONE)
+                    .build())
+                .build())
+            .build())
+        .build();
+
+  }
+
+  private void configureGroup() throws IOException {
+    ClientId clientId = ClientId.randomId();
+
+    RaftGroupId groupId = RaftGroupId
+        .valueOf(UUID.fromString(pipelineId));
+    RaftPeerId peerId =
+        RaftPeerId.getRaftPeerId(serverId);
+
+    RaftGroup group = RaftGroup.valueOf(groupId,
+        new RaftPeer(RaftPeerId.valueOf(serverId), serverAddress),
+        new RaftPeer(RaftPeerId.valueOf(FAKE_FOLLOWER_ID1),
+            FAKE_LEADER_ADDDRESS1),
+        new RaftPeer(RaftPeerId.valueOf(FAKE_FOLLOWER_ID1),
+            FAKE_LEADER_ADDDRESS2));
+    RaftClient client = RaftClient.newBuilder()
+        .setClientId(clientId)
+        .setProperties(new RaftProperties(true))
+        .setRaftGroup(group)
+        .build();
+
+    RaftClientReply raftClientReply = client.groupAdd(group, peerId);
+
+    LOG.info(
+        "Group is configured in the RAFT server (with two fake leader leader)"
+            + ": {}",
+        raftClientReply);
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Similart to #542 it provides a Freon (load-) test to test an isolated datanode with using full Ratis/ContainerStateMachine code path. The Freon test configures the Raft group and sends chunk write requests.

A byteman script is provided to fake/mock the leader components. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3023

## How was this patch tested?

1. To test the patch you need RATIS-816 (create new build and change the Ratis version to a snapshot)

2. Datanode should be started in standalone mode and the Ratis Grpc server protocol should be mocked.

The first can be achieved by setting the following environment variable:

```
OZONE_DATANODE_STANDALONE_TEST=follower
```

The second one requires a [byteman](https://byteman.jboss.org/) install

```
-javaagent:/home/elek/prog/byteman/lib/byteman.jar=script:/home/elek/projects/ozone/dev-support/byteman/ratis-mock-followers.btm,boot:/home/elek/prog/byteman/lib/byteman.jar -Dorg.jboss.byteman.transform.all
```


3. And start the Datanode (you can start it from IDE as it doesn't require any other components like OM or SCM)

4. Finally freon can be started:

```
ozone freon --verbose lalg -t1 -n100000 -s 1024
```