### PR TITLE
HDDS-3175. Healthy datanodes are marked as stale

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/RegisterEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/RegisterEndpointTask.java
@@ -102,25 +102,27 @@ public final class RegisterEndpointTask implements
   public EndpointStateMachine.EndPointStates call() throws Exception {
 
     if (getDatanodeDetails() == null) {
-      LOG.error("DatanodeDetails cannot be null in RegisterEndpoint task, " +
-          "shutting down the endpoint.");
+      LOG.error("DatanodeDetails cannot be null in RegisterEndpoint task, "
+          + "shutting down the endpoint.");
       return rpcEndPoint.setState(EndpointStateMachine.EndPointStates.SHUTDOWN);
     }
 
     rpcEndPoint.lock();
     try {
 
-      if (rpcEndPoint.getState().equals(
-          EndpointStateMachine.EndPointStates.REGISTER)) {
+      if (rpcEndPoint.getState()
+          .equals(EndpointStateMachine.EndPointStates.REGISTER)) {
         ContainerReportsProto containerReport =
             datanodeContainerManager.getController().getContainerReport();
         NodeReportProto nodeReport = datanodeContainerManager.getNodeReport();
-        PipelineReportsProto pipelineReportsProto = datanodeContainerManager.getPipelineReport();
+        PipelineReportsProto pipelineReportsProto =
+            datanodeContainerManager.getPipelineReport();
         // TODO : Add responses to the command Queue.
         SCMRegisteredResponseProto response = rpcEndPoint.getEndPoint()
             .register(datanodeDetails.getProtoBufMessage(), nodeReport,
                 containerReport, pipelineReportsProto);
-        Preconditions.checkState(UUID.fromString(response.getDatanodeUUID()).equals(datanodeDetails.getUuid()),
+        Preconditions.checkState(UUID.fromString(response.getDatanodeUUID())
+                .equals(datanodeDetails.getUuid()),
             "Unexpected datanode ID in the response.");
         Preconditions.checkState(!StringUtils.isBlank(response.getClusterID()),
             "Invalid cluster ID in the response.");
@@ -132,7 +134,8 @@ public final class RegisterEndpointTask implements
           datanodeDetails.setNetworkName(response.getNetworkName());
           datanodeDetails.setNetworkLocation(response.getNetworkLocation());
         }
-        EndpointStateMachine.EndPointStates nextState = rpcEndPoint.getState().getNextState();
+        EndpointStateMachine.EndPointStates nextState =
+            rpcEndPoint.getState().getNextState();
         rpcEndPoint.setState(nextState);
         rpcEndPoint.zeroMissedCount();
         this.stateContext.configureHeartbeatFrequency();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/RegisterEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/RegisterEndpointTask.java
@@ -110,33 +110,33 @@ public final class RegisterEndpointTask implements
     rpcEndPoint.lock();
     try {
 
-      ContainerReportsProto containerReport = datanodeContainerManager
-          .getController().getContainerReport();
-      NodeReportProto nodeReport = datanodeContainerManager.getNodeReport();
-      PipelineReportsProto pipelineReportsProto =
-              datanodeContainerManager.getPipelineReport();
-      // TODO : Add responses to the command Queue.
-      SCMRegisteredResponseProto response = rpcEndPoint.getEndPoint()
-          .register(datanodeDetails.getProtoBufMessage(), nodeReport,
-                  containerReport, pipelineReportsProto);
-      Preconditions.checkState(UUID.fromString(response.getDatanodeUUID())
-              .equals(datanodeDetails.getUuid()),
-          "Unexpected datanode ID in the response.");
-      Preconditions.checkState(!StringUtils.isBlank(response.getClusterID()),
-          "Invalid cluster ID in the response.");
-      if (response.hasHostname() && response.hasIpAddress()) {
-        datanodeDetails.setHostName(response.getHostname());
-        datanodeDetails.setIpAddress(response.getIpAddress());
+      if (rpcEndPoint.getState().equals(
+          EndpointStateMachine.EndPointStates.REGISTER)) {
+        ContainerReportsProto containerReport =
+            datanodeContainerManager.getController().getContainerReport();
+        NodeReportProto nodeReport = datanodeContainerManager.getNodeReport();
+        PipelineReportsProto pipelineReportsProto = datanodeContainerManager.getPipelineReport();
+        // TODO : Add responses to the command Queue.
+        SCMRegisteredResponseProto response = rpcEndPoint.getEndPoint()
+            .register(datanodeDetails.getProtoBufMessage(), nodeReport,
+                containerReport, pipelineReportsProto);
+        Preconditions.checkState(UUID.fromString(response.getDatanodeUUID()).equals(datanodeDetails.getUuid()),
+            "Unexpected datanode ID in the response.");
+        Preconditions.checkState(!StringUtils.isBlank(response.getClusterID()),
+            "Invalid cluster ID in the response.");
+        if (response.hasHostname() && response.hasIpAddress()) {
+          datanodeDetails.setHostName(response.getHostname());
+          datanodeDetails.setIpAddress(response.getIpAddress());
+        }
+        if (response.hasNetworkName() && response.hasNetworkLocation()) {
+          datanodeDetails.setNetworkName(response.getNetworkName());
+          datanodeDetails.setNetworkLocation(response.getNetworkLocation());
+        }
+        EndpointStateMachine.EndPointStates nextState = rpcEndPoint.getState().getNextState();
+        rpcEndPoint.setState(nextState);
+        rpcEndPoint.zeroMissedCount();
+        this.stateContext.configureHeartbeatFrequency();
       }
-      if (response.hasNetworkName() && response.hasNetworkLocation()) {
-        datanodeDetails.setNetworkName(response.getNetworkName());
-        datanodeDetails.setNetworkLocation(response.getNetworkLocation());
-      }
-      EndpointStateMachine.EndPointStates nextState =
-          rpcEndPoint.getState().getNextState();
-      rpcEndPoint.setState(nextState);
-      rpcEndPoint.zeroMissedCount();
-      this.stateContext.configureHeartbeatFrequency();
     } catch (IOException ex) {
       rpcEndPoint.logIfNeeded(ex);
     } finally {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The datanode state machine stops as the state moves to SHUTDOWN. As a result datanode stops sending heartbeats to SCM.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3175

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

On the cluster.
