### PR TITLE
HDDS-3030. Key Rename should preserve the ObjectID.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -480,14 +480,6 @@ public final class OmKeyInfo extends WithObjectID {
    * Return a new copy of the object.
    */
   public OmKeyInfo copyObject() {
-    return copyObject(true);
-  }
-
-  /**
-   * Return a copy of the OMKeyInfo without setting the objectID and updateID.
-   * This is used during key renames.
-   */
-  public OmKeyInfo copyObject(boolean copyObjectID) {
     OmKeyInfo.Builder builder = new OmKeyInfo.Builder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
@@ -497,11 +489,9 @@ public final class OmKeyInfo extends WithObjectID {
         .setDataSize(dataSize)
         .setReplicationType(type)
         .setReplicationFactor(factor)
-        .setFileEncryptionInfo(encInfo);
+        .setFileEncryptionInfo(encInfo)
+        .setObjectID(objectID).setUpdateID(updateID);
 
-    if (copyObjectID) {
-      builder.setObjectID(objectID).setUpdateID(updateID);
-    }
 
     keyLocationVersions.forEach(keyLocationVersion -> {
       List<OmKeyLocationInfo> keyLocationInfos = new ArrayList<>();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -210,15 +210,11 @@ public class OMKeyRenameRequest extends OMKeyRequest {
           throw new OMException("Key not found " + fromKey, KEY_NOT_FOUND);
         }
 
-        // Copy fromKeyValue into toKeyValue and set objectID and updateID to
-        // current transactionLogIndex
-        toKeyValue = fromKeyValue.copyObject(false);
-        toKeyValue.setObjectID(trxnLogIndex);
-        toKeyValue.setUpdateID(trxnLogIndex);
+        fromKeyValue.setUpdateID(trxnLogIndex);
 
-        toKeyValue.setKeyName(toKeyName);
+        fromKeyValue.setKeyName(toKeyName);
         //Set modification time
-        toKeyValue.setModificationTime(renameKeyArgs.getModificationTime());
+        fromKeyValue.setModificationTime(renameKeyArgs.getModificationTime());
 
         // Add to cache.
         // fromKey should be deleted, toKey should be added with newly updated
@@ -229,11 +225,11 @@ public class OMKeyRenameRequest extends OMKeyRequest {
             new CacheValue<>(Optional.absent(), trxnLogIndex));
 
         keyTable.addCacheEntry(new CacheKey<>(toKey),
-            new CacheValue<>(Optional.of(toKeyValue), trxnLogIndex));
+            new CacheValue<>(Optional.of(fromKeyValue), trxnLogIndex));
 
         omClientResponse = new OMKeyRenameResponse(omResponse
             .setRenameKeyResponse(RenameKeyResponse.newBuilder()).build(),
-            fromKeyName, toKeyName, toKeyValue);
+            fromKeyName, toKeyName, fromKeyValue);
 
         result = Result.SUCCESS;
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

On Key Renames, objectID should be preserved from the original Key. 
Currently it is being set to the new transactionLogIndex of the rename request.

Use original ObjectID from actual Key when renaming.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3030

## How was this patch tested?

Existing UT should cover this.
