### PR TITLE
HDDS-2874. Fixed description of return type.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
@@ -316,7 +316,7 @@ public class OzoneVolume extends WithMetadata {
     /**
      * Gets the next set of bucket list using proxy.
      * @param prevBucket
-     * @return {@code List<OzoneVolume>}
+     * @return {@code List<OzoneBucket>}
      */
     private List<OzoneBucket> getNextListOfBuckets(String prevBucket) {
       try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed description of return type in getNextListOfBuckets, replacing
`* @return {@code List<OzoneVolume>} (line.319)`
with
`* @return {@code List<OzoneBucket>} (line.319)`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2874

## How was this patch tested?

Ran UTs