### PR TITLE
HDDS-3177. Periodic dependency update (Java)

### DIFF
--- a/hadoop-hdds/tools/pom.xml
+++ b/hadoop-hdds/tools/pom.xml
@@ -54,6 +54,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>ratis-tools</artifactId>
       <groupId>org.apache.ratis</groupId>
       <version>${ratis.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.ratis</groupId>
+          <artifactId>ratis-examples</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/hadoop-ozone/ozonefs-lib-legacy/pom.xml
+++ b/hadoop-ozone/ozonefs-lib-legacy/pom.xml
@@ -60,7 +60,7 @@
             <configuration>
               <outputDirectory>target/classes/libs</outputDirectory>
               <includeScope>compile</includeScope>
-              <excludes>META-INF/*.SF</excludes>
+              <excludes>META-INF/*.SF,module-info.class</excludes>
               <excludeArtifactIds>
                 slf4j-api,slf4j-log4j12,log4j-api,log4j-core,log4j,hadoop-ozone-filesystem
               </excludeArtifactIds>
@@ -78,8 +78,7 @@
             <phase>prepare-package</phase>
             <configuration>
               <outputDirectory>target/classes</outputDirectory>
-              <includeArtifactIds>hadoop-ozone-filesystem,hadoop-ozone-common
-              </includeArtifactIds>
+              <includeArtifactIds>hadoop-ozone-filesystem,hadoop-ozone-common</includeArtifactIds>
               <includeScope>compile</includeScope>
               <excludes>META-INF/*.SF</excludes>
               <markersDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -1186,16 +1186,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <version>0.1.54</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.htrace</groupId>
-        <artifactId>htrace-core</artifactId>
-        <version>3.1.0-incubating</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.htrace</groupId>
-        <artifactId>htrace-core4</artifactId>
-        <version>4.1.0-incubating</version>
-      </dependency>
-      <dependency>
         <groupId>org.jdom</groupId>
         <artifactId>jdom</artifactId>
         <version>1.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -111,15 +111,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- Version number for xerces used by JDiff -->
     <xerces.jdiff.version>2.11.0</xerces.jdiff.version>
 
-    <hadoop.assemblies.version>3.2.0</hadoop.assemblies.version>
     <commons-daemon.version>1.0.13</commons-daemon.version>
 
     <test.build.dir>${project.build.directory}/test-dir</test.build.dir>
     <test.build.data>${test.build.dir}</test.build.data>
 
-    <!-- Used for building path to native library loaded by tests.  Projects -->
-    <!-- at different nesting levels in the source tree may need to override. -->
-    <hadoop.common.build.dir>${basedir}/../../hadoop-common-project/hadoop-common/target</hadoop.common.build.dir>
     <java.security.egd>file:///dev/urandom</java.security.egd>
 
     <!-- avro version -->
@@ -1712,11 +1708,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
           <!-- @argLine is filled by jacoco maven plugin. @{} means late evaluation -->
           <argLine>${maven-surefire-plugin.argLine} @{argLine}</argLine>
           <environmentVariables>
-            <HADOOP_COMMON_HOME>${hadoop.common.build.dir}</HADOOP_COMMON_HOME>
-            <!-- HADOOP_HOME required for tests on Windows to find winutils -->
-            <HADOOP_HOME>${hadoop.common.build.dir}</HADOOP_HOME>
-            <LD_LIBRARY_PATH>${env.LD_LIBRARY_PATH}:${project.build.directory}/native/target/usr/local/lib:${hadoop.common.build.dir}/native/target/usr/local/lib</LD_LIBRARY_PATH>
-            <DYLD_LIBRARY_PATH>${env.DYLD_LIBRARY_PATH}:${project.build.directory}/native/target/usr/local/lib:${hadoop.common.build.dir}/native/target/usr/local/lib</DYLD_LIBRARY_PATH>
             <MALLOC_ARENA_MAX>4</MALLOC_ARENA_MAX>
           </environmentVariables>
           <trimStackTrace>false</trimStackTrace>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <!-- jackson versions -->
     <jackson.version>1.9.13</jackson.version>
-    <jackson2.version>2.9.9</jackson2.version>
+    <jackson2.version>2.10.3</jackson2.version>
 
     <!-- jaegertracing veresion -->
     <jaeger.version>0.34.0</jaeger.version>
@@ -911,7 +911,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.0.52.Final</version>
+        <version>4.1.47.Final</version>
       </dependency>
 
       <dependency>
@@ -1339,7 +1339,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk16</artifactId>
-        <version>1.46</version>
+        <version>${bouncycastle.version}</version>
         <scope>test</scope>
       </dependency>
 
@@ -1352,7 +1352,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>com.nimbusds</groupId>
         <artifactId>nimbus-jose-jwt</artifactId>
-        <version>4.41.1</version>
+        <version>7.9</version>
         <scope>compile</scope>
         <exclusions>
           <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -227,8 +227,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <swagger-annotations-version>1.5.4</swagger-annotations-version>
     <snakeyaml.version>1.16</snakeyaml.version>
-    <hbase.one.version>1.2.6</hbase.one.version>
-    <hbase.two.version>2.0.0-beta-1</hbase.two.version>
     <sonar.java.binaries>${basedir}/target/classes</sonar.java.binaries>
   </properties>
 
@@ -1371,73 +1369,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>org.skyscreamer</groupId>
         <artifactId>jsonassert</artifactId>
         <version>1.3.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.hbase</groupId>
-        <artifactId>hbase-common</artifactId>
-        <version>${hbase.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>jdk.tools</artifactId>
-            <groupId>jdk.tools</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.hbase</groupId>
-        <artifactId>hbase-common</artifactId>
-        <version>${hbase.version}</version>
-        <scope>test</scope>
-        <classifier>tests</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.hbase</groupId>
-        <artifactId>hbase-client</artifactId>
-        <version>${hbase.version}</version>
-        <exclusions>
-          <!-- exclude jdk.tools (1.7) as we're not managing it -->
-          <exclusion>
-            <groupId>jdk.tools</groupId>
-            <artifactId>jdk.tools</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.hbase</groupId>
-        <artifactId>hbase-server</artifactId>
-        <version>${hbase.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.hbase</groupId>
-        <artifactId>hbase-server</artifactId>
-        <version>${hbase.version}</version>
-        <scope>test</scope>
-        <classifier>tests</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.hbase</groupId>
-        <artifactId>hbase-testing-util</artifactId>
-        <version>${hbase.version}</version>
-        <scope>test</scope>
-        <optional>true</optional>
-        <exclusions>
-          <exclusion>
-            <groupId>org.jruby</groupId>
-            <artifactId>jruby-complete</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-hdfs</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-minicluster</artifactId>
-          </exclusion>
-          <exclusion>
-            <artifactId>jdk.tools</artifactId>
-            <groupId>jdk.tools</groupId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.kerby</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Upgrade:
   * jackson-databind2.9.9 --> 2.10.3
   * netty-all 4.0.52 --> 4.1.47
   * nimbus-jose-jwt 4.41.1 --> 7.9
2. Use existing `bouncycastle.version` property (= 1.60)
3. Remove unused dependencies:
   * `org.apache.htrace:*`
   * `org.apache.hbase:*`
4. Remove unused/useless properties:
   * `hadoop.assemblies.version`
   * `hadoop.common.build.dir` (hadoop-common source no longer present in the same repo)
   * `hbase.*.version`
5. Exclude `ratis-examples` (accidental dependency of `ratis-tools`)

https://issues.apache.org/jira/browse/HDDS-3177
https://issues.apache.org/jira/browse/HDDS-3176

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/507994482