### PR TITLE
HDDS-3104. Integration test crashes due to critical error in datanode.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -407,6 +407,7 @@ public class DatanodeStateMachine implements Closeable {
   public synchronized void stopDaemon() {
     try {
       supervisor.stop();
+      context.setShutdownGracefully();
       context.setState(DatanodeStates.SHUTDOWN);
       reportManager.shutdown();
       this.close();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -365,7 +365,6 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
   public void shutdown() {
     try {
       LOG.info("Shutting down the Mini Ozone Cluster");
-
       File baseDir = new File(GenericTestUtils.getTempPath(
           MiniOzoneClusterImpl.class.getSimpleName() + "-" +
               scm.getClientProtocolServer().getScmInfo().getClusterId()));


### PR DESCRIPTION
## What changes were proposed in this pull request?
Created a flag to tell StateContext that shutDown was called and not to overreact!
(More details in Jira comments)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3104

## How was this patch tested?
Verified by running TestContainerStateMachineFailureOnRead.