### PR TITLE
HDDS-3059 Changed auditing in OzoneManager#getFileStatus to read

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2780,13 +2780,13 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     } catch (IOException ex) {
       metrics.incNumGetFileStatusFails();
       auditSuccess = false;
-      AUDIT.logWriteFailure(
+      AUDIT.logReadFailure(
           buildAuditMessageForFailure(OMAction.GET_FILE_STATUS,
               (args == null) ? null : args.toAuditMap(), ex));
       throw ex;
     } finally {
       if (auditSuccess) {
-        AUDIT.logWriteSuccess(
+        AUDIT.logReadSuccess(
             buildAuditMessageForSuccess(OMAction.GET_FILE_STATUS,
                 (args == null) ? null : args.toAuditMap()));
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed the auditing used in OzoneManager#getFileStatus from write to read.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3059

## How was this patch tested?

Ran Maven build and unit tests.
