### PR TITLE
HDDS-2980. Delete replayed entry from OpenKeyTable during commit

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMReplayException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMReplayException.java
@@ -27,12 +27,24 @@ import java.io.IOException;
  */
 public class OMReplayException extends IOException {
 
+  private final boolean needsDBOperations;
+
   public OMReplayException() {
-    // Dummy message. This exception is not thrown to client.
-    super("Replayed transaction");
+    this(false);
   }
 
-  public OMReplayException(String message) {
-    super(message);
+  /**
+   * When the transaction is a replay but still needs some DB operations to
+   * be performed (such as cleanup of old keys).
+   * @param needsDBOperations
+   */
+  public OMReplayException(boolean needsDBOperations) {
+    // Dummy message. This exception is not thrown to client.
+    super("Replayed transaction");
+    this.needsDBOperations = needsDBOperations;
+  }
+
+  public boolean isDBOperationNeeded() {
+    return needsDBOperations;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -84,12 +84,6 @@ public class OMFileCreateRequest extends OMKeyRequest {
     super(omRequest);
   }
 
-  private enum Result {
-    SUCCESS,
-    REPLAY,
-    FAILURE
-  }
-
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     CreateFileRequest createFileRequest = getOmRequest().getCreateFileRequest();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -198,7 +198,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
           new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
 
       omClientResponse = new OMKeyCommitResponse(omResponse.build(),
-          omKeyInfo, dbOpenKey);
+          omKeyInfo, dbOzoneKey, dbOpenKey);
 
       result = Result.SUCCESS;
     } catch (IOException ex) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -68,6 +68,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
   private enum Result {
     SUCCESS,
     REPLAY,
+    DELETE_OPEN_KEY_ONLY,
     FAILURE
   }
 
@@ -113,7 +114,8 @@ public class OMKeyCommitRequest extends OMKeyRequest {
     OzoneManagerProtocolProtos.OMResponse.Builder omResponse =
         OzoneManagerProtocolProtos.OMResponse.newBuilder().setCmdType(
             OzoneManagerProtocolProtos.Type.CommitKey).setStatus(
-            OzoneManagerProtocolProtos.Status.OK).setSuccess(true);
+            OzoneManagerProtocolProtos.Status.OK).setSuccess(true)
+            .setCommitKeyResponse(CommitKeyResponse.newBuilder());
 
     IOException exception = null;
     OmKeyInfo omKeyInfo = null;
@@ -122,6 +124,11 @@ public class OMKeyCommitRequest extends OMKeyRequest {
     Result result = null;
 
     OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
+    String dbOzoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
+        keyName);
+    String dbOpenKey = omMetadataManager.getOpenKey(volumeName, bucketName,
+        keyName, commitKeyRequest.getClientID());
+
     try {
       // check Acl
       checkKeyAclsInOpenKeyTable(ozoneManager, volumeName, bucketName,
@@ -132,11 +139,6 @@ public class OMKeyCommitRequest extends OMKeyRequest {
           .getKeyLocationsList().stream()
           .map(OmKeyLocationInfo::getFromProtobuf)
           .collect(Collectors.toList());
-
-      String dbOzoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
-          keyName);
-      String dbOpenKey = omMetadataManager.getOpenKey(volumeName, bucketName,
-          keyName, commitKeyRequest.getClientID());
 
       bucketLockAcquired = omMetadataManager.getLock().acquireLock(BUCKET_LOCK,
           volumeName, bucketName);
@@ -152,9 +154,20 @@ public class OMKeyCommitRequest extends OMKeyRequest {
         if (dbKeyInfo != null) {
           // Check if this transaction is a replay of ratis logs
           if (isReplay(ozoneManager, dbKeyInfo, trxnLogIndex)) {
-            // Replay implies the response has already been returned to
-            // the client. So take no further action and return a dummy
-            // OMClientResponse.
+            // During KeyCreate, we do not check the OpenKey Table for replay.
+            // This is so as to avoid an extra DB read during KeyCreate.
+            // If KeyCommit is a replay, the KeyCreate request could also have
+            // been replayed. And since we do not check for replay in KeyCreate,
+            // we should scrub the key from OpenKey table now, is it exists.
+
+            omKeyInfo = omMetadataManager.getOpenKeyTable().get(dbOpenKey);
+            if (omKeyInfo != null) {
+              omMetadataManager.getOpenKeyTable().addCacheEntry(
+                  new CacheKey<>(dbOpenKey),
+                  new CacheValue<>(Optional.absent(), trxnLogIndex));
+
+              throw new OMReplayException(true);
+            }
             throw new OMReplayException();
           }
         }
@@ -163,7 +176,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       omKeyInfo = omMetadataManager.getOpenKeyTable().get(dbOpenKey);
       if (omKeyInfo == null) {
         throw new OMException("Failed to commit key, as " + dbOpenKey +
-            "entry is not found in the openKey table", KEY_NOT_FOUND);
+            "entry is not found in the OpenKey table", KEY_NOT_FOUND);
       }
       omKeyInfo.setDataSize(commitKeyArgs.getDataSize());
 
@@ -184,21 +197,26 @@ public class OMKeyCommitRequest extends OMKeyRequest {
           new CacheKey<>(dbOzoneKey),
           new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
 
-      omResponse.setCommitKeyResponse(CommitKeyResponse.newBuilder().build());
       omClientResponse = new OMKeyCommitResponse(omResponse.build(),
-          omKeyInfo, commitKeyRequest.getClientID());
+          omKeyInfo, dbOpenKey);
 
       result = Result.SUCCESS;
     } catch (IOException ex) {
       if (ex instanceof OMReplayException) {
-        result = Result.REPLAY;
-        omClientResponse = new OMKeyCommitResponse(createReplayOMResponse(
-            omResponse));
+        if (((OMReplayException) ex).isDBOperationNeeded()) {
+          result = Result.DELETE_OPEN_KEY_ONLY;
+          omClientResponse = new OMKeyCommitResponse(omResponse.build(),
+              dbOpenKey);
+        } else {
+          result = Result.REPLAY;
+          omClientResponse = new OMKeyCommitResponse(createReplayOMResponse(
+              omResponse));
+        }
       } else {
         result = Result.FAILURE;
         exception = ex;
-        omClientResponse = new OMKeyCommitResponse(
-            createErrorOMResponse(omResponse, exception));
+        omClientResponse = new OMKeyCommitResponse(createErrorOMResponse(
+            omResponse, exception));
       }
     } finally {
       addResponseToDoubleBuffer(trxnLogIndex, omClientResponse,
@@ -211,15 +229,13 @@ public class OMKeyCommitRequest extends OMKeyRequest {
     }
 
     // Performing audit logging outside of the lock.
-    if (result != Result.REPLAY) {
+    if (result != Result.REPLAY && result != Result.DELETE_OPEN_KEY_ONLY) {
       auditLog(auditLogger, buildAuditMessage(OMAction.COMMIT_KEY, auditMap,
           exception, getOmRequest().getUserInfo()));
     }
 
     switch (result) {
     case SUCCESS:
-      omResponse.setCommitKeyResponse(CommitKeyResponse.newBuilder().build());
-
       // As when we commit the key, then it is visible in ozone, so we should
       // increment here.
       // As key also can have multiple versions, we need to increment keys
@@ -235,6 +251,10 @@ public class OMKeyCommitRequest extends OMKeyRequest {
     case REPLAY:
       LOG.debug("Replayed Transaction {} ignored. Request: {}", trxnLogIndex,
           commitKeyRequest);
+      break;
+    case DELETE_OPEN_KEY_ONLY:
+      LOG.debug("Replayed Transaction {}. Deleting old key {} from OpenKey " +
+          "table. Request: {}", trxnLogIndex, dbOpenKey, commitKeyRequest);
       break;
     case FAILURE:
       LOG.error("Key commit failed. Volume:{}, Bucket:{}, Key:{}. Exception:{}",

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -60,12 +60,6 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
   private static final Logger LOG =
       LoggerFactory.getLogger(S3InitiateMultipartUploadRequest.class);
 
-  private enum Result {
-    SUCCESS,
-    REPLAY,
-    FAILURE
-  }
-
   public S3InitiateMultipartUploadRequest(OMRequest omRequest) {
     super(omRequest);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
@@ -33,13 +33,27 @@ import javax.annotation.Nonnull;
 public class OMKeyCommitResponse extends OMClientResponse {
 
   private OmKeyInfo omKeyInfo;
-  private long openKeySessionID;
+  private String openKeyName;
 
   public OMKeyCommitResponse(@Nonnull OMResponse omResponse,
-      @Nonnull OmKeyInfo omKeyInfo, long openKeySessionID) {
+      @Nonnull OmKeyInfo omKeyInfo, String openKeyName) {
     super(omResponse);
     this.omKeyInfo = omKeyInfo;
-    this.openKeySessionID = openKeySessionID;
+    this.openKeyName = openKeyName;
+  }
+
+  /**
+   * When the KeyCommit request is a replay but the openKey should be deleted
+   * from the OpenKey table.
+   * Note that this response will result in openKey deletion only. Key will
+   * not be added to Key table.
+   * @param openKeyName openKey to be deleted from OpenKey table
+   */
+  public OMKeyCommitResponse(@Nonnull OMResponse omResponse,
+      String openKeyName) {
+    super(omResponse);
+    this.omKeyInfo = null;
+    this.openKeyName = openKeyName;
   }
 
   /**
@@ -55,18 +69,18 @@ public class OMKeyCommitResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    String volumeName = omKeyInfo.getVolumeName();
-    String bucketName = omKeyInfo.getBucketName();
-    String keyName = omKeyInfo.getKeyName();
-    String openKey = omMetadataManager.getOpenKey(volumeName,
-        bucketName, keyName, openKeySessionID);
-    String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
-        keyName);
-
-    // Delete from open key table and add entry to key table.
+    // Delete from OpenKey table
     omMetadataManager.getOpenKeyTable().deleteWithBatch(batchOperation,
-        openKey);
-    omMetadataManager.getKeyTable().putWithBatch(batchOperation, ozoneKey,
-        omKeyInfo);
+        openKeyName);
+
+    // Add entry to Key table if omKeyInfo is available i.e. it is not a
+    // replayed transaction.
+    if (omKeyInfo != null) {
+      String ozoneKey = omMetadataManager.getOzoneKey(omKeyInfo.getVolumeName(),
+          omKeyInfo.getBucketName(), omKeyInfo.getKeyName());
+
+      omMetadataManager.getKeyTable().putWithBatch(batchOperation, ozoneKey,
+          omKeyInfo);
+    }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
@@ -33,12 +33,14 @@ import javax.annotation.Nonnull;
 public class OMKeyCommitResponse extends OMClientResponse {
 
   private OmKeyInfo omKeyInfo;
+  private String ozoneKeyName;
   private String openKeyName;
 
   public OMKeyCommitResponse(@Nonnull OMResponse omResponse,
-      @Nonnull OmKeyInfo omKeyInfo, String openKeyName) {
+      @Nonnull OmKeyInfo omKeyInfo, String ozoneKeyName, String openKeyName) {
     super(omResponse);
     this.omKeyInfo = omKeyInfo;
+    this.ozoneKeyName = ozoneKeyName;
     this.openKeyName = openKeyName;
   }
 
@@ -76,10 +78,7 @@ public class OMKeyCommitResponse extends OMClientResponse {
     // Add entry to Key table if omKeyInfo is available i.e. it is not a
     // replayed transaction.
     if (omKeyInfo != null) {
-      String ozoneKey = omMetadataManager.getOzoneKey(omKeyInfo.getVolumeName(),
-          omKeyInfo.getBucketName(), omKeyInfo.getKeyName());
-
-      omMetadataManager.getKeyTable().putWithBatch(batchOperation, ozoneKey,
+      omMetadataManager.getKeyTable().putWithBatch(batchOperation, ozoneKeyName,
           omKeyInfo);
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.response.s3.multipart;
 
-import com.google.common.base.Preconditions;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
@@ -87,8 +87,7 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
       String openKey, @Nonnull OmKeyInfo openPartKeyInfoToBeDeleted,
       boolean isRatisEnabled) {
     super(omResponse);
-    Preconditions.checkArgument(!omResponse.getStatus().equals(
-        NO_SUCH_MULTIPART_UPLOAD_ERROR));
+    checkStatusNotOK();
     this.openKey = openKey;
     this.openPartKeyInfoToBeDeleted = openPartKeyInfoToBeDeleted;
     this.isRatisEnabled = isRatisEnabled;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.response.s3.multipart;
 
+import com.google.common.base.Preconditions;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -44,24 +45,52 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
 
   private String multipartKey;
   private String openKey;
-  private OmKeyInfo deletePartKeyInfo;
   private OmMultipartKeyInfo omMultipartKeyInfo;
-  private OzoneManagerProtocolProtos.PartKeyInfo oldMultipartKeyInfo;
+  private OzoneManagerProtocolProtos.PartKeyInfo oldPartKeyInfo;
+  private OmKeyInfo openPartKeyInfoToBeDeleted;
   private boolean isRatisEnabled;
 
-
+  /**
+   * Regular response.
+   * 1. Update MultipartKey in MultipartInfoTable with new PartKeyInfo
+   * 2. Delete openKey from OpenKeyTable
+   * 3. If old PartKeyInfo exists, put it in DeletedKeyTable
+   * @param omResponse
+   * @param multipartKey
+   * @param openKey
+   * @param omMultipartKeyInfo
+   * @param oldPartKeyInfo
+   */
   public S3MultipartUploadCommitPartResponse(@Nonnull OMResponse omResponse,
-      String multipartKey,
-      String openKey, @Nonnull OmKeyInfo deletePartKeyInfo,
+      String multipartKey, String openKey,
       @Nonnull OmMultipartKeyInfo omMultipartKeyInfo,
       @Nonnull OzoneManagerProtocolProtos.PartKeyInfo oldPartKeyInfo,
       boolean isRatisEnabled) {
     super(omResponse);
     this.multipartKey = multipartKey;
     this.openKey = openKey;
-    this.deletePartKeyInfo = deletePartKeyInfo;
     this.omMultipartKeyInfo = omMultipartKeyInfo;
-    this.oldMultipartKeyInfo = oldPartKeyInfo;
+    this.oldPartKeyInfo = oldPartKeyInfo;
+    this.isRatisEnabled = isRatisEnabled;
+  }
+
+  /**
+   * For the case when Multipart Upload does not exist (could have been
+   * aborted).
+   * 1. Put the partKeyInfo from openKeyTable into DeletedTable
+   * 2. Deleted openKey from OpenKeyTable
+   * @param omResponse
+   * @param openKey
+   * @param openPartKeyInfoToBeDeleted
+   */
+  public S3MultipartUploadCommitPartResponse(@Nonnull OMResponse omResponse,
+      String openKey, @Nonnull OmKeyInfo openPartKeyInfoToBeDeleted,
+      boolean isRatisEnabled) {
+    super(omResponse);
+    Preconditions.checkArgument(!omResponse.getStatus().equals(
+        NO_SUCH_MULTIPART_UPLOAD_ERROR));
+    this.openKey = openKey;
+    this.openPartKeyInfoToBeDeleted = openPartKeyInfoToBeDeleted;
     this.isRatisEnabled = isRatisEnabled;
   }
 
@@ -84,9 +113,9 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
       RepeatedOmKeyInfo repeatedOmKeyInfo =
           omMetadataManager.getDeletedTable().get(openKey);
 
-      repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(deletePartKeyInfo,
-          repeatedOmKeyInfo, deletePartKeyInfo.getUpdateID(), isRatisEnabled);
-
+      repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
+          openPartKeyInfoToBeDeleted, repeatedOmKeyInfo,
+          openPartKeyInfoToBeDeleted.getUpdateID(), isRatisEnabled);
 
       omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
           openKey, repeatedOmKeyInfo);
@@ -110,19 +139,19 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
 
     // This means for this multipart upload part upload, we have an old
     // part information, so delete it.
-    if (oldMultipartKeyInfo != null) {
-      OmKeyInfo partKey =
-          OmKeyInfo.getFromProtobuf(oldMultipartKeyInfo.getPartKeyInfo());
+    if (oldPartKeyInfo != null) {
+      OmKeyInfo partKeyToBeDeleted =
+          OmKeyInfo.getFromProtobuf(oldPartKeyInfo.getPartKeyInfo());
 
       RepeatedOmKeyInfo repeatedOmKeyInfo =
           omMetadataManager.getDeletedTable()
-              .get(oldMultipartKeyInfo.getPartName());
+              .get(oldPartKeyInfo.getPartName());
 
-      repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(partKey,
+      repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(partKeyToBeDeleted,
           repeatedOmKeyInfo, omMultipartKeyInfo.getUpdateID(), isRatisEnabled);
 
       omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
-          oldMultipartKeyInfo.getPartName(), repeatedOmKeyInfo);
+          oldPartKeyInfo.getPartName(), repeatedOmKeyInfo);
     }
 
     omMetadataManager.getMultipartInfoTable().putWithBatch(batchOperation,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -244,6 +244,48 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         replayResponse.getOMResponse().getStatus());
   }
 
+  @Test
+  public void testReplayRequestDeletesOpenKeyEntry() throws Exception {
+
+    // Manually add Volume, Bucket to DB
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
+    // Manually add Key to OpenKey table in DB
+    TestOMRequestUtils.addKeyToTable(true, false, volumeName, bucketName,
+        keyName, clientID, replicationType, replicationFactor, 1L,
+        omMetadataManager);
+
+    OMRequest modifiedOmRequest = doPreExecute(createCommitKeyRequest());
+    OMKeyCommitRequest omKeyCommitRequest = new OMKeyCommitRequest(
+        modifiedOmRequest);
+
+    // Execute original KeyCommit request
+    omKeyCommitRequest.validateAndUpdateCache(ozoneManager, 10L,
+        ozoneManagerDoubleBufferHelper);
+
+    // Replay the Key Create request - add Key to OpenKey table manually again
+    TestOMRequestUtils.addKeyToTable(true, true, volumeName, bucketName,
+        keyName, clientID, replicationType, replicationFactor, 1L,
+        omMetadataManager);
+
+    // Key should be present in OpenKey table
+    String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,
+        keyName, clientID);
+    OmKeyInfo openKeyInfo = omMetadataManager.getOpenKeyTable().get(openKey);
+    Assert.assertNotNull(openKeyInfo);
+
+    // Replay the transaction - Execute the createKey request again
+    OMClientResponse replayResponse = omKeyCommitRequest.validateAndUpdateCache(
+        ozoneManager, 10L, ozoneManagerDoubleBufferHelper);
+
+    // Replay should result in DELETE_OPEN_KEY_ONLY response and delete the
+    // key from OpenKey table
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        replayResponse.getOMResponse().getStatus());
+    openKeyInfo = omMetadataManager.getOpenKeyTable().get(openKey);
+    Assert.assertNull(openKeyInfo);
+  }
+
   /**
    * This method calls preExecute and verify the modified request.
    * @param originalOMRequest

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
@@ -53,7 +53,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
     Assert.assertTrue(omMetadataManager.getOpenKeyTable().isExist(openKey));
 
     OMKeyCommitResponse omKeyCommitResponse = new OMKeyCommitResponse(
-        omResponse, omKeyInfo, clientID);
+        omResponse, omKeyInfo, openKey);
 
     omKeyCommitResponse.addToDBBatch(omMetadataManager, batchOperation);
 
@@ -79,18 +79,18 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
             .setCmdType(OzoneManagerProtocolProtos.Type.CommitKey)
             .build();
 
+    String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,
+        keyName, clientID);
+
     OMKeyCommitResponse omKeyCommitResponse = new OMKeyCommitResponse(
-        omResponse, omKeyInfo, clientID);
+        omResponse, omKeyInfo, openKey);
 
     // As during commit Key, entry will be already there in openKeyTable.
     // Adding it here.
     TestOMRequestUtils.addKeyToTable(true, volumeName, bucketName, keyName,
         clientID, replicationType, replicationFactor, omMetadataManager);
 
-    String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,
-        keyName, clientID);
     Assert.assertTrue(omMetadataManager.getOpenKeyTable().isExist(openKey));
-
 
     omKeyCommitResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
@@ -52,8 +52,10 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
         keyName, clientID);
     Assert.assertTrue(omMetadataManager.getOpenKeyTable().isExist(openKey));
 
+    String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
+        keyName);
     OMKeyCommitResponse omKeyCommitResponse = new OMKeyCommitResponse(
-        omResponse, omKeyInfo, openKey);
+        omResponse, omKeyInfo, ozoneKey, openKey);
 
     omKeyCommitResponse.addToDBBatch(omMetadataManager, batchOperation);
 
@@ -81,9 +83,11 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
 
     String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,
         keyName, clientID);
+    String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
+        keyName);
 
     OMKeyCommitResponse omKeyCommitResponse = new OMKeyCommitResponse(
-        omResponse, omKeyInfo, openKey);
+        omResponse, omKeyInfo, ozoneKey, openKey);
 
     // As during commit Key, entry will be already there in openKeyTable.
     // Adding it here.


### PR DESCRIPTION
## What changes were proposed in this pull request?

During KeyCreate (and S3InitiateMultipartUpload), we do not check the OpenKeyTable if the key already exists. If it does exist and the transaction is replayed, we just override the key in OpenKeyTable. This is done to avoid extra DB reads.

During KeyCommit (or S3MultipartUploadCommit), if the key was already committed, then we do not replay the transaction. This would result in the OpenKeyTable entry to remain in the DB till it is garbage collected. 

To avoid storing stale entries in OpenKeyTable, during commit replays, we should check the openKeyTable and delete the entry if it exists.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2980

## How was this patch tested?

Added unit test.
