### PR TITLE
HDDS-3150. Implement getIfExist in Table and use it in CreateKey/File

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBMetrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBMetrics.java
@@ -47,6 +47,34 @@ public class RDBMetrics {
   private @Metric MutableCounterLong numDBKeyMayExistChecks;
   private @Metric MutableCounterLong numDBKeyMayExistMisses;
 
+  private @Metric MutableCounterLong numDBKeyGetIfExistChecks;
+  private @Metric MutableCounterLong numDBKeyGetIfExistMisses;
+  private @Metric MutableCounterLong numDBKeyGetIfExistGets;
+
+
+  public long getNumDBKeyGetIfExistGets() {
+    return numDBKeyGetIfExistGets.value();
+  }
+
+  public void incNumDBKeyGetIfExistGets() {
+    this.numDBKeyGetIfExistGets.incr();
+  }
+
+  public long getNumDBKeyGetIfExistChecks() {
+    return numDBKeyGetIfExistChecks.value();
+  }
+
+  public void incNumDBKeyGetIfExistChecks() {
+    this.numDBKeyGetIfExistChecks.incr();
+  }
+
+  public long getNumDBKeyGetIfExistMisses() {
+    return numDBKeyGetIfExistMisses.value();
+  }
+
+  public void incNumDBKeyGetIfExistMisses() {
+    this.numDBKeyGetIfExistMisses.incr();
+  }
 
   public void incNumDBKeyMayExistChecks() {
     numDBKeyMayExistChecks.incr();

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -156,6 +156,33 @@ class RDBTable implements Table<byte[], byte[]> {
   }
 
   @Override
+  public byte[] getIfExist(byte[] key) throws IOException {
+    try {
+      // RocksDB#keyMayExist
+      // If the key definitely does not exist in the database, then this
+      // method returns false, else true.
+      rdbMetrics.incNumDBKeyGetIfExistChecks();
+      StringBuilder outValue = new StringBuilder();
+      boolean keyMayExist = db.keyMayExist(handle, key, outValue);
+      if (keyMayExist) {
+        // Not using out value from string builder, as that is causing
+        // IllegalArgumentException during protobuf parsing.
+        rdbMetrics.incNumDBKeyGetIfExistGets();
+        byte[] val;
+        val = db.get(handle, key);
+        if (val == null) {
+          rdbMetrics.incNumDBKeyGetIfExistMisses();
+        }
+        return val;
+      }
+      return null;
+    } catch (RocksDBException e) {
+      throw toIOException(
+          "Error in accessing DB. ", e);
+    }
+  }
+
+  @Override
   public void delete(byte[] key) throws IOException {
     try {
       db.delete(handle, key);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -177,8 +177,7 @@ class RDBTable implements Table<byte[], byte[]> {
       }
       return null;
     } catch (RocksDBException e) {
-      throw toIOException(
-          "Error in accessing DB. ", e);
+      throw toIOException("Error in accessing DB. ", e);
     }
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -82,6 +82,23 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
   VALUE get(KEY key) throws IOException;
 
   /**
+   * Returns the value mapped to the given key in byte array or returns null
+   * if the key is not found.
+   *
+   * This method first checks using keyMayExist, if it returns false, we are
+   * 100% sure that key does not exist in DB, so it returns null with out
+   * calling db.get. If keyMayExist return true, then we use db.get and then
+   * return the value. This method will be useful in the cases where the
+   * caller is more sure that this key does not exist in DB and keyMayExist
+   * will help here.
+   *
+   * @param key metadata key
+   * @return value in byte array or null if the key is not found.
+   * @throws IOException on Failure
+   */
+  VALUE getIfExist(KEY key) throws IOException;
+
+  /**
    * Deletes a key from the metadata store.
    *
    * @param key metadata key

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestTypedRDBTableStore.java
@@ -339,6 +339,24 @@ public class TestTypedRDBTableStore {
   }
 
   @Test
+  public void testGetIfExist() throws Exception {
+    try (Table<String, String> testTable = createTypedTable(
+        "Eighth")) {
+      String key =
+          RandomStringUtils.random(10);
+      String value = RandomStringUtils.random(10);
+      testTable.put(key, value);
+      Assert.assertNotNull(testTable.getIfExist(key));
+
+      String invalidKey = key + RandomStringUtils.random(1);
+      Assert.assertNull(testTable.getIfExist(invalidKey));
+
+      testTable.delete(key);
+      Assert.assertNull(testTable.getIfExist(key));
+    }
+  }
+
+  @Test
   public void testIsExistCache() throws Exception {
     try (Table<String, String> testTable = createTypedTable(
         "Eighth")) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -218,7 +218,8 @@ public class OMFileCreateRequest extends OMKeyRequest {
       // replay.
       String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
           keyName);
-      OmKeyInfo dbKeyInfo = omMetadataManager.getKeyTable().get(ozoneKey);
+      OmKeyInfo dbKeyInfo = omMetadataManager.getKeyTable()
+          .getIfExist(ozoneKey);
       if (dbKeyInfo != null) {
         // Check if this transaction is a replay of ratis logs.
         // We check only the KeyTable here and not the OpenKeyTable. In case

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -147,7 +147,8 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       // enabled.
       if (ozoneManager.isRatisEnabled()) {
         // Check if OzoneKey already exists in DB
-        OmKeyInfo dbKeyInfo = omMetadataManager.getKeyTable().get(dbOzoneKey);
+        OmKeyInfo dbKeyInfo = omMetadataManager.getKeyTable()
+            .getIfExist(dbOzoneKey);
         if (dbKeyInfo != null) {
           // Check if this transaction is a replay of ratis logs
           if (isReplay(ozoneManager, dbKeyInfo, trxnLogIndex)) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -192,7 +192,8 @@ public class OMKeyCreateRequest extends OMKeyRequest {
       // Check if Key already exists
       String dbKeyName = omMetadataManager.getOzoneKey(volumeName, bucketName,
           keyName);
-      OmKeyInfo dbKeyInfo = omMetadataManager.getKeyTable().get(dbKeyName);
+      OmKeyInfo dbKeyInfo =
+          omMetadataManager.getKeyTable().getIfExist(dbKeyName);
       if (dbKeyInfo != null) {
         // Check if this transaction is a replay of ratis logs.
         // We check only the KeyTable here and not the OpenKeyTable. In case


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implement getIfExist in Table and use it in CreateKey/File

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3150

## How was this patch tested?

Added UT.
And also deployed this fix on a laptop and ran the benchmark with/without fix.

**Using db.getIfExist**
```
$ support-tools-0.1.0-SNAPSHOT/bin/ozone-tools benchmark om write -d=35m -w=50
Final Stats!
Time elapsed: 2100 sec.
Number of Threads: 50
Number of Keys written: 6335987
Average Key write time (CPU Time): 16.5624 milliseconds. 
Average Key write time (Real): .3312 milliseconds. 
Max Key write time (CPU Time): 558 milliseconds.
****************************************************************
```


Metrics
So, out of 6.33 million calls of getIfExist, only 15599 calls performed db.get and all those are misses. So, it proves that using db.getIfExist in a negative case is better.
"NumDBKeyGetIfExistChecks": 6335987, (Total calls to API)

"NumDBKeyGetIfExistMisses": 15599, (keyMay Exist returned true, we call db.get, this metric value says how many times we called db.get())

"NumDBKeyGetIfExistGets": 15599 (keyMay Exist returned true, we called db.get(), but turns out that db.get() returns null, so this is a miss where keyMayExist was not able to find out correctly)


**Without getIfExist/ With get**
```
$ support-tools-0.1.0-SNAPSHOT/bin/ozone-tools benchmark om write -d=60m -w=50
================================================================
2020-03-09T14:06:33.169
================================================================
Time elapsed: 2100 sec.
Number of Threads: 50
Number of Keys written: 5815634
Average Key write time (CPU Time): 18.0492 milliseconds. 
Average Key write time (Real): .3610 milliseconds. 
Max Key write time (CPU Time): 1080 milliseconds.
****************************************************************
```

**Conclusion:**
**With getIfExists:** 
6335987 Keys created in 35 mts 
Throughput: 3017 keys/sec
**With get:**
5815634 Keys created in 35 mts 
Throughput: 2769 keys/sec





