### PR TITLE
HDDS-3149. Make o3fs support set and get acl

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OzoneAcl.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OzoneAcl.java
@@ -21,11 +21,13 @@ package org.apache.hadoop.ozone;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.protobuf.ByteString;
+import org.apache.hadoop.fs.permission.AclEntry;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAclInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAclInfo.OzoneAclScope;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAclInfo.OzoneAclType;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
+import org.apache.hadoop.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -339,5 +341,38 @@ public class OzoneAcl {
   public enum AclScope {
     ACCESS,
     DEFAULT;
+  }
+
+  public String toAclString(AclEntry aclEntry) {
+    StringBuilder sb = new StringBuilder();
+
+    if (aclEntry.getType() != null) {
+      sb.append(StringUtils.toLowerCase(aclEntry.getType().toString()));
+    }
+    sb.append(':');
+    if (aclEntry.getName() != null) {
+      sb.append(aclEntry.getName());
+    }
+    sb.append(':');
+    // For example, change "r-x" to "rx"
+    if (aclEntry.getPermission() != null) {
+      sb.append(aclEntry.getPermission().SYMBOL.replace("-", ""));
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Convert a List of AclEntries into a string.
+   *
+   * @param aclSpec List of AclEntries to convert
+   * @return String representation of aclSpec
+   */
+  public String aclSpecToString(List<AclEntry> aclSpec) {
+    StringBuilder buf = new StringBuilder();
+    for (AclEntry e : aclSpec) {
+      buf.append(toAclString(e));
+      buf.append(",");
+    }
+    return buf.substring(0, buf.length()-1);
   }
 }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -336,7 +336,6 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
         .setBucketName(bucket.getName()).setVolumeName(volume.getName())
         .setKeyName(keyName).setResType(OzoneObj.ResourceType.KEY)
         .setStoreType(OZONE).build();
-    Map<String, List<OzoneAcl>> ozoneAcls = new HashMap<>();
     List<OzoneAcl> userResult = new ArrayList<OzoneAcl>();
     List<OzoneAcl> groupResult = new ArrayList<OzoneAcl>();
 
@@ -347,6 +346,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
             groupResult.add(ozoneAcl);
         }
     });
+    Map<String, List<OzoneAcl>> ozoneAcls = new HashMap<>();
     ozoneAcls.put(ACLIdentityType.USER.toString(),userResult);
     ozoneAcls.put(ACLIdentityType.GROUP.toString(),groupResult);
     return ozoneAcls;

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -331,7 +331,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   }
 
   @Override
