### PR TITLE
HDDS-2989. Intermittent timeout in TestBlockManager

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModePrecheck.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModePrecheck.java
@@ -24,11 +24,16 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ScmOps;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException.ResultCodes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Safe mode pre-check for SCM operations.
  * */
 public class SafeModePrecheck implements Precheck<ScmOps> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SafeModePrecheck.class);
 
   private AtomicBoolean inSafeMode;
   public static final String PRECHECK_TYPE = "SafeModePrecheck";
@@ -64,6 +69,8 @@ public class SafeModePrecheck implements Precheck<ScmOps> {
   }
 
   public void setInSafeMode(boolean inSafeMode) {
+    LOG.info("Setting safe mode {} -> {} in {}",
+        isInSafeMode(), inSafeMode, this, new Exception("for debug"));
     this.inSafeMode.set(inSafeMode);
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModePrecheck.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModePrecheck.java
@@ -24,16 +24,11 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ScmOps;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException.ResultCodes;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Safe mode pre-check for SCM operations.
  * */
 public class SafeModePrecheck implements Precheck<ScmOps> {
-
-  private static final Logger LOG =
-      LoggerFactory.getLogger(SafeModePrecheck.class);
 
   private AtomicBoolean inSafeMode;
   public static final String PRECHECK_TYPE = "SafeModePrecheck";
@@ -69,8 +64,6 @@ public class SafeModePrecheck implements Precheck<ScmOps> {
   }
 
   public void setInSafeMode(boolean inSafeMode) {
-    LOG.info("Setting safe mode {} -> {} in {}",
-        isInSafeMode(), inSafeMode, this, new Exception("for debug"));
     this.inSafeMode.set(inSafeMode);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -119,8 +119,6 @@ public class TestBlockManager {
     // Initialize these fields so that the tests can pass.
     mapping = (SCMContainerManager) scm.getContainerManager();
     blockManager = (BlockManagerImpl) scm.getScmBlockManager();
-    eventQueue.addHandler(SCMEvents.SAFE_MODE_STATUS,
-        scm.getSafeModeHandler());
     DatanodeCommandHandler handler = new DatanodeCommandHandler();
     eventQueue.addHandler(SCMEvents.DATANODE_COMMAND, handler);
     CloseContainerEventHandler closeContainerHandler =


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestBlockManager` intermittently times out waiting for exit from safe mode.  This happens due to race condition between two safe mode status events in different handler threads (but the same handler object): one from SCM, another from the test code.

Temporary debug log (in "passing" order):

```
(SafeModeHandler.java:onMessage(103)) - SafeModeHandler@2bde2598 handling safe mode status event in thread 26: true
(SafeModeHandler.java:onMessage(103)) - SafeModeHandler@2bde2598 handling safe mode status event in thread 28: false
```

If the order is reversed, SCM may stay in safe mode as far as `BlockManagerImpl` sees it.  Worse, it may return to safe mode while `BlockManagerImpl` is trying to perform some operation, eg.:

```
SCMException: SafeModePrecheck failed for allocateBlock
...
  at org.apache.hadoop.hdds.scm.block.BlockManagerImpl.allocateBlock(BlockManagerImpl.java:160)
  at org.apache.hadoop.hdds.scm.block.TestBlockManager.testAllocateBlock(TestBlockManager.java:150)
```

The proposed fix is to disable safe mode status emission (ie. ignore the event from SCM) and let the test set safe mode explicitly in `BlockManagerImpl`.  This should be fine since this is a unit test, not integration one.

https://issues.apache.org/jira/browse/HDDS-2989

## How was this patch tested?

Ran TestBlockManager 10x:
https://github.com/adoroszlai/hadoop-ozone/runs/497791137

then 50x:
https://github.com/adoroszlai/hadoop-ozone/runs/497839450

and regular full CI:
https://github.com/adoroszlai/hadoop-ozone/runs/498781616