### PR TITLE
HDDS-3089. TestSCMNodeManager intermittent crash

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RocksDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RocksDBStore.java
@@ -387,6 +387,7 @@ public class RocksDBStore implements MetadataStore {
     }
     if (db != null) {
       db.close();
+      db = null;
     }
 
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Based on the logs the test crashes during teardown when trying to delete pipeline in `EventQueue-DeadNodeForDeadNodeHandler` thread, as the RocksDB for pipelines was already closed during SCM stop.

1. Clear `db` reference in `RocksDBStore` after closing it, to avoid calls on closed RocksDB.  This might result in NPE, which would be handled in Ozone normally, while call on closed DB might result in seg.fault in native code.
2. Protect `pipelineStore.close()` call with write lock in `SCMPipelineManager` to avoid concurrent `pipelineStore.delete()` (or other similar operations).

https://issues.apache.org/jira/browse/HDDS-3089

## How was this patch tested?

Executed TestSCMNodeManager 2x20 times successfully:
https://github.com/adoroszlai/hadoop-ozone/runs/491868681
https://github.com/adoroszlai/hadoop-ozone/runs/491888786

Regular CI with all checks (only it-freon failed):
https://github.com/adoroszlai/hadoop-ozone/runs/491950482