### PR TITLE
HDDS-3152. Reduce number of chunkwriter threads in integration tests

### DIFF
--- a/hadoop-ozone/integration-test/src/test/resources/ozone-site.xml
+++ b/hadoop-ozone/integration-test/src/test/resources/ozone-site.xml
@@ -26,4 +26,9 @@
     <value>org.apache.hadoop.hdds.fs.MockSpaceUsageCheckFactory$None</value>
   </property>
 
+  <property>
+    <name>dfs.container.ratis.num.write.chunk.threads</name>
+    <value>4</value>
+  </property>
+
 </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Integration tests run multiple datanodes in the same JVM.  Each datanode comes with 60 chunk writer threads by default (may be decreased in [HDDS-3053](https://issues.apache.org/jira/browse/HDDS-3053)).  This makes thread dumps (eg. produced by `GenericTestUtils.waitFor` on timeout) really hard to navigate, as there may be 300+ such threads.

Since integration tests are generally run with a single disk which is even shared among the datanodes, a few threads per datanode should be enough.

https://issues.apache.org/jira/browse/HDDS-3152

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/runs/497866229