### PR TITLE
HDDS-3008. parse and dump ozonemanager ratis segment file to printable text.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OMRatisHelper.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OMRatisHelper.java
@@ -18,10 +18,12 @@
 package org.apache.hadoop.ozone.om.helpers;
 
 import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.TextFormat;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
+import org.apache.ratis.proto.RaftProtos.StateMachineLogEntryProto;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftPeerId;
@@ -65,5 +67,24 @@ public final class OMRatisHelper {
     return OMResponse.newBuilder(OMResponse.parseFrom(bytes))
         .setLeaderOMNodeId(reply.getReplierId())
         .build();
+  }
+
+  /**
+   * Convert StateMachineLogEntryProto to String.
+   * @param proto - {@link StateMachineLogEntryProto}
+   * @return String
+   */
+  public static String smProtoToString(StateMachineLogEntryProto proto) {
+    StringBuilder builder = new StringBuilder();
+    try {
+      builder.append(TextFormat.shortDebugString(
+          OMRatisHelper.convertByteStringToOMRequest(proto.getLogData())));
+
+    } catch (Throwable ex) {
+      LOG.info("smProtoToString failed", ex);
+      builder.append("smProtoToString failed with");
+      builder.append(ex.getMessage());
+    }
+    return builder.toString();
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/parser/TestOMRatisLogParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/parser/TestOMRatisLogParser.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.parser;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.segmentparser.OMRatisLogParser;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.util.UUID;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
+
+/**
+ * Test Datanode Ratis log parser.
+ */
+public class TestOMRatisLogParser {
+
+  private static MiniOzoneHAClusterImpl cluster = null;
+  private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+  private final ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+  @Before
+  public void setup() throws Exception {
+    String clusterId = UUID.randomUUID().toString();
+    String scmId = UUID.randomUUID().toString();
+    String omServiceId = "omServiceId1";
+    OzoneConfiguration conf = new OzoneConfiguration();
+    cluster =  (MiniOzoneHAClusterImpl) MiniOzoneCluster.newHABuilder(conf)
+        .setClusterId(clusterId)
+        .setScmId(scmId)
+        .setOMServiceId(omServiceId)
+        .setNumOfOzoneManagers(3)
+        .build();
+    cluster.waitForClusterToBeReady();
+    ObjectStore objectStore = OzoneClientFactory.getRpcClient(omServiceId, conf)
+        .getObjectStore();
+    performFewRequests(objectStore);
+    System.setOut(new PrintStream(out));
+    System.setErr(new PrintStream(err));
+  }
+
+  private void performFewRequests(ObjectStore objectStore) throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    objectStore.createVolume(volumeName);
+    objectStore.getVolume(volumeName).createBucket(
+        UUID.randomUUID().toString());
+  }
+
+  @After
+  public void destroy() throws Exception {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+
+    out.close();
+    err.close();
+  }
+
+  @Test
+  public void testRatisLogParsing() {
+    OzoneConfiguration ozoneConfiguration =
+        cluster.getOMLeader().getConfiguration();
+
+    cluster.stop();
+
+    File omMetaDir = new File(ozoneConfiguration.get(OZONE_METADATA_DIRS),
+        "ratis");
+    Assert.assertTrue(omMetaDir.isDirectory());
+
+    String[] ratisDirs = omMetaDir.list();
+    File groupDir = null;
+
+    Assert.assertEquals(2, ratisDirs.length);
+
+    for (int i=0; i< ratisDirs.length; i++) {
+      if (ratisDirs[i].equals("snapshot")) {
+        continue;
+      }
+      groupDir = new File(omMetaDir, omMetaDir.list()[1]);
+    }
+
+    Assert.assertNotNull(groupDir);
+    Assert.assertTrue(groupDir.isDirectory());
+    File currentDir = new File(groupDir, "current");
+    File logFile = new File(currentDir, "log_inprogress_0");
+    Assert.assertTrue(logFile.exists());
+    Assert.assertTrue(logFile.isFile());
+
+    OMRatisLogParser omRatisLogParser = new OMRatisLogParser();
+    omRatisLogParser.setSegmentFile(logFile);
+    omRatisLogParser.parseRatisLogs(OMRatisHelper::smProtoToString);
+
+
+    // Not checking total entry count, because of not sure of exact count of
+    // metadata entry changes.
+    Assert.assertTrue(out.toString().contains("Num Total Entries:"));
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.ozone.protocolPB.OzoneManagerRequestHandler;
 import org.apache.hadoop.ozone.protocolPB.RequestHandler;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
 import org.apache.ratis.proto.RaftProtos;
+import org.apache.ratis.proto.RaftProtos.StateMachineLogEntryProto;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.RaftGroupId;
@@ -382,6 +383,11 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
   public void notifyNotLeader(Collection<TransactionContext> pendingEntries)
       throws IOException {
     omRatisServer.updateServerRole();
+  }
+
+  @Override
+  public String toStateMachineLogEntryString(StateMachineLogEntryProto proto) {
+    return OMRatisHelper.smProtoToString(proto);
   }
 
   /**

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/segmentparser/BaseLogParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/segmentparser/BaseLogParser.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.segmentparser;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.tools.ParseRatisLog;
 import picocli.CommandLine;
@@ -45,5 +46,10 @@ public abstract class BaseLogParser {
       System.out.println(DatanodeRatisLogParser.class.getSimpleName()
           + "failed with exception  " + e.toString());
     }
+  }
+
+  @VisibleForTesting
+  public void setSegmentFile(File segmentFile) {
+    this.segmentFile = segmentFile;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/segmentparser/OMRatisLogParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/segmentparser/OMRatisLogParser.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.ozone.segmentparser;
 
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/segmentparser/OMRatisLogParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/segmentparser/OMRatisLogParser.java
@@ -1,0 +1,27 @@
+package org.apache.hadoop.ozone.segmentparser;
+
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Command line utility to parse and dump a OM ratis segment file.
+ */
+@CommandLine.Command(
+    name = "om",
+    description = "dump om ratis segment file",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class)
+public class OMRatisLogParser extends BaseLogParser implements Callable<Void> {
+
+  @Override
+  public Void call() throws Exception {
+    System.out.println("Dumping OM Ratis Log");
+
+    parseRatisLogs(OMRatisHelper::smProtoToString);
+    return null;
+  }
+}
+

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/segmentparser/RatisLogParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/segmentparser/RatisLogParser.java
@@ -30,7 +30,8 @@ import picocli.CommandLine;
     subcommands = {
         DatanodeRatisLogParser.class,
         GenericRatisLogParser.class,
-        //TODO: Add more parsers like for OM and SCM here.
+        OMRatisLogParser.class
+        //TODO: After SCM HA implementation, we can add log parser for SCM.
     },
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a CLI command to dump OM ratis logs.

And also fix DNRatisParser test.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3008

## How was this patch tested?

Added UT and also tested via docker compose ozone-om-ha-s3 cluster.
