### PR TITLE
HDDS-3140. Remove hard-coded SNAPSHOT version from GitHub workflows

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -106,7 +106,7 @@ jobs:
             args: ./hadoop-ozone/dev-support/checks/build.sh
         - run: sudo pip install robotframework
         - run: sudo chown runner -R .
-        - run: cd ./hadoop-ozone/dist/target/ozone-*-SNAPSHOT/ && mkdir .aws && sudo chown 1000 .aws 
+        - run: cd ./hadoop-ozone/dist/target/ozone-*/ && mkdir .aws && sudo chown 1000 .aws
         - run: ./hadoop-ozone/dev-support/checks/acceptance.sh
         - uses: actions/upload-artifact@master
           if: always()

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -99,7 +99,7 @@ jobs:
             args: ./hadoop-ozone/dev-support/checks/build.sh
         - run: sudo pip install robotframework
         - run: sudo chown runner -R .
-        - run: cd ./hadoop-ozone/dist/target/ozone-*-SNAPSHOT/ && mkdir .aws && sudo chown 1000 .aws 
+        - run: cd ./hadoop-ozone/dist/target/ozone-*/ && mkdir .aws && sudo chown 1000 .aws
         - run: ./hadoop-ozone/dev-support/checks/acceptance.sh
         - uses: actions/upload-artifact@master
           if: always()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove hard-coded `-SNAPSHOT` version from GitHub workflow definitions.

https://issues.apache.org/jira/browse/HDDS-3140

## How was this patch tested?

post-commit: https://github.com/adoroszlai/hadoop-ozone/runs/494759838