### PR TITLE
HDDS-3159. Bump RocksDB version to the latest one.

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -114,7 +114,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.rocksdb</groupId>
       <artifactId>rocksdbjni</artifactId>
-      <version>6.0.1</version>
+      <version>6.6.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBProfile.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBProfile.java
@@ -25,6 +25,7 @@ import org.rocksdb.BloomFilter;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.CompactionStyle;
 import org.rocksdb.DBOptions;
+import org.rocksdb.LRUCache;
 
 import java.math.BigDecimal;
 
@@ -62,11 +63,11 @@ public enum DBProfile {
           .setWriteBufferSize(writeBufferSize)
           .setTableFormatConfig(
               new BlockBasedTableConfig()
-                  .setBlockCacheSize(blockCacheSize)
+                  .setBlockCache(new LRUCache(blockCacheSize))
                   .setBlockSize(blockSize)
                   .setCacheIndexAndFilterBlocks(true)
                   .setPinL0FilterAndIndexBlocksInCache(true)
-                  .setFilter(new BloomFilter()));
+                  .setFilterPolicy(new BloomFilter()));
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

6.0.1 – our current version from RocksDB – released one year ago. Since than many new versions are released with important bug fixes.

I propose to update to the latest one...

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3159

## How was this patch tested?

Tested with `freon`:  I wrote 200M keys (allocate + close) to the OM with simulated SCM (which means that I had very high tp, ~10k key allocation / sec). It worked well.

For more details about the test please see #656 