### PR TITLE
HDDS-3118. Possible deadlock in LockManager.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -104,9 +104,6 @@ public final class HddsConfigKeys {
   public static final double
       HDDS_SCM_SAFEMODE_ONE_NODE_REPORTED_PIPELINE_PCT_DEFAULT = 0.90;
 
-  public static final String HDDS_LOCK_MAX_CONCURRENCY =
-      "hdds.lock.max.concurrency";
-  public static final int HDDS_LOCK_MAX_CONCURRENCY_DEFAULT = 100;
   // This configuration setting is used as a fallback location by all
   // Ozone/HDDS services for their metadata. It is useful as a single
   // config point for test/PoC clusters.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/LockManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/LockManager.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.lock;
 
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +58,7 @@ public class LockManager<R> {
   public LockManager(final Configuration conf, boolean fair) {
     lockPool =
         new GenericObjectPool<>(new PooledLockFactory(fair));
+    lockPool.setMaxTotal(-1);
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/LockManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/LockManager.java
@@ -183,19 +183,19 @@ public class LockManager<R> {
      * the object pool.
      */
     return activeLocks.compute(resource, (k, v) -> {
+      final ActiveLock lock;
       try {
-        final ActiveLock lock;
         if (v == null) {
           lock = lockPool.borrowObject();
         } else {
           lock = v;
         }
         lock.incrementActiveCount();
-        return lock;
       } catch (Exception ex) {
         LOG.error("Unable to obtain lock.", ex);
         throw new RuntimeException(ex);
       }
+      return lock;
     });
   }
 

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1396,16 +1396,6 @@
   </property>
 
   <property>
-    <name>hdds.lock.max.concurrency</name>
-    <value>100</value>
-    <tag>HDDS</tag>
-    <description>Locks in HDDS/Ozone uses object pool to maintain active locks
-      in the system, this property defines the max limit for the locks that
-      will be maintained in the pool.
-    </description>
-  </property>
-
-  <property>
     <name>ozone.s3g.authentication.kerberos.principal</name>
     <value/>
     <tag>OZONE, S3GATEWAY</tag>

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/lock/TestLockManager.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/lock/TestLockManager.java
@@ -26,8 +26,6 @@ import org.junit.Test;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_LOCK_MAX_CONCURRENCY;
-
 /**
  * Test-cases to test LockManager.
  */
@@ -179,7 +177,6 @@ public class TestLockManager {
   public void testConcurrentWriteLockWithDifferentResource() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     final int count = 100;
-    conf.setInt(HDDS_LOCK_MAX_CONCURRENCY, count/4);
     final LockManager<Integer> manager = new LockManager<>(conf);
     final int sleep = 10;
     final AtomicInteger done = new AtomicInteger();

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/lock/TestLockManager.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/lock/TestLockManager.java
@@ -18,10 +18,15 @@
 package org.apache.hadoop.ozone.lock;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.util.Daemon;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_LOCK_MAX_CONCURRENCY;
 
 /**
  * Test-cases to test LockManager.
@@ -170,4 +175,32 @@ public class TestLockManager {
     Assert.assertTrue(gotLock.get());
   }
 
+  @Test
+  public void testConcurrentWriteLockWithDifferentResource() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    final int count = 100;
+    conf.setInt(HDDS_LOCK_MAX_CONCURRENCY, count/4);
+    final LockManager<Integer> manager = new LockManager<>(conf);
+    final int sleep = 10;
+    final AtomicInteger done = new AtomicInteger();
+    for (int i = 0; i < count; i++) {
+      final Integer id = i;
+      Daemon d1 = new Daemon(() -> {
+        try {
+          manager.writeLock(id);
+          Thread.sleep(sleep);
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        } finally {
+          manager.writeUnlock(id);
+        }
+        done.getAndIncrement();
+      });
+      d1.setName("Locker-" + i);
+      d1.start();
+    }
+    GenericTestUtils.waitFor(() -> done.get() == count, 100,
+        10 * count * sleep);
+    Assert.assertEquals(count, done.get());
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
@@ -61,7 +61,6 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Daemon;
 import org.mockito.Mockito;
 
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_LOCK_MAX_CONCURRENCY;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -94,7 +93,6 @@ public class TestOzoneManagerDoubleBufferWithOMResponse {
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
         folder.newFolder().getAbsolutePath());
-    ozoneConfiguration.setInt(HDDS_LOCK_MAX_CONCURRENCY, 2 * MAX_VOLUMES);
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration);
     when(ozoneManager.getMetrics()).thenReturn(omMetrics);
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Possible deadlock in lock manager.
This is because of lockPool.borrowObject waits indefinitely and activeLocks.compute is an atomic operation that holds a map lock.
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3118

## How was this patch tested?

The reproed patch is now passing. 
