### PR TITLE
HDDS-3120. Freon work with OM HA.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
@@ -83,7 +83,7 @@ public final class OzoneClientFactory {
     Preconditions.checkNotNull(omRpcPort);
     Preconditions.checkNotNull(config);
     config.set(OZONE_OM_ADDRESS_KEY, omHost + ":" + omRpcPort);
-    return getRpcClient(config);
+    return getRpcClient(getClientProtocol(config), config);
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
@@ -24,7 +24,6 @@ import java.lang.reflect.Proxy;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OmUtils;
-import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.client.rpc.RpcClient;
 
@@ -32,7 +31,6 @@ import com.google.common.base.Preconditions;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 
-import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Proxy;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.client.rpc.RpcClient;
 
@@ -31,6 +32,7 @@ import com.google.common.base.Preconditions;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 
+import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,6 +76,17 @@ public final class OzoneClientFactory {
   public static OzoneClient getClient(Configuration config)
       throws IOException {
     Preconditions.checkNotNull(config);
+
+    // Doing this explicitly so that when service ids are defined in the
+    // configuration, we don't fall back to default ozone.om.address defined
+    // in ozone-default.xml.
+
+    if (OmUtils.isServiceIdsDefined(config)) {
+      throw new IOException("Following ServiceID's " +
+          config.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY) + " are" +
+          " defined in the configuration. Use the method getClient which " +
+          "takes serviceID and configuration as param");
+    }
     return getClient(getClientProtocol(config), config);
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
@@ -23,11 +23,14 @@ import java.lang.reflect.Proxy;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.client.rpc.RpcClient;
 
 import com.google.common.base.Preconditions;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,9 +120,14 @@ public final class OzoneClientFactory {
       Configuration config) throws IOException {
     Preconditions.checkNotNull(omServiceId);
     Preconditions.checkNotNull(config);
-    // Won't set OZONE_OM_ADDRESS_KEY here since service id is passed directly,
-    // leaving OZONE_OM_ADDRESS_KEY value as is.
-    return getClient(getClientProtocol(config, omServiceId), config);
+    if (OmUtils.isOmHAServiceId(config, omServiceId)) {
+      return getClient(getClientProtocol(config, omServiceId), config);
+    } else {
+      throw new IOException("Service ID specified " +
+          "does not match with " + OZONE_OM_SERVICE_IDS_KEY + " defined in " +
+          "the configuration. Configured " + OZONE_OM_SERVICE_IDS_KEY + " are" +
+          config.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY));
+    }
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
@@ -55,37 +55,9 @@ public final class OzoneClientFactory {
    *
    * @throws IOException
    */
-  public static OzoneClient getClient() throws IOException {
+  public static OzoneClient getRpcClient() throws IOException {
     LOG.info("Creating OzoneClient with default configuration.");
-    return getClient(new OzoneConfiguration());
-  }
-
-  /**
-   * Constructs and return an OzoneClient based on the configuration object.
-   * Protocol type is decided by <code>ozone.client.protocol</code>.
-   *
-   * @param config
-   *        Configuration to be used for OzoneClient creation
-   *
-   * @return OzoneClient
-   *
-   * @throws IOException
-   */
-  public static OzoneClient getClient(Configuration config)
-      throws IOException {
-    Preconditions.checkNotNull(config);
-
-    // Doing this explicitly so that when service ids are defined in the
-    // configuration, we don't fall back to default ozone.om.address defined
-    // in ozone-default.xml.
-
-    if (OmUtils.isServiceIdsDefined(config)) {
-      throw new IOException("Following ServiceID's " +
-          config.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY) + " are" +
-          " defined in the configuration. Use the method getClient which " +
-          "takes serviceID and configuration as param");
-    }
-    return getClient(getClientProtocol(config), config);
+    return getRpcClient(new OzoneConfiguration());
   }
 
   /**
@@ -132,7 +104,7 @@ public final class OzoneClientFactory {
     Preconditions.checkNotNull(omServiceId);
     Preconditions.checkNotNull(config);
     if (OmUtils.isOmHAServiceId(config, omServiceId)) {
-      return getClient(getClientProtocol(config, omServiceId), config);
+      return getRpcClient(getClientProtocol(config, omServiceId), config);
     } else {
       throw new IOException("Service ID specified " +
           "does not match with " + OZONE_OM_SERVICE_IDS_KEY + " defined in " +
@@ -154,7 +126,18 @@ public final class OzoneClientFactory {
   public static OzoneClient getRpcClient(Configuration config)
       throws IOException {
     Preconditions.checkNotNull(config);
-    return getClient(getClientProtocol(config), config);
+
+    // Doing this explicitly so that when service ids are defined in the
+    // configuration, we don't fall back to default ozone.om.address defined
+    // in ozone-default.xml.
+
+    if (OmUtils.isServiceIdsDefined(config)) {
+      throw new IOException("Following ServiceID's " +
+          config.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY) + " are" +
+          " defined in the configuration. Use the method getRpcClient which " +
+          "takes serviceID and configuration as param");
+    }
+    return getRpcClient(getClientProtocol(config), config);
   }
 
   /**
@@ -166,7 +149,7 @@ public final class OzoneClientFactory {
    * @param config
    *        Configuration to be used for OzoneClient creation
    */
-  private static OzoneClient getClient(ClientProtocol clientProtocol,
+  private static OzoneClient getRpcClient(ClientProtocol clientProtocol,
                                        Configuration config) {
     OzoneClientInvocationHandler clientHandler =
         new OzoneClientInvocationHandler(clientProtocol);

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha-s3/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha-s3/test.sh
@@ -19,6 +19,7 @@ COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 
 export SECURITY_ENABLED=false
+export OM_HA_PARAM="--om-service-id=id1"
 
 # shellcheck source=/dev/null
 source "$COMPOSE_DIR/../testlib.sh"

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha-s3/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha-s3/test.sh
@@ -27,6 +27,9 @@ start_docker_env
 
 execute_robot_test scm s3
 
+execute_robot_test scm freon
+
 stop_docker_env
 
 generate_report
+

--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -44,6 +44,8 @@ execute_robot_test scm recon
 
 execute_robot_test scm om-ratis
 
+execute_robot_test scm freon
+
 stop_docker_env
 
 generate_report

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -99,7 +99,7 @@ execute_robot_test(){
   OUTPUT_PATH="$RESULT_DIR_INSIDE/robot-$OUTPUT_NAME.xml"
   # shellcheck disable=SC2068
   docker-compose -f "$COMPOSE_FILE" exec -T "$CONTAINER" mkdir -p "$RESULT_DIR_INSIDE" \
-    && docker-compose -f "$COMPOSE_FILE" exec -T -e  SECURITY_ENABLED="${SECURITY_ENABLED}" "$CONTAINER" python -m robot ${ARGUMENTS[@]} --log NONE -N "$TEST_NAME" --report NONE "${OZONE_ROBOT_OPTS[@]}" --output "$OUTPUT_PATH" "$SMOKETEST_DIR_INSIDE/$TEST"
+    && docker-compose -f "$COMPOSE_FILE" exec -T -e SECURITY_ENABLED="${SECURITY_ENABLED}" -e OM_HA_PARAM="${OM_HA_PARAM}" "$CONTAINER" python -m robot ${ARGUMENTS[@]} --log NONE -N "$TEST_NAME" --report NONE "${OZONE_ROBOT_OPTS[@]}" --output "$OUTPUT_PATH" "$SMOKETEST_DIR_INSIDE/$TEST"
   local -i rc=$?
 
   FULL_CONTAINER_NAME=$(docker-compose -f "$COMPOSE_FILE" ps | grep "_${CONTAINER}_" | head -n 1 | awk '{print $1}')

--- a/hadoop-ozone/dist/src/main/smoketest/commonlib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/commonlib.robot
@@ -20,6 +20,7 @@ Library             BuiltIn
 
 *** Variables ***
 ${SECURITY_ENABLED}                 %{SECURITY_ENABLED}
+${OM_HA_PARAM}                      %{OM_HA_PARAM}
 
 *** Keywords ***
 Execute

--- a/hadoop-ozone/dist/src/main/smoketest/freon/freon.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/freon/freon.robot
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Smoketest ozone cluster startup
+Library             OperatingSystem
+Resource            ../commonlib.robot
+
+*** Test Cases ***
+Freon Randomkey Generator
+    ${result} =        Execute              ozone freon rk --om-service-id=id1 --numOfVolumes 1 --numOfBuckets=1  --numOfKeys=1 --numOfThreads=1
+                       Wait Until Keyword Succeeds      3min       10sec     Should contain   ${result}   Number of Keys added: 1
+
+Freon Ozone Key Generator
+    ${result} =        Execute              ozone freon ockg --om-service-id=id1 -t=1 -n=1
+                       Wait Until Keyword Succeeds      3min       10sec     Should contain   ${result}   Successful executions: 1
+
+Freon OM Key Generator
+    ${result} =        Execute              ozone freon omkg --om-service-id=id1 -t=1 -n=1
+                       Wait Until Keyword Succeeds      3min       10sec     Should contain   ${result}   Successful executions: 1
+
+Freon OM Bucket Generator
+    ${result} =        Execute              ozone freon ombg --om-service-id=id1 -t=1 -n=1
+                       Wait Until Keyword Succeeds      3min       10sec     Should contain   ${result}   Successful executions: 1

--- a/hadoop-ozone/dist/src/main/smoketest/freon/freon.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/freon/freon.robot
@@ -20,17 +20,17 @@ Resource            ../commonlib.robot
 
 *** Test Cases ***
 Freon Randomkey Generator
-    ${result} =        Execute              ozone freon rk --om-service-id=id1 --numOfVolumes=1 --numOfBuckets=1 --numOfKeys=1 --numOfThreads=1
+    ${result} =        Execute              ozone freon rk ${OM_HA_PARAM} --numOfVolumes=1 --numOfBuckets=1 --numOfKeys=1 --numOfThreads=1
                        Wait Until Keyword Succeeds      3min       10sec     Should contain   ${result}   Number of Keys added: 1
 
 Freon Ozone Key Generator
-    ${result} =        Execute              ozone freon ockg --om-service-id=id1 -t=1 -n=1
+    ${result} =        Execute              ozone freon ockg ${OM_HA_PARAM} -t=1 -n=1
                        Wait Until Keyword Succeeds      3min       10sec     Should contain   ${result}   Successful executions: 1
 
 Freon OM Key Generator
-    ${result} =        Execute              ozone freon omkg --om-service-id=id1 -t=1 -n=1
+    ${result} =        Execute              ozone freon omkg ${OM_HA_PARAM} -t=1 -n=1
                        Wait Until Keyword Succeeds      3min       10sec     Should contain   ${result}   Successful executions: 1
 
 Freon OM Bucket Generator
-    ${result} =        Execute              ozone freon ombg --om-service-id=id1 -t=1 -n=1
+    ${result} =        Execute              ozone freon ombg ${OM_HA_PARAM} -t=1 -n=1
                        Wait Until Keyword Succeeds      3min       10sec     Should contain   ${result}   Successful executions: 1

--- a/hadoop-ozone/dist/src/main/smoketest/freon/freon.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/freon/freon.robot
@@ -20,7 +20,7 @@ Resource            ../commonlib.robot
 
 *** Test Cases ***
 Freon Randomkey Generator
-    ${result} =        Execute              ozone freon rk --om-service-id=id1 --numOfVolumes=1 --numOfBuckets=1  --numOfKeys=1 --numOfThreads=1
+    ${result} =        Execute              ozone freon rk --om-service-id=id1 --numOfVolumes=1 --numOfBuckets=1 --numOfKeys=1 --numOfThreads=1
                        Wait Until Keyword Succeeds      3min       10sec     Should contain   ${result}   Number of Keys added: 1
 
 Freon Ozone Key Generator

--- a/hadoop-ozone/dist/src/main/smoketest/freon/freon.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/freon/freon.robot
@@ -20,7 +20,7 @@ Resource            ../commonlib.robot
 
 *** Test Cases ***
 Freon Randomkey Generator
-    ${result} =        Execute              ozone freon rk --om-service-id=id1 --numOfVolumes 1 --numOfBuckets=1  --numOfKeys=1 --numOfThreads=1
+    ${result} =        Execute              ozone freon rk --om-service-id=id1 --numOfVolumes=1 --numOfBuckets=1  --numOfKeys=1 --numOfThreads=1
                        Wait Until Keyword Succeeds      3min       10sec     Should contain   ${result}   Number of Keys added: 1
 
 Freon Ozone Key Generator

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -243,7 +243,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
 
   @Override
   public OzoneClient getClient() throws IOException {
-    return OzoneClientFactory.getClient(conf);
+    return OzoneClientFactory.getRpcClient(conf);
   }
 
   @Override

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/Test2WayCommitInRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/Test2WayCommitInRatis.java
@@ -119,7 +119,7 @@ public class Test2WayCommitInRatis {
     cluster.waitForClusterToBeReady();
     cluster.waitTobeOutOfSafeMode();
     //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     volumeName = "watchforcommithandlingtest";
     bucketName = volumeName;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBCSID.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBCSID.java
@@ -89,7 +89,7 @@ public class TestBCSID {
             .build();
     cluster.waitForClusterToBeReady();
     //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     volumeName = "bcsid";
     bucketName = volumeName;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStream.java
@@ -93,7 +93,7 @@ public class TestBlockOutputStream {
         .build();
     cluster.waitForClusterToBeReady();
     //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     keyString = UUID.randomUUID().toString();
     volumeName = "testblockoutputstream";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
@@ -115,7 +115,7 @@ public class TestBlockOutputStreamWithFailures {
         .setStreamBufferSizeUnit(StorageUnit.BYTES).build();
     cluster.waitForClusterToBeReady();
     //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     keyString = UUID.randomUUID().toString();
     volumeName = "testblockoutputstream";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCloseContainerHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCloseContainerHandlingByClient.java
@@ -94,7 +94,7 @@ public class TestCloseContainerHandlingByClient {
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(7).build();
     cluster.waitForClusterToBeReady();
     //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     keyString = UUID.randomUUID().toString();
     volumeName = "closecontainerexceptionhandlingtest";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitWatcher.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitWatcher.java
@@ -134,7 +134,7 @@ public class TestCommitWatcher {
         .build();
     cluster.waitForClusterToBeReady();
     //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     keyString = UUID.randomUUID().toString();
     volumeName = "testblockoutputstream";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerReplicationEndToEnd.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerReplicationEndToEnd.java
@@ -119,7 +119,7 @@ public class TestContainerReplicationEndToEnd {
     cluster.waitForClusterToBeReady();
     cluster.getStorageContainerManager().getReplicationManager().start();
     //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     xceiverClientManager = new XceiverClientManager(conf);
     volumeName = "testcontainerstatemachinefailures";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachine.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachine.java
@@ -99,7 +99,7 @@ public class TestContainerStateMachine {
     cluster.waitForClusterToBeReady();
     cluster.getOzoneManager().startSecretManager();
     //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     volumeName = "testcontainerstatemachinefailures";
     bucketName = volumeName;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailureOnRead.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailureOnRead.java
@@ -121,7 +121,7 @@ public class TestContainerStateMachineFailureOnRead {
         .setHbInterval(200)
         .build();
     cluster.waitForClusterToBeReady();
-    OzoneClient client = OzoneClientFactory.getClient(conf);
+    OzoneClient client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     volumeName = "testcontainerstatemachinefailures";
     bucketName = volumeName;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -140,7 +140,7 @@ public class TestContainerStateMachineFailures {
             .build();
     cluster.waitForClusterToBeReady();
     //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     xceiverClientManager = new XceiverClientManager(conf);
     volumeName = "testcontainerstatemachinefailures";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithSlowFollower.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithSlowFollower.java
@@ -149,7 +149,7 @@ public class TestDeleteWithSlowFollower {
             .build();
     cluster.waitForClusterToBeReady();
     //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     xceiverClientManager = new XceiverClientManager(conf);
     volumeName = "testcontainerstatemachinefailures";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -126,7 +126,7 @@ public class TestFailureHandlingByClient {
         .setNumDatanodes(10).setTotalPipelineNumLimit(15).build();
     cluster.waitForClusterToBeReady();
     //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     keyString = UUID.randomUUID().toString();
     volumeName = "datanodefailurehandlingtest";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestHybridPipelineOnDatanode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestHybridPipelineOnDatanode.java
@@ -71,7 +71,7 @@ public class TestHybridPipelineOnDatanode {
         .setTotalPipelineNumLimit(5).build();
     cluster.waitForClusterToBeReady();
     //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestKeyInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestKeyInputStream.java
@@ -91,7 +91,7 @@ public class TestKeyInputStream {
         .build();
     cluster.waitForClusterToBeReady();
     //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     keyString = UUID.randomUUID().toString();
     volumeName = "test-key-input-stream-volume";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestMultiBlockWritesWithDnFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestMultiBlockWritesWithDnFailures.java
@@ -113,7 +113,7 @@ public class TestMultiBlockWritesWithDnFailures {
         .build();
     cluster.waitForClusterToBeReady();
     //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     keyString = UUID.randomUUID().toString();
     volumeName = "datanodefailurehandlingtest";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientRetriesOnException.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientRetriesOnException.java
@@ -103,7 +103,7 @@ public class TestOzoneClientRetriesOnException {
         .build();
     cluster.waitForClusterToBeReady();
     //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     xceiverClientManager = new XceiverClientManager(conf);
     keyString = UUID.randomUUID().toString();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -110,7 +110,7 @@ public class TestWatchForCommit {
         .build();
     cluster.waitForClusterToBeReady();
     //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     keyString = UUID.randomUUID().toString();
     volumeName = "watchforcommithandlingtest";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
@@ -85,7 +85,7 @@ public class TestCloseContainerByPipeline {
         .build();
     cluster.waitForClusterToBeReady();
     //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getClient(conf);
+    client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     objectStore.createVolume("test");
     objectStore.getVolume("test").createBucket("test");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
@@ -76,7 +76,7 @@ public class TestCloseContainerHandler {
     cluster.waitForClusterToBeReady();
 
     //the easiest way to create an open container is creating a key
-    OzoneClient client = OzoneClientFactory.getClient(conf);
+    OzoneClient client = OzoneClientFactory.getRpcClient(conf);
     ObjectStore objectStore = client.getObjectStore();
     objectStore.createVolume("test");
     objectStore.getVolume("test").createBucket("test");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
@@ -72,7 +72,7 @@ public class TestDeleteContainerHandler {
         .setNumDatanodes(1).build();
     cluster.waitForClusterToBeReady();
 
-    OzoneClient client = OzoneClientFactory.getClient(conf);
+    OzoneClient client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
     objectStore.createVolume(volumeName);
     objectStore.getVolume(volumeName).createBucket(bucketName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestContainerReportWithKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestContainerReportWithKeys.java
@@ -87,7 +87,7 @@ public class TestContainerReportWithKeys {
     final String keyName = "key" + RandomStringUtils.randomNumeric(5);
     final int keySize = 100;
 
-    OzoneClient client = OzoneClientFactory.getClient(conf);
+    OzoneClient client = OzoneClientFactory.getRpcClient(conf);
     ObjectStore objectStore = client.getObjectStore();
     objectStore.createVolume(volumeName);
     objectStore.getVolume(volumeName).createBucket(bucketName);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -109,7 +109,7 @@ public class OzoneClientProducer {
     }
 
     if (omServiceID == null) {
-      return OzoneClientFactory.getClient(ozoneConfiguration);
+      return OzoneClientFactory.getRpcClient(ozoneConfiguration);
     } else {
       // As in HA case, we need to pass om service ID.
       return OzoneClientFactory.getRpcClient(omServiceID, ozoneConfiguration);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -372,17 +372,9 @@ public class BaseFreonGenerator {
   public void ensureVolumeAndBucketExist(OzoneClient rpcClient,
       String volumeName, String bucketName) throws IOException {
 
-    OzoneVolume volume = null;
-    try {
-      volume = rpcClient.getObjectStore().getVolume(volumeName);
-    } catch (OMException ex) {
-      if (ex.getResult() == ResultCodes.VOLUME_NOT_FOUND) {
-        rpcClient.getObjectStore().createVolume(volumeName);
-        volume = rpcClient.getObjectStore().getVolume(volumeName);
-      } else {
-        throw ex;
-      }
-    }
+    OzoneVolume volume;
+    ensureVolumeExists(rpcClient, volumeName);
+    volume = rpcClient.getObjectStore().getVolume(volumeName);
 
     try {
       volume.getBucket(bucketName);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -399,6 +399,8 @@ public class BaseFreonGenerator {
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.VOLUME_NOT_FOUND) {
         rpcClient.getObjectStore().createVolume(volumeName);
+      } else {
+        throw ex;
       }
     }
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -400,19 +400,14 @@ public class BaseFreonGenerator {
    * Create missing target volume.
    */
   public void ensureVolumeExists(
-      OzoneConfiguration ozoneConfiguration,
+      OzoneClient rpcClient,
       String volumeName) throws IOException {
-    try (OzoneClient rpcClient = OzoneClientFactory
-        .getRpcClient(ozoneConfiguration)) {
-
-      try {
-        rpcClient.getObjectStore().getVolume(volumeName);
-      } catch (OMException ex) {
-        if (ex.getResult() == ResultCodes.VOLUME_NOT_FOUND) {
-          rpcClient.getObjectStore().createVolume(volumeName);
-        }
+    try {
+      rpcClient.getObjectStore().getVolume(volumeName);
+    } catch (OMException ex) {
+      if (ex.getResult() == ResultCodes.VOLUME_NOT_FOUND) {
+        rpcClient.getObjectStore().createVolume(volumeName);
       }
-
     }
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.ipc.Client;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.net.NetUtils;
-import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
@@ -305,17 +304,13 @@ public class BaseFreonGenerator {
    * Create the OM RPC client to use it for testing.
    */
   public OzoneManagerProtocolClientSideTranslatorPB createOmClient(
-      OzoneConfiguration conf) throws IOException {
+      OzoneConfiguration conf, String omServiceID) throws IOException {
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
-    long omVersion = RPC.getProtocolVersion(OzoneManagerProtocolPB.class);
-    InetSocketAddress omAddress = OmUtils.getOmAddressForClients(conf);
     RPC.setProtocolEngine(conf, OzoneManagerProtocolPB.class,
         ProtobufRpcEngine.class);
     String clientId = ClientId.randomId().toString();
-    return new OzoneManagerProtocolClientSideTranslatorPB(
-        RPC.getProxy(OzoneManagerProtocolPB.class, omVersion, omAddress,
-            ugi, conf, NetUtils.getDefaultSocketFactory(conf),
-            Client.getRpcTimeout(conf)), clientId);
+    return new OzoneManagerProtocolClientSideTranslatorPB(conf, clientId,
+        omServiceID, ugi);
   }
 
   public StorageContainerLocationProtocol createStorageContainerLocationClient(
@@ -374,34 +369,31 @@ public class BaseFreonGenerator {
   /**
    * Create missing target volume/bucket.
    */
-  public void ensureVolumeAndBucketExist(OzoneConfiguration ozoneConfiguration,
+  public void ensureVolumeAndBucketExist(OzoneClient rpcClient,
       String volumeName, String bucketName) throws IOException {
 
-    try (OzoneClient rpcClient = OzoneClientFactory
-        .getRpcClient(ozoneConfiguration)) {
-
-      OzoneVolume volume = null;
-      try {
+    OzoneVolume volume = null;
+    try {
+      volume = rpcClient.getObjectStore().getVolume(volumeName);
+    } catch (OMException ex) {
+      if (ex.getResult() == ResultCodes.VOLUME_NOT_FOUND) {
+        rpcClient.getObjectStore().createVolume(volumeName);
         volume = rpcClient.getObjectStore().getVolume(volumeName);
-      } catch (OMException ex) {
-        if (ex.getResult() == ResultCodes.VOLUME_NOT_FOUND) {
-          rpcClient.getObjectStore().createVolume(volumeName);
-          volume = rpcClient.getObjectStore().getVolume(volumeName);
-        } else {
-          throw ex;
-        }
-      }
-
-      try {
-        volume.getBucket(bucketName);
-      } catch (OMException ex) {
-        if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
-          volume.createBucket(bucketName);
-        } else {
-          throw ex;
-        }
+      } else {
+        throw ex;
       }
     }
+
+    try {
+      volume.getBucket(bucketName);
+    } catch (OMException ex) {
+      if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
+        volume.createBucket(bucketName);
+      } else {
+        throw ex;
+      }
+    }
+
   }
 
   /**
@@ -468,5 +460,14 @@ public class BaseFreonGenerator {
 
   public int getThreadNo() {
     return threadNo;
+  }
+
+  protected OzoneClient createOzoneClient(String omServiceID,
+      OzoneConfiguration conf) throws Exception {
+    if (omServiceID != null) {
+      return OzoneClientFactory.getRpcClient(omServiceID, conf);
+    } else {
+      return OzoneClientFactory.getRpcClient(conf);
+    }
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmBucketGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmBucketGenerator.java
@@ -46,6 +46,12 @@ public class OmBucketGenerator extends BaseFreonGenerator
       defaultValue = "vol1")
   private String volumeName;
 
+  @Option(
+      names = "--om-service-id",
+      description = "OM Service ID"
+  )
+  private String omServiceID = null;
+
   private OzoneManagerProtocol ozoneManagerClient;
 
   private Timer bucketCreationTimer;
@@ -56,8 +62,8 @@ public class OmBucketGenerator extends BaseFreonGenerator
     init();
 
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
-
-    ozoneManagerClient = createOmClient(ozoneConfiguration);
+    
+    ozoneManagerClient = createOmClient(ozoneConfiguration, omServiceID);
 
     ensureVolumeExists(ozoneConfiguration, volumeName);
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmKeyGenerator.java
@@ -75,28 +75,21 @@ public class OmKeyGenerator extends BaseFreonGenerator
 
   @Override
   public Void call() throws Exception {
+    init();
 
-    OzoneClient rpcClient = null;
-    try {
-      init();
+    OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
 
-      OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
-
-      rpcClient = createOzoneClient(omServiceID, ozoneConfiguration);
+    try (OzoneClient rpcClient = createOzoneClient(omServiceID,
+        ozoneConfiguration)) {
 
       ensureVolumeAndBucketExist(rpcClient, volumeName, bucketName);
 
-      System.out.print("Bharat " + omServiceID);
       ozoneManagerClient = createOmClient(ozoneConfiguration, omServiceID);
 
       timer = getMetrics().timer("key-create");
 
       runTests(this::createKey);
     } finally {
-      if (rpcClient != null) {
-        rpcClient.close();
-      }
-
       if (ozoneManagerClient != null) {
         ozoneManagerClient.close();
       }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmKeyGenerator.java
@@ -96,6 +96,10 @@ public class OmKeyGenerator extends BaseFreonGenerator
       if (rpcClient != null) {
         rpcClient.close();
       }
+
+      if (ozoneManagerClient != null) {
+        ozoneManagerClient.close();
+      }
     }
 
     return null;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
 
 import com.codahale.metrics.Timer;
 import picocli.CommandLine.Command;
@@ -73,6 +72,12 @@ public class OzoneClientKeyGenerator extends BaseFreonGenerator
   )
   private ReplicationFactor factor = ReplicationFactor.THREE;
 
+  @Option(
+      names = "--om-service-id",
+      description = "OM Service ID"
+  )
+  private String omServiceID = null;
+
   private Timer timer;
 
   private OzoneBucket bucket;
@@ -86,22 +91,24 @@ public class OzoneClientKeyGenerator extends BaseFreonGenerator
 
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
 
-    ensureVolumeAndBucketExist(ozoneConfiguration, volumeName, bucketName);
 
     contentGenerator = new ContentGenerator(keySize, bufferSize);
     metadata = new HashMap<>();
 
-    try (OzoneClient rpcClient = OzoneClientFactory
-        .getRpcClient(ozoneConfiguration)) {
-
-      bucket =
-          rpcClient.getObjectStore().getVolume(volumeName)
-              .getBucket(bucketName);
+    OzoneClient rpcClient = null;
+    try {
+      rpcClient = createOzoneClient(omServiceID, ozoneConfiguration);
+      ensureVolumeAndBucketExist(rpcClient, volumeName, bucketName);
+      bucket = rpcClient.getObjectStore().getVolume(volumeName)
+          .getBucket(bucketName);
 
       timer = getMetrics().timer("key-create");
 
       runTests(this::createKey);
-
+    } finally {
+      if (rpcClient != null) {
+        rpcClient.close();
+      }
     }
     return null;
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
@@ -91,13 +91,11 @@ public class OzoneClientKeyGenerator extends BaseFreonGenerator
 
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
 
-
     contentGenerator = new ContentGenerator(keySize, bufferSize);
     metadata = new HashMap<>();
 
-    OzoneClient rpcClient = null;
-    try {
-      rpcClient = createOzoneClient(omServiceID, ozoneConfiguration);
+    try (OzoneClient rpcClient = createOzoneClient(omServiceID,
+        ozoneConfiguration)) {
       ensureVolumeAndBucketExist(rpcClient, volumeName, bucketName);
       bucket = rpcClient.getObjectStore().getVolume(volumeName)
           .getBucket(bucketName);
@@ -105,10 +103,6 @@ public class OzoneClientKeyGenerator extends BaseFreonGenerator
       timer = getMetrics().timer("key-create");
 
       runTests(this::createKey);
-    } finally {
-      if (rpcClient != null) {
-        rpcClient.close();
-      }
     }
     return null;
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyValidator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyValidator.java
@@ -24,7 +24,6 @@ import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
 
 import com.codahale.metrics.Timer;
 import org.apache.commons.io.IOUtils;
@@ -66,6 +65,12 @@ public class OzoneClientKeyValidator extends BaseFreonGenerator
       defaultValue = "false")
   private boolean stream;
 
+  @Option(
+      names = "--om-service-id",
+      description = "OM Service ID"
+  )
+  private String omServiceID = null;
+
   private Timer timer;
 
   private byte[] referenceDigest;
@@ -80,7 +85,7 @@ public class OzoneClientKeyValidator extends BaseFreonGenerator
 
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
 
-    rpcClient = OzoneClientFactory.getRpcClient(ozoneConfiguration);
+    rpcClient = createOzoneClient(omServiceID, ozoneConfiguration);
 
     readReference();
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -177,6 +177,12 @@ public final class RandomKeyGenerator implements Callable<Void> {
   )
   private ReplicationFactor factor = ReplicationFactor.ONE;
 
+  @Option(
+      names = "--om-service-id",
+      description = "OM Service ID"
+  )
+  private String omServiceID = null;
+
   private int threadPoolSize;
 
   private OzoneClient ozoneClient;
@@ -223,7 +229,7 @@ public final class RandomKeyGenerator implements Callable<Void> {
     this.ozoneConfiguration = ozoneConfiguration;
   }
 
-  public void init(OzoneConfiguration configuration) throws IOException {
+  public void init(OzoneConfiguration configuration) throws Exception {
     startTime = System.nanoTime();
     jobStartTime = System.currentTimeMillis();
     volumeCreationTime = new AtomicLong();
@@ -239,7 +245,11 @@ public final class RandomKeyGenerator implements Callable<Void> {
     keyCounter = new AtomicLong();
     volumes = new ConcurrentHashMap<>();
     buckets = new ConcurrentHashMap<>();
-    ozoneClient = OzoneClientFactory.getClient(configuration);
+    if (omServiceID != null) {
+      ozoneClient = OzoneClientFactory.getRpcClient(omServiceID, configuration);
+    } else {
+      ozoneClient = OzoneClientFactory.getRpcClient(configuration);
+    }
     objectStore = ozoneClient.getObjectStore();
     for (FreonOps ops : FreonOps.values()) {
       histograms.add(ops.ordinal(), new Histogram(new UniformReservoir()));

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -229,7 +229,7 @@ public final class RandomKeyGenerator implements Callable<Void> {
     this.ozoneConfiguration = ozoneConfiguration;
   }
 
-  public void init(OzoneConfiguration configuration) throws Exception {
+  public void init(OzoneConfiguration configuration) throws IOException {
     startTime = System.nanoTime();
     jobStartTime = System.currentTimeMillis();
     volumeCreationTime = new AtomicLong();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make Freon work with OM HA.
And also refactor OzoneClientFactory.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3120

## How was this patch tested?

Tested it on ozone-om-ha-s3 docker-compose cluster.

Freon tests are added to test with OM HA.

```
bash-4.2$ ozone freon rk --om-service-id=id1 --numOfVolumes=1 --numOfBuckets=1 --numOfKeys=1 --numOfThreads=1
2020-03-06 20:46:21,267 [main] INFO impl.MetricsConfig: Loaded properties from hadoop-metrics2.properties
2020-03-06 20:46:21,529 [main] INFO impl.MetricsSystemImpl: Scheduled Metric snapshot period at 10 second(s).
2020-03-06 20:46:21,529 [main] INFO impl.MetricsSystemImpl: ozone-freon metrics system started
2020-03-06 20:46:23,391 [main] INFO freon.RandomKeyGenerator: Number of Threads: 1
2020-03-06 20:46:23,392 [main] INFO freon.RandomKeyGenerator: Number of Volumes: 1.
2020-03-06 20:46:23,392 [main] INFO freon.RandomKeyGenerator: Number of Buckets per Volume: 1.
2020-03-06 20:46:23,393 [main] INFO freon.RandomKeyGenerator: Number of Keys per Bucket: 1.
2020-03-06 20:46:23,393 [main] INFO freon.RandomKeyGenerator: Key size: 10240 bytes
2020-03-06 20:46:23,393 [main] INFO freon.RandomKeyGenerator: Buffer size: 4096 bytes
2020-03-06 20:46:23,394 [main] INFO freon.RandomKeyGenerator: validateWrites : false
2020-03-06 20:46:23,398 [main] INFO freon.RandomKeyGenerator: Starting progress bar Thread.

 0.00% |?                                                                                                    |  0/1 Time: 0:00:002020-03-06 20:46:23,466 [pool-2-thread-1] INFO rpc.RpcClient: Creating Volume: vol-0-45597, with hadoop as owner.
2020-03-06 20:46:23,533 [pool-2-thread-1] INFO rpc.RpcClient: Creating Bucket: vol-0-45597/bucket-0-56744, with Versioning false and Storage Type set to DISK and Encryption set to false 
2020-03-06 20:46:24,103 [pool-2-thread-1] WARN impl.MetricsSystemImpl: ozone-freon metrics system already initialized!
 100.00% |?????????????????????????????????????????????????????????????????????????????????????????????????????|  1/1 Time: 0:00:01

***************************************************
Status: Success
Git Base Revision: e97acb3bd8f3befd27418996fa5d4b50bf2e17bf
Number of Volumes created: 1
Number of Buckets created: 1
Number of Keys added: 1
Ratis replication factor: ONE
Ratis replication type: STAND_ALONE
Average Time spent in volume creation: 00:00:00,104
Average Time spent in bucket creation: 00:00:00,026
Average Time spent in key creation: 00:00:00,079
Average Time spent in key write: 00:00:00,735
Total bytes written: 10240
Total Execution time: 00:00:06,431
***************************************************
```

