### PR TITLE
HDDS-3144. Fixed failed test case.

### DIFF
--- a/hadoop-ozone/insight/src/test/java/org/apache/hadoop/ozone/insight/TestLogSubcommand.java
+++ b/hadoop-ozone/insight/src/test/java/org/apache/hadoop/ozone/insight/TestLogSubcommand.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.insight;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -26,18 +25,17 @@ import org.junit.Test;
  */
 public class TestLogSubcommand {
 
-  @Ignore("HDDS-3144")
   @Test
   public void filterLog() {
     LogSubcommand logSubcommand = new LogSubcommand();
     String result = logSubcommand.processLogLine(
-        "2019-08-04 12:27:08,648 [TRACE|org.apache.hadoop.hdds.scm.node"
+        "2020-03-12 20:57:54,001 [TRACE|org.apache.hadoop.hdds.scm.node"
             + ".SCMNodeManager|SCMNodeManager] HB is received from "
             + "[datanode=localhost]: <json>storageReport {\\n  storageUuid: "
-            + "\"DS-29204db6-a615-4106-9dd4-ce294c2f4cf6\"\\n  "
-            + "storageLocation: \"/tmp/hadoop-elek/dfs/data\"\\n  capacity: "
-            + "8348086272\\n  scmUsed: 4096\\n  remaining: 8246956032n  "
-            + "storageType: DISK\\n  failed: falsen}\\n</json>\n");
-    Assert.assertEquals(3, result.split("\n").length);
+            + "\"DS-f65eb957-fc2d-4b77-b4a3-e96ae2bd2ca6\"\\n  "
+            + "storageLocation: \"/tmp/hadoop-neo/dfs/data\"\\n  capacity: "
+            + "250438021120\\n  scmUsed: 16384\\n  remaining: 212041244672\\n  "
+            + "storageType: DISK\\n  failed: false\\n}\\n</json>");
+    Assert.assertEquals(10, result.split("\n").length);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

I use the debugger to get a log string that calls the [processLogLine(...)](https://github.com/apache/hadoop-ozone/blob/c1997218a4e1a6695a275c73cf85360cd046329c/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/LogSubcommand.java#L147) method, which is:
```
2020-03-12 20:57:54,001 [TRACE|org.apache.hadoop.hdds.scm.node.SCMNodeManager|SCMNodeManager] HB is received from [datanode=localhost]: <json>storageReport {\n  storageUuid: "DS-f65eb957-fc2d-4b77-b4a3-e96ae2bd2ca6"\n  storageLocation: "/tmp/hadoop-neo/dfs/data"\n  capacity: 250438021120\n  scmUsed: 16384\n  remaining: 212041244672\n  storageType: DISK\n  failed: false\n}\n</json>
```
![debug1](https://user-images.githubusercontent.com/14295594/76533507-29b6f080-64b3-11ea-9ce0-397882d146a8.png)

When I call this method with this string as a parameter, it outputs:
```
2020-03-12 20:57:54,001 [TRACE|org.apache.hadoop.hdds.scm.node.SCMNodeManager|SCMNodeManager] HB is received from [datanode=localhost]: \n
storageReport {\n
  storageUuid: "DS-f65eb957-fc2d-4b77-b4a3-e96ae2bd2ca6"\n
  storageLocation: "/tmp/hadoop-neo/dfs/data"\n
  capacity: 250438021120\n
  scmUsed: 16384\n
  remaining: 212041244672\n
  storageType: DISK\n
  failed: false\n
}\n
```
![debug2](https://user-images.githubusercontent.com/14295594/76533741-7bf81180-64b3-11ea-93e6-121634481797.png)

Finally, I modified the test case to apply the above test strings and results.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3144

## How was this patch tested?

Ran UTs & checkstyle.sh