### PR TITLE
HDDS-3047. ObjectStore#listVolumesByUser and CreateVolumeHandler#call should get principal name by default

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -250,7 +250,7 @@ public class ObjectStore {
       String volumePrefix, String prevVolume)
       throws IOException {
     if(Strings.isNullOrEmpty(user)) {
-      user = UserGroupInformation.getCurrentUser().getShortUserName();
+      user = UserGroupInformation.getCurrentUser().getUserName();
     }
     return new VolumeIterator(user, volumePrefix, prevVolume);
   }

--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs.robot
@@ -33,7 +33,7 @@ Check volume from ozonefs
     ${result} =         Execute               ozone sh volume list
                         Should contain    ${result}         fstest
                         Should contain    ${result}         fstest2
-                        Should contain    ${result}         "admin" : "testuser/scm@EXAMPLE.COM"
+                        Should Match Regexp  ${result}      "admin" : "(hadoop|testuser\/scm@EXAMPLE\.COM)"
     ${result} =         Execute               ozone fs -ls o3fs://bucket1.fstest/
 
 Run ozoneFS tests

--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs.robot
@@ -30,6 +30,10 @@ Create volume and bucket
     Execute             ozone sh bucket create o3://om/fstest2/bucket3
 
 Check volume from ozonefs
+    ${result} =         Execute               ozone sh volume list
+                        Should contain    ${result}         fstest
+                        Should contain    ${result}         fstest2
+                        Should contain    ${result}         "admin" : "testuser/scm@EXAMPLE.COM"
     ${result} =         Execute               ozone fs -ls o3fs://bucket1.fstest/
 
 Run ozoneFS tests

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/CreateVolumeHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/CreateVolumeHandler.java
@@ -43,25 +43,20 @@ public class CreateVolumeHandler extends Handler {
 
   @Option(names = {"--user", "-u"},
       description = "Owner of of the volume")
-  private String userName;
+  private String ownerName;
 
   @Option(names = {"--quota", "-q"},
       description =
           "Quota of the newly created volume (eg. 1G)")
   private String quota;
 
-  @Option(names = {"--root"},
-      description = "Development flag to execute the "
-          + "command as the admin (hdfs) user.")
-  private boolean root;
-
   /**
    * Executes the Create Volume.
    */
   @Override
   public Void call() throws Exception {
-    if(userName == null) {
-      userName = UserGroupInformation.getCurrentUser().getUserName();
+    if (ownerName == null) {
+      ownerName = UserGroupInformation.getCurrentUser().getUserName();
     }
 
     OzoneAddress address = new OzoneAddress(uri);
@@ -75,16 +70,10 @@ public class CreateVolumeHandler extends Handler {
         System.out.printf("Volume name : %s%n", volumeName);
       }
 
-      String rootName;
-      if (root) {
-        rootName = "hdfs";
-      } else {
-        rootName = UserGroupInformation.getCurrentUser().getUserName();
-      }
-
+      String adminName = UserGroupInformation.getCurrentUser().getUserName();
       VolumeArgs.Builder volumeArgsBuilder = VolumeArgs.newBuilder()
-          .setAdmin(rootName)
-          .setOwner(userName);
+          .setAdmin(adminName)
+          .setOwner(ownerName);
       if (quota != null) {
         volumeArgsBuilder.setQuota(quota);
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/CreateVolumeHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/volume/CreateVolumeHandler.java
@@ -79,7 +79,7 @@ public class CreateVolumeHandler extends Handler {
       if (root) {
         rootName = "hdfs";
       } else {
-        rootName = UserGroupInformation.getCurrentUser().getShortUserName();
+        rootName = UserGroupInformation.getCurrentUser().getUserName();
       }
 
       VolumeArgs.Builder volumeArgsBuilder = VolumeArgs.newBuilder()


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ObjectStore#listVolumesByUser` and `CreateVolumeHandler#call` should get user's full principal name instead of login name by default. When Kerberos is enabled, `getUserName()` returns full principal name e.g. `om/om@EXAMPLE.COM`, but `getShortUserName()` will return login name e.g. `hadoop`.

When the user creates a volume with ozone shell (uses `getUserName()` internally) then try to list it with `ObjectStore#listVolumesByUser(null, ...)` (uses `getShortUserName()` by default), the user won't see any volumes listed because of the mismatch.

For more information, see the Apache JIRA description.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3047

## How was this patch tested?

- Manually tested in `ozonesecure` docker-compose cluster.
- ~Might add a test case in secure integration test, like in `TestSecureOzoneRpcClient` or `TestSecureOzoneCluster`~ After discussing with Xiaoyu, it seems it is not viable to do the test via integration test because in unit test/integration test scm, om, etc. all run in one JVM, and one JVM can't have multiple security context (?). Will add an acceptance (robot) test instead.