### PR TITLE
HDDS-2877. Fixed description of return type.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -609,7 +609,7 @@ public class OzoneBucket extends WithMetadata {
     /**
      * Gets the next set of key list using proxy.
      * @param prevKey
-     * @return {@code List<OzoneVolume>}
+     * @return {@code List<OzoneKey>}
      */
     private List<OzoneKey> getNextListOfKeys(String prevKey) {
       try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed description of return type in getNextListOfKeys, replacing
`* @return {@code List<OzoneVolume>} (line.612)`
with
`* @return {@code List<OzoneKey>} (line.612)`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2877

## How was this patch tested?

Ran UTs