### PR TITLE
HDDS-3181. Intermittent failure in TestReconWithOzoneManager due to BindException

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -286,8 +286,6 @@ public interface MiniOzoneCluster {
     protected Optional<Long> blockSize = Optional.empty();
     protected Optional<StorageUnit> streamBufferSizeUnit = Optional.empty();
     protected boolean includeRecon = false;
-    protected OptionalInt reconHttpPort = OptionalInt.empty();
-    protected OptionalInt reconDatanodePort = OptionalInt.empty();
 
     // Use relative smaller number of handlers for testing
     protected int numOfOmHandlers = 20;
@@ -492,16 +490,6 @@ public interface MiniOzoneCluster {
 
     public Builder setOMServiceId(String serviceId) {
       this.omServiceId = serviceId;
-      return this;
-    }
-
-    public Builder setReconHttpPort(int port) {
-      this.reconHttpPort = OptionalInt.of(port);
-      return this;
-    }
-
-    public Builder setReconDatanodePort(int port) {
-      this.reconDatanodePort = OptionalInt.of(port);
       return this;
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -778,15 +778,9 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       conf.set(OZONE_RECON_SQL_DB_JDBC_URL, "jdbc:sqlite:" +
           tempNewFolder.getAbsolutePath() + "/ozone_recon_sqlite.db");
 
-      int httpPort = reconHttpPort.orElse(0);
-      conf.set(OZONE_RECON_HTTP_ADDRESS_KEY, "0.0.0.0:" + httpPort);
-
-      int rpcPort = NetUtils.getFreeSocketPort();
-      if (reconDatanodePort.isPresent()) {
-        rpcPort = reconDatanodePort.getAsInt();
-      }
-      conf.set(OZONE_RECON_DATANODE_ADDRESS_KEY, "0.0.0.0:" + rpcPort);
-      conf.set(OZONE_RECON_ADDRESS_KEY, "0.0.0.0:" + rpcPort);
+      conf.set(OZONE_RECON_HTTP_ADDRESS_KEY, "0.0.0.0:0");
+      conf.set(OZONE_RECON_DATANODE_ADDRESS_KEY, "0.0.0.0:0");
+      conf.set(OZONE_RECON_ADDRESS_KEY, "0.0.0.0:0");
 
       ConfigurationProvider.setConfiguration(conf);
     }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -226,4 +226,9 @@ public class ReconServer extends GenericCli {
   public ContainerDBServiceProvider getContainerDBServiceProvider() {
     return containerDBServiceProvider;
   }
+
+  @VisibleForTesting
+  ReconHttpServer getHttpServer() {
+    return httpServer;
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Start the HTTP server with random port and use the actual one it bound to.  Getting a free port and setting it explicitly should be avoided, as there is no guarantee that the port remains free until the server is started.

https://issues.apache.org/jira/browse/HDDS-3181

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/508905507