### PR TITLE
HDDS-3131. Disable TestMiniChaosOzoneCluster.

### DIFF
--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.ozone.utils.LoadBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.junit.BeforeClass;
 import org.junit.AfterClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -135,6 +136,7 @@ public class TestMiniChaosOzoneCluster implements Runnable {
     CommandLine.run(new TestMiniChaosOzoneCluster(), System.err, args);
   }
 
+  @Ignore
   @Test
   public void testReadWriteWithChaosCluster() {
     cluster.startChaos(5, 10, TimeUnit.SECONDS);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Disable TestMiniChaosOzoneCluster by ignoring the test.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3131

## How was this patch tested?
By re-running the mvn test.