### PR TITLE
HDDS-3051. Periodic HDDS volume checker thread should be a daemon

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeSet.java
@@ -120,7 +120,11 @@ public class VolumeSet {
     this.volumeSetRWLock = new ReentrantReadWriteLock();
     this.volumeChecker = getVolumeChecker(conf);
     this.diskCheckerservice = Executors.newScheduledThreadPool(
-        1, r -> new Thread(r, "Periodic HDDS volume checker"));
+        1, r -> {
+          Thread t = new Thread(r, "Periodic HDDS volume checker");
+          t.setDaemon(true);
+          return t;
+        });
     this.periodicDiskChecker =
       diskCheckerservice.scheduleWithFixedDelay(() -> {
         try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Periodic HDDS volume checker is an auxiliary thread. It can be stopped if the main threads are stopped. Therefore we need to mark it as daemon thread.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3051

## How was this patch tested?

Originally I noticed it during a custom Freon test (which couldn't be stopped until I fixed this problem), but you can also check it from a stack trace.