### PR TITLE
HDDS-2984. Allocate Block failing with NPE

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineMetrics.java
@@ -130,7 +130,7 @@ public final class SCMPipelineMetrics implements MetricsSource {
    * Increments number of blocks allocated for the pipeline.
    */
   void incNumBlocksAllocated(PipelineID pipelineID) {
-    Optional.of(numBlocksAllocated.get(pipelineID)).ifPresent(
+    Optional.ofNullable(numBlocksAllocated.get(pipelineID)).ifPresent(
         MutableCounterLong::incr);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

NPE may happen in `SCMPipelineMetrics#incNumBlocksAllocated` if pipeline is not found while incrementing counter.  Given that `Optional#ifPresent` is already checked, I think the intention was to allow such cases.  The problem is that `Optional#of` does not allow `null`.  This change simply replaces it with `Optional#ofNullable`.

https://issues.apache.org/jira/browse/HDDS-2984

## How was this patch tested?

Passes existing tests, although I don't think any specific test covers this case.

https://github.com/adoroszlai/hadoop-ozone/runs/465744823