### PR TITLE
HDDS-3055. SCM crash during startup does not print any error message to log.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerStarter.java
@@ -61,8 +61,13 @@ public class StorageContainerManagerStarter extends GenericCli {
 
   @Override
   public Void call() throws Exception {
-    commonInit();
-    startScm();
+    try {
+      commonInit();
+      startScm();
+    } catch (Exception ex) {
+      LOG.error("SCM start failed with exception", ex);
+      throw ex;
+    }
     return null;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

SCM start up failed due to a pipelineNotFoundException, there is no error message logged in to SCM log.

In the log file, we can see just below log message no reason for the crash is logged.

```
2020-02-20 15:37:56,079 [shutdown-hook-0] INFO org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter: SHUTDOWN_MSG:
/************************************************************
SHUTDOWN_MSG: Shutting down StorageContainerManager at xx.xx.xx/10.65.51.49
```
In the out file, we can see below, but not complete exception message.

`PipelineID=xxxxx not found`
 

The actual reason for failure is not clearly logged if an exception has occurred during SCM startup.

This Jira is to fix issue of not logging to SCM, the reason for the crash issue will be fixed in a new Jira.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3004

## How was this patch tested?

Deployed fix in the cluster, now able to see complete error message logged to the file.

```
2020-02-21 13:57:34,888 [main] ERROR org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter: SCM start failed with exception
org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException: PipelineID=35dff62d-9bfa-449b-b6e8-6f00cc8c1b6e not found
        at org.apache.hadoop.hdds.scm.pipeline.PipelineStateMap.getPipeline(PipelineStateMap.java:133)
        at org.apache.hadoop.hdds.scm.pipeline.PipelineStateMap.addContainerToPipeline(PipelineStateMap.java:110)
        at org.apache.hadoop.hdds.scm.pipeline.PipelineStateManager.addContainerToPipeline(PipelineStateManager.java:59)
        at org.apache.hadoop.hdds.scm.pipeline.SCMPipelineManager.addContainerToPipeline(SCMPipelineManager.java:309)
        at org.apache.hadoop.hdds.scm.container.SCMContainerManager.loadExistingContainers(SCMContainerManager.java:121)
        at org.apache.hadoop.hdds.scm.container.SCMContainerManager.<init>(SCMContainerManager.java:107)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManager.initializeSystemManagers(StorageContainerManager.java:412)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManager.<init>(StorageContainerManager.java:283)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManager.<init>(StorageContainerManager.java:215)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManager.createSCM(StorageContainerManager.java:612)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter$SCMStarterHelper.start(StorageContainerManagerStarter.java:142)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter.startScm(StorageContainerManagerStarter.java:117)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter.call(StorageContainerManagerStarter.java:66)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter.call(StorageContainerManagerStarter.java:42)
        at picocli.CommandLine.execute(CommandLine.java:1173)
        at picocli.CommandLine.access$800(CommandLine.java:141)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:1367)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:1335)
        at picocli.CommandLine$AbstractParseResultHandler.handleParseResult(CommandLine.java:1243)
        at picocli.CommandLine.parseWithHandlers(CommandLine.java:1526)
        at picocli.CommandLine.parseWithHandler(CommandLine.java:1465)
        at org.apache.hadoop.hdds.cli.GenericCli.execute(GenericCli.java:65)
        at org.apache.hadoop.hdds.cli.GenericCli.run(GenericCli.java:56)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter.main(StorageContainerManagerStarter.java:55)
2020-02-21 13:57:34,892 [shutdown-hook-0] INFO org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter: SHUTDOWN_MSG:
/************************************************************
SHUTDOWN_MSG: Shutting down StorageContainerManager at om-ha-1.vpc.cloudera.com/10.65.51.49
************************************************************/
```