-  public Map<String, List<OzoneAcl>> getAcl(String keyName) throws IOException {
+  public Map<String, List<OzoneAcl>> getAcls(String keyName) throws IOException {
     OzoneObj obj = OzoneObjInfo.Builder.newBuilder()
         .setBucketName(bucket.getName()).setVolumeName(volume.getName())
         .setKeyName(keyName).setResType(OzoneObj.ResourceType.KEY)
@@ -353,7 +353,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   }
 
   @Override
-  public void setAcl(String keyName, String acls) throws IOException {
+  public void setAcls(String keyName, String acls) throws IOException {
     OzoneObj obj = OzoneObjInfo.Builder.newBuilder()
         .setBucketName(bucket.getName()).setVolumeName(volume.getName())
         .setKeyName(keyName).setResType(OzoneObj.ResourceType.KEY)

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -341,9 +341,9 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
 
     ozoneClient.getObjectStore().getAcl(obj).forEach(ozoneAcl -> {
       if (ozoneAcl.getType().equals(ACLIdentityType.USER)) {
-          userResult.add(ozoneAcl);
+        userResult.add(ozoneAcl);
       } else if (ozoneAcl.getType().equals(ACLIdentityType.GROUP)) {
-            groupResult.add(ozoneAcl);
+        groupResult.add(ozoneAcl);
       }
     });
     Map<String, List<OzoneAcl>> ozoneAcls = new HashMap<>();

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -331,7 +331,8 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   }
 
   @Override
-  public Map<String, List<OzoneAcl>> getAcls(String keyName) throws IOException {
+  public Map<String, List<OzoneAcl>> getAcls(String keyName)
+      throws IOException {
     OzoneObj obj = OzoneObjInfo.Builder.newBuilder()
         .setBucketName(bucket.getName()).setVolumeName(volume.getName())
         .setKeyName(keyName).setResType(OzoneObj.ResourceType.KEY)

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -340,15 +340,15 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
     List<OzoneAcl> groupResult = new ArrayList<OzoneAcl>();
 
     ozoneClient.getObjectStore().getAcl(obj).forEach(ozoneAcl -> {
-        if (ozoneAcl.getType().equals(ACLIdentityType.USER)) {
-            userResult.add(ozoneAcl);
-        } else if (ozoneAcl.getType().equals(ACLIdentityType.GROUP)) {
+      if (ozoneAcl.getType().equals(ACLIdentityType.USER)) {
+          userResult.add(ozoneAcl);
+      } else if (ozoneAcl.getType().equals(ACLIdentityType.GROUP)) {
             groupResult.add(ozoneAcl);
-        }
+      }
     });
     Map<String, List<OzoneAcl>> ozoneAcls = new HashMap<>();
-    ozoneAcls.put(ACLIdentityType.USER.toString(),userResult);
-    ozoneAcls.put(ACLIdentityType.GROUP.toString(),groupResult);
+    ozoneAcls.put(ACLIdentityType.USER.toString(), userResult);
+    ozoneAcls.put(ACLIdentityType.GROUP.toString(), groupResult);
     return ozoneAcls;
   }
 

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -749,7 +749,7 @@ public class BasicOzoneFileSystem extends FileSystem {
     adapter.setAcl(pathToKey(path), aclSpecToString(aclSpec));
   }
 
-  private String toAclString(AclEntry aclEntry) {
+  public String toAclString(AclEntry aclEntry) {
     StringBuilder sb = new StringBuilder();
 
     if (aclEntry.getType() != null) {
@@ -760,6 +760,7 @@ public class BasicOzoneFileSystem extends FileSystem {
       sb.append(aclEntry.getName());
     }
     sb.append(':');
+    // For example, change "r-x" to "rx"
     if (aclEntry.getPermission() != null) {
       sb.append(aclEntry.getPermission().SYMBOL.replace("-", ""));
     }
@@ -771,7 +772,7 @@ public class BasicOzoneFileSystem extends FileSystem {
    * @param aclSpec List of AclEntries to convert
    * @return String representation of aclSpec
    */
-  private String aclSpecToString(List<AclEntry> aclSpec) {
+  public String aclSpecToString(List<AclEntry> aclSpec) {
     StringBuilder buf = new StringBuilder();
     for ( AclEntry e : aclSpec ) {
       buf.append(toAclString(e));

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -768,13 +768,14 @@ public class BasicOzoneFileSystem extends FileSystem {
   }
 
   /**
-   * Convert a List of AclEntries into a string
+   * Convert a List of AclEntries into a string.
+   *
    * @param aclSpec List of AclEntries to convert
    * @return String representation of aclSpec
    */
   public String aclSpecToString(List<AclEntry> aclSpec) {
     StringBuilder buf = new StringBuilder();
-    for ( AclEntry e : aclSpec ) {
+    for (AclEntry e : aclSpec) {
       buf.append(toAclString(e));
       buf.append(",");
     }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -63,7 +63,6 @@ import static org.apache.hadoop.fs.ozone.Constants.OZONE_USER_DIR;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_SCHEME;
 
-import org.apache.hadoop.util.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -52,7 +52,6 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType;
-import org.apache.hadoop.ozone.web.utils.JsonUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Progressable;
@@ -721,13 +720,11 @@ public class BasicOzoneFileSystem extends FileSystem {
    */
   @Override
   public AclStatus getAclStatus(Path path) throws IOException {
-    Map<String, List<OzoneAcl>> ozoneAcls = adapter.getAcl(pathToKey(path));
+    Map<String, List<OzoneAcl>> ozoneAcls = adapter.getAcls(pathToKey(path));
     String userAcls =
-        JsonUtils.toJsonStringWithDefaultPrettyPrinter(
-            ozoneAcls.get(ACLIdentityType.USER.toString()));
+        ozoneAcls.get(ACLIdentityType.USER.toString()).toString();
     String groupAcls =
-        JsonUtils.toJsonStringWithDefaultPrettyPrinter(
-            ozoneAcls.get(ACLIdentityType.GROUP.toString()));
+        ozoneAcls.get(ACLIdentityType.GROUP.toString()).toString();
     return new AclStatus.Builder()
             .owner(userAcls)
             .group(groupAcls)
@@ -746,40 +743,7 @@ public class BasicOzoneFileSystem extends FileSystem {
    */
   @Override
   public void setAcl(Path path, List<AclEntry> aclSpec) throws IOException {
-    adapter.setAcl(pathToKey(path), aclSpecToString(aclSpec));
-  }
-
-  public String toAclString(AclEntry aclEntry) {
-    StringBuilder sb = new StringBuilder();
-
-    if (aclEntry.getType() != null) {
-      sb.append(StringUtils.toLowerCase(aclEntry.getType().toString()));
-    }
-    sb.append(':');
-    if (aclEntry.getName() != null) {
-      sb.append(aclEntry.getName());
-    }
-    sb.append(':');
-    // For example, change "r-x" to "rx"
-    if (aclEntry.getPermission() != null) {
-      sb.append(aclEntry.getPermission().SYMBOL.replace("-", ""));
-    }
-    return sb.toString();
-  }
-
-  /**
-   * Convert a List of AclEntries into a string.
-   *
-   * @param aclSpec List of AclEntries to convert
-   * @return String representation of aclSpec
-   */
-  public String aclSpecToString(List<AclEntry> aclSpec) {
-    StringBuilder buf = new StringBuilder();
-    for (AclEntry e : aclSpec) {
-      buf.append(toAclString(e));
-      buf.append(",");
-    }
-    return buf.substring(0, buf.length()-1);
+    adapter.setAcls(pathToKey(path), new OzoneAcl().aclSpecToString(aclSpec));
   }
 
   /**

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
@@ -22,9 +22,11 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.security.token.Token;
 
@@ -51,6 +53,10 @@ public interface OzoneClientAdapter {
   boolean deleteObject(String keyName);
 
   Iterator<BasicKeyInfo> listKeys(String pathKey);
+
+  Map<String, List<OzoneAcl>> getAcl(String pathKey) throws IOException;
+
+  void setAcl(String keyName, String acls) throws IOException;
 
   List<FileStatusAdapter> listStatus(String keyName, boolean recursive,
       String startKey, long numEntries, URI uri,

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
@@ -54,9 +54,9 @@ public interface OzoneClientAdapter {
 
   Iterator<BasicKeyInfo> listKeys(String pathKey);
 
-  Map<String, List<OzoneAcl>> getAcl(String pathKey) throws IOException;
+  Map<String, List<OzoneAcl>> getAcls(String pathKey) throws IOException;
 
-  void setAcl(String keyName, String acls) throws IOException;
+  void setAcls(String keyName, String acls) throws IOException;
 
   List<FileStatusAdapter> listStatus(String keyName, boolean recursive,
       String startKey, long numEntries, URI uri,

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestReadWriteStatistics.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestReadWriteStatistics.java
@@ -499,7 +499,7 @@ public class TestReadWriteStatistics {
     groupAcl.add(new OzoneAcl(GROUP, "group2", READ, ACCESS));
     Map<String, List<OzoneAcl>> ozoneAcls = new HashMap<>();
     ozoneAcls.put(IAccessAuthorizer.ACLIdentityType.USER.toString(), userAcl);
-    ozoneAcls.put(IAccessAuthorizer.ACLIdentityType.GROUP.toString(),groupAcl);
+    ozoneAcls.put(IAccessAuthorizer.ACLIdentityType.GROUP.toString(), groupAcl);
 
     when(fakeAdapter.getAcl(anyString())).thenReturn(ozoneAcls);
   }

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestReadWriteStatistics.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestReadWriteStatistics.java
@@ -366,7 +366,7 @@ public class TestReadWriteStatistics {
         .setType(AclEntryType.USER).build();
     aclEntries.add(aclEntry);
 
-    assertFalse(fs.aclSpecToString(aclEntries).contains("-"));
+    assertFalse(new OzoneAcl().aclSpecToString(aclEntries).contains("-"));
   }
 
   // INTERNALS
@@ -501,6 +501,6 @@ public class TestReadWriteStatistics {
     ozoneAcls.put(IAccessAuthorizer.ACLIdentityType.USER.toString(), userAcl);
     ozoneAcls.put(IAccessAuthorizer.ACLIdentityType.GROUP.toString(), groupAcl);
 
-    when(fakeAdapter.getAcl(anyString())).thenReturn(ozoneAcls);
+    when(fakeAdapter.getAcls(anyString())).thenReturn(ozoneAcls);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

BasicOzoneFileSystem currently lacks an interface to set and get acls through HDFS. Supplement with this PR.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3149

## How was this patch tested?

Ut has been added
