### PR TITLE
HDDS-3035. Add ability to enable Ratis metrics in OzoneManager.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -17,6 +17,7 @@
 package org.apache.hadoop.ozone.om;
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.time.Instant;
@@ -34,6 +35,7 @@ import java.util.UUID;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.OzoneMultipartUploadPartListParts;
+import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -96,7 +98,12 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.USER;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.READ;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.WRITE;
+import static org.apache.ratis.server.metrics.RatisMetrics.RATIS_APPLICATION_NAME_METRICS;
 import static org.junit.Assert.fail;
+
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
 
 /**
  * Test Ozone Manager operation in distributed handler scenario.
@@ -1083,8 +1090,6 @@ public class TestOzoneManagerHA {
     Assert.assertTrue(removeAcl);
   }
 
-
-
   @Test
   public void testOMRatisSnapshot() throws Exception {
     String userName = "user" + RandomStringUtils.randomNumeric(5);
@@ -1316,6 +1321,21 @@ public class TestOzoneManagerHA {
 
     validateVolumesList(userName, expectedVolumes);
 
+  }
+
+  @Test
+  public void testJMXMetrics() throws Exception {
+    // Verify any one ratis metric is exposed by JMX MBeanServer
+    OzoneManagerRatisServer ratisServer =
+        cluster.getOzoneManager(0).getOmRatisServer();
+    ObjectName oname = new ObjectName(RATIS_APPLICATION_NAME_METRICS, "name",
+        RATIS_APPLICATION_NAME_METRICS + ".log_worker." +
+            ratisServer.getRaftPeerId().toString() + ".flushCount");
+    MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+    MBeanInfo mBeanInfo = mBeanServer.getMBeanInfo(oname);
+    Assert.assertNotNull(mBeanInfo);
+    Object flushCount = mBeanServer.getAttribute(oname, "Count");
+    Assert.assertTrue((long) flushCount >= 0);
   }
 
   private void validateVolumesList(String userName,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1078,8 +1078,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     HddsServerUtil.initializeMetrics(configuration, "OzoneManager");
     if (configuration.getBoolean(
         OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY, false)) {
-      //All the Ratis metrics (registered from now) will be published via JMX and
-      //via the prometheus exporter (used by the /prom servlet
+      // All the Ratis metrics (registered from now) will be published via JMX
+      // and via the prometheus exporter (used by the /prom servlet
       MetricRegistries.global()
           .addReporterRegistration(MetricsReporting.jmxReporter());
       MetricRegistries.global().addReporterRegistration(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1076,14 +1076,17 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public void start() throws IOException {
     omClientProtocolMetrics.register();
     HddsServerUtil.initializeMetrics(configuration, "OzoneManager");
-    //All the Ratis metrics (registered from now) will be published via JMX and
-    //via the prometheus exporter (used by the /prom servlet
-    MetricRegistries.global()
-        .addReporterRegistration(MetricsReporting.jmxReporter());
-    MetricRegistries.global().addReporterRegistration(
-        registry -> CollectorRegistry.defaultRegistry.register(
-            new RatisDropwizardExports(
-                registry.getDropWizardMetricRegistry())));
+    if (configuration.getBoolean(
+        OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY, false)) {
+      //All the Ratis metrics (registered from now) will be published via JMX and
+      //via the prometheus exporter (used by the /prom servlet
+      MetricRegistries.global()
+          .addReporterRegistration(MetricsReporting.jmxReporter());
+      MetricRegistries.global().addReporterRegistration(
+          registry -> CollectorRegistry.defaultRegistry.register(
+              new RatisDropwizardExports(
+                  registry.getDropWizardMetricRegistry())));
+    }
 
     LOG.info(buildRpcServerStartMessage("OzoneManager RPC server",
         omRpcAddress));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
+import org.apache.hadoop.hdds.server.http.RatisDropwizardExports;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
@@ -208,6 +209,9 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TOKE
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.S3_BUCKET_LOCK;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_LOCK;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneManagerService.newReflectiveBlockingService;
+
+import org.apache.ratis.metrics.MetricRegistries;
+import org.apache.ratis.metrics.MetricsReporting;
 import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.util.FileUtils;
@@ -215,6 +219,8 @@ import org.apache.ratis.util.LifeCycle;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.prometheus.client.CollectorRegistry;
 
 /**
  * Ozone Manager is the metadata manager of ozone.
@@ -1068,13 +1074,19 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * Start service.
    */
   public void start() throws IOException {
-
     omClientProtocolMetrics.register();
+    HddsServerUtil.initializeMetrics(configuration, "OzoneManager");
+    //All the Ratis metrics (registered from now) will be published via JMX and
+    //via the prometheus exporter (used by the /prom servlet
+    MetricRegistries.global()
+        .addReporterRegistration(MetricsReporting.jmxReporter());
+    MetricRegistries.global().addReporterRegistration(
+        registry -> CollectorRegistry.defaultRegistry.register(
+            new RatisDropwizardExports(
+                registry.getDropWizardMetricRegistry())));
 
     LOG.info(buildRpcServerStartMessage("OzoneManager RPC server",
         omRpcAddress));
-
-    HddsServerUtil.initializeMetrics(configuration, "OzoneManager");
 
     // Start Ratis services
     if (omRatisServer != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Enabled Dropwizard metrics registry to publish all OM Ratis metrics to JMX and configured metrics system endpoint.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3035

## How was this patch tested?
1. Added an integration test 
2. Verified using docker build
