### PR TITLE
HDDS-3220. Filesystem client should not retry on AccessControlException.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -272,7 +272,7 @@ public class RpcClient implements ClientProtocol {
     userGroups.stream().forEach((group) -> listOfAcls.add(
         new OzoneAcl(ACLIdentityType.GROUP, group, groupRights, ACCESS)));
     //ACLs from VolumeArgs
-    if(volArgs.getAcls() != null) {
+    if (volArgs.getAcls() != null) {
       listOfAcls.addAll(volArgs.getAcls());
     }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -146,6 +146,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.VolumeI
 import org.apache.hadoop.ozone.protocolPB.OMPBHelper;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
+import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.proto.SecurityProtos.CancelDelegationTokenRequestProto;
 import org.apache.hadoop.security.proto.SecurityProtos.GetDelegationTokenRequestProto;
@@ -241,6 +242,9 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
       public RetryAction shouldRetry(Exception exception, int retries,
           int failovers, boolean isIdempotentOrAtMostOnce)
           throws Exception {
+        if (isAccessControlException(exception)) {
+          return RetryAction.FAIL; // do not retry
+        }
         if (exception instanceof ServiceException) {
           OMNotLeaderException notLeaderException =
               getNotLeaderException(exception);
@@ -271,7 +275,6 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         // does not perform any failover.
         omFailoverProxyProvider.performFailoverToNextProxy();
         return getRetryAction(FAILOVER_AND_RETRY, failovers);
-
       }
 
       private RetryAction getRetryAction(RetryAction fallbackAction,
@@ -293,12 +296,29 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   }
 
   /**
+   * Unwrap exception to check if it is a {@link AccessControlException}.
+   */
+  private boolean isAccessControlException(Exception ex) {
+    if (ex instanceof ServiceException) {
+      Throwable t = ex.getCause();
+      if (t instanceof IOException) {
+        t = t.getCause();
+        if (t instanceof IOException) {
+          t = t.getCause();
+          return t instanceof AccessControlException;
+        }
+      }
+    }
+    return false;
+  }
+  
+  /**
    * Check if exception is a OMNotLeaderException.
    * @return OMNotLeaderException.
    */
   private OMNotLeaderException getNotLeaderException(Exception exception) {
     Throwable cause = exception.getCause();
-    if (cause != null && cause instanceof RemoteException) {
+    if (cause instanceof RemoteException) {
       IOException ioException =
           ((RemoteException) cause).unwrapRemoteException();
       if (ioException instanceof OMNotLeaderException) {
@@ -316,7 +336,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   private OMLeaderNotReadyException getLeaderNotReadyException(
       Exception exception) {
     Throwable cause = exception.getCause();
-    if (cause != null && cause instanceof RemoteException) {
+    if (cause instanceof RemoteException) {
       IOException ioException =
           ((RemoteException) cause).unwrapRemoteException();
       if (ioException instanceof OMLeaderNotReadyException) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -301,12 +301,11 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   private boolean isAccessControlException(Exception ex) {
     if (ex instanceof ServiceException) {
       Throwable t = ex.getCause();
-      if (t instanceof IOException) {
-        t = t.getCause();
-        if (t instanceof IOException) {
-          t = t.getCause();
-          return t instanceof AccessControlException;
+      while (t != null) {
+        if (t instanceof AccessControlException) {
+          return true;
         }
+        t = t.getCause();
       }
     }
     return false;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -455,7 +455,7 @@ public final class TestSecureOzoneCluster {
     logs = LogCapturer.captureLogs(Client.LOG);
     LambdaTestUtils.intercept(IOException.class, exMessage,
         () -> unsecureClient.listAllVolumes(null, null, 0));
-    assertEquals("There should ni retry on AccessControlException", 1,
+    assertEquals("There should no retry on AccessControlException", 1,
         StringUtils.countMatches(logs.getOutput(), exMessage));
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -34,6 +34,7 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
@@ -61,6 +62,7 @@ import org.apache.hadoop.ozone.common.Storage;
 import org.apache.hadoop.ozone.om.OMStorage;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
@@ -104,6 +106,8 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TOKE
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TOKEN_EXPIRED;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
 import static org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod.KERBEROS;
+
+import org.apache.ratis.protocol.ClientId;
 import org.bouncycastle.asn1.x500.RDN;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.style.BCStyle;
@@ -115,6 +119,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -404,6 +409,54 @@ public final class TestSecureOzoneCluster {
       // kerberos should succeed.
       assertTrue(logs.getOutput().contains("Ozone Manager login successful"));
     }
+  }
+
+  @Test
+  public void testAccessControlExceptionOnClient() throws Exception {
+    initSCM();
+    // Create a secure SCM instance as om client will connect to it
+    scm = StorageContainerManager.createSCM(conf);
+    LogCapturer logs = LogCapturer.captureLogs(OzoneManager.getLogger());
+    GenericTestUtils.setLogLevel(OzoneManager.getLogger(), INFO);
+    setupOm(conf);
+    long omVersion = RPC.getProtocolVersion(OzoneManagerProtocolPB.class);
+    try {
+      om.setCertClient(new CertificateClientTestImpl(conf));
+      om.start();
+    } catch (Exception ex) {
+      // Expects timeout failure from scmClient in om but om user login via
+      // kerberos should succeed.
+      assertTrue(logs.getOutput().contains("Ozone Manager login successful"));
+    }
+    UserGroupInformation ugi =
+        UserGroupInformation.loginUserFromKeytabAndReturnUGI(
+            testUserPrincipal, testUserKeytab.getCanonicalPath());
+    ugi.setAuthenticationMethod(KERBEROS);
+    OzoneManagerProtocolClientSideTranslatorPB secureClient =
+        new OzoneManagerProtocolClientSideTranslatorPB(conf,
+            ClientId.randomId().toString(), null, ugi);
+    try {
+      secureClient.createVolume(
+          new OmVolumeArgs.Builder().setVolume("vol1")
+              .setOwnerName("owner1")
+              .setAdminName("admin")
+              .build());
+    } catch (IOException ex) {
+      fail("Secure client should be able to create volume.");
+    }
+
+    ugi = UserGroupInformation.createUserForTesting(
+        "testuser1", new String[]{"test"});
+    OzoneManagerProtocolClientSideTranslatorPB unsecureClient =
+        new OzoneManagerProtocolClientSideTranslatorPB(conf,
+            ClientId.randomId().toString(), null, ugi);
+    String exMessage = "org.apache.hadoop.security.AccessControlException: " +
+        "Client cannot authenticate via:[TOKEN, KERBEROS]";
+    logs = LogCapturer.captureLogs(Client.LOG);
+    LambdaTestUtils.intercept(IOException.class, exMessage,
+        () -> unsecureClient.listAllVolumes(null, null, 0));
+    assertEquals("There should ni retry on AccessControlException", 1,
+        StringUtils.countMatches(logs.getOutput(), exMessage));
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -455,7 +455,7 @@ public final class TestSecureOzoneCluster {
     logs = LogCapturer.captureLogs(Client.LOG);
     LambdaTestUtils.intercept(IOException.class, exMessage,
         () -> unsecureClient.listAllVolumes(null, null, 0));
-    assertEquals("There should no retry on AccessControlException", 1,
+    assertEquals("There should be no retry on AccessControlException", 1,
         StringUtils.countMatches(logs.getOutput(), exMessage));
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Change retry policy on the client if the exception is of type AccessControlException.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3220

## How was this patch tested?
Verified fix running ozone secure using docker. I will add an integration test later.