### PR TITLE
HDDS-3179 Pipeline placement based on Topology does not have fallback

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -70,7 +70,7 @@ public class DatanodeDetails extends NodeImpl implements
     this.certSerialId = certSerialId;
   }
 
-  protected DatanodeDetails(DatanodeDetails datanodeDetails) {
+  public DatanodeDetails(DatanodeDetails datanodeDetails) {
     super(datanodeDetails.getHostName(), datanodeDetails.getNetworkLocation(),
         datanodeDetails.getCost());
     this.uuid = datanodeDetails.uuid;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -408,7 +408,7 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
   @VisibleForTesting
   protected DatanodeDetails chooseNodeFromNetworkTopology(
       NetworkTopology networkTopology, DatanodeDetails anchor,
-      List<DatanodeDetails> excludedNodes) throws SCMException {
+      List<DatanodeDetails> excludedNodes) {
     Preconditions.checkArgument(networkTopology != null);
 
     Collection<Node> excluded = new ArrayList<>();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -94,6 +94,7 @@ public class MockNodeManager implements NodeManager {
   private ConcurrentMap<String, Set<String>> dnsToUuidMap;
 
   public MockNodeManager(NetworkTopologyImpl clusterMap,
+                         List<DatanodeDetails> nodes,
                          boolean initializeFakeNodes, int nodeCount) {
     this.healthyNodes = new LinkedList<>();
     this.staleNodes = new LinkedList<>();
@@ -104,6 +105,13 @@ public class MockNodeManager implements NodeManager {
     this.dnsToUuidMap = new ConcurrentHashMap<>();
     this.aggregateStat = new SCMNodeStat();
     this.clusterMap = clusterMap;
+    if (!nodes.isEmpty()) {
+      for (int x = 0; x < nodes.size(); x++) {
+        DatanodeDetails node = nodes.get(x);
+        register(node, null, null);
+        populateNodeMetric(node, x);
+      }
+    }
     if (initializeFakeNodes) {
       for (int x = 0; x < nodeCount; x++) {
         DatanodeDetails dd = MockDatanodeDetails.randomDatanodeDetails();
@@ -116,7 +124,7 @@ public class MockNodeManager implements NodeManager {
   }
 
   public MockNodeManager(boolean initializeFakeNodes, int nodeCount) {
-    this(new NetworkTopologyImpl(new OzoneConfiguration()),
+    this(new NetworkTopologyImpl(new OzoneConfiguration()), new ArrayList<>(),
         initializeFakeNodes, nodeCount);
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdds.scm.pipeline;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.MockNodeManager;
@@ -35,6 +36,9 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
+import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
+import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
+import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
 
 /**
  * Test for PipelinePlacementPolicy.
@@ -43,25 +47,55 @@ public class TestPipelinePlacementPolicy {
   private MockNodeManager nodeManager;
   private OzoneConfiguration conf;
   private PipelinePlacementPolicy placementPolicy;
+  private NetworkTopologyImpl cluster;
   private static final int PIPELINE_PLACEMENT_MAX_NODES_COUNT = 10;
+
+  private List<DatanodeDetails> nodesWithOutRackAwareness = new ArrayList<>();
+  private List<DatanodeDetails> nodesWithRackAwareness = new ArrayList<>();
 
   @Before
   public void init() throws Exception {
-    nodeManager = new MockNodeManager(true,
-        PIPELINE_PLACEMENT_MAX_NODES_COUNT);
+    cluster = initTopology();
+    // start with nodes with rack awareness.
+    nodeManager = new MockNodeManager(cluster, getNodesWithRackAwareness(),
+        false, PIPELINE_PLACEMENT_MAX_NODES_COUNT);
     conf = new OzoneConfiguration();
     conf.setInt(OZONE_DATANODE_PIPELINE_LIMIT, 5);
     placementPolicy = new PipelinePlacementPolicy(
         nodeManager, new PipelineStateManager(), conf);
   }
 
+  private NetworkTopologyImpl initTopology() {
+    NodeSchema[] schemas = new NodeSchema[]
+        {ROOT_SCHEMA, RACK_SCHEMA, LEAF_SCHEMA};
+    NodeSchemaManager.getInstance().init(schemas, true);
+    NetworkTopologyImpl topology =
+        new NetworkTopologyImpl(NodeSchemaManager.getInstance());
+    return topology;
+  }
+
+  private List<DatanodeDetails> getNodesWithRackAwareness() {
+    List<DatanodeDetails> datanodes = new ArrayList<>();
+    for (Node node : NODES) {
+      DatanodeDetails datanode = overwriteLocationInNode(
+          getNodesWithoutRackAwareness(), node);
+      nodesWithRackAwareness.add(datanode);
+      datanodes.add(datanode);
+    }
+    return datanodes;
+  }
+
+  private DatanodeDetails getNodesWithoutRackAwareness() {
+    DatanodeDetails node = MockDatanodeDetails.randomDatanodeDetails();
+    nodesWithOutRackAwareness.add(node);
+    return node;
+  }
+
   @Test
-  public void testChooseNodeBasedOnNetworkTopology() {
-    List<DatanodeDetails> healthyNodes =
-        nodeManager.getNodes(HddsProtos.NodeState.HEALTHY);
-    DatanodeDetails anchor = placementPolicy.chooseNode(healthyNodes);
+  public void testChooseNodeBasedOnNetworkTopology() throws SCMException {
+    DatanodeDetails anchor = placementPolicy.chooseNode(nodesWithRackAwareness);
     // anchor should be removed from healthyNodes after being chosen.
-    Assert.assertFalse(healthyNodes.contains(anchor));
+    Assert.assertFalse(nodesWithRackAwareness.contains(anchor));
 
     List<DatanodeDetails> excludedNodes =
         new ArrayList<>(PIPELINE_PLACEMENT_MAX_NODES_COUNT);
@@ -69,8 +103,11 @@ public class TestPipelinePlacementPolicy {
     DatanodeDetails nextNode = placementPolicy.chooseNodeFromNetworkTopology(
         nodeManager.getClusterNetworkTopologyMap(), anchor, excludedNodes);
     Assert.assertFalse(excludedNodes.contains(nextNode));
-    // nextNode should not be the same as anchor.
+    // next node should not be the same as anchor.
     Assert.assertTrue(anchor.getUuid() != nextNode.getUuid());
+    // next node should be on the same rack based on topology.
+    Assert.assertEquals(anchor.getNetworkLocation(),
+        nextNode.getNetworkLocation());
   }
 
   @Test
@@ -84,8 +121,9 @@ public class TestPipelinePlacementPolicy {
         healthyNodes, new ArrayList<>(PIPELINE_PLACEMENT_MAX_NODES_COUNT),
         topologyWithDifRacks, anchor);
     Assert.assertNotNull(nextNode);
-    Assert.assertFalse(anchor.getNetworkLocation().equals(
-        nextNode.getNetworkLocation()));
+    // next node should be on a different rack.
+    Assert.assertNotEquals(anchor.getNetworkLocation(),
+        nextNode.getNetworkLocation());
   }
 
   @Test
@@ -115,25 +153,25 @@ public class TestPipelinePlacementPolicy {
 
   @Test
   public void testRackAwarenessNotEnabledWithFallBack() throws SCMException{
-    List<DatanodeDetails> healthyNodes =
-        nodeManager.getNodes(HddsProtos.NodeState.HEALTHY);
-    DatanodeDetails anchor = placementPolicy.chooseNode(healthyNodes);
-    DatanodeDetails randomNode = placementPolicy.chooseNode(healthyNodes);
+    DatanodeDetails anchor = placementPolicy
+        .chooseNode(nodesWithOutRackAwareness);
+    DatanodeDetails randomNode = placementPolicy
+        .chooseNode(nodesWithOutRackAwareness);
     // rack awareness is not enabled.
     Assert.assertTrue(anchor.getNetworkLocation().equals(
         randomNode.getNetworkLocation()));
 
     NetworkTopology topology = new NetworkTopologyImpl(new Configuration());
     DatanodeDetails nextNode = placementPolicy.chooseNodeBasedOnRackAwareness(
-        healthyNodes, new ArrayList<>(PIPELINE_PLACEMENT_MAX_NODES_COUNT),
-        topology, anchor);
+        nodesWithOutRackAwareness, new ArrayList<>(
+            PIPELINE_PLACEMENT_MAX_NODES_COUNT), topology, anchor);
     // RackAwareness should not be able to choose any node.
     Assert.assertNull(nextNode);
 
     // PlacementPolicy should still be able to pick a set of 3 nodes.
     int numOfNodes = HddsProtos.ReplicationFactor.THREE.getNumber();
     List<DatanodeDetails> results = placementPolicy
-        .getResultSet(numOfNodes, healthyNodes);
+        .getResultSet(numOfNodes, nodesWithOutRackAwareness);
     
     Assert.assertEquals(numOfNodes, results.size());
     // All nodes are on same rack.
@@ -146,12 +184,12 @@ public class TestPipelinePlacementPolicy {
   private final static Node[] NODES = new NodeImpl[] {
       new NodeImpl("h1", "/r1", NetConstants.NODE_COST_DEFAULT),
       new NodeImpl("h2", "/r1", NetConstants.NODE_COST_DEFAULT),
-      new NodeImpl("h3", "/r1", NetConstants.NODE_COST_DEFAULT),
-      new NodeImpl("h4", "/r1", NetConstants.NODE_COST_DEFAULT),
-      new NodeImpl("h5", "/r2", NetConstants.NODE_COST_DEFAULT),
-      new NodeImpl("h6", "/r2", NetConstants.NODE_COST_DEFAULT),
-      new NodeImpl("h7", "/r2", NetConstants.NODE_COST_DEFAULT),
-      new NodeImpl("h8", "/r2", NetConstants.NODE_COST_DEFAULT),
+      new NodeImpl("h3", "/r2", NetConstants.NODE_COST_DEFAULT),
+      new NodeImpl("h4", "/r2", NetConstants.NODE_COST_DEFAULT),
+      new NodeImpl("h5", "/r3", NetConstants.NODE_COST_DEFAULT),
+      new NodeImpl("h6", "/r3", NetConstants.NODE_COST_DEFAULT),
+      new NodeImpl("h7", "/r4", NetConstants.NODE_COST_DEFAULT),
+      new NodeImpl("h8", "/r4", NetConstants.NODE_COST_DEFAULT),
   };
 
 
@@ -163,20 +201,26 @@ public class TestPipelinePlacementPolicy {
     return topology;
   }
 
+  private DatanodeDetails overwriteLocationInNode(
+      DatanodeDetails datanode, Node node) {
+    DatanodeDetails result = DatanodeDetails.newBuilder()
+        .setUuid(datanode.getUuidString())
+        .setHostName(datanode.getHostName())
+        .setIpAddress(datanode.getIpAddress())
+        .addPort(datanode.getPort(DatanodeDetails.Port.Name.STANDALONE))
+        .addPort(datanode.getPort(DatanodeDetails.Port.Name.RATIS))
+        .addPort(datanode.getPort(DatanodeDetails.Port.Name.REST))
+        .setNetworkLocation(node.getNetworkLocation()).build();
+    return result;
+  }
+
   private List<DatanodeDetails> overWriteLocationInNodes(
       List<DatanodeDetails> datanodes) {
     List<DatanodeDetails> results = new ArrayList<>(datanodes.size());
     for (int i = 0; i < datanodes.size(); i++) {
-      DatanodeDetails datanode = datanodes.get(i);
-      DatanodeDetails result = DatanodeDetails.newBuilder()
-          .setUuid(datanode.getUuidString())
-          .setHostName(datanode.getHostName())
-          .setIpAddress(datanode.getIpAddress())
-          .addPort(datanode.getPort(DatanodeDetails.Port.Name.STANDALONE))
-          .addPort(datanode.getPort(DatanodeDetails.Port.Name.RATIS))
-          .addPort(datanode.getPort(DatanodeDetails.Port.Name.REST))
-          .setNetworkLocation(NODES[i].getNetworkLocation()).build();
-      results.add(result);
+      DatanodeDetails datanode = overwriteLocationInNode(
+          datanodes.get(i), NODES[i]);
+      results.add(datanode);
     }
     return results;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
When rack awareness and topology is enabled, pipeline placement can fail when there is only one node on the rack.
Should add fall back logic to search for nodes from other racks.
(Please fill in changes proposed in this fix)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3179

(Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HDDS-XXXX. Fix a typo in YYY.)

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?
UT
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
