### PR TITLE
HDDS-3063. Add test to verify replication factor of ozone fs

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -36,6 +36,8 @@ execute_robot_test scm basic
 
 execute_robot_test scm gdpr
 
+execute_robot_test scm ozonefs/ozonefs.robot
+
 execute_robot_test scm s3
 
 execute_robot_test scm recon

--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs.robot
@@ -39,6 +39,8 @@ Run ozoneFS tests
                         Execute               ozone fs -copyFromLocal NOTICE.txt o3fs://bucket1.fstest/testdir/deep/
     ${result} =         Execute               ozone sh key list o3://om/fstest/bucket1 | jq -r '.name'
                         Should contain    ${result}         NOTICE.txt
+    ${result} =         Execute               ozone sh key info o3://om/fstest/bucket1/testdir/deep/NOTICE.txt | jq -r '.replicationFactor'
+                        Should Be Equal   ${result}         3
 
                         Execute               ozone fs -put NOTICE.txt o3fs://bucket1.fstest/testdir/deep/PUTFILE.txt
     ${result} =         Execute               ozone sh key list o3://om/fstest/bucket1 | jq -r '.name'


### PR DESCRIPTION
## What changes were proposed in this pull request?

Amend existing `ozonefs` acceptance test to verify replication factor of a key created by `ozone fs`.

https://issues.apache.org/jira/browse/HDDS-3063

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/464815333