### PR TITLE
HDDS-3221. Refactor SafeModeHandler to use a Notification Interface

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManager.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
+import org.apache.hadoop.hdds.scm.safemode.SafeModeTransition;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -31,7 +32,7 @@ import java.util.List;
  *  Block APIs.
  *  Container is transparent to these APIs.
  */
-public interface BlockManager extends Closeable {
+public interface BlockManager extends Closeable, SafeModeTransition {
   /**
    * Allocates a new block for a given size.
    * @param size - Block Size
@@ -80,10 +81,4 @@ public interface BlockManager extends Closeable {
    */
   SCMBlockDeletingService getSCMBlockDeletingService();
 
-  /**
-   * Set SafeMode status.
-   *
-   * @param safeModeStatus
-   */
-  void setSafeModeStatus(boolean safeModeStatus);
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManager.java
@@ -21,7 +21,7 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
-import org.apache.hadoop.hdds.scm.safemode.SafeModeTransition;
+import org.apache.hadoop.hdds.scm.safemode.SafeModeNotification;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -32,7 +32,7 @@ import java.util.List;
  *  Block APIs.
  *  Container is transparent to these APIs.
  */
-public interface BlockManager extends Closeable, SafeModeTransition {
+public interface BlockManager extends Closeable, SafeModeNotification {
   /**
    * Allocates a new block for a given size.
    * @param size - Block Size

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ScmOps;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.ScmUtils;
+import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
 import org.apache.hadoop.hdds.scm.safemode.SafeModePrecheck;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
@@ -358,10 +359,10 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
   }
 
   @Override
-  public void setSafeModeStatus(boolean safeModeStatus) {
-    this.safeModePrecheck.setInSafeMode(safeModeStatus);
+  public void handleSafeModeTransition(
+      SCMSafeModeManager.SafeModeStatus status) {
+    this.safeModePrecheck.setInSafeMode(status.getSafeModeStatus());
   }
-
   /**
    * Returns status of scm safe mode determined by SAFE_MODE_STATUS event.
    * */

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -43,7 +43,7 @@ import org.apache.hadoop.hdds.protocol.proto
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
-import org.apache.hadoop.hdds.scm.safemode.SafeModeTransition;
+import org.apache.hadoop.hdds.scm.safemode.SafeModeNotification;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsInfo;
@@ -72,7 +72,7 @@ import org.slf4j.LoggerFactory;
  * that the containers are properly replicated. Replication Manager deals only
  * with Quasi Closed / Closed container.
  */
-public class ReplicationManager implements MetricsSource, SafeModeTransition {
+public class ReplicationManager implements MetricsSource, SafeModeNotification {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(ReplicationManager.class);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -42,6 +42,8 @@ import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
+import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
+import org.apache.hadoop.hdds.scm.safemode.SafeModeTransition;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsInfo;
@@ -70,7 +72,7 @@ import org.slf4j.LoggerFactory;
  * that the containers are properly replicated. Replication Manager deals only
  * with Quasi Closed / Closed container.
  */
-public class ReplicationManager implements MetricsSource {
+public class ReplicationManager implements MetricsSource, SafeModeTransition {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(ReplicationManager.class);
@@ -771,6 +773,14 @@ public class ReplicationManager implements MetricsSource {
         .addGauge(ReplicationManagerMetrics.INFLIGHT_DELETION,
             inflightDeletion.size())
         .endRecord();
+  }
+
+  @Override
+  public void handleSafeModeTransition(
+      SCMSafeModeManager.SafeModeStatus status) {
+    if (!status.getSafeModeStatus() && !this.isRunning()) {
+      this.start();
+    }
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
-import org.apache.hadoop.hdds.scm.safemode.SafeModeTransition;
+import org.apache.hadoop.hdds.scm.safemode.SafeModeNotification;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -34,7 +34,7 @@ import java.util.NavigableSet;
  * Interface which exposes the api for pipeline management.
  */
 public interface PipelineManager extends Closeable, PipelineManagerMXBean,
-    SafeModeTransition {
+    SafeModeNotification {
 
   Pipeline createPipeline(ReplicationType type, ReplicationFactor factor)
       throws IOException;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.safemode.SafeModeTransition;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -32,7 +33,8 @@ import java.util.NavigableSet;
 /**
  * Interface which exposes the api for pipeline management.
  */
-public interface PipelineManager extends Closeable, PipelineManagerMXBean {
+public interface PipelineManager extends Closeable, PipelineManagerMXBean,
+    SafeModeTransition {
 
   Pipeline createPipeline(ReplicationType type, ReplicationFactor factor)
       throws IOException;
@@ -112,13 +114,6 @@ public interface PipelineManager extends Closeable, PipelineManagerMXBean {
   default void waitPipelineReady(PipelineID pipelineID, long timeout)
       throws IOException {
   }
-
-  /**
-   * Set SafeMode status.
-   *
-   * @param safeModeStatus
-   */
-  void setSafeModeStatus(boolean safeModeStatus);
 
   /**
    * Get SafeMode status.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -645,6 +645,8 @@ public class SCMPipelineManager implements PipelineManager {
       SCMSafeModeManager.SafeModeStatus status) {
     this.isInSafeMode.set(status.getSafeModeStatus());
     if (!status.getSafeModeStatus()) {
+      // TODO: #CLUTIL if we reenter safe mode the fixed interval pipeline
+      // creation job needs to stop
       startPipelineCreator();
       triggerPipelineCreation();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
 import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.metrics2.util.MBeans;
@@ -635,13 +636,18 @@ public class SCMPipelineManager implements PipelineManager {
   }
 
   @Override
-  public void setSafeModeStatus(boolean safeModeStatus) {
-    this.isInSafeMode.set(safeModeStatus);
+  public boolean getSafeModeStatus() {
+    return this.isInSafeMode.get();
   }
 
   @Override
-  public boolean getSafeModeStatus() {
-    return this.isInSafeMode.get();
+  public void handleSafeModeTransition(
+      SCMSafeModeManager.SafeModeStatus status) {
+    this.isInSafeMode.set(status.getSafeModeStatus());
+    if (!status.getSafeModeStatus()) {
+      startPipelineCreator();
+      triggerPipelineCreation();
+    }
   }
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -204,9 +204,6 @@ public class SCMSafeModeManager implements SafeModeManager {
     // register events anymore.
 
     emitSafeModeStatus();
-    // TODO: #CLUTIL if we reenter safe mode the fixed interval pipeline
-    // creation job needs to stop
-    pipelineManager.startPipelineCreator();
   }
 
   public boolean getInSafeMode() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeHandler.java
@@ -52,22 +52,8 @@ public class SafeModeHandler implements EventHandler<SafeModeStatus> {
   /**
    * SafeModeHandler, to handle the logic once we exit safe mode.
    * @param configuration
-   * @param clientProtocolServer
-   * @param blockManager
-   * @param replicationManager
    */
-  public SafeModeHandler(Configuration configuration,
-      SCMClientProtocolServer clientProtocolServer,
-      BlockManager blockManager,
-      ReplicationManager replicationManager, PipelineManager pipelineManager) {
-    Objects.requireNonNull(configuration, "Configuration cannot be null");
-    Objects.requireNonNull(clientProtocolServer, "SCMClientProtocolServer " +
-        "object cannot be null");
-    Objects.requireNonNull(blockManager, "BlockManager object cannot be null");
-    Objects.requireNonNull(replicationManager, "ReplicationManager " +
-        "object cannot be null");
-    Objects.requireNonNull(pipelineManager, "PipelineManager object cannot " +
-        "be" + "null");
+  public SafeModeHandler(Configuration configuration) {
     this.waitTime = configuration.getTimeDuration(
         HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT,
         HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT_DEFAULT,
@@ -77,12 +63,13 @@ public class SafeModeHandler implements EventHandler<SafeModeStatus> {
         HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED,
         HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED_DEFAULT);
     isInSafeMode.set(safeModeEnabled);
-    immediate.add(clientProtocolServer);
-    immediate.add(blockManager);
-    delayed.add(replicationManager);
-    delayed.add(pipelineManager);
   }
 
+  /**
+   * Add any objects which should be notified immediately on a safemode status
+   * change.
+   * @param objs List of objects to be notified.
+   */
   public void notifyImmediately(SafeModeTransition...objs) {
     for (SafeModeTransition o : objs) {
       Objects.requireNonNull(o, "Only non null objects can be notified");
@@ -90,6 +77,11 @@ public class SafeModeHandler implements EventHandler<SafeModeStatus> {
     }
   }
 
+  /**
+   * Add any object which should be notified when safemode is ended and after
+   * the configured safemode delay.
+   * @param objs List of objects to be notified.
+   */
   public void notifyAfterDelay(SafeModeTransition...objs) {
     for (SafeModeTransition o : objs) {
       Objects.requireNonNull(o, "Only non null objects can be notified");

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeNotification.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeNotification.java
@@ -20,6 +20,6 @@ package org.apache.hadoop.hdds.scm.safemode;
  * Interface which should be implemented by any object that wishes to be
  * notified by the SafeModeManager when the safe mode state changes.
  */
-public interface SafeModeTransition {
+public interface SafeModeNotification {
   void handleSafeModeTransition(SCMSafeModeManager.SafeModeStatus status);
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeTransition.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeTransition.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * <p>Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.hdds.scm.safemode;
+
+/**
+ * Interface which should be implemented by any object that wishes to be
+ * notified by the SafeModeManager when the safe mode state changes.
+ */
+public interface SafeModeTransition {
+  void handleSafeModeTransition(SCMSafeModeManager.SafeModeStatus status);
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -32,6 +32,8 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ScmOps;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerLocationProtocolProtos;
+import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
+import org.apache.hadoop.hdds.scm.safemode.SafeModeTransition;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.ScmUtils;
@@ -95,7 +97,7 @@ import static org.apache.hadoop.hdds.scm.server.StorageContainerManager
  * The RPC server that listens to requests from clients.
  */
 public class SCMClientProtocolServer implements
-    StorageContainerLocationProtocol, Auditor {
+    StorageContainerLocationProtocol, Auditor, SafeModeTransition {
   private static final Logger LOG =
       LoggerFactory.getLogger(SCMClientProtocolServer.class);
   private static final AuditLogger AUDIT =
@@ -599,12 +601,9 @@ public class SCMClientProtocolServer implements
     stop();
   }
 
-  /**
-   * Set SafeMode status.
-   *
-   * @param safeModeStatus
-   */
-  public void setSafeModeStatus(boolean safeModeStatus) {
-    safeModePrecheck.setInSafeMode(safeModeStatus);
+  @Override
+  public void handleSafeModeTransition(
+      SCMSafeModeManager.SafeModeStatus status) {
+    safeModePrecheck.setInSafeMode(status.getSafeModeStatus());
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ScmOps;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerLocationProtocolProtos;
 import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
-import org.apache.hadoop.hdds.scm.safemode.SafeModeTransition;
+import org.apache.hadoop.hdds.scm.safemode.SafeModeNotification;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.ScmUtils;
@@ -97,7 +97,7 @@ import static org.apache.hadoop.hdds.scm.server.StorageContainerManager
  * The RPC server that listens to requests from clients.
  */
 public class SCMClientProtocolServer implements
-    StorageContainerLocationProtocol, Auditor, SafeModeTransition {
+    StorageContainerLocationProtocol, Auditor, SafeModeNotification {
   private static final Logger LOG =
       LoggerFactory.getLogger(SCMClientProtocolServer.class);
   private static final AuditLogger AUDIT =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -333,9 +333,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     clientProtocolServer = new SCMClientProtocolServer(conf, this);
     httpServer = new StorageContainerManagerHttpServer(conf);
 
-    safeModeHandler = new SafeModeHandler(configuration,
-        clientProtocolServer, scmBlockManager, replicationManager,
-        pipelineManager);
+    safeModeHandler = new SafeModeHandler(configuration);
+    safeModeHandler.notifyImmediately(clientProtocolServer, scmBlockManager);
+    safeModeHandler.notifyAfterDelay(replicationManager, pipelineManager);
 
     eventQueue.addHandler(SCMEvents.DATANODE_COMMAND, scmNodeManager);
     eventQueue.addHandler(SCMEvents.RETRIABLE_DATANODE_COMMAND, scmNodeManager);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -139,7 +139,8 @@ public class TestBlockManager {
     factor = HddsProtos.ReplicationFactor.THREE;
     type = HddsProtos.ReplicationType.RATIS;
 
-    blockManager.setSafeModeStatus(false);
+    blockManager.handleSafeModeTransition(
+        new SCMSafeModeManager.SafeModeStatus(false));
   }
 
   @After
@@ -233,7 +234,8 @@ public class TestBlockManager {
 
   @Test
   public void testAllocateBlockFailureInSafeMode() throws Exception {
-    blockManager.setSafeModeStatus(true);
+    blockManager.handleSafeModeTransition(
+        new SCMSafeModeManager.SafeModeStatus(true));
     // Test1: In safe mode expect an SCMException.
     thrown.expectMessage("SafeModePrecheck failed for "
         + "allocateBlock");

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSafeModeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSafeModeHandler.java
@@ -73,9 +73,9 @@ public class TestSafeModeHandler {
         eventQueue, new LockManager(configuration));
     scmPipelineManager = Mockito.mock(SCMPipelineManager.class);
     blockManager = Mockito.mock(BlockManagerImpl.class);
-    safeModeHandler =
-        new SafeModeHandler(configuration, scmClientProtocolServer,
-            blockManager, replicationManager, scmPipelineManager);
+    safeModeHandler = new SafeModeHandler(configuration);
+    safeModeHandler.notifyImmediately(scmClientProtocolServer, blockManager);
+    safeModeHandler.notifyAfterDelay(replicationManager, scmPipelineManager);
 
     eventQueue.addHandler(SCMEvents.SAFE_MODE_STATUS, safeModeHandler);
     safeModeStatus = new SCMSafeModeManager.SafeModeStatus(false);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMClientProtocolServer.java
@@ -58,9 +58,9 @@ public class TestSCMClientProtocolServer {
     ReplicationManager replicationManager =
         Mockito.mock(ReplicationManager.class);
     PipelineManager pipelineManager = Mockito.mock(SCMPipelineManager.class);
-    SafeModeHandler safeModeHandler = new SafeModeHandler(config,
-        scmClientProtocolServer, blockManager, replicationManager,
-        pipelineManager);
+    SafeModeHandler safeModeHandler = new SafeModeHandler(config);
+    safeModeHandler.notifyImmediately(scmClientProtocolServer, blockManager);
+    safeModeHandler.notifyAfterDelay(replicationManager, pipelineManager);
     eventQueue.addHandler(SCMEvents.SAFE_MODE_STATUS, safeModeHandler);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The SafeModeHandler currently accepts several objects which it notifies when the safe mode status changes.

Each of these object are notified using a different method (there is no "notification interface") and some of the logic which really belongs in those objects (ie what to do when safemode goes on or off) is in the safemode classes rather than in the receiving class.

As we may need to extend safemode somewhat to delay pipeline creation until sufficient nodes have registered, I think it is worthwhile to refactor this area to do the following:

1. Introduce a new Interface "SafeModeTransition" which must be implemented by any object which wants to listen for safemode starting or ending.
```
public interface SafeModeTransition {
  void handleSafeModeTransition(SCMSafeModeManager.SafeModeStatus status);
}
```
2. Pass the SafeModeStatus object over this new interface. That way, we can extend SafeModeStatus to include more states in the future than just safemode = true / false.

3. Change the constructor of SafeModeHandler to allow any number of objects to be registered to make it more flexible going forward.

4. Ensure the logic of what action to take on safemode transition lives within the notified objects rather than in the Safemode clases.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3221

## How was this patch tested?

Depends on existing unit tests
