### PR TITLE
HDDS-3038. TestRatisPipelineLeader fails since we no longer wait for leader in the HealthyPipelineSafeModeExitRule.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
@@ -41,16 +41,14 @@ import com.google.common.annotations.VisibleForTesting;
  * Once safe mode exit happens, this rules take care of writes can go
  * through in a cluster.
  */
-public class HealthyPipelineSafeModeRule
-    extends SafeModeExitRule<Pipeline>{
+public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
 
   public static final Logger LOG =
       LoggerFactory.getLogger(HealthyPipelineSafeModeRule.class);
   private int healthyPipelineThresholdCount;
   private int currentHealthyPipelineCount = 0;
   private final double healthyPipelinesPercent;
-  private final Set<PipelineID> processedPipelineIDs =
-      new HashSet<>();
+  private final Set<PipelineID> processedPipelineIDs = new HashSet<>();
 
   HealthyPipelineSafeModeRule(String ruleName, EventQueue eventQueue,
       PipelineManager pipelineManager,
@@ -121,12 +119,12 @@ public class HealthyPipelineSafeModeRule
     // create new pipelines.
     Preconditions.checkNotNull(pipeline);
     if (pipeline.getType() == HddsProtos.ReplicationType.RATIS &&
-        pipeline.getFactor() == HddsProtos.ReplicationFactor.THREE) {
-      if (!processedPipelineIDs.contains(pipeline.getId())) {
-        getSafeModeMetrics().incCurrentHealthyPipelinesCount();
-        currentHealthyPipelineCount++;
-        processedPipelineIDs.add(pipeline.getId());
-      }
+        pipeline.getFactor() == HddsProtos.ReplicationFactor.THREE &&
+        pipeline.isHealthy() &&
+        !processedPipelineIDs.contains(pipeline.getId())) {
+      getSafeModeMetrics().incCurrentHealthyPipelinesCount();
+      currentHealthyPipelineCount++;
+      processedPipelineIDs.add(pipeline.getId());
     }
 
     if (scmInSafeMode()) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockRatisPipelineProvider.java
@@ -34,6 +34,7 @@ import java.util.List;
 public class MockRatisPipelineProvider extends RatisPipelineProvider {
 
   private boolean autoOpenPipeline;
+  private  boolean isHealthy;
 
   public MockRatisPipelineProvider(NodeManager nodeManager,
       PipelineStateManager stateManager, Configuration conf,
@@ -46,6 +47,13 @@ public class MockRatisPipelineProvider extends RatisPipelineProvider {
                             PipelineStateManager stateManager,
                             Configuration conf) {
     super(nodeManager, stateManager, conf, new EventQueue());
+  }
+
+  public MockRatisPipelineProvider(NodeManager nodeManager,
+                                   PipelineStateManager stateManager,
+                                   Configuration conf, boolean isHealthy) {
+    super(nodeManager, stateManager, conf, new EventQueue());
+    this.isHealthy = isHealthy;
   }
 
   public MockRatisPipelineProvider(NodeManager nodeManager,
@@ -66,7 +74,7 @@ public class MockRatisPipelineProvider extends RatisPipelineProvider {
       return super.create(factor);
     } else {
       Pipeline initialPipeline = super.create(factor);
-      return Pipeline.newBuilder()
+      Pipeline pipeline = Pipeline.newBuilder()
           .setId(initialPipeline.getId())
           // overwrite pipeline state to main ALLOCATED
           .setState(Pipeline.PipelineState.ALLOCATED)
@@ -74,6 +82,13 @@ public class MockRatisPipelineProvider extends RatisPipelineProvider {
           .setFactor(factor)
           .setNodes(initialPipeline.getNodes())
           .build();
+      if (isHealthy) {
+        for (DatanodeDetails datanodeDetails : initialPipeline.getNodes()) {
+          pipeline.reportDatanode(datanodeDetails);
+        }
+        pipeline.setLeaderId(initialPipeline.getFirstNode().getUuid());
+      }
+      return pipeline;
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
@@ -54,8 +54,8 @@ public class TestHealthyPipelineSafeModeRule {
         TestHealthyPipelineSafeModeRule.class.getName() + UUID.randomUUID());
     try {
       EventQueue eventQueue = new EventQueue();
-      List<ContainerInfo> containers = new ArrayList<>();
-      containers.addAll(HddsTestUtils.getContainerInfo(1));
+      List<ContainerInfo> containers =
+          new ArrayList<>(HddsTestUtils.getContainerInfo(1));
 
       OzoneConfiguration config = new OzoneConfiguration();
       MockNodeManager nodeManager = new MockNodeManager(true, 0);
@@ -94,11 +94,10 @@ public class TestHealthyPipelineSafeModeRule {
 
     try {
       EventQueue eventQueue = new EventQueue();
-      List<ContainerInfo> containers = new ArrayList<>();
-      containers.addAll(HddsTestUtils.getContainerInfo(1));
+      List<ContainerInfo> containers =
+          new ArrayList<>(HddsTestUtils.getContainerInfo(1));
 
       OzoneConfiguration config = new OzoneConfiguration();
-
       // In Mock Node Manager, first 8 nodes are healthy, next 2 nodes are
       // stale and last one is dead, and this repeats. So for a 12 node, 9
       // healthy, 2 stale and one dead.
@@ -115,7 +114,7 @@ public class TestHealthyPipelineSafeModeRule {
 
       PipelineProvider mockRatisProvider =
           new MockRatisPipelineProvider(nodeManager,
-              pipelineManager.getStateManager(), config);
+              pipelineManager.getStateManager(), config, true);
       pipelineManager.setPipelineProvider(HddsProtos.ReplicationType.RATIS,
           mockRatisProvider);
 
@@ -130,13 +129,11 @@ public class TestHealthyPipelineSafeModeRule {
           pipelineManager.createPipeline(HddsProtos.ReplicationType.RATIS,
               HddsProtos.ReplicationFactor.THREE);
 
-
       SCMSafeModeManager scmSafeModeManager = new SCMSafeModeManager(
           config, containers, pipelineManager, eventQueue);
 
       HealthyPipelineSafeModeRule healthyPipelineSafeModeRule =
           scmSafeModeManager.getHealthyPipelineSafeModeRule();
-
 
       // No datanodes have sent pipelinereport from datanode
       Assert.assertFalse(healthyPipelineSafeModeRule.validate());
@@ -169,8 +166,8 @@ public class TestHealthyPipelineSafeModeRule {
 
     try {
       EventQueue eventQueue = new EventQueue();
-      List<ContainerInfo> containers = new ArrayList<>();
-      containers.addAll(HddsTestUtils.getContainerInfo(1));
+      List<ContainerInfo> containers =
+          new ArrayList<>(HddsTestUtils.getContainerInfo(1));
 
       OzoneConfiguration config = new OzoneConfiguration();
 
@@ -189,7 +186,7 @@ public class TestHealthyPipelineSafeModeRule {
           nodeManager, eventQueue);
       PipelineProvider mockRatisProvider =
           new MockRatisPipelineProvider(nodeManager,
-              pipelineManager.getStateManager(), config);
+              pipelineManager.getStateManager(), config, true);
       pipelineManager.setPipelineProvider(HddsProtos.ReplicationType.RATIS,
           mockRatisProvider);
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -260,7 +260,7 @@ public class TestSCMSafeModeManager {
         mockNodeManager, queue);
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(mockNodeManager,
-            pipelineManager.getStateManager(), config);
+            pipelineManager.getStateManager(), config, true);
     pipelineManager.setPipelineProvider(HddsProtos.ReplicationType.RATIS,
         mockRatisProvider);
 
@@ -478,7 +478,7 @@ public class TestSCMSafeModeManager {
 
       PipelineProvider mockRatisProvider =
           new MockRatisPipelineProvider(nodeManager,
-              pipelineManager.getStateManager(), config);
+              pipelineManager.getStateManager(), config, true);
       pipelineManager.setPipelineProvider(HddsProtos.ReplicationType.RATIS,
           mockRatisProvider);
 
@@ -492,8 +492,6 @@ public class TestSCMSafeModeManager {
       queue.fireEvent(SCMEvents.NODE_REGISTRATION_CONT_REPORT,
           HddsTestUtils.createNodeRegistrationContainerReport(containers));
       assertTrue(scmSafeModeManager.getInSafeMode());
-
-
 
       firePipelineEvent(pipelineManager, pipeline);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestRatisPipelineLeader.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestRatisPipelineLeader.java
@@ -39,7 +39,6 @@ import org.apache.ratis.protocol.RaftGroupId;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -74,7 +73,6 @@ public class TestRatisPipelineLeader {
             HddsProtos.ReplicationFactor.THREE);
     Assert.assertFalse(pipelines.isEmpty());
     Pipeline ratisPipeline = pipelines.iterator().next();
-//    GenericTestUtils.waitFor(ratisPipeline::isHealthy, 100, 20000);
     Assert.assertTrue(ratisPipeline.isHealthy());
     // Verify correct leader info populated
     verifyLeaderInfo(ratisPipeline);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fixed the HealthyPipelineSafeModeExitRule to wait on pipeline healthy state implying, the pipeline leader is available upon OPEN, fixed related tests.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3038

## How was this patch tested?
Ran related integration tests.