### PR TITLE
HDDS-3129. Skip KeyTable check in OMKeyCommit.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -143,15 +143,19 @@ public class OMKeyCommitRequest extends OMKeyRequest {
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
 
-      // Check if OzoneKey already exists in DB
-      OmKeyInfo dbKeyInfo = omMetadataManager.getKeyTable().get(dbOzoneKey);
-      if (dbKeyInfo != null) {
-        // Check if this transaction is a replay of ratis logs
-        if (isReplay(ozoneManager, dbKeyInfo, trxnLogIndex)) {
-          // Replay implies the response has already been returned to
-          // the client. So take no further action and return a dummy
-          // OMClientResponse.
-          throw new OMReplayException();
+      // Revisit this logic to see how we can skip this check when ratis is
+      // enabled.
+      if (ozoneManager.isRatisEnabled()) {
+        // Check if OzoneKey already exists in DB
+        OmKeyInfo dbKeyInfo = omMetadataManager.getKeyTable().get(dbOzoneKey);
+        if (dbKeyInfo != null) {
+          // Check if this transaction is a replay of ratis logs
+          if (isReplay(ozoneManager, dbKeyInfo, trxnLogIndex)) {
+            // Replay implies the response has already been returned to
+            // the client. So take no further action and return a dummy
+            // OMClientResponse.
+            throw new OMReplayException();
+          }
         }
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Perform the additional KeyTable check only when ratis is enabled. This check is only required for ratis scenario.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3129

## How was this patch tested?

Deployed this on a cluster and checked the perf.
Tested on mac, with 50 client threads

2295 Keys/sec with Additional Key Table check
2824 Keys/sec with removing that check
