### PR TITLE
HDDS-2780. Fixed javadoc of OMVolume response classes.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeCreateResponse.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import javax.annotation.Nonnull;
 
 /**
- * Response for CreateBucket request.
+ * Response for CreateVolume request.
  */
 public class OMVolumeCreateResponse extends OMClientResponse {
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeDeleteResponse.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import javax.annotation.Nonnull;
 
 /**
- * Response for CreateVolume request.
+ * Response for DeleteVolume request.
  */
 public class OMVolumeDeleteResponse extends OMClientResponse {
   private String volume;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed javadoc of OMVolumeCreateResponse and OMVolumeDeleteResponse, now is:

```java
OMVolumeCreateResponse.java

/**
 * Response for CreateVolume request.
 */
public class OMVolumeCreateResponse extends OMClientResponse {
```
```java
OMVolumeDeleteResponse.java

/**
 * Response for DeleteVolume request.
 */
public class OMVolumeDeleteResponse extends OMClientResponse {
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2780

## How was this patch tested?

Ran UTs