### PR TITLE
HDDS-3018. Fix TestContainerStateMachineFailures.java

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -237,19 +237,25 @@ public class ContainerStateMachine extends BaseStateMachine {
 
     // initialize the dispatcher with snapshot so that it build the missing
     // container list
+    buildMissingContainerSet(snapshotFile);
+    return last.getIndex();
+  }
+
+  @VisibleForTesting
+  public void buildMissingContainerSet(File snapshotFile) throws IOException {
+    // initialize the dispatcher with snapshot so that it build the missing
+    // container list
     try (FileInputStream fin = new FileInputStream(snapshotFile)) {
       ContainerProtos.Container2BCSIDMapProto proto =
-          ContainerProtos.Container2BCSIDMapProto
-              .parseFrom(fin);
+              ContainerProtos.Container2BCSIDMapProto
+                      .parseFrom(fin);
       // read the created containers list from the snapshot file and add it to
       // the container2BCSIDMap here.
       // container2BCSIDMap will further grow as and when containers get created
       container2BCSIDMap.putAll(proto.getContainer2BCSIDMap());
       dispatcher.buildMissingContainerSetAndValidate(container2BCSIDMap);
     }
-    return last.getIndex();
   }
-
   /**
    * As a part of taking snapshot with Ratis StateMachine, it will persist
    * the existing container set in the snapshotFile.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -424,7 +424,6 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     if (!isStarted) {
       LOG.info("Starting {} {} at port {}", getClass().getSimpleName(),
           server.getId(), getIPCPort());
-      LOG.info(" Ratis log dir is {}", HddsServerUtil.getOzoneDatanodeRatisDirectory(conf));
       for (ThreadPoolExecutor executor : chunkExecutors) {
         executor.prestartAllCoreThreads();
       }
@@ -455,7 +454,6 @@ public final class XceiverServerRatis implements XceiverServerSpi {
       try {
         // shutdown server before the executors as while shutting down,
         // some of the tasks would be executed using the executors.
-        LOG.info(" Ratis log dir is {}", HddsServerUtil.getOzoneDatanodeRatisDirectory(conf));
         server.close();
         for (ExecutorService executor : chunkExecutors) {
           executor.shutdown();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -424,6 +424,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     if (!isStarted) {
       LOG.info("Starting {} {} at port {}", getClass().getSimpleName(),
           server.getId(), getIPCPort());
+      LOG.info(" Ratis log dir is {}", HddsServerUtil.getOzoneDatanodeRatisDirectory(conf));
       for (ThreadPoolExecutor executor : chunkExecutors) {
         executor.prestartAllCoreThreads();
       }
@@ -454,6 +455,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
       try {
         // shutdown server before the executors as while shutting down,
         // some of the tasks would be executed using the executors.
+        LOG.info(" Ratis log dir is {}", HddsServerUtil.getOzoneDatanodeRatisDirectory(conf));
         server.close();
         for (ExecutorService executor : chunkExecutors) {
           executor.shutdown();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -261,7 +261,6 @@ public class TestContainerStateMachineFailures {
       // the cluster
       key.close();
     } catch(IOException ioe) {
-      Assert.assertTrue(ioe instanceof OMException);
     }
 
     long containerID = omKeyLocationInfo.getContainerID();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -106,7 +106,8 @@ public class TestContainerStateMachineFailures {
   @Before
   public void init() throws Exception {
     conf = new OzoneConfiguration();
-    conf.setBoolean(OzoneConfigKeys.OZONE_CLIENT_STREAM_BUFFER_FLUSH_DELAY, false);
+    conf.setBoolean(OzoneConfigKeys.
+            OZONE_CLIENT_STREAM_BUFFER_FLUSH_DELAY, false);
     conf.setTimeDuration(HDDS_CONTAINER_REPORT_INTERVAL, 200,
         TimeUnit.MILLISECONDS);
     conf.setTimeDuration(HDDS_COMMAND_STATUS_REPORT_INTERVAL, 200,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -106,10 +106,6 @@ public class TestContainerStateMachineFailures {
   @Before
   public void init() throws Exception {
     conf = new OzoneConfiguration();
-    //path = GenericTestUtils
-    //    .getTempPath(TestContainerStateMachineFailures.class.getSimpleName());
-    // File baseDir = new File(path);
-    // baseDir.mkdirs();
     conf.setBoolean(OzoneConfigKeys.OZONE_CLIENT_STREAM_BUFFER_FLUSH_DELAY, false);
     conf.setTimeDuration(HDDS_CONTAINER_REPORT_INTERVAL, 200,
         TimeUnit.MILLISECONDS);
@@ -190,8 +186,8 @@ public class TestContainerStateMachineFailures {
     FileUtil.fullyDelete(new File(
             cluster.getHddsDatanodes().get(0).getDatanodeStateMachine()
                     .getContainer().getContainerSet()
-                    .getContainer(omKeyLocationInfo.getContainerID()).getContainerData()
-                    .getContainerPath()));
+                    .getContainer(omKeyLocationInfo.getContainerID()).
+                    getContainerData().getContainerPath()));
     try {
       // there is only 1 datanode in the pipeline, the pipeline will be closed
       // and allocation to new pipeline will fail as there is no other dn in
@@ -216,15 +212,15 @@ public class TestContainerStateMachineFailures {
 
     // restart the hdds datanode, container should not in the regular set
     OzoneConfiguration config = cluster.getHddsDatanodes().get(0).getConf();
-    final String dir = config.get
-            (OzoneConfigKeys.DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR)
+    final String dir = config.get(OzoneConfigKeys.
+            DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR)
             + UUID.randomUUID();
     config.set(OzoneConfigKeys.DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR, dir);
     cluster.restartHddsDatanode(0, true);
     ozoneContainer = cluster.getHddsDatanodes().get(0)
             .getDatanodeStateMachine().getContainer();
-    Assert
-            .assertNull(ozoneContainer.getContainerSet().getContainer(containerID));
+    Assert.assertNull(ozoneContainer.getContainerSet().
+                    getContainer(containerID));
   }
 
   @Test
@@ -277,8 +273,8 @@ public class TestContainerStateMachineFailures {
     assertThat(keyValueContainerData.getState(), is(UNHEALTHY));
 
     OzoneConfiguration config = cluster.getHddsDatanodes().get(0).getConf();
-    final String dir = config.get
-            (OzoneConfigKeys.DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR)
+    final String dir = config.get(OzoneConfigKeys.
+            DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR)
             + UUID.randomUUID();
     config.set(OzoneConfigKeys.DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR, dir);
     // restart the hdds datanode and see if the container is listed in the
@@ -300,7 +296,8 @@ public class TestContainerStateMachineFailures {
     request.setCloseContainer(
             ContainerProtos.CloseContainerRequestProto.getDefaultInstance());
     request.setDatanodeUuid(
-            cluster.getHddsDatanodes().get(0).getDatanodeDetails().getUuidString());
+            cluster.getHddsDatanodes().get(0).getDatanodeDetails()
+                    .getUuidString());
     Assert.assertEquals(ContainerProtos.Result.CONTAINER_UNHEALTHY,
             dispatcher.dispatch(request.build(), null).getResult());
   }
@@ -499,7 +496,8 @@ public class TestContainerStateMachineFailures {
         request.setCmdType(ContainerProtos.Type.CloseContainer);
         request.setContainerID(containerID);
         request.setCloseContainer(
-                ContainerProtos.CloseContainerRequestProto.getDefaultInstance());
+                ContainerProtos.CloseContainerRequestProto.
+                        getDefaultInstance());
         xceiverClient.sendCommand(request.build());
       } catch (IOException e) {
         failCount.incrementAndGet();
@@ -592,11 +590,11 @@ public class TestContainerStateMachineFailures {
             cluster.getHddsDatanodes().get(0).getDatanodeStateMachine()
                     .getContainer();
     // make sure the missing containerSet is not empty
-    HddsDispatcher dispatcher = (HddsDispatcher) ozoneContainer.getDispatcher();
+    HddsDispatcher dispatcher = (HddsDispatcher)ozoneContainer.getDispatcher();
     Assert.assertTrue(!dispatcher.getMissingContainerSet().isEmpty());
     Assert
-            .assertTrue(dispatcher.getMissingContainerSet().contains(containerID));
-
+            .assertTrue(dispatcher.getMissingContainerSet()
+                    .contains(containerID));
     cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.ONE, 60000);
     // write a new key
     key = objectStore.getVolume(volumeName).getBucket(bucketName)
@@ -613,13 +611,15 @@ public class TestContainerStateMachineFailures {
     containerID = omKeyLocationInfo.getContainerID();
     containerData = cluster.getHddsDatanodes().get(0).getDatanodeStateMachine()
             .getContainer().getContainerSet()
-            .getContainer(omKeyLocationInfo.getContainerID()).getContainerData();
+            .getContainer(omKeyLocationInfo.getContainerID())
+            .getContainerData();
     Assert.assertTrue(containerData instanceof KeyValueContainerData);
     keyValueContainerData = (KeyValueContainerData) containerData;
     ReferenceCountedDB db = BlockUtils.
             getDB(keyValueContainerData, conf);
     byte[] blockCommitSequenceIdKey =
-            StringUtils.string2Bytes(OzoneConsts.BLOCK_COMMIT_SEQUENCE_ID_PREFIX);
+            StringUtils.
+                    string2Bytes(OzoneConsts.BLOCK_COMMIT_SEQUENCE_ID_PREFIX);
 
     // modify the bcsid for the container in the ROCKS DB thereby inducing
     // corruption

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -336,8 +336,8 @@ public class TestContainerStateMachineFailures {
             (KeyValueContainerData) containerData;
     key.close();
     ContainerStateMachine stateMachine =
-            (ContainerStateMachine) TestHelper.getStateMachine(cluster.
-                    getHddsDatanodes().get(index), omKeyLocationInfo.getPipeline());
+        (ContainerStateMachine) TestHelper.getStateMachine(cluster.
+            getHddsDatanodes().get(index), omKeyLocationInfo.getPipeline());
     SimpleStateMachineStorage storage =
             (SimpleStateMachineStorage) stateMachine.getStateMachineStorage();
     stateMachine.takeSnapshot();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestValidateBCSIDOnRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestValidateBCSIDOnRestart.java
@@ -1,0 +1,259 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.client.rpc;
+
+import com.google.common.primitives.Longs;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.hdds.StringUtils;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.ratis.RatisHelper;
+import org.apache.hadoop.hdds.scm.XceiverClientManager;
+import org.apache.hadoop.ozone.HddsDatanodeService;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.io.KeyOutputStream;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.container.TestHelper;
+import org.apache.hadoop.ozone.container.common.impl.ContainerData;
+import org.apache.hadoop.ozone.container.common.impl.HddsDispatcher;
+import org.apache.hadoop.ozone.container.common.transport.server.ratis.ContainerStateMachine;
+import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
+import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
+import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
+import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+
+import org.apache.ratis.server.storage.FileInfo;
+import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.
+        HDDS_COMMAND_STATUS_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.
+        HDDS_CONTAINER_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys
+        .HDDS_PIPELINE_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.
+        OZONE_SCM_STALENODE_INTERVAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.
+        OZONE_SCM_PIPELINE_DESTROY_TIMEOUT;
+
+/**
+ * Tests the containerStateMachine failure handling.
+ */
+
+public class TestValidateBCSIDOnRestart {
+  private static MiniOzoneCluster cluster;
+  private static OzoneConfiguration conf;
+  private static OzoneClient client;
+  private static ObjectStore objectStore;
+  private static String volumeName;
+  private static String bucketName;
+  private static XceiverClientManager xceiverClientManager;
+
+  /**
+   * Create a MiniDFSCluster for testing.
+   *
+   * @throws IOException
+   */
+  @BeforeClass
+  public static void init() throws Exception {
+    conf = new OzoneConfiguration();
+    conf.setBoolean(OzoneConfigKeys.
+            OZONE_CLIENT_STREAM_BUFFER_FLUSH_DELAY, false);
+    conf.setTimeDuration(HDDS_CONTAINER_REPORT_INTERVAL, 200,
+            TimeUnit.MILLISECONDS);
+    conf.setTimeDuration(HDDS_COMMAND_STATUS_REPORT_INTERVAL, 200,
+            TimeUnit.MILLISECONDS);
+    conf.setTimeDuration(HDDS_PIPELINE_REPORT_INTERVAL, 200,
+            TimeUnit.MILLISECONDS);
+    conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 10, TimeUnit.SECONDS);
+    conf.setTimeDuration(OZONE_SCM_PIPELINE_DESTROY_TIMEOUT, 1,
+            TimeUnit.SECONDS);
+
+    conf.setTimeDuration(RatisHelper.HDDS_DATANODE_RATIS_PREFIX_KEY
+            + ".client.request.write.timeout", 10, TimeUnit.SECONDS);
+    conf.setTimeDuration(RatisHelper.HDDS_DATANODE_RATIS_PREFIX_KEY
+            + ".client.request.watch.timeout", 10, TimeUnit.SECONDS);
+    conf.setTimeDuration(
+            RatisHelper.HDDS_DATANODE_RATIS_SERVER_PREFIX_KEY + "." +
+                    DatanodeRatisServerConfig.RATIS_SERVER_REQUEST_TIMEOUT_KEY,
+            3, TimeUnit.SECONDS);
+    conf.setTimeDuration(
+            RatisHelper.HDDS_DATANODE_RATIS_SERVER_PREFIX_KEY + "." +
+                    DatanodeRatisServerConfig.
+                            RATIS_SERVER_WATCH_REQUEST_TIMEOUT_KEY,
+            10, TimeUnit.SECONDS);
+    conf.setTimeDuration(
+            RatisHelper.HDDS_DATANODE_RATIS_CLIENT_PREFIX_KEY + "." +
+                    "rpc.request.timeout",
+            3, TimeUnit.SECONDS);
+    conf.setTimeDuration(
+            RatisHelper.HDDS_DATANODE_RATIS_CLIENT_PREFIX_KEY + "." +
+                    "watch.request.timeout",
+            10, TimeUnit.SECONDS);
+    conf.setQuietMode(false);
+    cluster =
+            MiniOzoneCluster.newBuilder(conf).setNumDatanodes(2).
+                    setHbInterval(200)
+                    .build();
+    cluster.waitForClusterToBeReady();
+    cluster.waitForPipelineTobeReady
+            (HddsProtos.ReplicationFactor.ONE, 60000);
+    //the easiest way to create an open container is creating a key
+    client = OzoneClientFactory.getRpcClient(conf);
+    objectStore = client.getObjectStore();
+    xceiverClientManager = new XceiverClientManager(conf);
+    volumeName = "testcontainerstatemachinefailures";
+    bucketName = volumeName;
+    objectStore.createVolume(volumeName);
+    objectStore.getVolume(volumeName).createBucket(bucketName);
+  }
+
+  /**
+   * Shutdown MiniDFSCluster.
+   */
+  @AfterClass
+  public static void shutdown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void testValidateBCSIDOnDnRestart() throws Exception {
+    OzoneOutputStream key =
+            objectStore.getVolume(volumeName).getBucket(bucketName)
+                    .createKey("ratis", 1024, ReplicationType.RATIS,
+                            ReplicationFactor.ONE, new HashMap<>());
+    // First write and flush creates a container in the datanode
+    key.write("ratis".getBytes());
+    key.flush();
+    key.write("ratis".getBytes());
+    KeyOutputStream groupOutputStream = (KeyOutputStream) key.getOutputStream();
+    List<OmKeyLocationInfo> locationInfoList =
+            groupOutputStream.getLocationInfoList();
+    Assert.assertEquals(1, locationInfoList.size());
+    OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
+    HddsDatanodeService dn = TestHelper.getDatanodeService(omKeyLocationInfo,
+            cluster);
+    ContainerData containerData =
+            TestHelper.getDatanodeService(omKeyLocationInfo, cluster)
+                    .getDatanodeStateMachine()
+                    .getContainer().getContainerSet()
+                    .getContainer(omKeyLocationInfo.getContainerID())
+                    .getContainerData();
+    Assert.assertTrue(containerData instanceof KeyValueContainerData);
+    KeyValueContainerData keyValueContainerData =
+            (KeyValueContainerData) containerData;
+    key.close();
+
+    long containerID = omKeyLocationInfo.getContainerID();
+    int index = cluster.getHddsDatanodeIndex(dn.getDatanodeDetails());
+    // delete the container db file
+    FileUtil.fullyDelete(new File(keyValueContainerData.getContainerPath()));
+
+    HddsDatanodeService dnService = cluster.getHddsDatanodes().get(index);
+    OzoneContainer ozoneContainer =
+            dnService.getDatanodeStateMachine()
+                    .getContainer();
+    ozoneContainer.getContainerSet().removeContainer(containerID);
+    ContainerStateMachine stateMachine =
+            (ContainerStateMachine) TestHelper.getStateMachine(cluster.
+                    getHddsDatanodes().get(index),
+                    omKeyLocationInfo.getPipeline());
+    SimpleStateMachineStorage storage =
+            (SimpleStateMachineStorage) stateMachine.getStateMachineStorage();
+    stateMachine.takeSnapshot();
+    Path parentPath = storage.findLatestSnapshot().getFile().getPath();
+    stateMachine.buildMissingContainerSet(parentPath.toFile());
+    // Since the snapshot threshold is set to 1, since there are
+    // applyTransactions, we should see snapshots
+    Assert.assertTrue(parentPath.getParent().toFile().listFiles().length > 0);
+    FileInfo snapshot = storage.findLatestSnapshot().getFile();
+
+    // make sure the missing containerSet is not empty
+    HddsDispatcher dispatcher = (HddsDispatcher) ozoneContainer.getDispatcher();
+    Assert.assertTrue(!dispatcher.getMissingContainerSet().isEmpty());
+    Assert
+            .assertTrue(dispatcher.getMissingContainerSet()
+                    .contains(containerID));
+    // write a new key
+    key = objectStore.getVolume(volumeName).getBucket(bucketName)
+            .createKey("ratis", 1024, ReplicationType.RATIS,
+                    ReplicationFactor.ONE, new HashMap<>());
+    // First write and flush creates a container in the datanode
+    key.write("ratis1".getBytes());
+    key.flush();
+    groupOutputStream = (KeyOutputStream) key.getOutputStream();
+    locationInfoList = groupOutputStream.getLocationInfoList();
+    Assert.assertEquals(1, locationInfoList.size());
+    omKeyLocationInfo = locationInfoList.get(0);
+    key.close();
+    containerID = omKeyLocationInfo.getContainerID();
+    dn = TestHelper.getDatanodeService(omKeyLocationInfo,
+            cluster);
+    containerData = dn.getDatanodeStateMachine()
+            .getContainer().getContainerSet()
+            .getContainer(omKeyLocationInfo.getContainerID())
+            .getContainerData();
+    Assert.assertTrue(containerData instanceof KeyValueContainerData);
+    keyValueContainerData = (KeyValueContainerData) containerData;
+    ReferenceCountedDB db = BlockUtils.
+            getDB(keyValueContainerData, conf);
+    byte[] blockCommitSequenceIdKey =
+            StringUtils.
+                    string2Bytes(OzoneConsts.BLOCK_COMMIT_SEQUENCE_ID_PREFIX);
+
+    // modify the bcsid for the container in the ROCKS DB thereby inducing
+    // corruption
+    db.getStore().put(blockCommitSequenceIdKey, Longs.toByteArray(0));
+    db.decrementReference();
+    // after the restart, there will be a mismatch in BCSID of what is recorded
+    // in the and what is there in RockSDB and hence the container would be
+    // marked unhealthy
+    index = cluster.getHddsDatanodeIndex(dn.getDatanodeDetails());
+    cluster.restartHddsDatanode(dn.getDatanodeDetails(), false);
+    // Make sure the container is marked unhealthy
+    Assert.assertTrue(
+            cluster.getHddsDatanodes().get(index)
+                    .getDatanodeStateMachine()
+                    .getContainer().getContainerSet().getContainer(containerID)
+                    .getContainerState()
+                    == ContainerProtos.ContainerDataProto.State.UNHEALTHY);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestValidateBCSIDOnRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestValidateBCSIDOnRestart.java
@@ -132,8 +132,7 @@ public class TestValidateBCSIDOnRestart {
                     setHbInterval(200)
                     .build();
     cluster.waitForClusterToBeReady();
-    cluster.waitForPipelineTobeReady
-            (HddsProtos.ReplicationFactor.ONE, 60000);
+    cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.ONE, 60000);
     //the easiest way to create an open container is creating a key
     client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.transport.server.XceiverServerSpi;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.XceiverServerRatis;
 
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.server.impl.RaftServerImpl;
@@ -300,6 +301,15 @@ public final class TestHelper {
   public static StateMachine getStateMachine(HddsDatanodeService dn,
       Pipeline pipeline) throws Exception {
     return getRaftServerImpl(dn, pipeline).getStateMachine();
+  }
+
+  public static HddsDatanodeService getDatanodeService(OmKeyLocationInfo info,
+                                                 MiniOzoneCluster cluster)
+          throws IOException {
+    DatanodeDetails dnDetails =  info.getPipeline().
+            getFirstNode();
+    return cluster.getHddsDatanodes().get(cluster.
+            getHddsDatanodeIndex(dnDetails));
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The unit tests are written withe single node ratis into consideration. The expectation is the datanode fails, client should see an exception after next io as there is no new dn for new pipeline to form. Tuned watch, rpc and stale node timeouts.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3018

## How was this patch tested?

Ran the unit tests to verify the fix.
