### PR TITLE
HDDS-3049. Fix Replication factor passed in create API doesn't take effect

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
@@ -210,6 +210,25 @@ public class TestOzoneFileInterfaces {
     assertEquals(statistics.getLong("objects_read").longValue(), 1);
   }
 
+  @Test
+  public void testReplication() throws IOException {
+    int stringLen = 20;
+    String data = RandomStringUtils.randomAlphanumeric(stringLen);
+    String filePath = RandomStringUtils.randomAlphanumeric(5);
+
+    Path pathIllegal = createPath("/" + filePath + "illegal");
+    try (FSDataOutputStream streamIllegal = fs.create(pathIllegal, (short)2)) {
+      streamIllegal.writeBytes(data);
+    }
+    assertEquals(3, fs.getFileStatus(pathIllegal).getReplication());
+
+    Path pathLegal = createPath("/" + filePath + "legal");
+    try (FSDataOutputStream streamLegal = fs.create(pathLegal, (short)1)) {
+      streamLegal.writeBytes(data);
+    }
+    assertEquals(1, fs.getFileStatus(pathLegal).getReplication());
+  }
+
   private void verifyOwnerGroup(FileStatus fileStatus) {
     String owner = getCurrentUser();
     assertEquals(owner, fileStatus.getOwner());

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -210,13 +210,21 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   }
 
   @Override
