### PR TITLE
HDDS-3134. Debug Tool that gives chunk location information given a key.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
@@ -141,9 +141,6 @@ public class KeyValueContainerData extends ContainerData {
    * @return Path to base dir
    */
   public String getContainerPath() {
-    if (metadataPath == null) {
-      return null;
-    }
     return new File(metadataPath).getParent();
   }
 
@@ -226,7 +223,7 @@ public class KeyValueContainerData extends ContainerData {
   public ContainerDataProto getProtoBufMessage() {
     ContainerDataProto.Builder builder = ContainerDataProto.newBuilder();
     builder.setContainerID(this.getContainerID());
-    builder.setContainerPath(this.getMetadataPath());
+    builder.setContainerPath(this.getContainerPath());
     builder.setState(this.getState());
 
     for (Map.Entry<String, String> entry : getMetadata().entrySet()) {

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -69,6 +69,11 @@ public class ContainerOperationClient implements ScmClient {
   private final HddsProtos.ReplicationType replicationType;
   private final StorageContainerLocationProtocol
       storageContainerLocationClient;
+
+  public XceiverClientManager getXceiverClientManager() {
+    return xceiverClientManager;
+  }
+
   private final XceiverClientManager xceiverClientManager;
 
   public ContainerOperationClient(Configuration conf) throws IOException {

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
@@ -118,7 +118,7 @@ Test key handling
                     Should Contain      ${result}       NOTICE.txt.1 exists
     ${result} =     Execute             ozone sh key get --force ${protocol}${server}/${volume}/bb1/key1 /tmp/NOTICE.txt.1
                     Should Not Contain  ${result}       NOTICE.txt.1 exists
-    ${result} =     Execute             ozone sh key info ${protocol}${server}/${volume}/bb1/key1 | jq '. | select(.name=="key1")'
+    ${result} =     Execute             ozone sh key info ${protocol}${server}/${volume}/bb1/key1 | jq -r '. | select(.name=="key1")'
                     Should contain      ${result}       creationTime
     ${result} =     Execute             ozone debug chunkinfo ${protocol}${server}/${volume}/bb1/key1 | jq -r '.[]'
                     Should contain      ${result}       chunks

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
@@ -18,7 +18,7 @@ Documentation       Test ozone shell CLI usage
 Library             OperatingSystem
 Resource            ../commonlib.robot
 Test Setup          Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
-Test Timeout        2 minute
+Test Timeout        3 minute
 Suite Setup         Generate prefix
 
 *** Variables ***

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
@@ -120,6 +120,8 @@ Test key handling
                     Should Not Contain  ${result}       NOTICE.txt.1 exists
     ${result} =     Execute             ozone sh key info ${protocol}${server}/${volume}/bb1/key1 | jq -r '. | select(.name=="key1")'
                     Should contain      ${result}       creationTime
+    ${result} =     Execute             ozone debug chunkinfo ${protocol}${server}/${volume}/bb1/key1 | jq  '.[]'
+                    Should contain      ${result}       chunks
     ${result} =     Execute             ozone sh key list ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="key1") | .name'
                     Should Be Equal     ${result}       key1
                     Execute             ozone sh key rename ${protocol}${server}/${volume}/bb1 key1 key2

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
@@ -118,7 +118,7 @@ Test key handling
                     Should Contain      ${result}       NOTICE.txt.1 exists
     ${result} =     Execute             ozone sh key get --force ${protocol}${server}/${volume}/bb1/key1 /tmp/NOTICE.txt.1
                     Should Not Contain  ${result}       NOTICE.txt.1 exists
-    ${result} =     Execute             ozone sh key info ${protocol}${server}/${volume}/bb1/key1 | jq -r '. | select(.name=="key1")'
+    ${result} =     Execute             ozone sh key info ${protocol}${server}/${volume}/bb1/key1 | jq '. | select(.name=="key1")'
                     Should contain      ${result}       creationTime
     ${result} =     Execute             ozone debug chunkinfo ${protocol}${server}/${volume}/bb1/key1 | jq -r '.[]'
                     Should contain      ${result}       chunks

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
@@ -120,7 +120,7 @@ Test key handling
                     Should Not Contain  ${result}       NOTICE.txt.1 exists
     ${result} =     Execute             ozone sh key info ${protocol}${server}/${volume}/bb1/key1 | jq -r '. | select(.name=="key1")'
                     Should contain      ${result}       creationTime
-    ${result} =     Execute             ozone debug chunkinfo ${protocol}${server}/${volume}/bb1/key1 | jq  '.[]'
+    ${result} =     Execute             ozone debug chunkinfo ${protocol}${server}/${volume}/bb1/key1 | jq -r '.[]'
                     Should contain      ${result}       chunks
     ${result} =     Execute             ozone sh key list ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="key1") | .name'
                     Should Be Equal     ${result}       key1

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -55,7 +55,7 @@ function hadoop_usage
   hadoop_add_subcommand "dtutil" client "operations related to delegation tokens"
   hadoop_add_subcommand "upgrade" client "HDFS to Ozone in-place upgrade tool"
   hadoop_add_subcommand "admin" client "Ozone admin tool"
-  hadoop_add_subcommand "ratislogparser" client "ozone debug tool, to convert Ratis log files into readable text"
+  hadoop_add_subcommand "debug" client "Ozone debug tool"
 
   hadoop_generate_usage "${HADOOP_SHELL_EXECNAME}" false
 }
@@ -207,8 +207,8 @@ function ozonecmd_case
       HADOOP_CLASSNAME=org.apache.hadoop.ozone.admin.OzoneAdmin
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-tools"
     ;;
-    ratislogparser)
-      HADOOP_CLASSNAME=org.apache.hadoop.ozone.segmentparser.RatisLogParser
+    debug)
+      HADOOP_CLASSNAME=org.apache.hadoop.ozone.debug.OzoneDebug
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-tools"
     ;;
     *)

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkDataNodeDetails.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkDataNodeDetails.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug;
+/**
+ * Class that gives datanode details on which the chunk is present.
+ */
+public class ChunkDataNodeDetails {
+  private String ipAddress;
+  private String hostName;
+
+  public ChunkDataNodeDetails(String ipAddress, String hostName) {
+    this.ipAddress = ipAddress;
+    this.hostName = hostName;
+  }
+
+  @Override
+    public String toString() {
+    return "{"
+            + "ipAddress='"
+            + ipAddress
+            + '\''
+            + ", hostName='"
+            + hostName
+            + '\''
+            + '}';
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkDetails.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkDetails.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug;
+
+/**
+ * Class that gives chunkDetails.
+ */
+public class ChunkDetails {
+  private String chunkName;
+  private long chunkOffset;
+
+  public String getChunkName() {
+    return chunkName;
+  }
+
+  public void setChunkName(String chunkName) {
+    this.chunkName = chunkName;
+  }
+
+  @Override
+    public String toString() {
+    return "{"
+            + "chunkName='"
+            + chunkName
+            + '\''
+            + ", chunkOffset="
+            + chunkOffset
+            + '}';
+  }
+
+  public long getChunkOffset() {
+    return chunkOffset;
+  }
+
+  public void setChunkOffset(long chunkOffset) {
+    this.chunkOffset = chunkOffset;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.debug;
 
-import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -27,23 +26,19 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
-import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.*;
-import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
-import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
 import org.apache.hadoop.ozone.shell.OzoneAddress;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -82,7 +82,6 @@ public class ChunkKeyHandler  extends KeyHandler {
     OzoneKeyDetails key = bucket.getKey(keyName);
     // querying  the keyLocations.The OM is queried to get containerID and
     // localID pertaining to a given key
-    System.out.println("Key:" + keyName);
     List<OzoneKeyLocation> keyLocationList = key.getOzoneKeyLocations();
     for (OzoneKeyLocation keyLocation:keyLocationList) {
       ContainerChunkInfo containerChunkInfoVerbose = new ContainerChunkInfo();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -116,14 +116,17 @@ public class ChunkKeyHandler  extends KeyHandler {
               + File.separator
               + chunkInfo.getChunkName());
       }
-      containerChunkInfoVerbose.setContainerPath(containerData.getContainerPath());
-      containerChunkInfoVerbose.setDataNodeList(container.getPipeline().getNodes());
+      containerChunkInfoVerbose
+              .setContainerPath(containerData.getContainerPath());
+      containerChunkInfoVerbose
+              .setDataNodeList(container.getPipeline().getNodes());
       containerChunkInfoVerbose.setPipeline(container.getPipeline());
       containerChunkInfoVerbose.setChunkInfos(chunkDetailsList);
       containerChunkInfo.setChunks(chunkPaths);
       List<ChunkDataNodeDetails> chunkDataNodeDetails = new
               ArrayList<ChunkDataNodeDetails>();
-      for (DatanodeDetails datanodeDetails:container.getPipeline().getNodes()) {
+      for (DatanodeDetails datanodeDetails:container
+              .getPipeline().getNodes()) {
         chunkDataNodeDetails.add(
                 new ChunkDataNodeDetails(datanodeDetails.getIpAddress(),
                 datanodeDetails.getHostName()));
@@ -142,7 +145,7 @@ public class ChunkKeyHandler  extends KeyHandler {
                 + "blockId :" + blockId + "", element);
       }
     }
-    xceiverClientManager.releaseClient(xceiverClient,false);
+    xceiverClientManager.releaseClient(xceiverClient, false);
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
     String prettyJson = gson.toJson(jsonObj);
     System.out.println(prettyJson);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -37,8 +37,8 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.*;
-import org.apache.hadoop.ozone.web.ozShell.OzoneAddress;
-import org.apache.hadoop.ozone.web.ozShell.keys.KeyHandler;
+import org.apache.hadoop.ozone.shell.OzoneAddress;
+import org.apache.hadoop.ozone.shell.keys.KeyHandler;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Parameters;
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -66,8 +66,8 @@ public class ChunkKeyHandler  extends KeyHandler {
           throws IOException, OzoneClientException {
     containerOperationClient = new
             ContainerOperationClient(createOzoneConfiguration());
-    xceiverClientManager = new
-            XceiverClientManager(createOzoneConfiguration());
+    xceiverClientManager = containerOperationClient
+            .getXceiverClientManager();
     address.ensureKeyAddress();
     JsonObject jsonObj = new JsonObject();
     JsonElement element;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.scm.XceiverClientManager;
+import org.apache.hadoop.hdds.scm.XceiverClientSpi;
+import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
+import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
+import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.client.*;
+import org.apache.hadoop.ozone.web.ozShell.OzoneAddress;
+import org.apache.hadoop.ozone.web.ozShell.keys.KeyHandler;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/**
+ * Class that gives chunk location given a specific key.
+ */
+@Command(name = "chunkinfo",
+        description = "returns chunk location information about an existing key")
+public class ChunkKeyHandler  extends KeyHandler {
+
+  @Parameters(arity = "1..1", description = "key to be located")
+    private String uri;
+
+  private ContainerOperationClient containerOperationClient;
+  private  XceiverClientManager xceiverClientManager;
+  private XceiverClientSpi xceiverClient;
+
+  private String getChunkLocationPath(String containerLocation) {
+    return containerLocation + File.separator + OzoneConsts.STORAGE_DIR_CHUNKS;
+  }
+
+  @Override
+  protected void execute(OzoneClient client, OzoneAddress address)
+          throws IOException, OzoneClientException {
+    containerOperationClient = new ContainerOperationClient(createOzoneConfiguration());
+    xceiverClientManager = new XceiverClientManager(createOzoneConfiguration());
+    address.ensureKeyAddress();
+    JsonObject jsonObj = new JsonObject();
+    JsonElement element;
+    String volumeName = address.getVolumeName();
+    String bucketName = address.getBucketName();
+    String keyName = address.getKeyName();
+    List<ContainerProtos.ChunkInfo> tempchunks = null;
+    List<ChunkDetails> chunkDetailsList = new ArrayList<ChunkDetails>();
+    List<String> chunkPaths = new ArrayList<String>();
+    OzoneVolume vol = client.getObjectStore().getVolume(volumeName);
+    OzoneBucket bucket = vol.getBucket(bucketName);
+    OzoneKeyDetails key = bucket.getKey(keyName);
+    // querying  the keyLocations.The OM is queried to get containerID and
+    // localID pertaining to a given key
+    System.out.println("Key:" + keyName);
+    List<OzoneKeyLocation> keyLocationList = key.getOzoneKeyLocations();
+    for (OzoneKeyLocation keyLocation:keyLocationList) {
+      ContainerChunkInfo containerChunkInfoVerbose = new ContainerChunkInfo();
+      ContainerChunkInfo containerChunkInfo = new ContainerChunkInfo();
+      long containerId = keyLocation.getContainerID();
+      long blockId = keyLocation.getLocalID();
+      // scmClient is used to get container specific information like ContainerPath amd so on
+      ContainerWithPipeline container = containerOperationClient
+              .getContainerWithPipeline(containerId);
+      xceiverClient = xceiverClientManager.acquireClient(container.getPipeline());
+      // Datanode is queried to get chunk information.Thus querying the OM,SCM
+      // and datanode helps us get chunk location information
+      ContainerProtos.DatanodeBlockID datanodeBlockID =
+              new BlockID(containerId,keyLocation.getLocalID())
+                .getDatanodeBlockIDProtobuf();
+      ContainerProtos.GetBlockResponseProto response = ContainerProtocolCalls
+                 .getBlock(xceiverClient, datanodeBlockID);
+      tempchunks = response.getBlockData().getChunksList();
+      Preconditions.checkNotNull(container, "Container cannot be null");
+      ContainerProtos.ContainerDataProto containerData = containerOperationClient
+              .readContainer(container
+              .getContainerInfo().getContainerID(), container.getPipeline());
+      for (ContainerProtos.ChunkInfo chunkInfo:tempchunks) {
+        ChunkDetails chunkDetails = new ChunkDetails();
+        chunkDetails.setChunkName(chunkInfo.getChunkName());
+        chunkDetails.setChunkOffset(chunkInfo.getOffset());
+        chunkDetailsList.add(chunkDetails);
+        chunkPaths.add(getChunkLocationPath(containerData.getContainerPath())
+              + File.separator
+              + chunkInfo.getChunkName());
+      }
+      containerChunkInfoVerbose.setContainerPath(containerData.getContainerPath());
+      containerChunkInfoVerbose.setDataNodeList(container.getPipeline().getNodes());
+      containerChunkInfoVerbose.setPipeline(container.getPipeline());
+      containerChunkInfoVerbose.setChunkInfos(chunkDetailsList);
+      containerChunkInfo.setChunks(chunkPaths);
+      List<ChunkDataNodeDetails> chunkDataNodeDetails = new ArrayList<ChunkDataNodeDetails>();
+      for (DatanodeDetails datanodeDetails:container.getPipeline().getNodes()) {
+        chunkDataNodeDetails.add(new ChunkDataNodeDetails(datanodeDetails.getIpAddress(),
+                datanodeDetails.getHostName()));
+      }
+      containerChunkInfo.setChunkDataNodeDetails(chunkDataNodeDetails);
+      containerChunkInfo.setPipelineID(container.getPipeline().getId().getId());
+      Gson gson = new GsonBuilder().create();
+      if (isVerbose()) {
+        element = gson.toJsonTree(containerChunkInfoVerbose);
+        jsonObj.add("container Id :" + containerId + ""
+                + "blockId :" + blockId + "",element);
+      } else {
+        element = gson.toJsonTree(containerChunkInfo);
+        jsonObj.add("container Id :" + containerId + ""
+                + "blockId :" + blockId + "",element);
+      }
+    }
+    Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    String prettyJson = gson.toJson(jsonObj);
+    System.out.println(prettyJson);
+  }
+
+
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -81,7 +81,7 @@ public class ChunkKeyHandler  extends KeyHandler {
             new OzoneManagerProtocolClientSideTranslatorPB(
             getConf(), clientId.toString(),
             null, UserGroupInformation.getCurrentUser()),
-            OzoneManagerProtocol.class,getConf());
+            OzoneManagerProtocol.class, getConf());
     address.ensureKeyAddress();
     JsonObject jsonObj = new JsonObject();
     JsonElement element;
@@ -120,7 +120,8 @@ public class ChunkKeyHandler  extends KeyHandler {
                  .getBlock(xceiverClient, datanodeBlockID);
       tempchunks = response.getBlockData().getChunksList();
       ContainerProtos.ContainerDataProto containerData =
-              containerOperationClient.readContainer(keyLocation.getContainerID(),
+              containerOperationClient.readContainer(
+                      keyLocation.getContainerID(),
                       keyLocation.getPipeline());
       for (ContainerProtos.ChunkInfo chunkInfo:tempchunks) {
         ChunkDetails chunkDetails = new ChunkDetails();
@@ -140,13 +141,15 @@ public class ChunkKeyHandler  extends KeyHandler {
       containerChunkInfo.setChunks(chunkPaths);
       List<ChunkDataNodeDetails> chunkDataNodeDetails = new
               ArrayList<ChunkDataNodeDetails>();
-      for (DatanodeDetails datanodeDetails:keyLocation.getPipeline().getNodes()) {
+      for (DatanodeDetails datanodeDetails:keyLocation
+              .getPipeline().getNodes()) {
         chunkDataNodeDetails.add(
                 new ChunkDataNodeDetails(datanodeDetails.getIpAddress(),
                 datanodeDetails.getHostName()));
       }
       containerChunkInfo.setChunkDataNodeDetails(chunkDataNodeDetails);
-      containerChunkInfo.setPipelineID(keyLocation.getPipeline().getId().getId());
+      containerChunkInfo.setPipelineID(
+              keyLocation.getPipeline().getId().getId());
       Gson gson = new GsonBuilder().create();
       if (isVerbose()) {
         element = gson.toJsonTree(containerChunkInfoVerbose);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ContainerChunkInfo.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ContainerChunkInfo.java
@@ -37,7 +37,8 @@ public class ContainerChunkInfo {
   private UUID pipelineID;
   private Pipeline pipeline;
 
-  public void setChunkDataNodeDetails(List<ChunkDataNodeDetails> chunkDataNodeDetails) {
+  public void setChunkDataNodeDetails(List<ChunkDataNodeDetails>
+                                              chunkDataNodeDetails) {
     this.chunkDataNodeDetails = chunkDataNodeDetails;
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ContainerChunkInfo.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ContainerChunkInfo.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+import java.util.UUID;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+
+/**
+ * Class that gives container and chunk Information.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ContainerChunkInfo {
+  private String containerPath;
+  private List<DatanodeDetails> dataNodeList;
+  private List<ChunkDetails> chunkInfos;
+  private List<String> chunks;
+  private List<ChunkDataNodeDetails> chunkDataNodeDetails;
+  private UUID pipelineID;
+  private Pipeline pipeline;
+
+  public void setChunkDataNodeDetails(List<ChunkDataNodeDetails> chunkDataNodeDetails) {
+    this.chunkDataNodeDetails = chunkDataNodeDetails;
+  }
+
+  public void setChunks(List<String> chunks) {
+    this.chunks = chunks;
+  }
+
+  public void setPipelineID(UUID pipelineID) {
+    this.pipelineID = pipelineID;
+  }
+
+  public Pipeline getPipeline() {
+    return pipeline;
+  }
+
+  public void setPipeline(Pipeline pipeline) {
+    this.pipeline = pipeline;
+  }
+
+  public void setContainerPath(String containerPath) {
+    this.containerPath = containerPath;
+  }
+
+  public void setChunkInfos(List<ChunkDetails> chunkInfos) {
+    this.chunkInfos = chunkInfos;
+  }
+
+  public void setDataNodeList(List<DatanodeDetails> dataNodeList) {
+    this.dataNodeList = dataNodeList;
+  }
+
+  @Override
+  public String toString() {
+    return "Container{"
+            + "containerPath='"
+            + containerPath
+            + '\''
+            + ", dataNodeList="
+            + dataNodeList
+            + ", chunkInfos="
+            + chunkInfos
+            + ", pipeline="
+            + pipeline
+            + '}'
+            + "chunks="
+            + chunks
+            + "chunkdatanodeDetails="
+            + chunkDataNodeDetails
+            + "PipelineID="
+            + pipelineID;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/OzoneDebug.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/OzoneDebug.java
@@ -36,10 +36,9 @@ import picocli.CommandLine;
         },
         mixinStandardHelpOptions = true)
 public class OzoneDebug extends GenericCli {
-  private OzoneConfiguration ozoneConf;
 
   /**
-     * Main for the Ozone Admin shell Command handling.
+     * Main for the Ozone Debug shell Command handling.
      *
      * @param argv - System Args Strings[]
      * @throws Exception

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/OzoneDebug.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/OzoneDebug.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug;
+
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.segmentparser.RatisLogParser;
+import picocli.CommandLine;
+
+/**
+ * Ozone Debug Command line tool.
+ */
+@CommandLine.Command(name = "ozone debug",
+        description = "Developer tools for Ozone Debug operations",
+        versionProvider = HddsVersionProvider.class,
+        subcommands = {
+                ChunkKeyHandler.class,
+                RatisLogParser.class
+        },
+        mixinStandardHelpOptions = true)
+public class OzoneDebug extends GenericCli {
+  private OzoneConfiguration ozoneConf;
+
+  /**
+     * Main for the Ozone Admin shell Command handling.
+     *
+     * @param argv - System Args Strings[]
+     * @throws Exception
+     */
+  public static void main(String[] argv) throws Exception {
+
+    new OzoneDebug().run(argv);
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/OzoneDebug.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/OzoneDebug.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.debug;
 
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.segmentparser.RatisLogParser;
 import picocli.CommandLine;
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/package-info.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  * <p>
- * SCM related cli tools.
+ * 
  */
 
 /**

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/package-info.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  * <p>
- * 
+ *
  */
 
 /**

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/package-info.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * <p>
+ * SCM related cli tools.
+ */
+
+/**
+ * Ozone Debug tools.
+ */
+package org.apache.hadoop.ozone.debug;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Debug tool to display chunk information given a key.Apart from Chunks ,it also displays information about the container on which the chunks are present and the pipeline info


**`Non-Verbose output:`**
<img width="1679" alt="Screenshot 2020-04-02 at 4 40 20 PM" src="https://user-images.githubusercontent.com/31859223/78243258-1242b480-7501-11ea-8b86-d28cd3d4c8b4.png">

**`Verbose Output:`**
<img width="1679" alt="Screenshot 2020-04-02 at 4 41 46 PM" src="https://user-images.githubusercontent.com/31859223/78243602-af055200-7501-11ea-9826-6bfe8a18f47f.png">


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3134

## How was this patch tested?
Included robot tests in ozone-shell.robot
