### PR TITLE
HDDS-3064. Get Key is hung when READ delay is injected in chunk file path.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -189,7 +189,14 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     ManagedChannel channel = channelBuilder.build();
     XceiverClientProtocolServiceStub asyncStub =
         XceiverClientProtocolServiceGrpc.newStub(channel);
-    asyncStubs.put(dn.getUuid(), asyncStub);
+    long duration = config.getTimeDuration(OzoneConfigKeys.
+            OZONE_CLIENT_READ_TIMEOUT, OzoneConfigKeys
+            .OZONE_CLIENT_READ_TIMEOUT_DEFAULT, TimeUnit.SECONDS);
+
+    // set the grpc dealine here so as if the response is not received
+    // in the configured time, the rpc will fail with DEADLINE_EXCEEDED here
+    asyncStubs.put(dn.getUuid(), asyncStub.withDeadlineAfter(duration,
+            TimeUnit.SECONDS));
     channels.put(dn.getUuid(), channel);
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -359,6 +359,9 @@ public final class OzoneConfigKeys {
   public static final String OZONE_CLIENT_VERIFY_CHECKSUM =
       "ozone.client.verify.checksum";
   public static final boolean OZONE_CLIENT_VERIFY_CHECKSUM_DEFAULT = true;
+  public static final String OZONE_CLIENT_READ_TIMEOUT
+          = "ozone.client.read.timeout";
+  public static final String OZONE_CLIENT_READ_TIMEOUT_DEFAULT = "30s";
   public static final String OZONE_ACL_AUTHORIZER_CLASS =
       "ozone.acl.authorizer.class";
   public static final String OZONE_ACL_AUTHORIZER_CLASS_DEFAULT =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1526,6 +1526,15 @@
   </property>
 
   <property>
+    <name>ozone.client.read.timeout</name>
+    <value>30s</value>
+    <tag>OZONE, CLIENT, MANAGEMENT</tag>
+    <description>
+      Timeout for ozone grpc client during read.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.om.lock.fair</name>
     <value>false</value>
     <description>If this is true, the Ozone Manager lock will be used in Fair


### PR DESCRIPTION


## What changes were proposed in this pull request?
Added a deadline for rpc stub in the read path. It will ensure if a rpc response does not complete
within the deadline, it will fail.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3064

## How was this patch tested?
It was verified in the actual test up where the problem originated.
