### PR TITLE
HDDS-3050. Use meaningful name for ChunkWriter threads

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerDispatcher;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.opentracing.Scope;
 import org.apache.hadoop.ozone.container.common.transport.server.XceiverServerSpi;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
@@ -132,6 +133,10 @@ public final class XceiverServerRatis implements XceiverServerSpi {
         new ThreadPoolExecutor(numWriteChunkThreads, numWriteChunkThreads,
             100, TimeUnit.SECONDS,
             new ArrayBlockingQueue<>(queueLimit),
+            new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat("ChunkWriter-%d")
+                .build(),
             new ThreadPoolExecutor.CallerRunsPolicy());
     this.context = context;
     this.dispatcher = dispatcher;


### PR DESCRIPTION
## What changes were proposed in this pull request?

ChunkWriter threads acreated with a naming schema `pool-[x]thread[y]`. We can use better naming (especially as we have 60 threads...)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3050

## How was this patch tested?

Checked with jstack. Can't see any benefit of creating a complex unit test to check it.