### PR TITLE
HDDS-3095. Intermittent failure in TestFailureHandlingByClient#testDatanodeExclusionWithMajorityCommit

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -317,8 +317,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
   public void restartHddsDatanode(int i, boolean waitForDatanode)
       throws InterruptedException, TimeoutException {
     HddsDatanodeService datanodeService = hddsDatanodes.get(i);
-    datanodeService.stop();
-    datanodeService.join();
+    stopDatanode(datanodeService);
     // ensure same ports are used across restarts.
     OzoneConfiguration config = datanodeService.getConf();
     int currentPort = datanodeService.getDatanodeDetails()
@@ -353,7 +352,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
 
   @Override
   public void shutdownHddsDatanode(int i) {
-    hddsDatanodes.get(i).stop();
+    stopDatanode(hddsDatanodes.get(i));
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Intermittent failure in `TestFailureHandlingByClient` happens when the datanode just stopped is not excluded during subsequent write operation.

This PR proposes to make `MiniOzoneCluster` wait for datanode to stop, as it already does during "restart datanode".

https://issues.apache.org/jira/browse/HDDS-3095

## How was this patch tested?

Ran `TestFailureHandlingByClient` 20x successfully:
https://github.com/adoroszlai/hadoop-ozone/runs/497741382

and regular full CI:
https://github.com/adoroszlai/hadoop-ozone/runs/497755796
where only failure is (supposedly) unrelated in Test2WayCommitInRatis.