### PR TITLE
HDDS-3068. OM crash during startup does not print any error message to log.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
@@ -61,8 +61,13 @@ public class OzoneManagerStarter extends GenericCli {
      * if someone runs "ozone om" with no parameters, this is the method
      * which runs and starts the OM.
      */
-    commonInit();
-    startOm();
+    try {
+      commonInit();
+      startOm();
+    } catch (Exception ex) {
+      LOG.error("OM start failed with exception", ex);
+      throw ex;
+    }
     return null;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

During code read found a similar thing, we don't log for OM start also. As OM startup also using similar code for the startup.

In startup code, caught the exception and logging it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3068

## How was this patch tested?

Existing UT TestOzoneManagerStarter should cover this.
