### PR TITLE
HDDS-3124. Fix time interval calculate error

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
@@ -218,7 +218,7 @@ public class EndpointStateMachine
           "Unable to communicate to {} server at {} for past {} seconds.",
           serverName,
           getAddress().getHostString() + ":" + getAddress().getPort(),
-          TimeUnit.MILLISECONDS.toSeconds(this.getMissedCount() * 10 *
+          TimeUnit.MILLISECONDS.toSeconds(this.getMissedCount() *
                   getScmHeartbeatInterval(this.conf)), ex);
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Just as the image shows, the time interval in log "Unable to communicate to SCM server at scm-0.scm:9861 for past " is 0, 3000 seconds, but actually it is 0, 300 seconds.

![image](https://user-images.githubusercontent.com/51938049/75876351-85003780-5e50-11ea-8e9b-df275a6ece1f.png)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-3124

## How was this patch tested?

No need to test.
