### PR TITLE
HDDS-3078. Include output of timed out test in bundle

### DIFF
--- a/hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
+++ b/hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
@@ -46,6 +46,16 @@ grep -A1 'Crashed tests' "${REPORT_DIR}/output.log" \
   | sort -u \
   | tee -a "${REPORT_DIR}/summary.txt"
 
+# Add tests where "There was a timeout or other error in the fork"
+grep -e 'Running org' -e 'Tests run: .* in org' "${REPORT_DIR}/output.log" \
+  | sed -e 's/.* \(org[^ ]*\)/\1/' \
+  | uniq -c \
+  | grep -v ' 2 ' \
+  | awk '{ print $2 }' \
+  | sort -u \
+  | tee -a "${REPORT_DIR}/summary.txt"
+
+
 #Collect of all of the report files of FAILED tests
 for failed_test in $(< ${REPORT_DIR}/summary.txt); do
   for file in $(find "." -name "${failed_test}.txt" -or -name "${failed_test}-output.txt" -or -name "TEST-${failed_test}.xml"); do


### PR DESCRIPTION
## What changes were proposed in this pull request?

List timed out tests as failed in `summary.txt` of unit/integration tests.  This will also make sure their outputs are included in the bundle.

https://issues.apache.org/jira/browse/HDDS-3078

## How was this patch tested?

1. No unexpected output for [successful CI run](https://github.com/adoroszlai/hadoop-ozone/runs/471892599)
2. Repeated CI until [timeout happened](https://github.com/adoroszlai/hadoop-ozone/runs/472434011), verified that output for the timed out test is included in the [bundle](https://github.com/adoroszlai/hadoop-ozone/suites/485752102/artifacts/2299607)