### PR TITLE
HDDS-1995. Generate renewTime on OMLeader for GetDelegationToken

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -162,9 +162,8 @@ public class OzoneDelegationTokenSecretManager
    * @return renewTime - If updated successfully, return renewTime.
    */
   public long updateToken(Token<OzoneTokenIdentifier> token,
-      OzoneTokenIdentifier ozoneTokenIdentifier) {
-    long renewTime =
-        ozoneTokenIdentifier.getIssueDate() + getTokenRenewInterval();
+      OzoneTokenIdentifier ozoneTokenIdentifier, long tokenRenewInterval) {
+    long renewTime = ozoneTokenIdentifier.getIssueDate() + tokenRenewInterval;
     TokenInfo tokenInfo = new TokenInfo(renewTime, token.getPassword(),
         ozoneTokenIdentifier.getTrackingId());
     currentTokens.put(ozoneTokenIdentifier, tokenInfo);

--- a/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
+++ b/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
@@ -380,6 +380,7 @@ message UserInfo {
 */
 message UpdateGetDelegationTokenRequest {
     required GetDelegationTokenResponseProto getDelegationTokenResponse = 1;
+    optional uint64 tokenRenewInterval = 2;
 }
 
 /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMGetDelegationTokenRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMGetDelegationTokenRequest.java
@@ -86,7 +86,9 @@ public class OMGetDelegationTokenRequest extends OMClientRequest {
                               SecurityProtos.GetDelegationTokenResponseProto
                               .newBuilder().setToken(OMPBHelper
                                   .convertToTokenProto(token)).build())
-                          .build()))
+                          .build())
+                  .setTokenRenewInterval(ozoneManager.getDelegationTokenMgr()
+                      .getTokenRenewInterval()))
           .setCmdType(getOmRequest().getCmdType())
           .setClientId(getOmRequest().getClientId());
 
@@ -151,8 +153,11 @@ public class OMGetDelegationTokenRequest extends OMClientRequest {
           readProtoBuf(ozoneTokenIdentifierToken.getIdentifier());
 
       // Update in memory map of token.
+      long tokenRenewInterval = updateGetDelegationTokenRequest
+          .getTokenRenewInterval();
       long renewTime = ozoneManager.getDelegationTokenMgr()
-          .updateToken(ozoneTokenIdentifierToken, ozoneTokenIdentifier);
+          .updateToken(ozoneTokenIdentifierToken, ozoneTokenIdentifier,
+              tokenRenewInterval);
 
      // Update Cache.
       omMetadataManager.getDelegationTokenTable().addCacheEntry(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use renewTimeInterval of the OM leader across quorum of OM's.

Right now each OM generates renew time when updating token in-memory and DB using its own configured HDDS_BLOCK_TOKEN_EXPIRY_TIME.

If different OM's have different token renew interval set, for the same token we will have different renewal time across a quorum of OM's.
This Jira is to fix this issue.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-1995

## How was this patch tested?

Currently no unit tests for GetDelegationTokenRequest. Will add in the next commit.