### PR TITLE
HDDS-3170. Fix issues in File count by size task.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerKeyMapperTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerKeyMapperTask.java
@@ -127,6 +127,17 @@ public class ContainerKeyMapperTask implements ReconOmTask {
           deleteOMKeyFromContainerDB(updatedKey);
           break;
 
+        case UPDATE:
+          if (omdbUpdateEvent.getOldValue() != null) {
+            deleteOMKeyFromContainerDB(
+                omdbUpdateEvent.getOldValue().getKeyName());
+          } else {
+            LOG.warn("Update event does not have the old Key Info for {}.",
+                updatedKey);
+          }
+          writeOMKeyToContainerDB(updatedKey, updatedKeyValue);
+          break;
+
         default: LOG.debug("Skipping DB update event : {}",
             omdbUpdateEvent.getAction());
         }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.recon.tasks;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -38,10 +39,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
-import static org.apache.hadoop.ozone.recon.tasks.
-    OMDBUpdateEvent.OMDBUpdateAction.DELETE;
-import static org.apache.hadoop.ozone.recon.tasks.
-    OMDBUpdateEvent.OMDBUpdateAction.PUT;
 
 /**
  * Class to iterate over the OM DB and store the counts of existing/new
@@ -95,15 +92,13 @@ public class FileSizeCountTask implements ReconOmTask {
         keyIter = omKeyInfoTable.iterator()) {
       while (keyIter.hasNext()) {
         Table.KeyValue<String, OmKeyInfo> kv = keyIter.next();
-
-        // reprocess() is a PUT operation on the DB.
-        updateUpperBoundCount(kv.getValue(), PUT);
+        handlePutKeyEvent(kv.getValue());
       }
     } catch (IOException ioEx) {
       LOG.error("Unable to populate File Size Count in Recon DB. ", ioEx);
       return new ImmutablePair<>(getTaskName(), false);
     }
-    populateFileCountBySizeDB();
+    writeCountsToDB();
 
     LOG.info("Completed a 'reprocess' run of FileSizeCountTask.");
     return new ImmutablePair<>(getTaskName(), true);
@@ -119,7 +114,7 @@ public class FileSizeCountTask implements ReconOmTask {
     return Collections.singletonList(KEY_TABLE);
   }
 
-  private void updateCountFromDB() {
+  private void readCountsFromDB() {
     // Read - Write operations to DB are in ascending order
     // of file size upper bounds.
     List<FileCountBySize> resultSet = fileCountBySizeDao.findAll();
@@ -144,8 +139,7 @@ public class FileSizeCountTask implements ReconOmTask {
     Iterator<OMDBUpdateEvent> eventIterator = events.getIterator();
 
     //update array with file size count from DB
-    updateCountFromDB();
-
+    readCountsFromDB();
     while (eventIterator.hasNext()) {
       OMDBUpdateEvent<String, OmKeyInfo> omdbUpdateEvent = eventIterator.next();
       String updatedKey = omdbUpdateEvent.getKey();
@@ -154,23 +148,28 @@ public class FileSizeCountTask implements ReconOmTask {
       try{
         switch (omdbUpdateEvent.getAction()) {
         case PUT:
-          updateUpperBoundCount(omKeyInfo, PUT);
+          handlePutKeyEvent(omKeyInfo);
           break;
 
         case DELETE:
-          updateUpperBoundCount(omKeyInfo, DELETE);
+          handleDeleteKeyEvent(updatedKey, omKeyInfo);
+          break;
+
+        case UPDATE:
+          handleDeleteKeyEvent(updatedKey, omdbUpdateEvent.getOldValue());
+          handlePutKeyEvent(omKeyInfo);
           break;
 
         default: LOG.trace("Skipping DB update event : {}",
             omdbUpdateEvent.getAction());
         }
       } catch (Exception e) {
-        LOG.error("Unexpected exception while updating key data : {} {}",
-                updatedKey, e.getMessage());
+        LOG.error("Unexpected exception while processing key {}.",
+                updatedKey, e);
         return new ImmutablePair<>(getTaskName(), false);
       }
-      populateFileCountBySizeDB();
     }
+    writeCountsToDB();
     LOG.info("Completed a 'process' run of FileSizeCountTask.");
     return new ImmutablePair<>(getTaskName(), true);
   }
@@ -207,7 +206,7 @@ public class FileSizeCountTask implements ReconOmTask {
    * using the dao.
    *
    */
