### PR TITLE
HDDS-3071. Datanodes unable to connect to recon in Secure Environment

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfig.java
@@ -31,7 +31,7 @@ public class ReconConfig {
   @Config(key = "kerberos.principal",
       type = ConfigType.STRING,
       defaultValue = "",
-      tags = { ConfigTag.SECURITY, ConfigTag.OZONE },
+      tags = { ConfigTag.SECURITY, ConfigTag.RECON, ConfigTag.OZONE },
       description = "This Kerberos principal is used by the Recon service."
   )
   private String principal;
@@ -39,7 +39,7 @@ public class ReconConfig {
   @Config(key = "kerberos.keytab.file",
       type = ConfigType.STRING,
       defaultValue = "",
-      tags = { ConfigTag.SECURITY, ConfigTag.OZONE },
+      tags = { ConfigTag.SECURITY, ConfigTag.RECON, ConfigTag.OZONE },
       description = "The keytab file used by Recon daemon to login as "+
           "its service principal."
   )
@@ -47,8 +47,8 @@ public class ReconConfig {
 
   @Config(key = "security.client.datanode.container.protocol.acl",
       type = ConfigType.STRING,
-      defaultValue = "",
-      tags = { ConfigTag.SECURITY, ConfigTag.OZONE },
+      defaultValue = "*",
+      tags = { ConfigTag.SECURITY, ConfigTag.RECON, ConfigTag.OZONE },
       description = "Comma separated acls (users, groups) allowing clients " +
           "accessing datanode container protocol"
   )
@@ -68,6 +68,14 @@ public class ReconConfig {
 
   public String getKerberosKeytab() {
     return this.keytab;
+  }
+
+  public String getAcl() {
+    return acl;
+  }
+
+  public void setAcl(String acl) {
+    this.acl = acl;
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfig.java
@@ -49,7 +49,8 @@ public class ReconConfig {
       type = ConfigType.STRING,
       defaultValue = "",
       tags = { ConfigTag.SECURITY, ConfigTag.OZONE },
-      description = ""
+      description = "Comma separated acls (users, groups) allowing clients " +
+          "accessing datanode container protocol"
   )
   private String acl;
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfig.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.recon;
+
+import org.apache.hadoop.hdds.conf.Config;
+import org.apache.hadoop.hdds.conf.ConfigGroup;
+import org.apache.hadoop.hdds.conf.ConfigTag;
+import org.apache.hadoop.hdds.conf.ConfigType;
+
+/**
+ * The configuration class for the Recon service.
+ */
+@ConfigGroup(prefix = "ozone.recon")
+public class ReconConfig {
+
+  @Config(key = "kerberos.principal",
+      type = ConfigType.STRING,
+      defaultValue = "",
+      tags = { ConfigTag.SECURITY, ConfigTag.OZONE },
+      description = "This Kerberos principal is used by the Recon service."
+  )
+  private String principal;
+
+  @Config(key = "kerberos.keytab.file",
+      type = ConfigType.STRING,
+      defaultValue = "",
+      tags = { ConfigTag.SECURITY, ConfigTag.OZONE },
+      description = "The keytab file used by Recon daemon to login as "+
+          "its service principal."
+  )
+  private String keytab;
+
+  @Config(key = "security.client.datanode.container.protocol.acl",
+      type = ConfigType.STRING,
+      defaultValue = "",
+      tags = { ConfigTag.SECURITY, ConfigTag.OZONE },
+      description = ""
+  )
+  private String acl;
+
+  public void setKerberosPrincipal(String kerberosPrincipal) {
+    this.principal = kerberosPrincipal;
+  }
+
+  public void setKerberosKeytab(String kerberosKeytab) {
+    this.keytab = kerberosKeytab;
+  }
+
+  public String getKerberosPrincipal() {
+    return this.principal;
+  }
+
+  public String getKerberosKeytab() {
+    return this.keytab;
+  }
+
+  /**
+   * Config Keys for Recon.
+   */
+  public static class ConfigStrings {
+    public static final String OZONE_RECON_KERBEROS_PRINCIPAL_KEY =
+        "ozone.recon.kerberos.principal";
+    public static final String OZONE_RECON_KERBEROS_KEYTAB_FILE_KEY =
+        "ozone.recon.kerberos.keytab.file";
+    public static final String
+        OZONE_RECON_SECURITY_CLIENT_DATANODE_CONTAINER_PROTOCOL_ACL =
+        "ozone.recon.security.client.datanode.container.protocol.acl";
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
@@ -41,8 +41,4 @@ public final class ReconConfigKeys {
   public static final String OZONE_RECON_DATANODE_BIND_HOST_DEFAULT =
       "0.0.0.0";
   public static final int OZONE_RECON_DATANODE_PORT_DEFAULT = 9891;
-  public static final String OZONE_RECON_KERBEROS_KEYTAB_FILE_KEY =
-      "ozone.recon.kerberos.keytab.file";
-  public static final String OZONE_RECON_KERBEROS_PRINCIPAL_KEY =
-      "ozone.recon.kerberos.principal";
 }

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigTag.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigTag.java
@@ -41,5 +41,6 @@ public enum ConfigTag {
   PIPELINE,
   STANDALONE,
   S3GATEWAY,
-  DATANODE
+  DATANODE,
+  RECON
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
@@ -131,7 +131,40 @@ public class SCMConnectionManager
    * @throws IOException
    */
   public void addSCMServer(InetSocketAddress address) throws IOException {
-    addSCMServer(address, 1000, false);
+    writeLock();
+    try {
+      if (scmMachines.containsKey(address)) {
+        LOG.warn("Trying to add an existing SCM Machine to Machines group. " +
+            "Ignoring the request.");
+        return;
+      }
+
+      RPC.setProtocolEngine(conf, StorageContainerDatanodeProtocolPB.class,
+          ProtobufRpcEngine.class);
+      long version =
+          RPC.getProtocolVersion(StorageContainerDatanodeProtocolPB.class);
+
+      RetryPolicy retryPolicy =
+          RetryPolicies.retryForeverWithFixedSleep(
+              1000, TimeUnit.MILLISECONDS);
+
+      StorageContainerDatanodeProtocolPB rpcProxy = RPC.getProtocolProxy(
+          StorageContainerDatanodeProtocolPB.class, version,
+          address, UserGroupInformation.getCurrentUser(), conf,
+          NetUtils.getDefaultSocketFactory(conf), getRpcTimeout(),
+          retryPolicy).getProxy();
+
+      StorageContainerDatanodeProtocolClientSideTranslatorPB rpcClient =
+          new StorageContainerDatanodeProtocolClientSideTranslatorPB(
+          rpcProxy);
+
+      EndpointStateMachine endPoint =
+          new EndpointStateMachine(address, rpcClient, conf);
+      endPoint.setPassive(false);
+      scmMachines.put(address, endPoint);
+    } finally {
+      writeUnlock();
+    }
   }
 
   /**
@@ -141,19 +174,6 @@ public class SCMConnectionManager
    */
   public void addReconServer(InetSocketAddress address) throws IOException {
     LOG.info("Adding Recon Server : {}", address.toString());
-    addSCMServer(address, 60000, true);
-  }
-
-  /**
-   * Add scm server helper method.
-   * @param address address
-   * @param sleepTime sleepTime
-   * @param passiveScm flag to specify passive SCM or not. Recon is passive SCM.
-   * @throws IOException
-   */
-  private void addSCMServer(InetSocketAddress address, long sleepTime,
-                            boolean passiveScm)
-      throws IOException {
     writeLock();
     try {
       if (scmMachines.containsKey(address)) {
@@ -162,48 +182,26 @@ public class SCMConnectionManager
         return;
       }
 
-      StorageContainerDatanodeProtocolClientSideTranslatorPB rpcClient;
-      if (!passiveScm) {
-        RPC.setProtocolEngine(conf, StorageContainerDatanodeProtocolPB.class,
-            ProtobufRpcEngine.class);
-        long version =
-            RPC.getProtocolVersion(StorageContainerDatanodeProtocolPB.class);
+      RPC.setProtocolEngine(conf, ReconDatanodeProtocolPB.class,
+          ProtobufRpcEngine.class);
+      long version =
+          RPC.getProtocolVersion(ReconDatanodeProtocolPB.class);
 
-        RetryPolicy retryPolicy =
-            RetryPolicies.retryForeverWithFixedSleep(
-                sleepTime, TimeUnit.MILLISECONDS);
+      RetryPolicy retryPolicy =
+          RetryPolicies.retryUpToMaximumCountWithFixedSleep(10,
+              60000, TimeUnit.MILLISECONDS);
+      ReconDatanodeProtocolPB rpcProxy = RPC.getProtocolProxy(
+          ReconDatanodeProtocolPB.class, version,
+          address, UserGroupInformation.getCurrentUser(), conf,
+          NetUtils.getDefaultSocketFactory(conf), getRpcTimeout(),
+          retryPolicy).getProxy();
 
-        StorageContainerDatanodeProtocolPB rpcProxy = RPC.getProtocolProxy(
-            StorageContainerDatanodeProtocolPB.class, version,
-            address, UserGroupInformation.getCurrentUser(), conf,
-            NetUtils.getDefaultSocketFactory(conf), getRpcTimeout(),
-            retryPolicy).getProxy();
-
-        rpcClient = new StorageContainerDatanodeProtocolClientSideTranslatorPB(
-            rpcProxy);
-      } else {
-        RPC.setProtocolEngine(conf, ReconDatanodeProtocolPB.class,
-            ProtobufRpcEngine.class);
-        long version =
-            RPC.getProtocolVersion(ReconDatanodeProtocolPB.class);
-
-        RetryPolicy retryPolicy =
-            RetryPolicies.retryUpToMaximumCountWithFixedSleep(10,
-                sleepTime, TimeUnit.MILLISECONDS);
-        ReconDatanodeProtocolPB rpcProxy = RPC.getProtocolProxy(
-            ReconDatanodeProtocolPB.class, version,
-            address, UserGroupInformation.getCurrentUser(), conf,
-            NetUtils.getDefaultSocketFactory(conf), getRpcTimeout(),
-            retryPolicy).getProxy();
-
-        rpcClient =
-            new StorageContainerDatanodeProtocolClientSideTranslatorPB(
-                rpcProxy);
-      }
+      StorageContainerDatanodeProtocolClientSideTranslatorPB rpcClient =
+          new StorageContainerDatanodeProtocolClientSideTranslatorPB(rpcProxy);
 
       EndpointStateMachine endPoint =
           new EndpointStateMachine(address, rpcClient, conf);
-      endPoint.setPassive(passiveScm);
+      endPoint.setPassive(true);
       scmMachines.put(address, endPoint);
     } finally {
       writeUnlock();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/ReconDatanodeProtocol.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/ReconDatanodeProtocol.java
@@ -22,8 +22,8 @@ import org.apache.hadoop.hdds.recon.ReconConfig;
 import org.apache.hadoop.security.KerberosInfo;
 
 /**
- * The protocol spoken between datanodes and Recon. For specifics please the
- * Protoc file that defines the parent protocol.
+ * The protocol spoken between datanodes and Recon. For specifics please see
+ * the Protoc file that defines the parent protocol.
  */
 @KerberosInfo(serverPrincipal =
         ReconConfig.ConfigStrings.OZONE_RECON_KERBEROS_PRINCIPAL_KEY)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/ReconDatanodeProtocol.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/ReconDatanodeProtocol.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.protocol;
+
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.recon.ReconConfig;
+import org.apache.hadoop.security.KerberosInfo;
+
+/**
+ * The protocol spoken between datanodes and Recon. For specifics please the
+ * Protoc file that defines the parent protocol.
+ */
+@KerberosInfo(serverPrincipal =
+        ReconConfig.ConfigStrings.OZONE_RECON_KERBEROS_PRINCIPAL_KEY)
+@InterfaceAudience.Private
+public interface ReconDatanodeProtocol
+    extends StorageContainerDatanodeProtocol {
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocolPB/ReconDatanodeProtocolPB.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocolPB/ReconDatanodeProtocolPB.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.protocolPB;
+
+import static org.apache.hadoop.hdds.recon.ReconConfig.ConfigStrings.OZONE_RECON_KERBEROS_PRINCIPAL_KEY;
+
+import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
+import org.apache.hadoop.ipc.ProtocolInfo;
+import org.apache.hadoop.security.KerberosInfo;
+
+/**
+ * Protocol used from a datanode to Recon. This extends
+ * the Protocol Buffers service interface to add Hadoop-specific annotations.
+ */
+@ProtocolInfo(protocolName =
+    "org.apache.hadoop.ozone.protocol.ReconDatanodeProtocol",
+    protocolVersion = 1)
+@KerberosInfo(
+    serverPrincipal = OZONE_RECON_KERBEROS_PRINCIPAL_KEY,
+    clientPrincipal = DFSConfigKeysLegacy.DFS_DATANODE_KERBEROS_PRINCIPAL_KEY)
+public interface ReconDatanodeProtocolPB extends
+    StorageContainerDatanodeProtocolPB {
+}

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -37,8 +37,7 @@ execute_robot_test s3g s3
 
 execute_robot_test scm scmcli
 
-# TODO: https://issues.apache.org/jira/browse/HDDgS-3071
-# execute_robot_test scm recon
+execute_robot_test scm recon
 
 stop_docker_env
 

--- a/hadoop-ozone/dist/src/main/smoketest/recon/recon-api.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/recon/recon-api.robot
@@ -31,9 +31,10 @@ Recon REST API
                         Should contain      ${result}       containers
     ${result} =         Execute                             curl --negotiate -u : -v ${API_ENDPOINT_URL}/datanodes
                         Should contain      ${result}       datanodes
-                        Should contain      ${result}       ozone_datanode_1.ozone_default
-                        Should contain      ${result}       ozone_datanode_2.ozone_default
-                        Should contain      ${result}       ozone_datanode_3.ozone_default
+                        Should contain      ${result}       datanode_1
+                        Should contain      ${result}       datanode_2
+                        Should contain      ${result}       datanode_3
 Recon Web UI
+    Run Keyword if      '${SECURITY_ENABLED}' == 'true'     Kinit HTTP user
     ${result} =         Execute                             curl --negotiate -u : -v ${ENDPOINT_URL}
                         Should contain      ${result}       Ozone Recon

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -334,5 +334,10 @@
       <artifactId>activation</artifactId>
       <version>1.1.1</version>
     </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -18,9 +18,13 @@
 
 package org.apache.hadoop.ozone.recon;
 
+import static org.apache.hadoop.hdds.recon.ReconConfig.ConfigStrings.OZONE_RECON_KERBEROS_KEYTAB_FILE_KEY;
+import static org.apache.hadoop.hdds.recon.ReconConfig.ConfigStrings.OZONE_RECON_KERBEROS_PRINCIPAL_KEY;
+
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.recon.ReconConfig;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.ozone.recon.spi.ContainerDBServiceProvider;
@@ -39,10 +43,6 @@ import com.google.inject.Injector;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-
-import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_KERBEROS_KEYTAB_FILE_KEY;
-import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_KERBEROS_PRINCIPAL_KEY;
-
 
 /**
  * Recon server main class that stops and starts recon services.
@@ -179,21 +179,21 @@ public class ReconServer extends GenericCli {
 
     if (SecurityUtil.getAuthenticationMethod(conf).equals(
         UserGroupInformation.AuthenticationMethod.KERBEROS)) {
-
+      ReconConfig reconConfig = conf.getObject(ReconConfig.class);
       LOG.info("Ozone security is enabled. Attempting login for Recon user. "
-              + "Principal: {}, keytab: {}", conf.get(
-          OZONE_RECON_KERBEROS_PRINCIPAL_KEY),
-          conf.get(OZONE_RECON_KERBEROS_KEYTAB_FILE_KEY));
-      
+              + "Principal: {}, keytab: {}",
+          reconConfig.getKerberosPrincipal(),
+          reconConfig.getKerberosKeytab());
       UserGroupInformation.setConfiguration(conf);
-
       InetSocketAddress socAddr = HddsUtils.getReconAddresses(conf);
-      SecurityUtil.login(conf, OZONE_RECON_KERBEROS_KEYTAB_FILE_KEY,
-          OZONE_RECON_KERBEROS_PRINCIPAL_KEY, socAddr.getHostName());
+      SecurityUtil.login(conf,
+          OZONE_RECON_KERBEROS_KEYTAB_FILE_KEY,
+          OZONE_RECON_KERBEROS_PRINCIPAL_KEY,
+          socAddr.getHostName());
     } else {
       throw new AuthenticationException(SecurityUtil.getAuthenticationMethod(
-          conf) + " authentication method not supported. Recon user login "
-          + "failed.");
+          conf) + " authentication method not support. "
+          + "Recon user login failed.");
     }
     LOG.info("Recon login successful.");
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -192,7 +192,7 @@ public class ReconServer extends GenericCli {
           socAddr.getHostName());
     } else {
       throw new AuthenticationException(SecurityUtil.getAuthenticationMethod(
-          conf) + " authentication method not support. "
+          conf) + " authentication method not supported. "
           + "Recon user login failed.");
     }
     LOG.info("Recon login successful.");

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -180,7 +180,7 @@ public class ReconServer extends GenericCli {
     if (SecurityUtil.getAuthenticationMethod(conf).equals(
         UserGroupInformation.AuthenticationMethod.KERBEROS)) {
       ReconConfig reconConfig = conf.getObject(ReconConfig.class);
-      LOG.info("Ozone security is enabled. Attempting login for Recon user. "
+      LOG.info("Ozone security is enabled. Attempting login for Recon service. "
               + "Principal: {}, keytab: {}",
           reconConfig.getKerberosPrincipal(),
           reconConfig.getKerberosKeytab());
@@ -193,7 +193,7 @@ public class ReconServer extends GenericCli {
     } else {
       throw new AuthenticationException(SecurityUtil.getAuthenticationMethod(
           conf) + " authentication method not supported. "
-          + "Recon user login failed.");
+          + "Recon service login failed.");
     }
     LOG.info("Recon login successful.");
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
@@ -69,11 +69,18 @@ public class ReconContainerManager extends SCMContainerManager {
     return new File(metaDir, RECON_SCM_CONTAINER_DB);
   }
 
+  /**
+   * Check and add new container if not already present in Recon.
+   * @param containerID containerID to check.
+   * @param datanodeDetails Datanode from where we got this container.
+   * @throws IOException on Error.
+   */
   public void checkAndAddNewContainer(ContainerID containerID,
                                       DatanodeDetails datanodeDetails)
       throws IOException {
     if (!exists(containerID)) {
-      LOG.info("New container {} got from {}.", containerID, datanodeDetails);
+      LOG.info("New container {} got from {}.", containerID,
+          datanodeDetails.getHostName());
       ContainerWithPipeline containerWithPipeline =
           scmClient.getContainerWithPipeline(containerID.getId());
       LOG.debug("Verified new container from SCM {} ",

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerManager.java
@@ -24,12 +24,14 @@ import java.io.File;
 import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.SCMContainerManager;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.ozone.recon.ReconUtils;
+import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +42,7 @@ public class ReconContainerManager extends SCMContainerManager {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(ReconContainerManager.class);
+  private StorageContainerServiceProvider scmClient;
 
   /**
    * Constructs a mapping class that creates mapping between container names
@@ -54,14 +57,32 @@ public class ReconContainerManager extends SCMContainerManager {
    * @throws IOException on Failure.
    */
   public ReconContainerManager(
-      Configuration conf, PipelineManager pipelineManager) throws IOException {
+      Configuration conf, PipelineManager pipelineManager,
+      StorageContainerServiceProvider scm) throws IOException {
     super(conf, pipelineManager);
+    this.scmClient = scm;
   }
 
   @Override
   protected File getContainerDBPath(Configuration conf) {
     File metaDir = ReconUtils.getReconScmDbDir(conf);
     return new File(metaDir, RECON_SCM_CONTAINER_DB);
+  }
+
+  public void checkAndAddNewContainer(ContainerID containerID,
+                                      DatanodeDetails datanodeDetails)
+      throws IOException {
+    if (!exists(containerID)) {
+      LOG.info("New container {} got from {}.", containerID, datanodeDetails);
+      ContainerWithPipeline containerWithPipeline =
+          scmClient.getContainerWithPipeline(containerID.getId());
+      LOG.debug("Verified new container from SCM {} ",
+          containerWithPipeline.getContainerInfo().containerID());
+      // If no other client added this, go ahead and add this container.
+      if (!exists(containerID)) {
+        addNewContainer(containerID.getId(), containerWithPipeline);
+      }
+    }
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconDatanodeProtocolServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconDatanodeProtocolServer.java
@@ -28,19 +28,11 @@ import org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
-import org.apache.hadoop.ipc.ProtobufRpcEngine;
-import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.ozone.protocol.ReconDatanodeProtocol;
 import org.apache.hadoop.ozone.protocolPB.ReconDatanodeProtocolPB;
-import org.apache.hadoop.ozone.protocolPB.StorageContainerDatanodeProtocolServerSideTranslatorPB;
 import org.apache.hadoop.security.authorize.PolicyProvider;
 
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_DATANODE_ADDRESS_KEY;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_DEFAULT;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_KEY;
-import static org.apache.hadoop.hdds.scm.server.StorageContainerManager.startRpcServer;
-
-import com.google.protobuf.BlockingService;
 
 /**
  * Recon's Datanode protocol server extended from SCM.
@@ -53,31 +45,6 @@ public class ReconDatanodeProtocolServer extends SCMDatanodeProtocolServer
                                      EventPublisher eventPublisher)
       throws IOException {
     super(conf, scm, eventPublisher);
-  }
-
-  @Override
-  protected RPC.Server getRpcServer(OzoneConfiguration conf,
-      InetSocketAddress datanodeRpcAddr,
-      ProtocolMessageMetrics metrics) throws IOException {
-    final int handlerCount = conf.getInt(OZONE_SCM_HANDLER_COUNT_KEY,
-        OZONE_SCM_HANDLER_COUNT_DEFAULT);
-
-    RPC.setProtocolEngine(conf, ReconDatanodeProtocolPB.class,
-        ProtobufRpcEngine.class);
-
-    BlockingService dnProtoPbService =
-        StorageContainerDatanodeProtocolProtos
-            .StorageContainerDatanodeProtocolService
-            .newReflectiveBlockingService(
-                new StorageContainerDatanodeProtocolServerSideTranslatorPB(
-                    this, metrics));
-
-    return startRpcServer(
-            conf,
-            datanodeRpcAddr,
-            ReconDatanodeProtocolPB.class,
-            dnProtoPbService,
-            handlerCount);
   }
 
   @Override
@@ -101,4 +68,9 @@ public class ReconDatanodeProtocolServer extends SCMDatanodeProtocolServer
   protected PolicyProvider getPolicyProvider() {
     return ReconPolicyProvider.getInstance();
   }
+
+  protected Class<ReconDatanodeProtocolPB> getProtocolClass() {
+    return ReconDatanodeProtocolPB.class;
+  }
+
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPolicyProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPolicyProvider.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.ozone.recon.scm;
 
 import static org.apache.hadoop.hdds.recon.ReconConfig.ConfigStrings.OZONE_RECON_SECURITY_CLIENT_DATANODE_CONTAINER_PROTOCOL_ACL;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPolicyProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPolicyProvider.java
@@ -28,6 +28,8 @@ import org.apache.hadoop.ozone.protocol.ReconDatanodeProtocol;
 import org.apache.hadoop.security.authorize.PolicyProvider;
 import org.apache.hadoop.security.authorize.Service;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * {@link PolicyProvider} for Recon protocols.
  */
@@ -55,6 +57,7 @@ public final class ReconPolicyProvider extends PolicyProvider {
               ReconDatanodeProtocol.class)
       };
 
+  @SuppressFBWarnings("EI_EXPOSE_REP")
   @Override
   public Service[] getServices() {
     return RECON_SERVICES;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPolicyProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPolicyProvider.java
@@ -1,0 +1,45 @@
+package org.apache.hadoop.ozone.recon.scm;
+
+import static org.apache.hadoop.hdds.recon.ReconConfig.ConfigStrings.OZONE_RECON_SECURITY_CLIENT_DATANODE_CONTAINER_PROTOCOL_ACL;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceStability;
+import org.apache.hadoop.ozone.protocol.ReconDatanodeProtocol;
+import org.apache.hadoop.security.authorize.PolicyProvider;
+import org.apache.hadoop.security.authorize.Service;
+
+/**
+ * {@link PolicyProvider} for Recon protocols.
+ */
+public final class ReconPolicyProvider extends PolicyProvider {
+
+  private static AtomicReference<ReconPolicyProvider> atomicReference =
+      new AtomicReference<>();
+
+  private ReconPolicyProvider() {
+  }
+
+  @InterfaceAudience.Private
+  @InterfaceStability.Unstable
+  public static ReconPolicyProvider getInstance() {
+    if (atomicReference.get() == null) {
+      atomicReference.compareAndSet(null, new ReconPolicyProvider());
+    }
+    return atomicReference.get();
+  }
+
+  private static final Service[] RECON_SERVICES =
+      new Service[]{
+          new Service(
+              OZONE_RECON_SECURITY_CLIENT_DATANODE_CONTAINER_PROTOCOL_ACL,
+              ReconDatanodeProtocol.class)
+      };
+
+  @Override
+  public Service[] getServices() {
+    return RECON_SERVICES;
+  }
+
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -97,7 +97,8 @@ public class ReconStorageContainerManagerFacade
         conf, this, eventQueue);
     this.pipelineManager =
         new ReconPipelineManager(conf, nodeManager, eventQueue);
-    this.containerManager = new ReconContainerManager(conf, pipelineManager);
+    this.containerManager = new ReconContainerManager(conf, pipelineManager,
+        scmServiceProvider);
     this.scmServiceProvider = scmServiceProvider;
 
     NodeReportHandler nodeReportHandler =
@@ -117,12 +118,11 @@ public class ReconStorageContainerManagerFacade
         pipelineManager, containerManager);
 
     ContainerReportHandler containerReportHandler =
-        new ReconContainerReportHandler(nodeManager, containerManager,
-            scmServiceProvider);
+        new ReconContainerReportHandler(nodeManager, containerManager);
 
     IncrementalContainerReportHandler icrHandler =
         new ReconIncrementalContainerReportHandler(nodeManager,
-            containerManager, scmServiceProvider);
+            containerManager);
     CloseContainerEventHandler closeContainerHandler =
         new CloseContainerEventHandler(pipelineManager, containerManager);
     ContainerActionsHandler actionsHandler = new ContainerActionsHandler();

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconContainerManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconContainerManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.recon.scm;
 
+import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.OPEN;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.STAND_ALONE;
@@ -30,6 +31,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.NavigableSet;
 
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
@@ -76,6 +78,20 @@ public class TestReconContainerManager
         pipelineManager.getContainersInPipeline(pipeline.getId());
     assertEquals(1, containersInPipeline.size());
     assertEquals(containerID, containersInPipeline.first());
+  }
+
+  @Test
+  public void testCheckAndAddNewContainer() throws IOException {
+    ContainerID containerID = new ContainerID(100L);
+    ReconContainerManager containerManager = getContainerManager();
+    assertFalse(containerManager.exists(containerID));
+    DatanodeDetails datanodeDetails = randomDatanodeDetails();
+    containerManager.checkAndAddNewContainer(containerID, datanodeDetails);
+    assertTrue(containerManager.exists(containerID));
+
+    // Doing it one more time should not change any state.
+    containerManager.checkAndAddNewContainer(containerID, datanodeDetails);
+    assertTrue(containerManager.exists(containerID));
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added Kerberos security between Datanodes and Recon RPC protocol.
Addressed review comments from https://github.com/apache/hadoop-ozone/pull/624 . 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3071

## How was this patch tested?
Manually tested on docker cluster.