### PR TITLE
HDDS-3054. OzoneFileStatus#getModificationTime should return actual directory modification time when its OmKeyInfo is available

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFileStatus.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFileStatus.java
@@ -99,7 +99,7 @@ public class OzoneFileStatus extends FileStatus {
    */
   @Override
   public long getModificationTime(){
-    if (isDirectory()) {
+    if (isDirectory() && super.getModificationTime() == 0) {
       return System.currentTimeMillis();
     } else {
       return super.getModificationTime();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
@@ -311,9 +311,11 @@ public class TestOzoneFileInterfaces {
 
     assertTrue("The created path is not directory.", omStatus.isDirectory());
 
-    // For directories, the time returned is the current time.
+    // For directories, the time returned is the current time when the dir key
+    // doesn't actually exist on server; if it exists, it will be a fixed value.
+    // In this case, the dir key exists.
     assertEquals(0, omStatus.getLen());
-    assertTrue(omStatus.getModificationTime() >= currentTime);
+    assertTrue(omStatus.getModificationTime() <= currentTime);
     assertEquals(omStatus.getPath().getName(), o3fs.pathToKey(path));
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -87,6 +87,8 @@ public class TestOzoneFileSystem {
     testOzoneFsServiceLoader();
     o3fs = (OzoneFileSystem) fs;
 
+    testGetDirectoryModificationTime();
+
     testListStatusOnRoot();
     testListStatus();
     testListStatusOnSubDirs();
@@ -353,5 +355,46 @@ public class TestOzoneFileSystem {
 
   private void assertKeyNotFoundException(IOException ex) {
     GenericTestUtils.assertExceptionContains("KEY_NOT_FOUND", ex);
+  }
+
+  private void testGetDirectoryModificationTime() throws IOException {
+    Path mdir1 = new Path("/mdir1");
+    Path mdir11 = new Path(mdir1, "mdir11");
+    Path mdir111 = new Path(mdir11, "mdir111");
+    fs.mkdirs(mdir111);
+    rootItemCount++; // mdir1
+
+    // Case 1: Dir key exist on server
+    FileStatus[] fileStatuses = o3fs.listStatus(mdir11);
+    // Above listStatus result should only have one entry: mdir111
+    assertEquals(1, fileStatuses.length);
+    assertEquals(mdir111.toString(),
+        fileStatuses[0].getPath().toUri().getPath());
+    assertTrue(fileStatuses[0].isDirectory());
+    // The dir key is actually created on server,
+    // so modification time should always be the same value.
+    long modificationTime = fileStatuses[0].getModificationTime();
+    // Check modification time in a small loop, it should always be the same
+    for (int i = 0; i < 5; i++) {
+      fileStatuses = o3fs.listStatus(mdir11);
+      assertEquals(modificationTime, fileStatuses[0].getModificationTime());
+    }
+
+    // Case 2: Dir key doesn't exist on server
+    fileStatuses = o3fs.listStatus(mdir1);
+    // Above listStatus result should only have one entry: mdir11
+    assertEquals(1, fileStatuses.length);
+    assertEquals(mdir11.toString(),
+        fileStatuses[0].getPath().toUri().getPath());
+    assertTrue(fileStatuses[0].isDirectory());
+    // Since the dir key doesn't exist on server, the modification time is
+    // set to current time upon every listStatus request.
+    modificationTime = fileStatuses[0].getModificationTime();
+    // Check modification time in a small loop, it should be slightly larger
+    // each time
+    for (int i = 0; i < 5; i++) {
+      fileStatuses = o3fs.listStatus(mdir1);
+      assertTrue(modificationTime <= fileStatuses[0].getModificationTime());
+    }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -357,7 +357,8 @@ public class TestOzoneFileSystem {
     GenericTestUtils.assertExceptionContains("KEY_NOT_FOUND", ex);
   }
 
-  private void testGetDirectoryModificationTime() throws IOException {
+  private void testGetDirectoryModificationTime()
+      throws IOException, InterruptedException {
     Path mdir1 = new Path("/mdir1");
     Path mdir11 = new Path(mdir1, "mdir11");
     Path mdir111 = new Path(mdir11, "mdir111");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -376,6 +376,7 @@ public class TestOzoneFileSystem {
     long modificationTime = fileStatuses[0].getModificationTime();
     // Check modification time in a small loop, it should always be the same
     for (int i = 0; i < 5; i++) {
+      Thread.sleep(10);
       fileStatuses = o3fs.listStatus(mdir11);
       assertEquals(modificationTime, fileStatuses[0].getModificationTime());
     }
@@ -393,6 +394,7 @@ public class TestOzoneFileSystem {
     // Check modification time in a small loop, it should be slightly larger
     // each time
     for (int i = 0; i < 5; i++) {
+      Thread.sleep(10);
       fileStatuses = o3fs.listStatus(mdir1);
       assertTrue(modificationTime <= fileStatuses[0].getModificationTime());
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1979,7 +1979,6 @@ public class KeyManagerImpl implements KeyManager {
       // First, find key in TableCache
       listStatusFindKeyInTableCache(cacheIter, keyArgs, startCacheKey,
           recursive, cacheKeyMap, deletedKeySet);
-
       // Then, find key in DB
       String seekKeyInDb =
           metadataManager.getOzoneKey(volumeName, bucketName, startKey);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1963,6 +1963,7 @@ public class KeyManagerImpl implements KeyManager {
         if (fileStatus.isFile()) {
           return Collections.singletonList(fileStatus);
         }
+        // keyName is a directory
         startKey = OzoneFSUtils.addTrailingSlashIfNeeded(keyName);
       }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -2012,8 +2012,14 @@ public class KeyManagerImpl implements KeyManager {
               } else {
                 // if entry is a directory
                 if (!deletedKeySet.contains(entryInDb)) {
-                  cacheKeyMap.put(entryInDb,
-                      new OzoneFileStatus(immediateChild));
+                  if (!entryKeyName.equals(immediateChild)) {
+                    cacheKeyMap.put(entryInDb,
+                        new OzoneFileStatus(immediateChild));
+                  } else {
+                    // If entryKeyName matches dir name, we have the info
+                    cacheKeyMap.put(entryInDb,
+                        new OzoneFileStatus(value, 0, true));
+                  }
                   countEntries++;
                 }
                 // skip the other descendants of this child directory.


### PR DESCRIPTION
## What changes were proposed in this pull request?

As of current implementation, getModificationTime() always returns "fake" modification time (current time) for directory due to the reason that a directory in Ozone might be faked from a file key.

But, there are cases where real directory key exists in OzoneBucket. For example when user calls fs.mkdirs(directory). In this case, a reasonable thing to do would be getting the modification time from the OmInfoKey, rather than faking it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3054

## How was this patch tested?

So far passed manual test.

Will add a integration test case later.