### PR TITLE
HDDS-3110. Fix race condition in Recon's container and pipeline handling.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
@@ -88,7 +88,7 @@ public class NodeStateMap {
         throw new NodeAlreadyExistsException("Node UUID: " + id);
       }
       nodeMap.put(id, new DatanodeInfo(datanodeDetails));
-      nodeToContainer.put(id, Collections.emptySet());
+      nodeToContainer.put(id, new HashSet<>());
       stateMap.get(nodeState).add(id);
     } finally {
       lock.writeLock().unlock();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
@@ -106,12 +106,6 @@ public class PipelineReportHandler implements
 
     setReportedDatanode(pipeline, dn);
     setPipelineLeaderId(report, pipeline, dn);
-    // ONE replica pipeline doesn't have leader flag
-    if (report.getIsLeader() ||
-        pipeline.getFactor() == HddsProtos.ReplicationFactor.ONE) {
-      pipeline.setLeaderId(dn.getUuid());
-      metrics.incNumPipelineBytesWritten(pipeline, report.getBytesWritten());
-    }
 
     if (pipeline.getPipelineState() == Pipeline.PipelineState.ALLOCATED) {
       if (LOGGER.isDebugEnabled()) {
@@ -140,6 +134,7 @@ public class PipelineReportHandler implements
     if (report.getIsLeader() ||
         pipeline.getFactor() == HddsProtos.ReplicationFactor.ONE) {
       pipeline.setLeaderId(dn.getUuid());
+      metrics.incNumPipelineBytesWritten(pipeline, report.getBytesWritten());
     }
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/PipelineSyncTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/PipelineSyncTask.java
@@ -60,7 +60,7 @@ public class PipelineSyncTask extends ReconScmTask {
       while (canRun()) {
         long start = Time.monotonicNow();
         List<Pipeline> pipelinesFromScm = scmClient.getPipelines();
-        reconPipelineManager.removeInvalidPipelines(pipelinesFromScm);
+        reconPipelineManager.initializePipelines(pipelinesFromScm);
         LOG.info("Pipeline sync Thread took {} milliseconds.",
             Time.monotonicNow() - start);
         recordSingleRunCompletion();

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
@@ -81,6 +81,13 @@ public class ReconContainerManager extends SCMContainerManager {
         getContainerStateManager().addContainerInfo(containerId, containerInfo,
             getPipelineManager(), containerWithPipeline.getPipeline());
         addContainerToDB(containerInfo);
+        LOG.info("Successfully added container {} to Recon.",
+            containerInfo.containerID());
+      } else {
+        throw new IOException(
+            String.format("Pipeline %s not found. Cannot add container %s",
+                containerWithPipeline.getPipeline().getId(),
+                containerInfo.containerID()));
       }
     } catch (IOException ex) {
       LOG.info("Exception while adding container {} .",

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerReportHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerReportHandler.java
@@ -63,19 +63,21 @@ public class ReconContainerReportHandler extends ContainerReportHandler {
     for (ContainerReplicaProto containerReplicaProto : reportsList) {
       final ContainerID id = ContainerID.valueof(
           containerReplicaProto.getContainerID());
-      if (!getContainerManager().exists(id)) {
-        LOG.info("New container {} got from {}.", id,
-            reportFromDatanode.getDatanodeDetails());
-        try {
-          ContainerWithPipeline containerWithPipeline =
-              scmClient.getContainerWithPipeline(id.getId());
-          LOG.debug("Verified new container from SCM {} ",
-              containerWithPipeline.getContainerInfo().containerID());
-          containerManager.addNewContainer(id.getId(), containerWithPipeline);
-        } catch (IOException ioEx) {
-          LOG.error("Exception while getting new container info from SCM",
-              ioEx);
-          return;
+      synchronized (containerManager) {
+        if (!containerManager.exists(id)) {
+          LOG.info("New container {} got from {}.", id,
+              reportFromDatanode.getDatanodeDetails());
+          try {
+            ContainerWithPipeline containerWithPipeline =
+                scmClient.getContainerWithPipeline(id.getId());
+            LOG.debug("Verified new container from SCM {} ",
+                containerWithPipeline.getContainerInfo().containerID());
+            containerManager.addNewContainer(id.getId(), containerWithPipeline);
+          } catch (IOException ioEx) {
+            LOG.error("Exception while getting new container info from SCM",
+                ioEx);
+            return;
+          }
         }
       }
       LOG.debug("Got container report for containerID {} ",

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconIncrementalContainerReportHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconIncrementalContainerReportHandler.java
@@ -70,19 +70,22 @@ public class ReconIncrementalContainerReportHandler
         final DatanodeDetails dd = report.getDatanodeDetails();
         final ContainerID id = ContainerID.valueof(
             replicaProto.getContainerID());
-        if (!getContainerManager().exists(id)) {
-          LOG.info("New container {} got from {}.", id,
-              report.getDatanodeDetails());
-          try {
-            ContainerWithPipeline containerWithPipeline =
-                scmClient.getContainerWithPipeline(id.getId());
-            LOG.info("Verified new container from SCM {} ",
-                containerWithPipeline.getContainerInfo().containerID());
-            containerManager.addNewContainer(id.getId(), containerWithPipeline);
-          } catch (IOException ioEx) {
-            LOG.error("Exception while getting new container info from SCM",
-                ioEx);
-            return;
+        synchronized (containerManager) {
+          if (!containerManager.exists(id)) {
+            LOG.info("New container {} got from {}.", id,
+                report.getDatanodeDetails());
+            try {
+              ContainerWithPipeline containerWithPipeline =
+                  scmClient.getContainerWithPipeline(id.getId());
+              LOG.info("Verified new container from SCM {} ",
+                  containerWithPipeline.getContainerInfo().containerID());
+              containerManager
+                  .addNewContainer(id.getId(), containerWithPipeline);
+            } catch (IOException ioEx) {
+              LOG.error("Exception while getting new container info from SCM",
+                  ioEx);
+              return;
+            }
           }
         }
         getNodeManager().addContainer(dd, id);
@@ -100,6 +103,6 @@ public class ReconIncrementalContainerReportHandler
             replicaProto.getContainerID());
       }
     }
-    getContainerManager().notifyContainerReportProcessing(false, success);
+    containerManager.notifyContainerReportProcessing(false, success);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Both the Incremental container report handler and the regular container report handler add new containers from SCM whenever they see a new container. This test and add step must be synchronized between the 2 handlers to avoid any inconsistent metadata state.
- NodeStateMap in allow does not addition of a single container to the Map of Node -> Set of Containers since it instantiates with a Collections.emptySet(), and then relies on a map.put() to update the value. Changing this to a "new HashSet" allows addition of a container one by one which is possible in Recon.
- Improve logging in Recon Container Manager when it receives a container report from a node before receiving the pipeline report for a newly created pipeline.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3110

## How was this patch tested?
Unit, integration and docker based testing.