### PR TITLE
HDDS-3119. When ratis is enabled in OM, double Buffer metrics not get…

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/metrics/OzoneManagerDoubleBufferMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/metrics/OzoneManagerDoubleBufferMetrics.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.om.ratis.metrics;
 
 import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
@@ -30,6 +31,8 @@ import org.apache.hadoop.metrics2.lib.MutableRate;
  * Class which maintains metrics related to OzoneManager DoubleBuffer.
  */
 public class OzoneManagerDoubleBufferMetrics {
+
+  private static OzoneManagerDoubleBufferMetrics instance;
 
   private static final String SOURCE_NAME =
       OzoneManagerDoubleBufferMetrics.class.getSimpleName();
@@ -55,13 +58,18 @@ public class OzoneManagerDoubleBufferMetrics {
       "iteration")
   private MutableGaugeFloat avgFlushTransactionsInOneIteration;
 
-
-
-  public static OzoneManagerDoubleBufferMetrics create() {
-    MetricsSystem ms = DefaultMetricsSystem.instance();
-    return ms.register(SOURCE_NAME,
-        "OzoneManager DoubleBuffer Metrics",
-        new OzoneManagerDoubleBufferMetrics());
+  public synchronized static OzoneManagerDoubleBufferMetrics create() {
+    if (instance != null) {
+      return instance;
+    } else {
+      MetricsSystem ms = DefaultMetricsSystem.instance();
+      OzoneManagerDoubleBufferMetrics omDoubleBufferMetrics =
+          ms.register(SOURCE_NAME,
+              "OzoneManager DoubleBuffer Metrics",
+              new OzoneManagerDoubleBufferMetrics());
+      instance = omDoubleBufferMetrics;
+      return omDoubleBufferMetrics;
+    }
   }
 
   public void incrTotalNumOfFlushOperations() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
@@ -114,6 +114,11 @@ public class TestOzoneManagerDoubleBufferWithDummyResponse {
     assertTrue(metrics.getFlushTime().lastStat().mean() > 0);
     assertTrue(metrics.getAvgFlushTransactionsInOneIteration() > 0);
 
+    // Assert there is only instance of OM Double Metrics.
+    OzoneManagerDoubleBufferMetrics metricsCopy =
+        OzoneManagerDoubleBufferMetrics.create();
+    assertEquals(metrics, metricsCopy);
+
     // Check lastAppliedIndex is updated correctly or not.
     assertEquals(bucketCount, lastAppliedIndex);
   }


### PR DESCRIPTION
…ting updated.

## What changes were proposed in this pull request?
Ozone Manager creates 2 instances of OzoneManagerDoubleMetrics, and the way Hadoop metrics2 works, the second one overwrites the first. In our case, it is the first instance that is on the Ratis write path. Fixed this issue by making sure there is only instance of OzoneManagerDoubleMetrics.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3119

## How was this patch tested?
Manually tested.