-  void populateFileCountBySizeDB() {
+  void writeCountsToDB() {
     for (int i = 0; i < upperBoundCount.length; i++) {
       long fileSizeUpperBound = (i == upperBoundCount.length - 1) ?
           Long.MAX_VALUE : (long) Math.pow(2, (10 + i));
@@ -229,22 +228,39 @@ public class FileSizeCountTask implements ReconOmTask {
    * Used by reprocess() and process().
    *
    * @param omKeyInfo OmKey being updated for count
-   * @param operation (PUT, DELETE)
    */
-  void updateUpperBoundCount(OmKeyInfo omKeyInfo,
-      OMDBUpdateEvent.OMDBUpdateAction operation) {
+  void handlePutKeyEvent(OmKeyInfo omKeyInfo) {
     int binIndex = calculateBinIndex(omKeyInfo.getDataSize());
-    if (operation == PUT) {
-      upperBoundCount[binIndex]++;
-    } else if (operation == DELETE) {
-      if (upperBoundCount[binIndex] != 0) {
+    upperBoundCount[binIndex]++;
+  }
+
+  /**
+   * Calculate and update the count of files being tracked by
+   * upperBoundCount[].
+   * Used by reprocess() and process().
+   *
+   * @param omKeyInfo OmKey being updated for count
+   */
+  void handleDeleteKeyEvent(String key, OmKeyInfo omKeyInfo) {
+    if (omKeyInfo == null) {
+      LOG.warn("Unexpected error while handling DELETE key event. Key not " +
+          "found in Recon OM DB : {}", key);
+    } else {
+      int binIndex = calculateBinIndex(omKeyInfo.getDataSize());
+      if (upperBoundCount[binIndex] > 0) {
         //decrement only if it had files before, default DB value is 0
         upperBoundCount[binIndex]--;
       } else {
         LOG.warn("Unexpected error while updating bin count. Found 0 count " +
-            "for index : {} while processing DELETE event for {}", binIndex,
+                "for index : {} while processing DELETE event for {}", binIndex,
             omKeyInfo.getKeyName());
       }
     }
   }
+
+  @VisibleForTesting
+  protected long[] getUpperBoundCount() {
+    return upperBoundCount;
+  }
+
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -252,7 +252,7 @@ public class FileSizeCountTask implements ReconOmTask {
         upperBoundCount[binIndex]--;
       } else {
         LOG.warn("Unexpected error while updating bin count. Found 0 count " +
-                "for index : {} while processing DELETE event for {}", binIndex,
+            "for index : {} while processing DELETE event for {}", binIndex,
             omKeyInfo.getKeyName());
       }
     }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdateEvent.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdateEvent.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.ozone.recon.tasks;
 
+import java.util.Objects;
+
 /**
  * A class used to encapsulate a single OM DB update event.
  * Currently only PUT and DELETE are supported.
@@ -30,17 +32,20 @@ public final class OMDBUpdateEvent<KEY, VALUE> {
   private final String table;
   private final KEY updatedKey;
   private final VALUE updatedValue;
+  private final VALUE oldValue;
   private final long sequenceNumber;
 
   private OMDBUpdateEvent(OMDBUpdateAction action,
                           String table,
                           KEY updatedKey,
                           VALUE updatedValue,
+                          VALUE oldValue,
                           long sequenceNumber) {
     this.action = action;
     this.table = table;
     this.updatedKey = updatedKey;
     this.updatedValue = updatedValue;
+    this.oldValue = oldValue;
     this.sequenceNumber = sequenceNumber;
   }
 
@@ -60,8 +65,30 @@ public final class OMDBUpdateEvent<KEY, VALUE> {
     return updatedValue;
   }
 
+  public VALUE getOldValue() {
+    return oldValue;
+  }
+
   public long getSequenceNumber() {
     return sequenceNumber;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    OMDBUpdateEvent that = (OMDBUpdateEvent) o;
+    return this.updatedKey.equals(that.updatedKey) &&
+        this.action.equals(that.action);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(updatedKey, action);
   }
 
   /**
@@ -74,6 +101,7 @@ public final class OMDBUpdateEvent<KEY, VALUE> {
     private OMDBUpdateAction action;
     private String table;
     private KEY updatedKey;
+    private VALUE oldValue;
     private VALUE updatedValue;
     private long lastSequenceNumber;
 
@@ -97,6 +125,11 @@ public final class OMDBUpdateEvent<KEY, VALUE> {
       return this;
     }
 
+    OMUpdateEventBuilder setOldValue(VALUE value) {
+      this.oldValue = value;
+      return this;
+    }
+
     OMUpdateEventBuilder setSequenceNumber(long sequenceNumber) {
       this.lastSequenceNumber = sequenceNumber;
       return this;
@@ -112,6 +145,7 @@ public final class OMDBUpdateEvent<KEY, VALUE> {
           table,
           updatedKey,
           updatedValue,
+          oldValue,
           lastSequenceNumber);
     }
   }
@@ -120,6 +154,6 @@ public final class OMDBUpdateEvent<KEY, VALUE> {
    * Supported Actions - PUT, DELETE.
    */
   public enum OMDBUpdateAction {
-    PUT, DELETE
+    PUT, DELETE, UPDATE
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
@@ -104,7 +104,7 @@ public class OMDBUpdatesHandler extends WriteBatch.Handler {
       String key = codecRegistry.asObject(keyBytes, keyType);
       builder.setKey(key);
 
-      if (action.equals(PUT)) {
+      if (action == PUT) {
         Object value = codecRegistry.asObject(valueBytes, valueType);
         builder.setValue(value);
         // If a PUT key operation happens on an existing Key, it is tagged

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
@@ -21,6 +21,9 @@ package org.apache.hadoop.ozone.recon.tasks;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
+import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.DELETE;
+import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.PUT;
+import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.UPDATE;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,11 +51,13 @@ public class OMDBUpdatesHandler extends WriteBatch.Handler {
 
   private Map<Integer, String> tablesNames;
   private CodecRegistry codecRegistry;
+  private OMMetadataManager omMetadataManager;
   private List<OMDBUpdateEvent> omdbUpdateEvents = new ArrayList<>();
 
-  public OMDBUpdatesHandler(OMMetadataManager omMetadataManager) {
-    tablesNames = omMetadataManager.getStore().getTableNames();
-    codecRegistry = omMetadataManager.getStore().getCodecRegistry();
+  public OMDBUpdatesHandler(OMMetadataManager metadataManager) {
+    omMetadataManager = metadataManager;
+    tablesNames = metadataManager.getStore().getTableNames();
+    codecRegistry = metadataManager.getStore().getCodecRegistry();
   }
 
   @Override
@@ -88,30 +93,47 @@ public class OMDBUpdatesHandler extends WriteBatch.Handler {
       valueBytes, OMDBUpdateEvent.OMDBUpdateAction action)
       throws IOException {
     String tableName = tablesNames.get(cfIndex);
-    Class keyType = getKeyType();
+    Class<String> keyType = getKeyType();
     Class valueType = getValueType(tableName);
     if (valueType != null) {
       OMDBUpdateEvent.OMUpdateEventBuilder builder =
           new OMDBUpdateEvent.OMUpdateEventBuilder<>();
       builder.setTable(tableName);
+      builder.setAction(action);
 
-      Object key = codecRegistry.asObject(keyBytes, keyType);
+      String key = codecRegistry.asObject(keyBytes, keyType);
       builder.setKey(key);
 
-      if (!action.equals(OMDBUpdateEvent.OMDBUpdateAction.DELETE)) {
+      if (action.equals(PUT)) {
         Object value = codecRegistry.asObject(valueBytes, valueType);
         builder.setValue(value);
+        // If a PUT key operation happens on an existing Key, it is tagged
+        // as an "UPDATE" event.
+        if (tableName.equalsIgnoreCase(KEY_TABLE)) {
+          if (omMetadataManager.getKeyTable().isExist(key)) {
+            OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable().get(key);
+            builder.setOldValue(omKeyInfo);
+            builder.setAction(UPDATE);
+          }
+        }
+      } else if (action.equals(DELETE)) {
+        // When you delete a Key, we add the old OmKeyInfo to the event so that
+        // a downstream task can use it.
+        if (tableName.equalsIgnoreCase(KEY_TABLE)) {
+          OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable().get(key);
+          builder.setValue(omKeyInfo);
+        }
       }
 
-      builder.setAction(action);
       OMDBUpdateEvent event = builder.build();
       LOG.debug("Generated OM update Event for table : " + event.getTable()
           + ", Key = " + event.getKey() + ", action = " + event.getAction());
-      // Temporarily adding to an event buffer for testing. In subsequent JIRAs,
-      // a Recon side class will be implemented that requests delta updates
-      // from OM and calls on this handler. In that case, we will fill up
-      // this buffer and pass it on to the ReconTaskController which has
-      // tasks waiting on OM events.
+      if (omdbUpdateEvents.contains(event)) {
+        // If the same event is part of this batch, the last one only holds.
+        // For example, if there are 2 PUT key1 events, then the first one
+        // can be discarded.
+        omdbUpdateEvents.remove(event);
+      }
       omdbUpdateEvents.add(event);
     }
   }
@@ -244,7 +266,7 @@ public class OMDBUpdatesHandler extends WriteBatch.Handler {
    * @param name table name.
    * @return String.class by default.
    */
-  private Class getKeyType() {
+  private Class<String> getKeyType() {
     return String.class;
   }
 
@@ -264,7 +286,7 @@ public class OMDBUpdatesHandler extends WriteBatch.Handler {
   }
 
   /**
-   * Get List of events. (Temporary API to unit test the class).
+   * Get List of events.
    * @return List of events.
    */
   public List<OMDBUpdateEvent> getEvents() {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestFileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestFileSizeCountTask.java
@@ -18,28 +18,51 @@
 
 package org.apache.hadoop.ozone.recon.tasks;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.hdds.utils.db.TypedTable;
+import org.apache.hadoop.ozone.recon.persistence.AbstractSqlDatabaseTest;
+import org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMUpdateEventBuilder;
+import org.hadoop.ozone.recon.schema.UtilizationSchemaDefinition;
+import org.hadoop.ozone.recon.schema.tables.daos.FileCountBySizeDao;
+import org.jooq.Configuration;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Arrays;
 
+import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.DELETE;
 import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.PUT;
+import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.UPDATE;
 import static org.junit.Assert.assertEquals;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 /**
  * Unit test for File Size Count Task.
  */
-public class TestFileSizeCountTask {
+public class TestFileSizeCountTask extends AbstractSqlDatabaseTest {
+
+  private FileCountBySizeDao fileCountBySizeDao;
+
+  @Before
+  public void setUp() throws SQLException {
+    UtilizationSchemaDefinition schemaDefinition =
+        getInjector().getInstance(UtilizationSchemaDefinition.class);
+    schemaDefinition.initializeSchema();
+    Configuration sqlConfiguration =
+        getInjector().getInstance((Configuration.class));
+    fileCountBySizeDao = new FileCountBySizeDao(sqlConfiguration);
+  }
+
   @Test
   public void testCalculateBinIndex() {
     FileSizeCountTask fileSizeCountTask = mock(FileSizeCountTask.class);
@@ -94,14 +117,13 @@ public class TestFileSizeCountTask {
   }
 
   @Test
-  public void testFileCountBySizeReprocess() throws IOException {
+  public void testReprocess() throws IOException {
     OmKeyInfo omKeyInfo1 = mock(OmKeyInfo.class);
     given(omKeyInfo1.getKeyName()).willReturn("key1");
     given(omKeyInfo1.getDataSize()).willReturn(1000L);
 
     OMMetadataManager omMetadataManager = mock(OmMetadataManagerImpl.class);
     TypedTable<String, OmKeyInfo> keyTable = mock(TypedTable.class);
-
 
     TypedTable.TypedTableIterator mockKeyIter = mock(TypedTable
         .TypedTableIterator.class);
@@ -114,17 +136,88 @@ public class TestFileSizeCountTask {
     when(mockKeyIter.next()).thenReturn(mockKeyValue);
     when(mockKeyValue.getValue()).thenReturn(omKeyInfo1);
 
-    FileSizeCountTask fileSizeCountTask = mock(FileSizeCountTask.class);
-    when(fileSizeCountTask.getMaxFileSizeUpperBound()).
-        thenReturn(4096L);
-    when(fileSizeCountTask.getOneKB()).thenReturn(1024L);
+    FileSizeCountTask fileSizeCountTask =
+        new FileSizeCountTask(fileCountBySizeDao);
+    Pair<String, Boolean> result =
+        fileSizeCountTask.reprocess(omMetadataManager);
+    assertTrue(result.getRight());
 
-    when(fileSizeCountTask.reprocess(omMetadataManager)).thenCallRealMethod();
-    //call reprocess()
-    fileSizeCountTask.reprocess(omMetadataManager);
-    verify(fileSizeCountTask, times(1)).
-        updateUpperBoundCount(omKeyInfo1, PUT);
-    verify(fileSizeCountTask,
-        times(1)).populateFileCountBySizeDB();
+    long[] upperBoundCount = fileSizeCountTask.getUpperBoundCount();
+    assertEquals(1, upperBoundCount[0]);
+    for (int i = 1; i < upperBoundCount.length; i++) {
+      assertEquals(0, upperBoundCount[i]);
+    }
+  }
+
+  @Test
+  public void testProcess() {
+    FileSizeCountTask fileSizeCountTask =
+        new FileSizeCountTask(fileCountBySizeDao);
+
+    // Write 2 keys.
+    OmKeyInfo toBeDeletedKey = mock(OmKeyInfo.class);
+    given(toBeDeletedKey.getKeyName()).willReturn("deletedKey");
+    given(toBeDeletedKey.getDataSize()).willReturn(2000L); // Bin 1
+    OMDBUpdateEvent event = new OMUpdateEventBuilder()
+        .setAction(PUT)
+        .setKey("deletedKey")
+        .setValue(toBeDeletedKey)
+        .build();
+
+    OmKeyInfo toBeUpdatedKey = mock(OmKeyInfo.class);
+    given(toBeUpdatedKey.getKeyName()).willReturn("updatedKey");
+    given(toBeUpdatedKey.getDataSize()).willReturn(10000L); // Bin 4
+    OMDBUpdateEvent event2 = new OMUpdateEventBuilder()
+        .setAction(PUT)
+        .setKey("updatedKey")
+        .setValue(toBeUpdatedKey)
+        .build();
+
+    OMUpdateEventBatch omUpdateEventBatch =
+        new OMUpdateEventBatch(Arrays.asList(event, event2));
+    fileSizeCountTask.process(omUpdateEventBatch);
+
+    // Verify 2 keys are in correct bins.
+    long[] upperBoundCount = fileSizeCountTask.getUpperBoundCount();
+    assertEquals(1, upperBoundCount[4]); // updatedKey
+    assertEquals(1, upperBoundCount[1]); // deletedKey
+
+    // Add new key.
+    OmKeyInfo newKey = mock(OmKeyInfo.class);
+    given(newKey.getKeyName()).willReturn("newKey");
+    given(newKey.getDataSize()).willReturn(1000L); // Bin 0
+    OMDBUpdateEvent putEvent = new OMUpdateEventBuilder()
+        .setAction(PUT)
+        .setKey("newKey")
+        .setValue(newKey)
+        .build();
+
+    // Update existing key.
+    OmKeyInfo updatedKey = mock(OmKeyInfo.class);
+    given(updatedKey.getKeyName()).willReturn("updatedKey");
+    given(updatedKey.getDataSize()).willReturn(50000L); // Bin 6
+    OMDBUpdateEvent updateEvent = new OMUpdateEventBuilder()
+        .setAction(UPDATE)
+        .setKey("updatedKey")
+        .setValue(updatedKey)
+        .setOldValue(toBeUpdatedKey)
+        .build();
+
+    // Delete another existing key.
+    OMDBUpdateEvent deleteEvent = new OMUpdateEventBuilder()
+        .setAction(DELETE)
+        .setKey("deletedKey")
+        .setValue(toBeDeletedKey)
+        .build();
+
+    omUpdateEventBatch = new OMUpdateEventBatch(
+        Arrays.asList(updateEvent, putEvent, deleteEvent));
+    fileSizeCountTask.process(omUpdateEventBatch);
+
+    upperBoundCount = fileSizeCountTask.getUpperBoundCount();
+    assertEquals(1, upperBoundCount[0]); // newKey
+    assertEquals(0, upperBoundCount[1]); // deletedKey
+    assertEquals(0, upperBoundCount[4]); // updatedKey old
+    assertEquals(1, upperBoundCount[6]); // updatedKey new
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Recon has a task to maintain the number of files created in Ozone across various size bins (https://issues.apache.org/jira/browse/HDDS-1366). However, there are some bugs in the task's handling of DELETE and existing key PUT key operations from OM. This patch fixes the issues and adds tests to capture issues. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3170

## How was this patch tested?
Manually tested on docker.
Added unit tests for the new cases.