### PR TITLE
HDDS-3184. Fix MiniOzoneChaosTest to set the correct defaults.

### DIFF
--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/bin/start-chaos.sh
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/bin/start-chaos.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 date=$(date +"%Y-%m-%d-%H-%M-%S-%Z")
-logfiledirectory="/tmp/${date}/"
+logfiledirectory="/tmp/chaos-${date}/"
 completesuffix="complete.log"
 chaossuffix="chaos.log"
 compilesuffix="compile.log"
@@ -49,4 +49,5 @@ mvn exec:java \
   -Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false \
   -Dio.netty.leakDetection.level=advanced \
   -Dio.netty.leakDetectionLevel=advanced \
+  -Dtest.build.data="${logfiledirectory}" \
   -Dexec.args="$*" > "${logfilename}" 2>&1

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
@@ -214,13 +214,15 @@ public class MiniOzoneChaosCluster extends MiniOzoneClusterImpl {
     protected void initializeConfiguration() throws IOException {
       super.initializeConfiguration();
       conf.setStorageSize(ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_KEY,
-          2, StorageUnit.KB);
-      conf.setStorageSize(OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE,
-          16, StorageUnit.KB);
-      conf.setStorageSize(OzoneConfigKeys.OZONE_CLIENT_STREAM_BUFFER_FLUSH_SIZE,
           4, StorageUnit.KB);
-      conf.setStorageSize(OzoneConfigKeys.OZONE_CLIENT_STREAM_BUFFER_MAX_SIZE,
+      conf.setStorageSize(OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE,
+          32, StorageUnit.KB);
+      conf.setStorageSize(OzoneConfigKeys.OZONE_CLIENT_STREAM_BUFFER_FLUSH_SIZE,
           8, StorageUnit.KB);
+      conf.setStorageSize(OzoneConfigKeys.OZONE_CLIENT_STREAM_BUFFER_MAX_SIZE,
+          16, StorageUnit.KB);
+      conf.setStorageSize(OzoneConfigKeys.OZONE_CLIENT_STREAM_BUFFER_SIZE,
+          4, StorageUnit.KB);
       conf.setStorageSize(ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE,
           1, StorageUnit.MB);
       conf.setTimeDuration(ScmConfigKeys.HDDS_SCM_WATCHER_TIMEOUT, 1000,


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestMiniOzoneChaosCluster is failing because of incorrect default values.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3184

## How was this patch tested?
Fixed by running the unit tests.
