### PR TITLE
HDDS-3025. Fix fail to connect to s3g by http://ip:port

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/AWSV4SignatureProcessor.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/AWSV4SignatureProcessor.java
@@ -219,7 +219,8 @@ public class AWSV4SignatureProcessor implements SignatureProcessor {
     switch (header) {
     case HOST:
       try {
-        URI hostUri = new URI(headerValue);
+        String schema = context.getUriInfo().getRequestUri().getScheme();
+        URI hostUri = new URI(schema + "://" + headerValue);
         InetAddress.getByName(hostUri.getHost());
         // TODO: Validate if current request is coming from same host.
       } catch (UnknownHostException|URISyntaxException e) {

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestAWSV4SignatureProcessor.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestAWSV4SignatureProcessor.java
@@ -40,7 +40,7 @@ public class TestAWSV4SignatureProcessor {
 
     MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
     headers.putSingle("Content-Length", "123");
-    headers.putSingle("Host", "123");
+    headers.putSingle("Host", "0.0.0.0:9878");
     headers.putSingle("X-AMZ-Content-Sha256", "Content-SHA");
     headers.putSingle("X-AMZ-Date", "123");
     headers.putSingle("Content-Type", "ozone/mpu");
@@ -97,7 +97,7 @@ public class TestAWSV4SignatureProcessor {
             + "123\n"
             + "20181009/us-east-1/s3/aws4_request\n"
             +
-            "21478b9cf7d628717e9029a93c4ddc35bb38cf50669ada529b94673b23ff23e2",
+            "f20d4de80af2271545385e8d4c7df608cae70a791c69b97aab1527ed93a0d665",
         parser.getStringToSign());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

How to reproduce the problem:

If use command `aws s3api --endpoint http://0.0.0.0:9878 create-bucket --bucket test-bucket`, then log error message `Host value mentioned in signed header is not valid. Host: 0.0.0.0:9878` by https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/AWSV4SignatureProcessor.java#L226.

Root cause:
1. when use http://0.0.0.0:9878, `context.getHeaders()` contains <"Host", "0.0.0.0:9878">
2. `new URI("0.0.0.0:9878")` throw `URISyntaxException` in https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/AWSV4SignatureProcessor.java#L222.
3. It is also explained in the follow image from https://stackoverflow.com/questions/28114352/java-lang-illegalargumentexception-illegal-character-in-scheme-at-index-0-loca.

![image](https://user-images.githubusercontent.com/51938049/74697309-49048a00-5235-11ea-9ff5-145627d528f1.png)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3025

## How was this patch tested?

change UT to cover this case.