### PR TITLE
HDDS-3098. TestDeleteWithSlowFollower is failing intermittently.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithSlowFollower.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithSlowFollower.java
@@ -148,6 +148,7 @@ public class TestDeleteWithSlowFollower {
             .setHbInterval(100)
             .build();
     cluster.waitForClusterToBeReady();
+    cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.THREE, 60000);
     //the easiest way to create an open container is creating a key
     client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a wait condition for atleast one pipeline to become open before client starts IO

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3098

## How was this patch tested?
The test does not fail consistently enough. Ran the test multiple times and did not see any failure.