### PR TITLE
HDDS-3209. Recon should persist Node metadata.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
@@ -53,4 +53,6 @@ public final class ReconConstants {
       "recon-" + CONTAINER_DB_SUFFIX;
   public static final String RECON_SCM_PIPELINE_DB = "recon-"
       + PIPELINE_DB_SUFFIX;
+  public static final String RECON_SCM_NODE_DB =
+      "recon-node.db";
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/MissingContainerTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/MissingContainerTask.java
@@ -66,7 +66,7 @@ public class MissingContainerTask extends ReconScmTask {
         long currentTime = System.currentTimeMillis();
         final Set<ContainerID> containerIds =
             containerManager.getContainerIDs();
-        containerManager.getContainerIDs().forEach(containerID ->
+        containerIds.forEach(containerID ->
             processContainer(containerID, currentTime));
         recordSingleRunCompletion();
         LOG.info("Missing Container task Thread took {} milliseconds for" +

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
@@ -30,11 +30,16 @@ import org.apache.hadoop.hdds.scm.container.SCMContainerManager;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.ozone.recon.ReconUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Recon's overriding implementation of SCM's Container Manager.
  */
 public class ReconContainerManager extends SCMContainerManager {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ReconContainerManager.class);
 
   /**
    * Constructs a mapping class that creates mapping between container names
@@ -75,6 +80,7 @@ public class ReconContainerManager extends SCMContainerManager {
           getPipelineManager(), containerWithPipeline.getPipeline());
       addContainerToDB(containerInfo);
     } catch (IOException ex) {
+      LOG.info("Exception while adding container.", ex);
       getPipelineManager().removeContainerFromPipeline(
           containerInfo.getPipelineID(),
           new ContainerID(containerInfo.getContainerID()));

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
@@ -80,7 +80,8 @@ public class ReconContainerManager extends SCMContainerManager {
           getPipelineManager(), containerWithPipeline.getPipeline());
       addContainerToDB(containerInfo);
     } catch (IOException ex) {
-      LOG.info("Exception while adding container.", ex);
+      LOG.info("Exception while adding container {} .",
+          containerInfo.containerID(), ex);
       getPipelineManager().removeContainerFromPipeline(
           containerInfo.getPipelineID(),
           new ContainerID(containerInfo.getContainerID()));

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerReportHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerReportHandler.java
@@ -81,7 +81,7 @@ public class ReconContainerReportHandler extends ContainerReportHandler {
       LOG.debug("Got container report for containerID {} ",
           containerReplicaProto.getContainerID());
     }
-
+    super.onMessage(reportFromDatanode, publisher);
   }
 
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNewNodeHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNewNodeHandler.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.recon.scm;
 import java.io.IOException;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.slf4j.Logger;
@@ -37,8 +36,8 @@ public class ReconNewNodeHandler implements EventHandler<DatanodeDetails> {
       .getLogger(ReconNewNodeHandler.class);
   private ReconNodeManager nodeManager;
 
-  public ReconNewNodeHandler(NodeManager nodeManager) {
-    this.nodeManager = (ReconNodeManager) nodeManager;
+  public ReconNewNodeHandler(ReconNodeManager nodeManager) {
+    this.nodeManager = nodeManager;
   }
 
   @Override
@@ -47,7 +46,8 @@ public class ReconNewNodeHandler implements EventHandler<DatanodeDetails> {
     try {
       nodeManager.addNodeToDB(datanodeDetails);
     } catch (IOException e) {
-      LOG.error("Unable to add new node to Node DB.");
+      LOG.error("Unable to add new node {} to Node DB.",
+          datanodeDetails.getUuidString());
     }
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNewNodeHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNewNodeHandler.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.scm;
+
+import java.io.IOException;
+
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.server.events.EventHandler;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Adds the new node to Recon Node DB. Since we are not dependent on this
+ * update, we do this in async.
+ */
+public class ReconNewNodeHandler implements EventHandler<DatanodeDetails> {
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(ReconNewNodeHandler.class);
+  private ReconNodeManager nodeManager;
+
+  public ReconNewNodeHandler(NodeManager nodeManager) {
+    this.nodeManager = (ReconNodeManager) nodeManager;
+  }
+
+  @Override
+  public void onMessage(DatanodeDetails datanodeDetails,
+                        EventPublisher publisher) {
+    try {
+      nodeManager.addNodeToDB(datanodeDetails);
+    } catch (IOException e) {
+      LOG.error("Unable to add new node to Node DB.");
+    }
+  }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
@@ -24,10 +24,12 @@ import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_SCM_NODE_DB;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -90,7 +92,8 @@ public class ReconNodeManager extends SCMNodeManager {
    * @param datanodeDetails Datanode details.
    */
   public void addNodeToDB(DatanodeDetails datanodeDetails) throws IOException {
-    byte[] nodeIdBytes = datanodeDetails.getUuidString().getBytes();
+    byte[] nodeIdBytes =
+        StringUtils.string2Bytes(datanodeDetails.getUuidString());
     byte[] nodeDetailsBytes =
         datanodeDetails.getProtoBufMessage().toByteArray();
     nodeStore.put(nodeIdBytes, nodeDetailsBytes);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
@@ -24,7 +24,6 @@ import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_SCM_NODE_DB;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.scm;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DB_CACHE_SIZE_DEFAULT;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DB_CACHE_SIZE_MB;
+import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_SCM_NODE_DB;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.net.NetworkTopology;
+import org.apache.hadoop.hdds.scm.node.SCMNodeManager;
+import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
+import org.apache.hadoop.hdds.server.ServerUtils;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.apache.hadoop.hdds.utils.MetadataStore;
+import org.apache.hadoop.hdds.utils.MetadataStoreBuilder;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Recon SCM's Node manager that includes persistence.
+ */
+public class ReconNodeManager extends SCMNodeManager {
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(ReconNodeManager.class);
+
+  private final MetadataStore nodeStore;
+
+  public ReconNodeManager(OzoneConfiguration conf,
+                          SCMStorageConfig scmStorageConfig,
+                          EventPublisher eventPublisher,
+                          NetworkTopology networkTopology) throws IOException {
+    super(conf, scmStorageConfig, eventPublisher, networkTopology);
+    final File nodeDBPath = getNodeDBPath(conf);
+    final int cacheSize = conf.getInt(OZONE_SCM_DB_CACHE_SIZE_MB,
+        OZONE_SCM_DB_CACHE_SIZE_DEFAULT);
+    this.nodeStore = MetadataStoreBuilder.newBuilder()
+        .setConf(conf)
+        .setDbFile(nodeDBPath)
+        .setCacheSize(cacheSize * OzoneConsts.MB)
+        .build();
+    loadExistingNodes();
+  }
+
+  private void loadExistingNodes() {
+    try {
+      List<Map.Entry<byte[], byte[]>> range = nodeStore
+          .getSequentialRangeKVs(null, Integer.MAX_VALUE, null);
+      int nodeCount = 0;
+      for (Map.Entry<byte[], byte[]> entry : range) {
+        DatanodeDetails datanodeDetails = DatanodeDetails.getFromProtoBuf(
+            HddsProtos.DatanodeDetailsProto.PARSER.parseFrom(entry.getValue()));
+        register(datanodeDetails, null, null);
+        nodeCount++;
+      }
+      LOG.info("Loaded {} nodes from node DB.", nodeCount);
+    } catch (IOException ioEx) {
+      LOG.error("Exception while loading existing nodes.", ioEx);
+    }
+  }
+
+  /**
+   * Add a new new node to the NodeDB. Must be called after register.
+   * @param datanodeDetails Datanode details.
+   */
+  public void addNodeToDB(DatanodeDetails datanodeDetails) throws IOException {
+    byte[] nodeIdBytes = datanodeDetails.getUuidString().getBytes();
+    byte[] nodeDetailsBytes =
+        datanodeDetails.getProtoBufMessage().toByteArray();
+    nodeStore.put(nodeIdBytes, nodeDetailsBytes);
+    LOG.info("Adding new node {} to Node DB.", datanodeDetails.getUuid());
+  }
+
+  protected File getNodeDBPath(Configuration conf) {
+    File metaDir = ServerUtils.getScmDbDir(conf);
+    return new File(metaDir, RECON_SCM_NODE_DB);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (nodeStore != null) {
+      nodeStore.close();
+    }
+    super.close();
+  }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineFactory.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineFactory.java
@@ -26,17 +26,12 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineFactory;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Class to stub out SCM's pipeline providers. This makes sure Recon can
  * never be on the pipeline CREATE or CLOSE path.
  */
 public class ReconPipelineFactory extends PipelineFactory {
-
-  private static final Logger LOG =
-      LoggerFactory.getLogger(ReconPipelineFactory.class);
 
   ReconPipelineFactory() {
     ReconPipelineProvider reconMockPipelineProvider =
@@ -48,20 +43,22 @@ public class ReconPipelineFactory extends PipelineFactory {
 
     @Override
     public Pipeline create(HddsProtos.ReplicationFactor factor){
-      throw new RuntimeException(
+      // We don't expect this to be called at all. But adding this as a red
+      // flag for troubleshooting.
+      throw new UnsupportedOperationException(
           "Trying to create pipeline in Recon, which is prohibited!");
     }
 
     @Override
     public Pipeline create(HddsProtos.ReplicationFactor factor,
                            List<DatanodeDetails> nodes) {
-      LOG.warn("Trying to create pipeline in Recon, which is prohibited!");
-      return null;
+      throw new UnsupportedOperationException(
+          "Trying to create pipeline in Recon, which is prohibited!");
     }
 
     @Override
     public void close(Pipeline pipeline) {
-
+      // Do nothing in Recon.
     }
 
     @Override

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconScmTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconScmTask.java
@@ -41,15 +41,18 @@ public abstract class ReconScmTask {
   }
 
   public void register() {
-    String taskName = getClass().getSimpleName();
-    ReconTaskStatus reconTaskStatusRecord = new ReconTaskStatus(
-        taskName, 0L, 0L);
+    String taskName = getTaskName();
     if (!reconTaskStatusDao.existsById(taskName)) {
+      ReconTaskStatus reconTaskStatusRecord = new ReconTaskStatus(
+          taskName, 0L, 0L);
       reconTaskStatusDao.insert(reconTaskStatusRecord);
       LOG.info("Registered {} task ", taskName);
     }
   }
 
+  /**
+   * Start underlying start thread.
+   */
   public synchronized void start() {
     if (!isRunning()) {
       LOG.info("Starting {} Thread.", getTaskName());
@@ -64,7 +67,7 @@ public abstract class ReconScmTask {
   }
 
   /**
-   * Stops Replication Monitor thread.
+   * Stop underlying task thread.
    */
   public synchronized void stop() {
     if (running) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -73,7 +73,7 @@ public class ReconStorageContainerManagerFacade
   private final EventQueue eventQueue;
   private final SCMStorageConfig scmStorageConfig;
 
-  private NodeManager nodeManager;
+  private ReconNodeManager nodeManager;
   private ReconPipelineManager pipelineManager;
   private ContainerManager containerManager;
   private NetworkTopology clusterMap;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.hdds.scm.net.NetworkTopologyImpl;
 import org.apache.hadoop.hdds.scm.node.DeadNodeHandler;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeReportHandler;
-import org.apache.hadoop.hdds.scm.node.SCMNodeManager;
 import org.apache.hadoop.hdds.scm.node.StaleNodeHandler;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineActionHandler;
@@ -74,7 +73,7 @@ public class ReconStorageContainerManagerFacade
   private final EventQueue eventQueue;
   private final SCMStorageConfig scmStorageConfig;
 
-  private NodeManager scmNodeManager;
+  private NodeManager nodeManager;
   private ReconPipelineManager pipelineManager;
   private ContainerManager containerManager;
   private NetworkTopology clusterMap;
@@ -92,18 +91,18 @@ public class ReconStorageContainerManagerFacade
     this.ozoneConfiguration = getReconScmConfiguration(conf);
     this.scmStorageConfig = new ReconStorageConfig(conf);
     this.clusterMap = new NetworkTopologyImpl(conf);
-    this.scmNodeManager =
-        new SCMNodeManager(conf, scmStorageConfig, eventQueue, clusterMap);
+    this.nodeManager =
+        new ReconNodeManager(conf, scmStorageConfig, eventQueue, clusterMap);
     this.datanodeProtocolServer = new ReconDatanodeProtocolServer(
         conf, this, eventQueue);
     this.pipelineManager =
-        new ReconPipelineManager(conf, scmNodeManager, eventQueue);
+        new ReconPipelineManager(conf, nodeManager, eventQueue);
     this.containerManager = new ReconContainerManager(conf, pipelineManager);
     this.scmServiceProvider = scmServiceProvider;
     initializePipelinesFromScm();
 
     NodeReportHandler nodeReportHandler =
-        new NodeReportHandler(scmNodeManager);
+        new NodeReportHandler(nodeManager);
 
     SafeModeManager safeModeManager = new ReconSafeModeManager();
     ReconPipelineReportHandler pipelineReportHandler =
@@ -114,19 +113,20 @@ public class ReconStorageContainerManagerFacade
         new PipelineActionHandler(pipelineManager, conf);
 
     StaleNodeHandler staleNodeHandler =
-        new StaleNodeHandler(scmNodeManager, pipelineManager, conf);
-    DeadNodeHandler deadNodeHandler = new DeadNodeHandler(scmNodeManager,
+        new StaleNodeHandler(nodeManager, pipelineManager, conf);
+    DeadNodeHandler deadNodeHandler = new DeadNodeHandler(nodeManager,
         pipelineManager, containerManager);
 
     ContainerReportHandler containerReportHandler =
-        new ReconContainerReportHandler(scmNodeManager, containerManager,
+        new ReconContainerReportHandler(nodeManager, containerManager,
             scmServiceProvider);
     IncrementalContainerReportHandler icrHandler =
-        new ReconIncrementalContainerReportHandler(scmNodeManager,
+        new ReconIncrementalContainerReportHandler(nodeManager,
             containerManager, scmServiceProvider);
     CloseContainerEventHandler closeContainerHandler =
         new CloseContainerEventHandler(pipelineManager, containerManager);
     ContainerActionsHandler actionsHandler = new ContainerActionsHandler();
+    ReconNewNodeHandler newNodeHandler = new ReconNewNodeHandler(nodeManager);
 
     eventQueue.addHandler(SCMEvents.NODE_REPORT, nodeReportHandler);
     eventQueue.addHandler(SCMEvents.PIPELINE_REPORT, pipelineReportHandler);
@@ -137,6 +137,7 @@ public class ReconStorageContainerManagerFacade
     eventQueue.addHandler(SCMEvents.INCREMENTAL_CONTAINER_REPORT, icrHandler);
     eventQueue.addHandler(SCMEvents.CONTAINER_ACTIONS, actionsHandler);
     eventQueue.addHandler(SCMEvents.CLOSE_CONTAINER, closeContainerHandler);
+    eventQueue.addHandler(SCMEvents.NEW_NODE, newNodeHandler);
 
     reconScmTasks.add(new PipelineSyncTask(
         this,
@@ -207,7 +208,7 @@ public class ReconStorageContainerManagerFacade
     } catch (Exception ex) {
       LOG.error("SCM Event Queue stop failed", ex);
     }
-    IOUtils.cleanupWithLogger(LOG, scmNodeManager);
+    IOUtils.cleanupWithLogger(LOG, nodeManager);
     IOUtils.cleanupWithLogger(LOG, containerManager);
     IOUtils.cleanupWithLogger(LOG, pipelineManager);
   }
@@ -229,7 +230,7 @@ public class ReconStorageContainerManagerFacade
 
   @Override
   public NodeManager getScmNodeManager() {
-    return scmNodeManager;
+    return nodeManager;
   }
 
   @Override

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconNodeManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconNodeManager.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.scm;
+
+import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_DIRS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.net.NetworkTopology;
+import org.apache.hadoop.hdds.scm.net.NetworkTopologyImpl;
+import org.apache.hadoop.hdds.server.events.EventQueue;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests for Recon Node Manager.
+ */
+public class TestReconNodeManager {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private OzoneConfiguration conf;
+
+  @Before
+  public void setUp() throws Exception {
+    conf = new OzoneConfiguration();
+    conf.set(OZONE_METADATA_DIRS,
+        temporaryFolder.newFolder().getAbsolutePath());
+    conf.set(OZONE_SCM_NAMES, "localhost");
+  }
+
+  @Test
+  public void testReconNodeDB() throws IOException {
+    ReconStorageConfig scmStorageConfig = new ReconStorageConfig(conf);
+    EventQueue eventQueue = new EventQueue();
+    NetworkTopology clusterMap = new NetworkTopologyImpl(conf);
+    ReconNodeManager reconNodeManager = new ReconNodeManager(conf,
+        scmStorageConfig, eventQueue, clusterMap);
+    ReconNewNodeHandler reconNewNodeHandler =
+        new ReconNewNodeHandler(reconNodeManager);
+    assertTrue(reconNodeManager.getAllNodes().isEmpty());
+
+    DatanodeDetails datanodeDetails = randomDatanodeDetails();
+    String uuidString = datanodeDetails.getUuidString();
+
+    // Register a random datanode.
+    reconNodeManager.register(datanodeDetails, null, null);
+    reconNewNodeHandler.onMessage(reconNodeManager.getNodeByUuid(uuidString),
+        null);
+
+    assertEquals(1, reconNodeManager.getAllNodes().size());
+    assertNotNull(reconNodeManager.getNodeByUuid(uuidString));
+
+    // Close the DB, and recreate the instance of Recon Node Manager.
+    eventQueue.close();
+    reconNodeManager.close();
+    reconNodeManager = new ReconNodeManager(conf,
+        scmStorageConfig, eventQueue, clusterMap);
+
+    // Verify that the node information was persisted and loaded back.
+    assertEquals(1, reconNodeManager.getAllNodes().size());
+    assertNotNull(
+        reconNodeManager.getNodeByUuid(datanodeDetails.getUuidString()));
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
SCM does not persist Node metadata in a persistent store like RocksDB. It is needed in Recon since its UI will be a management console, and should be able to withstand DNs shutting down while it is not running. Whenever Recon starts up, it can display all registered Nodes from this DB (even before Heartbeats) and then gradually update state based on heartbeats.
In addition to the above, the patch also contains the following.
- Review comments from https://github.com/apache/hadoop-ozone/pull/546 addressed.
- Fixed issue in ReconContainerReportHandler.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3029

## How was this patch tested?
Manually tested.
Added unit test.