### PR TITLE
HDDS-3084. Extend network topology acceptance test to read data when datanodes are stopped.

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-topology/hdds-3084.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-topology/hdds-3084.sh
@@ -33,6 +33,24 @@ execute_robot_test scm basic/basic.robot
 
 execute_robot_test scm topology/scmcli.robot
 
+# Ensure data can be read even when a full rack
+# is stopped.
+execute_robot_test scm topology/loaddata.robot
+
+stop_containers datanode_1 datanode_2 datanode_3
+
+execute_robot_test scm topology/readdata.robot
+
+start_containers datanode_1 datanode_2 datanode_3
+
+wait_for_port datanode_1 9858 60
+wait_for_port datanode_2 9858 60
+wait_for_port datanode_3 9858 60
+
+stop_containers datanode_4 datanode_5 datanode_6
+
+execute_robot_test scm topology/readdata.robot
+
 stop_docker_env
 
 generate_report

--- a/hadoop-ozone/dist/src/main/compose/ozone-topology/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-topology/test.sh
@@ -43,6 +43,10 @@ execute_robot_test scm topology/readdata.robot
 
 start_containers datanode_1 datanode_2 datanode_3
 
+wait_for_port datanode_1 9858 60
+wait_for_port datanode_2 9858 60
+wait_for_port datanode_3 9858 60
+
 stop_containers datanode_4 datanode_5 datanode_6
 
 execute_robot_test scm topology/readdata.robot

--- a/hadoop-ozone/dist/src/main/compose/ozone-topology/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-topology/test.sh
@@ -33,6 +33,20 @@ execute_robot_test scm basic/basic.robot
 
 execute_robot_test scm topology/scmcli.robot
 
+# Ensure data can be read even when a full rack
+# is stopped.
+execute_robot_test scm topology/loaddata.robot
+
+stop_containers datanode_1 datanode_2 datanode_3
+
+execute_robot_test scm topology/readdata.robot
+
+start_containers datanode_1 datanode_2 datanode_3
+
+stop_containers datanode_4 datanode_5 datanode_6
+
+execute_robot_test scm topology/readdata.robot
+
 stop_docker_env
 
 generate_report

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -128,7 +128,7 @@ execute_command_in_container(){
 ## @param       List of container names, eg datanode_1 datanode_2
 stop_containers() {
   set -e
-  docker-compose -f "$COMPOSE_FILE" stop $@
+  docker-compose -f "$COMPOSE_FILE" --no-ansi stop $@
   set +e
 }
 
@@ -137,7 +137,7 @@ stop_containers() {
 ## @param       List of container names, eg datanode_1 datanode_2
 start_containers() {
   set -e
-  docker-compose -f "$COMPOSE_FILE" start $@
+  docker-compose -f "$COMPOSE_FILE" --no-ansi start $@
   set +e
 }
 

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -124,6 +124,23 @@ execute_command_in_container(){
   set +e
 }
 
+## @description Stop a list of named containers
+## @param       List of container names, eg datanode_1 datanode_2
+stop_containers() {
+  set -e
+  docker-compose -f "$COMPOSE_FILE" stop $@
+  set +e
+}
+
+
+## @description Start a list of named containers
+## @param       List of container names, eg datanode_1 datanode_2
+start_containers() {
+  set -e
+  docker-compose -f "$COMPOSE_FILE" start $@
+  set +e
+}
+
 
 ## @description  Stops a docker-compose based test environment (with saving the logs)
 stop_docker_env(){

--- a/hadoop-ozone/dist/src/main/smoketest/topology/loaddata.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/topology/loaddata.robot
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Smoketest ozone cluster startup
+Library             OperatingSystem
+Library             BuiltIn
+Resource            ../commonlib.robot
+
+*** Variables ***
+
+
+*** Test Cases ***
+Create a volume, bucket and key
+    ${output} =         Execute          ozone sh volume create topvol1 --quota 100TB
+                        Should not contain  ${output}       Failed
+    ${output} =         Execute          ozone sh bucket create /topvol1/bucket1
+                        Should not contain  ${output}       Failed
+    ${output} =         Execute          ozone sh key put /topvol1/bucket1/key1 /opt/hadoop/NOTICE.txt
+                        Should not contain  ${output}       Failed

--- a/hadoop-ozone/dist/src/main/smoketest/topology/readdata.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/topology/readdata.robot
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Smoketest ozone cluster startup
+Library             OperatingSystem
+Library             BuiltIn
+Resource            ../commonlib.robot
+
+*** Variables ***
+
+
+*** Test Cases ***
+Read data from previously created key
+    ${output} =         Execute          ozone sh key get /topvol1/bucket1/key1
+                        Should not contain  ${output}       Failed

--- a/hadoop-ozone/dist/src/main/smoketest/topology/readdata.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/topology/readdata.robot
@@ -24,5 +24,6 @@ Resource            ../commonlib.robot
 
 *** Test Cases ***
 Read data from previously created key
-    ${output} =         Execute          ozone sh key get /topvol1/bucket1/key1
+    ${random} =         Generate Random String  5  [NUMBERS]
+    ${output} =         Execute          ozone sh key get /topvol1/bucket1/key1 /tmp/key1-${random}
                         Should not contain  ${output}       Failed


### PR DESCRIPTION
## What changes were proposed in this pull request?

This adds a new robot test to the network-topology environment, which:

1. Creates a volume, bucket and key.
2. Stops 1 rack and ensures the data is still readable
3. Restart the rack and stop the other rack and again check the data is readable

That way we can have some confidence the data is being written to both racks OK.

One issue with a test like this on a small cluster, is that there is a high chance the data will end up on 2 racks naturally, even if no network topology is configured. If that was the case, we would expect intermittent test failures.

However, if network topology is working fine, then we would not expect any failures.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3084

## How was this patch tested?

Ran the new smoke test locally.
