### PR TITLE
HDDS-3109. Refactor 'Recon' in MiniOzoneCluster to use ephemeral port.

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-config
@@ -23,7 +23,6 @@ OZONE-SITE.XML_ozone.scm.datanode.id.dir=/data
 OZONE-SITE.XML_ozone.scm.block.client.address=scm
 OZONE-SITE.XML_ozone.metadata.dirs=/data/metadata
 OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
-OZONE-SITE.XML_ozone.recon.om.db.dir=/data/metadata/recon
 OZONE-SITE.XML_ozone.scm.client.address=scm
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 OZONE-SITE.XML_ozone.recon.address=recon:9891

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
@@ -218,6 +219,16 @@ public interface MiniOzoneCluster {
   void shutdownHddsDatanode(DatanodeDetails dn) throws IOException;
 
   /**
+   * Start Recon.
+   */
+  void startRecon();
+
+  /**
+   * Stop Recon.
+   */
+  void stopRecon();
+
+  /**
    * Shutdown the MiniOzoneCluster and delete the storage dirs.
    */
   void shutdown();
@@ -273,6 +284,10 @@ public interface MiniOzoneCluster {
     protected Optional<Long> streamBufferMaxSize = Optional.empty();
     protected Optional<Long> blockSize = Optional.empty();
     protected Optional<StorageUnit> streamBufferSizeUnit = Optional.empty();
+    protected boolean includeRecon = false;
+    protected OptionalInt reconHttpPort = OptionalInt.empty();
+    protected OptionalInt reconDatanodePort = OptionalInt.empty();
+
     // Use relative smaller number of handlers for testing
     protected int numOfOmHandlers = 20;
     protected int numOfScmHandlers = 20;
@@ -471,6 +486,21 @@ public interface MiniOzoneCluster {
 
     public Builder setOMServiceId(String serviceId) {
       this.omServiceId = serviceId;
+      return this;
+    }
+
+    public Builder setReconHttpPort(int port) {
+      this.reconHttpPort = OptionalInt.of(port);
+      return this;
+    }
+
+    public Builder setReconDatanodePort(int port) {
+      this.reconDatanodePort = OptionalInt.of(port);
+      return this;
+    }
+
+    public Builder includeRecon(boolean include) {
+      this.includeRecon = include;
       return this;
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
@@ -18,7 +18,6 @@ package org.apache.hadoop.ozone.recon;
 
 import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_OK;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_HTTP_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_CONNECTION_REQUEST_TIMEOUT;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_CONNECTION_TIMEOUT;
@@ -28,7 +27,6 @@ import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_SOCKE
 import static org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl.OmSnapshotTaskName.OmDeltaRequest;
 import static org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl.OmSnapshotTaskName.OmSnapshotRequest;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,7 +36,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -54,7 +51,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
-import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.config.RequestConfig;
@@ -73,7 +69,7 @@ import com.google.gson.internal.LinkedTreeMap;
 /**
  * Test Ozone Recon.
  */
-public class TestRecon {
+public class TestReconWithOzoneManager {
   private static MiniOzoneCluster cluster = null;
   private static OzoneConfiguration conf;
   private static OMMetadataManager metadataManager;
@@ -83,9 +79,7 @@ public class TestRecon {
 
   @BeforeClass
   public static void init() throws Exception {
-    File dir = GenericTestUtils.getRandomizedTestDir();
     conf = new OzoneConfiguration();
-    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, dir.toString());
     int socketTimeout = (int) conf.getTimeDuration(
         RECON_OM_SOCKET_TIMEOUT, RECON_OM_SOCKET_TIMEOUT_DEFAULT,
         TimeUnit.MILLISECONDS);
@@ -100,13 +94,19 @@ public class TestRecon {
         .setConnectionRequestTimeout(connectionTimeout)
         .setSocketTimeout(connectionRequestTimeout).build();
 
-    String reconHTTPAddress = "localhost:" + NetUtils.getFreeSocketPort();
-    conf.set(OZONE_RECON_HTTP_ADDRESS_KEY, reconHTTPAddress);
-    containerKeyServiceURL = "http://" + reconHTTPAddress + "/api/v1" +
-        "/containers";
+    int reconHttpPort = NetUtils.getFreeSocketPort();
+    String reconHTTPAddress = "0.0.0.0:" + reconHttpPort;
+    containerKeyServiceURL = "http://" + reconHTTPAddress +
+        "/api/v1/containers";
     taskStatusURL = "http://" + reconHTTPAddress + "/api/v1/task/status";
 
-    cluster =  MiniOzoneCluster.newBuilder(conf).setNumDatanodes(1).build();
+    cluster =
+        MiniOzoneCluster.newBuilder(conf)
+            .setNumDatanodes(1)
+            .includeRecon(true)
+            .setReconHttpPort(reconHttpPort)
+            .setReconDatanodePort(NetUtils.getFreeSocketPort())
+            .build();
     cluster.waitForClusterToBeReady();
     metadataManager = cluster.getOzoneManager().getMetadataManager();
 
@@ -154,7 +154,7 @@ public class TestRecon {
   }
 
   @Test
-  public void testReconWithOzoneManager() throws Exception {
+  public void testOmDBSyncing() throws Exception {
     // add a vol, bucket and key
     addKeys(0, 1);
 

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -276,6 +276,30 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <scope>test</scope>
+      <type>test-jar</type>
+      <exclusions>
+        <exclusion>
+          <artifactId>jersey-server</artifactId>
+          <groupId>com.sun.jersey</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jersey-core</artifactId>
+          <groupId>com.sun.jersey</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jersey-servlet</artifactId>
+          <groupId>com.sun.jersey</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>jersey-json</artifactId>
+          <groupId>com.sun.jersey</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.jooq</groupId>
       <artifactId>jooq</artifactId>
       <version>${jooq.version}</version>

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNodeEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNodeEndpoint.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.ozone.recon.persistence.AbstractSqlDatabaseTest;
 import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
 import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
 import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
+import org.apache.hadoop.test.LambdaTestUtils;
 import org.hadoop.ozone.recon.schema.ReconTaskSchemaDefinition;
 import org.hadoop.ozone.recon.schema.tables.daos.MissingContainersDao;
 import org.hadoop.ozone.recon.schema.tables.daos.ReconTaskStatusDao;
@@ -245,11 +246,14 @@ public class TestNodeEndpoint extends AbstractSqlDatabaseTest {
     reconScm.getDatanodeProtocolServer()
         .sendHeartbeat(heartbeatRequestProto);
 
-    response = nodeEndpoint.getDatanodes();
-    datanodesResponse =
-        (DatanodesResponse) response.getEntity();
-    datanodeMetadata = datanodesResponse.getDatanodes().iterator().next();
-    Assert.assertEquals(1, datanodeMetadata.getContainers());
+    LambdaTestUtils.await(30000, 5000, () -> {
+      Response response1 = nodeEndpoint.getDatanodes();
+      DatanodesResponse datanodesResponse1 =
+          (DatanodesResponse) response1.getEntity();
+      DatanodeMetadata datanodeMetadata1 =
+          datanodesResponse1.getDatanodes().iterator().next();
+      return (datanodeMetadata1.getContainers() == 1);
+    });
     Assert.assertEquals(1,
         reconScm.getPipelineManager()
             .getContainersInPipeline(pipeline.getId()).size());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, Recon uses an ephemeral port only in the integration test for Recon. In all other integration tests, we end up using the default (9888) that causes failures in other integration tests that start up a Mini ozone cluster. In addition, we want to start up Recon in MiniOzoneCluster by explicitly requesting it rather than by default.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3109

## How was this patch tested?
Unit, integration and docker based sanity testing.