### PR TITLE
HDDS-3040. Update Ratis version to 0.5.0 released.

### DIFF
--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisDropwizardExports.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisDropwizardExports.java
@@ -25,7 +25,6 @@ import com.codahale.metrics.MetricRegistry;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.common.TextFormat;
 import org.apache.ratis.server.metrics.RaftLogMetrics;
-import org.apache.ratis.server.metrics.RatisMetrics;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,9 +36,7 @@ public class TestRatisDropwizardExports {
   @Test
   public void export() throws IOException {
     //create Ratis metrics
-    RaftLogMetrics instance =
-        RatisMetrics.createMetricRegistryForLogWorker("instance");
-
+    RaftLogMetrics instance = new RaftLogMetrics("instance");
     instance.getRaftLogSyncTimer().update(10, TimeUnit.MILLISECONDS);
     MetricRegistry dropWizardMetricRegistry =
         instance.getRegistry().getDropWizardMetricRegistry();

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>0.5.0-90cd474-SNAPSHOT</ratis.version>
+    <ratis.version>0.5.0</ratis.version>
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>
     <distMgmtSnapshotsUrl>https://repository.apache.org/content/repositories/snapshots</distMgmtSnapshotsUrl>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change ozone to use latest released ratis 0.5.0.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3040

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

Build and unit test.