### PR TITLE
HDDS-3085. OM Delta updates request in Recon should work with secure Ozone Manager.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
@@ -41,4 +41,8 @@ public final class ReconConfigKeys {
   public static final String OZONE_RECON_DATANODE_BIND_HOST_DEFAULT =
       "0.0.0.0";
   public static final int OZONE_RECON_DATANODE_PORT_DEFAULT = 9891;
+  public static final String OZONE_RECON_KERBEROS_KEYTAB_FILE_KEY =
+      "ozone.recon.kerberos.keytab.file";
+  public static final String OZONE_RECON_KERBEROS_PRINCIPAL_KEY =
+      "ozone.recon.kerberos.principal";
 }

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2197,11 +2197,11 @@
     </description>
   </property>
   <property>
-    <name>ozone.recon.keytab.file</name>
+    <name>ozone.recon.http.kerberos.keytab.file</name>
     <value/>
     <tag>RECON, SECURITY</tag>
     <description>
-      The keytab file for Kerberos authentication in Recon.
+      The keytab file for HTTP Kerberos authentication in Recon.
     </description>
   </property>
   <property>

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -35,7 +35,10 @@ OZONE-SITE.XML_ozone.om.kerberos.keytab.file=/etc/security/keytabs/om.keytab
 OZONE-SITE.XML_ozone.s3g.keytab.file=/etc/security/keytabs/HTTP.keytab
 OZONE-SITE.XML_ozone.s3g.authentication.kerberos.principal=HTTP/s3g@EXAMPLE.COM
 OZONE-SITE.XML_ozone.recon.authentication.kerberos.principal=HTTP/recon@EXAMPLE.COM
-OZONE-SITE.XML_ozone.recon.keytab.file=/etc/security/keytabs/HTTP.keytab
+OZONE-SITE.XML_ozone.recon.http.kerberos.keytab.file=/etc/security/keytabs/HTTP.keytab
+OZONE-SITE.XML_ozone.recon.kerberos.keytab.file=/etc/security/keytabs/recon.keytab
+OZONE-SITE.XML_ozone.recon.kerberos.principal=recon/recon@EXAMPLE.COM
+OZONE-SITE.XML_recon.om.snapshot.task.interval.delay=1m
 OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
 OZONE-SITE.XML_recon.om.snapshot.task.initial.delay=20s
 OZONE-SITE.XML_ozone.recon.address=recon:9891
@@ -90,4 +93,4 @@ JSVC_HOME=/usr/bin
 SLEEP_SECONDS=5
 KERBEROS_ENABLED=true
 
