### PR TITLE
HDDS-3148. Logs cluttered by AlreadyExistsException from Ratis.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CreatePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CreatePipelineCommandHandler.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.ozone.protocol.commands.CreatePipelineCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.protocol.AlreadyExistsException;
 import org.apache.ratis.protocol.RaftGroup;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftPeer;
@@ -102,6 +103,8 @@ public class CreatePipelineCommandHandler implements CommandHandler {
               final RaftPeer peer = RatisHelper.toRaftPeer(d);
               try (RaftClient client = RatisHelper.newRaftClient(peer, conf)) {
                 client.groupAdd(group, peer.getId());
+              } catch (AlreadyExistsException ae) {
+                // do not log
               } catch (IOException ioe) {
                 LOG.warn("Add group failed for {}", d, ioe);
               }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Made changes so CreatePipelineCommandHandler will not log the warning. This will half the messages printed out, Ratis still prints out the warning, maybe should be Ratis side change.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3148

## How was this patch tested?
Ran IT which reproduces the exception.