### PR TITLE
HDDS-3067. Fix Bug in Scrub Pipeline causing destory pipelines after SCM restart.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -153,6 +153,8 @@ public class SCMPipelineManager implements PipelineManager {
           .newBuilder(HddsProtos.Pipeline.PARSER.parseFrom(entry.getValue()));
       Pipeline pipeline = Pipeline.getFromProtobuf(pipelineBuilder.setState(
           HddsProtos.PipelineState.PIPELINE_ALLOCATED).build());
+      // When SCM is restarted, set Creation time with current time.
+      pipeline.setCreationTimestamp(Instant.now());
       Preconditions.checkNotNull(pipeline);
       stateManager.addPipeline(pipeline);
       nodeManager.addPipeline(pipeline);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hdds.scm.container.MockNodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -143,7 +142,8 @@ public class TestRatisPipelineProvider {
   }
 
   @Test
-  public void testCreateFactorTHREEPipelineWithSameDatanodes() throws Exception {
+  public void testCreateFactorTHREEPipelineWithSameDatanodes()
+      throws Exception {
     init(2);
     List<DatanodeDetails> healthyNodes = nodeManager
         .getNodes(HddsProtos.NodeState.HEALTHY).stream()

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -46,7 +45,6 @@ import static org.junit.Assert.assertTrue;
 /**
  * Test for RatisPipelineProvider.
  */
-@Ignore("HDDS-3036")
 public class TestRatisPipelineProvider {
 
   private static final HddsProtos.ReplicationType REPLICATION_TYPE =
@@ -56,10 +54,9 @@ public class TestRatisPipelineProvider {
   private PipelineProvider provider;
   private PipelineStateManager stateManager;
   private OzoneConfiguration conf;
-  private int maxPipelinePerNode = 2;
 
-  @Before
-  public void init() throws Exception {
+
+  public void init(int maxPipelinePerNode) throws Exception {
     nodeManager = new MockNodeManager(true, 10);
     conf = new OzoneConfiguration();
     conf.setInt(ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT,
@@ -92,7 +89,8 @@ public class TestRatisPipelineProvider {
   }
 
   @Test
-  public void testCreatePipelineWithFactor() throws IOException {
+  public void testCreatePipelineWithFactor() throws Exception {
+    init(1);
     HddsProtos.ReplicationFactor factor = HddsProtos.ReplicationFactor.THREE;
     Pipeline pipeline = provider.create(factor);
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
@@ -110,12 +108,14 @@ public class TestRatisPipelineProvider {
   }
 
   @Test
-  public void testCreatePipelineWithFactorThree() throws IOException {
+  public void testCreatePipelineWithFactorThree() throws Exception {
+    init(1);
     createPipelineAndAssertions(HddsProtos.ReplicationFactor.THREE);
   }
 
   @Test
-  public void testCreatePipelineWithFactorOne() throws IOException {
+  public void testCreatePipelineWithFactorOne() throws Exception {
+    init(1);
     createPipelineAndAssertions(HddsProtos.ReplicationFactor.ONE);
   }
 
@@ -128,7 +128,8 @@ public class TestRatisPipelineProvider {
   }
 
   @Test
-  public void testCreatePipelineWithNodes() {
+  public void testCreatePipelineWithNodes() throws Exception {
+    init(1);
     HddsProtos.ReplicationFactor factor = HddsProtos.ReplicationFactor.THREE;
     Pipeline pipeline =
         provider.create(factor, createListOfNodes(factor.getNumber()));
@@ -142,7 +143,8 @@ public class TestRatisPipelineProvider {
   }
 
   @Test
-  public void testCreateFactorTHREEPipelineWithSameDatanodes() {
+  public void testCreateFactorTHREEPipelineWithSameDatanodes() throws Exception {
+    init(2);
     List<DatanodeDetails> healthyNodes = nodeManager
         .getNodes(HddsProtos.NodeState.HEALTHY).stream()
         .limit(3).collect(Collectors.toList());
@@ -156,7 +158,10 @@ public class TestRatisPipelineProvider {
   }
 
   @Test
-  public void testCreatePipelinesDnExclude() throws IOException {
+  public void testCreatePipelinesDnExclude() throws Exception {
+
+    int maxPipelinePerNode = 2;
+    init(maxPipelinePerNode);
     List<DatanodeDetails> healthyNodes =
         nodeManager.getNodes(HddsProtos.NodeState.HEALTHY);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix destroy of pipelines after SCM restart, due to a bug in loading pipeline setting timestamp with actual pipeline time. In the case of a restart, we should set time to when it is loading from pipeline DB.
 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3067

## How was this patch tested?

Tested it on the cluster and now SCM is not destroying pipelines after the restart. And also fixed RatisPipelineProvider test.
