### PR TITLE
HDDS-3137. OM RpcClient fail with java.lang.IllegalArgumentException.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -200,7 +200,7 @@ public class OMFailoverProxyProvider implements
       // dtService can be null when during client object creation when one of
       // the OM configured address in unreachable.
       if (dtService != null) {
-        rpcAddress.append(",").append(rpcAddress);
+        rpcAddress.append(",").append(dtService);
       }
     }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -112,7 +112,8 @@ public class OMFailoverProxyProvider implements
           continue;
         }
 
-        OMProxyInfo omProxyInfo = new OMProxyInfo(nodeId, rpcAddrStr);
+        OMProxyInfo omProxyInfo = new OMProxyInfo(serviceId, nodeId,
+            rpcAddrStr);
 
         if (omProxyInfo.getAddress() != null) {
 
@@ -191,20 +192,19 @@ public class OMFailoverProxyProvider implements
   private Text computeDelegationTokenService() {
     // For HA, this will return "," separated address of all OM's.
     StringBuilder rpcAddress = new StringBuilder();
-    int count = 0;
+
     for (Map.Entry<String, OMProxyInfo> omProxyInfoSet :
         omProxyInfos.entrySet()) {
-      count++;
-      rpcAddress =
-          rpcAddress.append(
-              omProxyInfoSet.getValue().getDelegationTokenService());
+      Text dtService = omProxyInfoSet.getValue().getDelegationTokenService();
 
-      if (omProxyInfos.size() != count) {
-        rpcAddress.append(",");
+      // dtService can be null when during client object creation when one of
+      // the OM configured address in unreachable.
+      if (dtService != null) {
+        rpcAddress.append(",").append(rpcAddress);
       }
     }
 
-    return new Text(rpcAddress.toString());
+    return new Text(rpcAddress.toString().substring(1));
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -197,8 +197,8 @@ public class OMFailoverProxyProvider implements
         omProxyInfos.entrySet()) {
       Text dtService = omProxyInfoSet.getValue().getDelegationTokenService();
 
-      // dtService can be null when during client object creation when one of
-      // the OM configured address in unreachable.
+      // During client object creation when one of the OM configured address
+      // in unreachable, dtService can be null.
       if (dtService != null) {
         rpcAddress.append(",").append(dtService);
       }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMProxyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMProxyInfo.java
@@ -46,22 +46,17 @@ public class OMProxyInfo {
     this.rpcAddr = NetUtils.createSocketAddr(rpcAddrStr);
     if (rpcAddr.isUnresolved()) {
       LOG.warn("OzoneManager address {} for serviceID {} remains unresolved " +
-          "for node ID {} Check your ozone-site.xml file to ensure ozone " +
-          "manager addresses are configured properly.",
+              "for node ID {} Check your ozone-site.xml file to ensure ozone " +
+              "manager addresses are configured properly.",
           rpcAddress, serviceId, nodeId);
+      this.dtService = null;
     } else {
 
       // This issue will be a problem with docker/kubernetes world where one of
       // the container is killed, and that OM address will be unresolved. For now
       // skip the unresolved OM address setting it to the token service field.
 
-
-      try {
-        this.dtService = SecurityUtil.buildTokenService(rpcAddr);
-      } catch (Throwable t) {
-        // As anyway, we have logged above for unresolved address skipping here.
-        this.dtService = null;
-      }
+      this.dtService = SecurityUtil.buildTokenService(rpcAddr);
     }
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMProxyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMProxyInfo.java
@@ -53,8 +53,9 @@ public class OMProxyInfo {
     } else {
 
       // This issue will be a problem with docker/kubernetes world where one of
-      // the container is killed, and that OM address will be unresolved. For now
-      // skip the unresolved OM address setting it to the token service field.
+      // the container is killed, and that OM address will be unresolved.
+      // For now skip the unresolved OM address setting it to the token
+      // service field.
 
       this.dtService = SecurityUtil.buildTokenService(rpcAddr);
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMProxyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMProxyInfo.java
@@ -21,6 +21,8 @@ package org.apache.hadoop.ozone.om.ha;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.SecurityUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 
@@ -28,16 +30,39 @@ import java.net.InetSocketAddress;
  * Class to store OM proxy information.
  */
 public class OMProxyInfo {
+  private String serviceId;
   private String nodeId;
   private String rpcAddrStr;
   private InetSocketAddress rpcAddr;
   private Text dtService;
 
-  OMProxyInfo(String nodeID, String rpcAddress) {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OMProxyInfo.class);
+
+  OMProxyInfo(String serviceID, String nodeID, String rpcAddress) {
+    this.serviceId = serviceID;
     this.nodeId = nodeID;
     this.rpcAddrStr = rpcAddress;
     this.rpcAddr = NetUtils.createSocketAddr(rpcAddrStr);
-    this.dtService = SecurityUtil.buildTokenService(rpcAddr);
+    if (rpcAddr.isUnresolved()) {
+      LOG.warn("OzoneManager address {} for serviceID {} remains unresolved " +
+          "for node ID {} Check your ozone-site.xml file to ensure ozone " +
+          "manager addresses are configured properly.",
+          rpcAddress, serviceId, nodeId);
+    }
+
+    // This issue will be a problem with docker/kubernetes world where one of
+    // the container is killed, and that OM address will be unresolved. For now
+    // skip the unresolved OM address setting it to the token service field.
+
+    // TODo: Retry rpcAddr when unresolved during getProxy which will be used
+    //  until next fail over. Fix setting of dtService also at that time.
+    try {
+      this.dtService = SecurityUtil.buildTokenService(rpcAddr);
+    } catch (Throwable t) {
+      // As anyway, we have logged above for unresolved address skipping here.
+      this.dtService = null;
+    }
   }
 
   public String toString() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMProxyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMProxyInfo.java
@@ -49,19 +49,19 @@ public class OMProxyInfo {
           "for node ID {} Check your ozone-site.xml file to ensure ozone " +
           "manager addresses are configured properly.",
           rpcAddress, serviceId, nodeId);
-    }
+    } else {
 
-    // This issue will be a problem with docker/kubernetes world where one of
-    // the container is killed, and that OM address will be unresolved. For now
-    // skip the unresolved OM address setting it to the token service field.
+      // This issue will be a problem with docker/kubernetes world where one of
+      // the container is killed, and that OM address will be unresolved. For now
+      // skip the unresolved OM address setting it to the token service field.
 
-    // TODo: Retry rpcAddr when unresolved during getProxy which will be used
-    //  until next fail over. Fix setting of dtService also at that time.
-    try {
-      this.dtService = SecurityUtil.buildTokenService(rpcAddr);
-    } catch (Throwable t) {
-      // As anyway, we have logged above for unresolved address skipping here.
-      this.dtService = null;
+
+      try {
+        this.dtService = SecurityUtil.buildTokenService(rpcAddr);
+      } catch (Throwable t) {
+        // As anyway, we have logged above for unresolved address skipping here.
+        this.dtService = null;
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix Rpcclient creation failing with java.lang.IllegalArgumentException

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3137

## How was this patch tested?

Previously in docker-compose om-ha-s3, when one of the OM is killed using docker stop <<containerid>> used to fail with IllegalArgumentException.

Now with the fix, tried on the docker-compose ha cluster.
```
$ docker ps
CONTAINER ID        IMAGE                            COMMAND                  CREATED             STATUS              PORTS                                            NAMES
4181d2fb54bb        apache/ozone-runner:20191107-1   "/usr/local/bin/dumb…"   31 minutes ago      Up 31 minutes       0.0.0.0:9878->9878/tcp                           ozone-om-ha-s3_s3g_1
81e613bda640        apache/ozone-runner:20191107-1   "/usr/local/bin/dumb…"   31 minutes ago      Up 31 minutes       0.0.0.0:9890->9872/tcp, 0.0.0.0:9880->9874/tcp   ozone-om-ha-s3_om1_1
cdd968cba61f        apache/ozone-runner:20191107-1   "/usr/local/bin/dumb…"   31 minutes ago      Up 31 minutes       0.0.0.0:32769->9864/tcp                          ozone-om-ha-s3_datanode_1
89f0e6a0f4c8        apache/ozone-runner:20191107-1   "/usr/local/bin/dumb…"   31 minutes ago      Up 31 minutes       0.0.0.0:9894->9872/tcp, 0.0.0.0:9884->9874/tcp   ozone-om-ha-s3_om3_1
c34627654655        apache/ozone-runner:20191107-1   "/usr/local/bin/dumb…"   31 minutes ago      Up 31 minutes       0.0.0.0:9876->9876/tcp                           ozone-om-ha-s3_scm_1
d97ff58182c1        apache/ozone-runner:20191107-1   "/usr/local/bin/dumb…"   31 minutes ago      Up 2 seconds        0.0.0.0:9892->9872/tcp, 0.0.0.0:9882->9874/tcp   ozone-om-ha-s3_om2_1


$ docker stop 81e613bda640
81e613bda640

bash-4.2$ ozone admin om getserviceroles -id=id1
proxyom1 : FOLLOWER
om2 : FOLLOWER
om3 : LEADER
```