-no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1
+no_proxy=om,scm,recon,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -879,10 +879,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   /**
-   * Logs in the OM use if security is enabled in the configuration.
+   * Logs in the OM user if security is enabled in the configuration.
    *
    * @param conf OzoneConfiguration
-   * @throws IOException, AuthenticationException in case login failes.
+   * @throws IOException, AuthenticationException in case login fails.
    */
   private static void loginOMUserIfSecurityEnabled(OzoneConfiguration  conf)
       throws IOException, AuthenticationException {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconHttpServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconHttpServer.java
@@ -72,7 +72,7 @@ public class ReconHttpServer extends BaseHttpServer {
 
   @Override
   protected String getKeytabFile() {
-    return ReconServerConfigKeys.OZONE_RECON_KEYTAB_FILE;
+    return ReconServerConfigKeys.OZONE_RECON_HTTP_KEYTAB_FILE;
   }
 
   @Override

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -40,8 +40,8 @@ import com.google.inject.Injector;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_KERBEROS_KEYTAB_FILE_KEY;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_KERBEROS_PRINCIPAL_KEY;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_KERBEROS_KEYTAB_FILE_KEY;
+import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_KERBEROS_PRINCIPAL_KEY;
 
 
 /**
@@ -50,7 +50,6 @@ import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_KE
 public class ReconServer extends GenericCli {
 
   private static final Logger LOG = LoggerFactory.getLogger(ReconServer.class);
-  private static boolean securityEnabled = false;
   private Injector injector;
 
   private ReconHttpServer httpServer;
@@ -164,8 +163,7 @@ public class ReconServer extends GenericCli {
    */
   private static void loginReconUserIfSecurityEnabled(OzoneConfiguration  conf)
       throws IOException, AuthenticationException {
-    securityEnabled = OzoneSecurityUtil.isSecurityEnabled(conf);
-    if (securityEnabled) {
+    if (OzoneSecurityUtil.isSecurityEnabled(conf)) {
       loginReconUser(conf);
     }
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -179,13 +179,12 @@ public class ReconServer extends GenericCli {
 
     if (SecurityUtil.getAuthenticationMethod(conf).equals(
         UserGroupInformation.AuthenticationMethod.KERBEROS)) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Ozone security is enabled. Attempting login for Recon user. "
-                + "Principal: {}, keytab: {}", conf.get(
-            OZONE_RECON_KERBEROS_PRINCIPAL_KEY),
-            conf.get(OZONE_RECON_KERBEROS_KEYTAB_FILE_KEY));
-      }
 
+      LOG.info("Ozone security is enabled. Attempting login for Recon user. "
+              + "Principal: {}, keytab: {}", conf.get(
+          OZONE_RECON_KERBEROS_PRINCIPAL_KEY),
+          conf.get(OZONE_RECON_KERBEROS_KEYTAB_FILE_KEY));
+      
       UserGroupInformation.setConfiguration(conf);
 
       InetSocketAddress socAddr = HddsUtils.getReconAddresses(conf);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
@@ -39,8 +39,12 @@ public final class ReconServerConfigKeys {
       "ozone.recon.http-address";
   public static final String OZONE_RECON_HTTPS_ADDRESS_KEY =
       "ozone.recon.https-address";
-  public static final String OZONE_RECON_KEYTAB_FILE =
-      "ozone.recon.keytab.file";
+  public static final String OZONE_RECON_HTTP_KEYTAB_FILE =
+      "ozone.recon.http.kerberos.keytab.file";
+  public static final String OZONE_RECON_KERBEROS_KEYTAB_FILE_KEY =
+      "ozone.recon.kerberos.keytab.file";
+  public static final String OZONE_RECON_KERBEROS_PRINCIPAL_KEY =
+      "ozone.recon.kerberos.principal";
   public static final String OZONE_RECON_HTTP_BIND_HOST_DEFAULT =
       "0.0.0.0";
   public static final int OZONE_RECON_HTTP_BIND_PORT_DEFAULT = 9888;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
@@ -41,10 +41,6 @@ public final class ReconServerConfigKeys {
       "ozone.recon.https-address";
   public static final String OZONE_RECON_HTTP_KEYTAB_FILE =
       "ozone.recon.http.kerberos.keytab.file";
-  public static final String OZONE_RECON_KERBEROS_KEYTAB_FILE_KEY =
-      "ozone.recon.kerberos.keytab.file";
-  public static final String OZONE_RECON_KERBEROS_PRINCIPAL_KEY =
-      "ozone.recon.kerberos.principal";
   public static final String OZONE_RECON_HTTP_BIND_HOST_DEFAULT =
       "0.0.0.0";
   public static final int OZONE_RECON_HTTP_BIND_PORT_DEFAULT = 9888;


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Introduced kerberos principal and keytab file configs for Recon
- Login Recon user with KDC while Recon starts up

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3085

## How was this patch tested?

This patch was tested using ozonesecure docker-compose setup.

```
cd hadoop-ozone/dist/target/ozone-0.5.0-SNAPSHOT/compose/ozonesecure
docker-compose up -d
docker-compose exec om bash
ozone freon rk --replicationType=RATIS --numOfVolumes=10 --numOfBuckets=10 --numOfKeys=10 --factor=ONE --numOfThreads=20
# wait for a couple minutes for recon to get full snapshot from OM for the first time
ozone freon rk --replicationType=RATIS --numOfVolumes=10 --numOfBuckets=10 --numOfKeys=10 --factor=ONE --numOfThreads=20
```
Now, recon correctly picks up the delta from OM using RPC call. This call was failing before with a Kerberos Authentication Exception.