-  public OzoneFSOutputStream createFile(String key, boolean overWrite,
-      boolean recursive) throws IOException {
+  public OzoneFSOutputStream createFile(String key, short replication,
+      boolean overWrite, boolean recursive) throws IOException {
     incrementCounter(Statistic.OBJECTS_CREATED);
     try {
-      OzoneOutputStream ozoneOutputStream = bucket
-          .createFile(key, 0, replicationType, replicationFactor, overWrite,
-              recursive);
+      OzoneOutputStream ozoneOutputStream = null;
+      if (replication == ReplicationFactor.ONE.getValue()
+          || replication == ReplicationFactor.THREE.getValue()) {
+        ReplicationFactor clientReplication = ReplicationFactor
+            .valueOf(replication);
+        ozoneOutputStream = bucket.createFile(key, 0, replicationType,
+            clientReplication, overWrite, recursive);
+      } else {
+        ozoneOutputStream = bucket.createFile(key, 0, replicationType,
+            replicationFactor, overWrite, recursive);
+      }
       return new OzoneFSOutputStream(ozoneOutputStream.getOutputStream());
     } catch (OMException ex) {
       if (ex.getResult() == OMException.ResultCodes.FILE_ALREADY_EXISTS

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -247,20 +247,13 @@ public class BasicOzoneFileSystem extends FileSystem {
     statistics.incrementWriteOps(1);
     final String key = pathToKey(path);
     return createOutputStream(key,
-        replication,
-        flags.contains(CreateFlag.OVERWRITE),
-        false);
+        replication, flags.contains(CreateFlag.OVERWRITE), false);
   }
 
-  private FSDataOutputStream createOutputStream(String key,
-      short replication,
-      boolean overwrite,
-      boolean recursive) throws IOException {
-    return new FSDataOutputStream(adapter.createFile(
-        key,
-        replication,
-        overwrite,
-        recursive), statistics);
+  private FSDataOutputStream createOutputStream(String key, short replication,
+      boolean overwrite, boolean recursive) throws IOException {
+    return new FSDataOutputStream(adapter.createFile(key,
+        replication, overwrite, recursive), statistics);
   }
 
   @Override

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -232,7 +232,7 @@ public class BasicOzoneFileSystem extends FileSystem {
     incrementCounter(Statistic.INVOCATION_CREATE);
     statistics.incrementWriteOps(1);
     final String key = pathToKey(f);
-    return createOutputStream(key, overwrite, true);
+    return createOutputStream(key, replication, overwrite, true);
   }
 
   @Override
@@ -246,13 +246,21 @@ public class BasicOzoneFileSystem extends FileSystem {
     incrementCounter(Statistic.INVOCATION_CREATE_NON_RECURSIVE);
     statistics.incrementWriteOps(1);
     final String key = pathToKey(path);
-    return createOutputStream(key, flags.contains(CreateFlag.OVERWRITE), false);
+    return createOutputStream(key,
+        replication,
+        flags.contains(CreateFlag.OVERWRITE),
+        false);
   }
 
-  private FSDataOutputStream createOutputStream(String key, boolean overwrite,
+  private FSDataOutputStream createOutputStream(String key,
+      short replication,
+      boolean overwrite,
       boolean recursive) throws IOException {
-    return new FSDataOutputStream(adapter.createFile(key, overwrite, recursive),
-        statistics);
+    return new FSDataOutputStream(adapter.createFile(
+        key,
+        replication,
+        overwrite,
+        recursive), statistics);
   }
 
   @Override

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
@@ -41,10 +41,8 @@ public interface OzoneClientAdapter {
 
   InputStream readFile(String key) throws IOException;
 
-  OzoneFSOutputStream createFile(String key,
-      short replication,
-      boolean overWrite,
-      boolean recursive) throws IOException;
+  OzoneFSOutputStream createFile(String key, short replication,
+      boolean overWrite, boolean recursive) throws IOException;
 
   void renameKey(String key, String newKeyName) throws IOException;
 

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
@@ -41,7 +41,9 @@ public interface OzoneClientAdapter {
 
   InputStream readFile(String key) throws IOException;
 
-  OzoneFSOutputStream createFile(String key, boolean overWrite,
+  OzoneFSOutputStream createFile(String key,
+      short replication,
+      boolean overWrite,
       boolean recursive) throws IOException;
 
   void renameKey(String key, String newKeyName) throws IOException;

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestReadWriteStatistics.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestReadWriteStatistics.java
@@ -323,14 +323,13 @@ public class TestReadWriteStatistics {
   }
 
   @Test
-  public void testIllegalReplication() throws Exception {
+  public void testSetReplication() throws Exception {
     EnumSet<CreateFlag> flags = EnumSet.of(CreateFlag.OVERWRITE);
-    for(int i = 1; i <=5; i++){
-      FSDataOutputStream stream =
-          fs.createNonRecursive(aPath, null, flags, 512, (short) 2, 512, null);
+    fs.createNonRecursive(aPath, null, flags, 512, (short) 2, 512, null);
+    assertEquals(3, fs.getFileStatus(aPath).getReplication());
+    fs.createNonRecursive(aPath, null, flags, 512, (short) 3, 512, null);
+    assertEquals(3, fs.getFileStatus(aPath).getReplication());
 
-      assertBytesWrittenAndWriteNumOps(0, i);
-    }
   }
 
   @Test(expected = UnsupportedOperationException.class)

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestReadWriteStatistics.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestReadWriteStatistics.java
@@ -322,6 +322,17 @@ public class TestReadWriteStatistics {
     }
   }
 
+  @Test
+  public void testIllegalReplication() throws Exception {
+    EnumSet<CreateFlag> flags = EnumSet.of(CreateFlag.OVERWRITE);
+    for(int i = 1; i <=5; i++){
+      FSDataOutputStream stream =
+          fs.createNonRecursive(aPath, null, flags, 512, (short) 2, 512, null);
+
+      assertBytesWrittenAndWriteNumOps(0, i);
+    }
+  }
+
   @Test(expected = UnsupportedOperationException.class)
   public void testsIfAppendGetsSupported() throws Exception {
     fs.append(aPath, 512, null);
@@ -399,8 +410,8 @@ public class TestReadWriteStatistics {
   }
 
   private void setupAdapterToReturnFakeOutputStreamOnCreate() throws Exception {
-    when(fakeAdapter.createFile(anyString(), anyBoolean(), anyBoolean()))
-        .thenReturn(new OzoneFSOutputStream(fakeOutputStream));
+    when(fakeAdapter.createFile(anyString(), anyShort(), anyBoolean(),
+        anyBoolean())).thenReturn(new OzoneFSOutputStream(fakeOutputStream));
   }
 
   private void setupFileSystemToUseFakeClientAdapter() throws IOException {

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestReadWriteStatistics.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestReadWriteStatistics.java
@@ -322,16 +322,6 @@ public class TestReadWriteStatistics {
     }
   }
 
-  @Test
-  public void testSetReplication() throws Exception {
-    EnumSet<CreateFlag> flags = EnumSet.of(CreateFlag.OVERWRITE);
-    fs.createNonRecursive(aPath, null, flags, 512, (short) 2, 512, null);
-    assertEquals(3, fs.getFileStatus(aPath).getReplication());
-    fs.createNonRecursive(aPath, null, flags, 512, (short) 3, 512, null);
-    assertEquals(3, fs.getFileStatus(aPath).getReplication());
-
-  }
-
   @Test(expected = UnsupportedOperationException.class)
   public void testsIfAppendGetsSupported() throws Exception {
     fs.append(aPath, 512, null);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replication did not take effect when we created the file through o3fs. This PR fix that.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3049

## How was this patch tested?

Ut already exists
