### PR TITLE
HDDS-2929. Implement ofs://: temp directory mount

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+CORE-SITE.XML_fs.ofs.impl=org.apache.hadoop.fs.ozone.RootedOzoneFileSystem
 CORE-SITE.XML_fs.o3fs.impl=org.apache.hadoop.fs.ozone.OzoneFileSystem
 
 OZONE-SITE.XML_ozone.om.address=om

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
 import org.apache.hadoop.ozone.security.acl.OzoneAclConfig;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Assert;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -731,7 +731,7 @@ public class TestRootedOzoneFileSystem {
     Assert.assertNotNull(vol);
 
     // Begin test
-    String hashedUsername = OFSPath.getTempMountBucketName(null);
+    String hashedUsername = OFSPath.getTempMountBucketNameOfCurrentUser();
 
     // Expect failure since temp bucket for current user is not created yet
     try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -128,12 +128,13 @@ public class TestRootedOzoneFileSystem {
 
   @Test
   public void testOzoneFsServiceLoader() throws IOException {
-    OzoneConfiguration cfg = new OzoneConfiguration();
+    OzoneConfiguration confTestLoader = new OzoneConfiguration();
     // Note: FileSystem#loadFileSystems won't load OFS class due to META-INF
     //  hence this workaround.
-    cfg.set("fs.ofs.impl", "org.apache.hadoop.fs.ozone.RootedOzoneFileSystem");
-    Assert.assertEquals(
-        FileSystem.getFileSystemClass(OzoneConsts.OZONE_OFS_URI_SCHEME, cfg),
+    confTestLoader.set("fs.ofs.impl",
+        "org.apache.hadoop.fs.ozone.RootedOzoneFileSystem");
+    Assert.assertEquals(FileSystem.getFileSystemClass(
+        OzoneConsts.OZONE_OFS_URI_SCHEME, confTestLoader),
         RootedOzoneFileSystem.class);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -745,12 +745,9 @@ public class TestRootedOzoneFileSystem {
     // Write under /tmp/, OFS will create the temp bucket if not exist
     fs.mkdirs(new Path("/tmp/dir1"));
 
-//    FSDataOutputStream stream = fs.create(new Path("/tmp/dir1/file1"));
-//    stream.write(1);
-
-//    try (FSDataOutputStream stream = fs.create(new Path("/tmp/dir1/file1"))) {
-//      stream.write(1);
-//    }
+    try (FSDataOutputStream stream = ofs.create(new Path("/tmp/dir1/file1"))) {
+      stream.write(1);
+    }
 
     // Verify temp bucket creation
     OzoneBucket bucket = vol.getBucket(hashedUsername);
@@ -760,6 +757,12 @@ public class TestRootedOzoneFileSystem {
     Assert.assertEquals(1, fileStatuses.length);
     Assert.assertEquals(
         "/tmp/dir1", fileStatuses[0].getPath().toUri().getPath());
+    // Verify file1 creation
+    FileStatus[] fileStatusesInDir1 =
+        fs.listStatus(new Path("/tmp/dir1"));
+    Assert.assertEquals(1, fileStatusesInDir1.length);
+    Assert.assertEquals("/tmp/dir1/file1",
+        fileStatusesInDir1[0].getPath().toUri().getPath());
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -29,12 +29,20 @@ import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.VolumeArgs;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
+import org.apache.hadoop.ozone.security.acl.OzoneAclConfig;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Assert;
@@ -45,6 +53,7 @@ import org.junit.rules.Timeout;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -53,8 +62,10 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.fs.ozone.Constants.LISTING_PAGE_SIZE;
+import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
 
 /**
  * Ozone file system tests that are not covered by contract tests.
@@ -65,10 +76,11 @@ public class TestRootedOzoneFileSystem {
   @Rule
   public Timeout globalTimeout = new Timeout(300_000);
 
-  private static MiniOzoneCluster cluster = null;
-  private static FileSystem fs;
-  private static RootedOzoneFileSystem ofs;
-  private static ObjectStore objectStore;
+  private OzoneConfiguration conf;
+  private MiniOzoneCluster cluster = null;
+  private FileSystem fs;
+  private RootedOzoneFileSystem ofs;
+  private ObjectStore objectStore;
   private static BasicRootedOzoneClientAdapterImpl adapter;
 
   private String volumeName;
@@ -79,7 +91,7 @@ public class TestRootedOzoneFileSystem {
 
   @Before
   public void init() throws Exception {
-    OzoneConfiguration conf = new OzoneConfiguration();
+    conf = new OzoneConfiguration();
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(3)
         .build();
@@ -117,12 +129,12 @@ public class TestRootedOzoneFileSystem {
 
   @Test
   public void testOzoneFsServiceLoader() throws IOException {
-    OzoneConfiguration conf = new OzoneConfiguration();
+    OzoneConfiguration cfg = new OzoneConfiguration();
     // Note: FileSystem#loadFileSystems won't load OFS class due to META-INF
     //  hence this workaround.
-    conf.set("fs.ofs.impl", "org.apache.hadoop.fs.ozone.RootedOzoneFileSystem");
+    cfg.set("fs.ofs.impl", "org.apache.hadoop.fs.ozone.RootedOzoneFileSystem");
     Assert.assertEquals(
-        FileSystem.getFileSystemClass(OzoneConsts.OZONE_OFS_URI_SCHEME, conf),
+        FileSystem.getFileSystemClass(OzoneConsts.OZONE_OFS_URI_SCHEME, cfg),
         RootedOzoneFileSystem.class);
   }
 
@@ -661,32 +673,99 @@ public class TestRootedOzoneFileSystem {
     // FileSystem because we can't change LISTING_PAGE_SIZE. Use adapter instead
 
     // numEntries > 5
-    FileStatus[] fileStatusesOver = customListStatus(
-        new Path("/"), false, "", 8);
+    FileStatus[] fileStatusesOver = customListStatus(new Path("/"),
+        false, "", 8);
     // There are only 5 volumes
     Assert.assertEquals(5, fileStatusesOver.length);
 
     // numEntries = 5
-    FileStatus[] fileStatusesExact = customListStatus(
-        new Path("/"), false, "", 5);
+    FileStatus[] fileStatusesExact = customListStatus(new Path("/"),
+        false, "", 5);
     Assert.assertEquals(5, fileStatusesExact.length);
 
     // numEntries < 5
-    FileStatus[] fileStatusesLimit1 = customListStatus(
-        new Path("/"), false, "", 3);
+    FileStatus[] fileStatusesLimit1 = customListStatus(new Path("/"),
+        false, "", 3);
     // Should only return 3 volumes even though there are more than that due to
     // the specified limit
     Assert.assertEquals(3, fileStatusesLimit1.length);
 
     // Get the last entry in the list as startPath
-    String nextStartPath = fileStatusesLimit1[fileStatusesLimit1.length - 1]
-        .getPath().toString();
-    FileStatus[] fileStatusesLimit2 = customListStatus(
-        new Path("/"), false, nextStartPath, 3);
+    String nextStartPath =
+        fileStatusesLimit1[fileStatusesLimit1.length - 1].getPath().toString();
+    FileStatus[] fileStatusesLimit2 = customListStatus(new Path("/"),
+        false, nextStartPath, 3);
     // Note: at the time of writing this test, OmMetadataManagerImpl#listVolumes
     //  excludes startVolume (startPath) from the result. Might change.
     Assert.assertEquals(fileStatusesOver.length,
         fileStatusesLimit1.length + fileStatusesLimit2.length);
+  }
+
+   /*
+   * OFS: Test /tmp mount behavior.
+   */
+  @Test
+  public void testTempMount() throws Exception {
+    // Prep
+    // Use ClientProtocol to pass in volume ACL, ObjectStore won't do it
+    ClientProtocol proxy = objectStore.getClientProxy();
+    // Get default acl rights for user
+    OzoneAclConfig aclConfig = conf.getObject(OzoneAclConfig.class);
+    ACLType userRights = aclConfig.getUserDefaultRights();
+    // Construct ACL for world access
+    OzoneAcl aclWorldAccess = new OzoneAcl(ACLIdentityType.WORLD, "",
+        userRights, ACCESS);
+    // Construct VolumeArgs
+    VolumeArgs volumeArgs = new VolumeArgs.Builder()
+        .setAcls(Collections.singletonList(aclWorldAccess)).build();
+    // Sanity check
+    Assert.assertNull(volumeArgs.getOwner());
+    Assert.assertNull(volumeArgs.getAdmin());
+    Assert.assertNull(volumeArgs.getQuota());
+    Assert.assertEquals(0, volumeArgs.getMetadata().size());
+    Assert.assertEquals(1, volumeArgs.getAcls().size());
+    // Create volume "tmp" with world access. allow non-admin to create buckets
+    proxy.createVolume(OFSPath.OFS_MOUNT_TMP_VOLUMENAME, volumeArgs);
+
+    OzoneVolume vol = objectStore.getVolume(OFSPath.OFS_MOUNT_TMP_VOLUMENAME);
+    Assert.assertNotNull(vol);
+
+    // Begin test
+    String username = "";
+    try {
+      username = UserGroupInformation.getCurrentUser().getUserName();
+    } catch (IOException ex) {
+      Assert.fail("Unable to get current user name.");
+    }
+
+    // Expect failure since temp bucket for current user is not created yet
+    try {
+      vol.getBucket(username);
+    } catch (OMException ex) {
+      // Expect BUCKET_NOT_FOUND
+      if (!ex.getResult().equals(BUCKET_NOT_FOUND)) {
+        Assert.fail("Temp bucket for current user shouldn't have been created");
+      }
+    }
+
+    // Write under /tmp/, OFS will create the temp bucket if not exist
+    fs.mkdirs(new Path("/tmp/dir1"));
+
+//    FSDataOutputStream stream = fs.create(new Path("/tmp/dir1/file1"));
+//    stream.write(1);
+
+//    try (FSDataOutputStream stream = fs.create(new Path("/tmp/dir1/file1"))) {
+//      stream.write(1);
+//    }
+
+    // Verify temp bucket creation
+    OzoneBucket bucket = vol.getBucket(username);
+    Assert.assertNotNull(bucket);
+    // Verify dir1 creation
+    FileStatus[] fileStatuses = fs.listStatus(new Path("/tmp/"));
+    Assert.assertEquals(1, fileStatuses.length);
+    Assert.assertEquals(
+        "/tmp/dir1", fileStatuses[0].getPath().toUri().getPath());
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -731,16 +731,11 @@ public class TestRootedOzoneFileSystem {
     Assert.assertNotNull(vol);
 
     // Begin test
-    String username = "";
-    try {
-      username = UserGroupInformation.getCurrentUser().getUserName();
-    } catch (IOException ex) {
-      Assert.fail("Unable to get current user name.");
-    }
+    String hashedUsername = OFSPath.getTempMountBucketName(null);
 
     // Expect failure since temp bucket for current user is not created yet
     try {
-      vol.getBucket(username);
+      vol.getBucket(hashedUsername);
     } catch (OMException ex) {
       // Expect BUCKET_NOT_FOUND
       if (!ex.getResult().equals(BUCKET_NOT_FOUND)) {
@@ -759,7 +754,7 @@ public class TestRootedOzoneFileSystem {
 //    }
 
     // Verify temp bucket creation
-    OzoneBucket bucket = vol.getBucket(username);
+    OzoneBucket bucket = vol.getBucket(hashedUsername);
     Assert.assertNotNull(bucket);
     // Verify dir1 creation
     FileStatus[] fileStatuses = fs.listStatus(new Path("/tmp/"));

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -213,7 +213,9 @@ public class BasicRootedOzoneClientAdapterImpl
     try {
       bucket = proxy.getBucketDetails(volumeStr, bucketStr);
     } catch (OMException ex) {
-      if (createIfNotExist) {
+      // Note: always create bucket if volumeStr matches "tmp" so -put works
+      if (createIfNotExist ||
+          volumeStr.equals(OFSPath.OFS_MOUNT_TMP_VOLUMENAME)) {
         // Note: getBucketDetails always throws BUCKET_NOT_FOUND, even if
         // the volume doesn't exist.
         if (ex.getResult().equals(BUCKET_NOT_FOUND)) {

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -292,7 +292,7 @@ public class BasicRootedOzoneClientAdapterImpl
     OFSPath ofsPath = new OFSPath(pathStr);
     String key = ofsPath.getKeyName();
     try {
-      OzoneBucket bucket = getBucket(ofsPath, false);
+      OzoneBucket bucket = getBucket(ofsPath, recursive);
       OzoneOutputStream ozoneOutputStream = bucket.createFile(
           key, 0, replicationType, replicationFactor, overWrite, recursive);
       return new OzoneFSOutputStream(ozoneOutputStream.getOutputStream());

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -214,8 +214,7 @@ public class BasicRootedOzoneClientAdapterImpl
       bucket = proxy.getBucketDetails(volumeStr, bucketStr);
     } catch (OMException ex) {
       // Note: always create bucket if volumeStr matches "tmp" so -put works
-      if (createIfNotExist ||
-          volumeStr.equals(OFSPath.OFS_MOUNT_TMP_VOLUMENAME)) {
+      if (createIfNotExist) {
         // Note: getBucketDetails always throws BUCKET_NOT_FOUND, even if
         // the volume doesn't exist.
         if (ex.getResult().equals(BUCKET_NOT_FOUND)) {
@@ -294,6 +293,7 @@ public class BasicRootedOzoneClientAdapterImpl
     OFSPath ofsPath = new OFSPath(pathStr);
     String key = ofsPath.getKeyName();
     try {
+      // Hadoop CopyCommands class always sets recursive to true
       OzoneBucket bucket = getBucket(ofsPath, recursive);
       OzoneOutputStream ozoneOutputStream = bucket.createFile(
           key, 0, replicationType, replicationFactor, overWrite, recursive);
@@ -460,6 +460,8 @@ public class BasicRootedOzoneClientAdapterImpl
     } catch (OMException e) {
       if (e.getResult() == OMException.ResultCodes.FILE_NOT_FOUND) {
         throw new FileNotFoundException(key + ": No such file or directory!");
+      } else if (e.getResult() == OMException.ResultCodes.BUCKET_NOT_FOUND) {
+        throw new FileNotFoundException(key + ": Bucket doesn't exist!");
       }
       throw e;
     }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
@@ -196,7 +196,7 @@ class OFSPath {
   }
 
   /**
-   * If input username String is null, will attempt to get user name from UGI.
+   * Get the bucket name of temp for the current user from UserGroupInformation.
    * @return Username MD5 hash in hex digits.
    */
   @VisibleForTesting

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
@@ -93,7 +93,12 @@ class OFSPath {
         // TODO: In the future, may retrieve volume and bucket from
         //  UserVolumeInfo on the server side. TBD.
         volumeName = OFS_MOUNT_TMP_VOLUMENAME;
-        bucketName = getTempMountBucketNameOfCurrentUser();
+        try {
+          bucketName = getTempMountBucketNameOfCurrentUser();
+        } catch (IOException ex) {
+          throw new ParseException(
+              "Failed to get temp bucket name for current user.");
+        }
       } else if (numToken >= 2) {
         // Regular volume and bucket path
         volumeName = firstToken;
@@ -102,7 +107,6 @@ class OFSPath {
         // Volume only
         volumeName = firstToken;
       }
-//    } else {  // TODO: Implement '/' case for ls.
     }
 
     // Compose key name
@@ -198,15 +202,10 @@ class OFSPath {
   /**
    * Get the bucket name of temp for the current user from UserGroupInformation.
    * @return Username MD5 hash in hex digits.
+   * @throws IOException When UserGroupInformation.getCurrentUser() fails.
    */
-  @VisibleForTesting
-  static String getTempMountBucketNameOfCurrentUser() {
-    String username;
-    try {
-      username = UserGroupInformation.getCurrentUser().getUserName();
-    } catch (IOException ex) {
-      username = "undefined"; // TODO: Any better idea?
-    }
+  static String getTempMountBucketNameOfCurrentUser() throws IOException {
+    String username = UserGroupInformation.getCurrentUser().getUserName();
     return getTempMountBucketName(username);
   }
 }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
@@ -54,8 +54,7 @@ class OFSPath {
   private String bucketName = "";
   private String mountName = "";
   private String keyName = "";
-  @VisibleForTesting
-  static final String OFS_MOUNT_NAME_TMP = "tmp";
+  private static final String OFS_MOUNT_NAME_TMP = "tmp";
   // Hard-code the volume name to tmp for the first implementation
   @VisibleForTesting
   static final String OFS_MOUNT_TMP_VOLUMENAME = "tmp";

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
@@ -17,11 +17,8 @@
  */
 package org.apache.hadoop.fs.ozone;
 
-import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.io.IOException;
 
 /**
  * Testing basic functions of utility class OFSPath.

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
@@ -103,7 +103,7 @@ public class TestOFSPath {
 
   @Test
   public void testParsingMount() {
-    String bucketName = OFSPath.getTempMountBucketName(null);
+    String bucketName = OFSPath.getTempMountBucketNameOfCurrentUser();
     // Mount only
     OFSPath ofsPath = new OFSPath("/tmp/");
     Assert.assertEquals(

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.fs.ozone;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
+
 /**
  * Testing basic functions of utility class OFSPath.
  */
@@ -103,7 +105,14 @@ public class TestOFSPath {
 
   @Test
   public void testParsingMount() {
-    String bucketName = OFSPath.getTempMountBucketNameOfCurrentUser();
+    String bucketName;
+    try {
+      bucketName = OFSPath.getTempMountBucketNameOfCurrentUser();
+    } catch (IOException ex) {
+      Assert.fail("Failed to get the current user name, "
+          + "thus failed to get temp bucket name.");
+      bucketName = "";  // Make javac happy
+    }
     // Mount only
     OFSPath ofsPath = new OFSPath("/tmp/");
     Assert.assertEquals(

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
@@ -17,8 +17,11 @@
  */
 package org.apache.hadoop.fs.ozone;
 
+import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.IOException;
 
 /**
  * Testing basic functions of utility class OFSPath.
@@ -103,11 +106,17 @@ public class TestOFSPath {
 
   @Test
   public void testParsingMount() {
+    String username = "";
+    try {
+      username = UserGroupInformation.getCurrentUser().getUserName();
+    } catch (IOException ex) {
+      Assert.fail("Unable to get current user name.");
+    }
     // Mount only
     OFSPath ofsPath = new OFSPath("/tmp/");
-    // TODO: Subject to change in HDDS-2929.
-    Assert.assertEquals("tempVolume", ofsPath.getVolumeName());
-    Assert.assertEquals("tempBucket", ofsPath.getBucketName());
+    Assert.assertEquals(
+        OFSPath.OFS_MOUNT_TMP_VOLUMENAME, ofsPath.getVolumeName());
+    Assert.assertEquals(username, ofsPath.getBucketName());
     Assert.assertEquals("tmp", ofsPath.getMountName());
     Assert.assertEquals("", ofsPath.getKeyName());
     Assert.assertEquals("/tmp", ofsPath.getNonKeyPath());
@@ -115,9 +124,9 @@ public class TestOFSPath {
 
     // Mount with key
     ofsPath = new OFSPath("/tmp/key1");
-    // TODO: Subject to change in HDDS-2929.
-    Assert.assertEquals("tempVolume", ofsPath.getVolumeName());
-    Assert.assertEquals("tempBucket", ofsPath.getBucketName());
+    Assert.assertEquals(
+        OFSPath.OFS_MOUNT_TMP_VOLUMENAME, ofsPath.getVolumeName());
+    Assert.assertEquals(username, ofsPath.getBucketName());
     Assert.assertEquals("tmp", ofsPath.getMountName());
     Assert.assertEquals("key1", ofsPath.getKeyName());
     Assert.assertEquals("/tmp", ofsPath.getNonKeyPath());

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
@@ -106,17 +106,12 @@ public class TestOFSPath {
 
   @Test
   public void testParsingMount() {
-    String username = "";
-    try {
-      username = UserGroupInformation.getCurrentUser().getUserName();
-    } catch (IOException ex) {
-      Assert.fail("Unable to get current user name.");
-    }
+    String bucketName = OFSPath.getTempMountBucketName(null);
     // Mount only
     OFSPath ofsPath = new OFSPath("/tmp/");
     Assert.assertEquals(
         OFSPath.OFS_MOUNT_TMP_VOLUMENAME, ofsPath.getVolumeName());
-    Assert.assertEquals(username, ofsPath.getBucketName());
+    Assert.assertEquals(bucketName, ofsPath.getBucketName());
     Assert.assertEquals("tmp", ofsPath.getMountName());
     Assert.assertEquals("", ofsPath.getKeyName());
     Assert.assertEquals("/tmp", ofsPath.getNonKeyPath());
@@ -126,7 +121,7 @@ public class TestOFSPath {
     ofsPath = new OFSPath("/tmp/key1");
     Assert.assertEquals(
         OFSPath.OFS_MOUNT_TMP_VOLUMENAME, ofsPath.getVolumeName());
-    Assert.assertEquals(username, ofsPath.getBucketName());
+    Assert.assertEquals(bucketName, ofsPath.getBucketName());
     Assert.assertEquals("tmp", ofsPath.getMountName());
     Assert.assertEquals("key1", ofsPath.getKeyName());
     Assert.assertEquals("/tmp", ofsPath.getNonKeyPath());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support client-side `/tmp/` mount for convention / legacy application support. Each user will have their own temp bucket in this implementation.

We plan to have globally-shared temp bucket once sticky-bit is implemented in Ozone.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2929

## How was this patch tested?

Added new test `testTempMount`.

## NOTES

1. An admin must create volume named `tmp` (hard-coded at the moment) with world access ACL before any user can use `/tmp/` correctly. i.e. Run the following for cluster initial setup:
```bash
ozone sh volume create tmp
ozone sh volume setacl tmp -al world::a
```
2. When a user is trying to read or write under `/tmp/`, a bucket with that user's name will be automatically created under volume `tmp` during the first operation:
```bash

bash-4.2$ HADOOP_USER_NAME=user2 ozone fs -ls ofs://om/tmp/
2020-02-20 12:02:08,931 [main] INFO rpc.RpcClient: Creating Bucket: tmp/user2

bash-4.2$ HADOOP_USER_NAME=user1 ozone fs -put README.md ofs://om/tmp/
2020-02-20 12:02:26,945 [main] INFO rpc.RpcClient: Creating Bucket: tmp/user1

bash-4.2$ HADOOP_USER_NAME=user1 ozone fs -ls ofs://om/tmp/
Found 1 items
-rw-rw-rw-   1 user1 user1       3813 2020-02-20 12:02 ofs://om/tmp/README.md

bash-4.2$ HADOOP_USER_NAME=user2 ozone fs -ls ofs://om/tmp/
```