### PR TITLE
HDDS-3024. README is missing from the source release tar

### DIFF
--- a/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
+++ b/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
@@ -33,7 +33,7 @@
       <outputDirectory>/</outputDirectory>
     </file>
     <file>
-      <source> hadoop-ozone/dist/src/main/license/src/licenses/LICENSE-angular-nvd3.txt</source>
+      <source>hadoop-ozone/dist/src/main/license/src/licenses/LICENSE-angular-nvd3.txt</source>
       <outputDirectory>/licenses</outputDirectory>
     </file>
     <file>
@@ -58,7 +58,7 @@
       <directory>.</directory>
       <includes>
         <include>pom.xml</include>
-        <include>README.txt</include>
+        <include>README.md</include>
       </includes>
     </fileSet>
     <fileSet>


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we do a dist build with `-Psrc` the `README.md` of the root project is not packaged to the tar file which makes it impossible to do a build from the source package as the `README.md` is required by the dist script.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3024

## How was this patch tested?

```
mvn clean install -DskipTests -Psrc -Pdist
cd hadoop-ozone/dist/target
tar zvxf hadoop-ozone-0.5.0-SNAPSHOT-src.tar.gz
cd hadoop-ozone-0.5.0-SNAPSHOT-src
#The build should work from here as this is the source release (=the release)
mvn clean install -DskipTests
```