### PR TITLE
HDDS-3141. Unit check fails to execute insight and mini-chaos-tests modules

### DIFF
--- a/hadoop-ozone/dev-support/checks/integration.sh
+++ b/hadoop-ozone/dev-support/checks/integration.sh
@@ -24,7 +24,7 @@ mkdir -p "$REPORT_DIR"
 
 export MAVEN_OPTS="-Xmx4096m"
 mvn -B install -DskipTests
-mvn -B -fae test -pl :hadoop-ozone-integration-test "$@" \
+mvn -B -fae test -pl :hadoop-ozone-integration-test,:mini-chaos-tests "$@" \
   | tee "${REPORT_DIR}/output.log"
 rc=$?
 

--- a/hadoop-ozone/dev-support/checks/unit.sh
+++ b/hadoop-ozone/dev-support/checks/unit.sh
@@ -23,7 +23,7 @@ REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/unit"}
 mkdir -p "$REPORT_DIR"
 
 export MAVEN_OPTS="-Xmx4096m"
-mvn -B -DskipShade -Dskip.yarn -fae test -pl \!:hadoop-ozone-integration-test "$@" \
+mvn -B -DskipShade -Dskip.yarn -fae test -pl \!:hadoop-ozone-integration-test,\!:mini-chaos-tests "$@" \
   | tee "${REPORT_DIR}/output.log"
 rc=$?
 

--- a/hadoop-ozone/insight/pom.xml
+++ b/hadoop-ozone/insight/pom.xml
@@ -107,12 +107,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-ozone-integration-test</artifactId>
-      <scope>test</scope>
-      <type>test-jar</type>
-    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Remove unnecessary dependency on `integration-test` from `insight` module.
2. Move test execution of `mini-chaos-tests` module to `integration.sh`.

https://issues.apache.org/jira/browse/HDDS-3141

## How was this patch tested?

Verified that `insight` module compiles and test can be run:

```
[INFO] Running org.apache.hadoop.ozone.insight.TestBaseInsightPoint
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.131 s - in org.apache.hadoop.ozone.insight.TestBaseInsightPoint
```

https://github.com/adoroszlai/hadoop-ozone/runs/494936624

Verified that `unit` check does not include `mini-chaos-tests`:

https://github.com/adoroszlai/hadoop-ozone/runs/494936624

and that `it-ozone` check does:

```
[INFO] Running org.apache.hadoop.ozone.TestMiniChaosOzoneCluster
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 69.139 s - in org.apache.hadoop.ozone.TestMiniChaosOzoneCluster
```

https://github.com/adoroszlai/hadoop-ozone/runs/494955611