### PR TITLE
HDDS-3056. Allow users to list volumes they have access to, and optionally allow all users to list all volumes

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -584,7 +584,7 @@
     </description>
   </property>
   <property>
-    <name>ozone.om.user.volume.listall.allowed</name>
+    <name>ozone.om.volume.listall.allowed</name>
     <value>true</value>
     <tag>OM, MANAGEMENT</tag>
     <description>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -584,6 +584,16 @@
     </description>
   </property>
   <property>
+    <name>ozone.om.user.volume.listall.allowed</name>
+    <value>true</value>
+    <tag>OM, MANAGEMENT</tag>
+    <description>
+      Allows everyone to list all volumes when set to true. Defaults to true.
+      When set to false, non-admin users can only list the volumes they have
+      access to. Admins can always list all volumes.
+    </description>
+  </property>
+  <property>
     <name>ozone.om.user.max.volume</name>
     <value>1024</value>
     <tag>OM, MANAGEMENT</tag>

--- a/hadoop-hdds/docs/content/shell/VolumeCommands.md
+++ b/hadoop-hdds/docs/content/shell/VolumeCommands.md
@@ -85,13 +85,15 @@ The above command will print out the information about hive volume.
 
 ### List
 
-The `volume list` command will list the volumes owned by a user.
+The `volume list` command will list the volumes accessible by a user.
 
 {{< highlight bash >}}
 ozone sh volume list --user hadoop
 {{< /highlight >}}
 
-The above command will print out all the volumes owned by the user hadoop.
+When ACL is enabled, the above command will print out volumes that the user
+hadoop has LIST permission to. When ACL is disabled, the above command will
+print out all the volumes owned by the user hadoop.
 
 ### Update
 

--- a/hadoop-hdds/docs/content/shell/VolumeCommands.zh.md
+++ b/hadoop-hdds/docs/content/shell/VolumeCommands.zh.md
@@ -80,13 +80,14 @@ ozone sh volume info /hive
 
 ### 列举
 
-`volume list` 命令用来列举一个用户拥有的所有卷。
+`volume list` 命令用来列举一个用户可以访问的所有卷。
 
 {{< highlight bash >}}
 ozone sh volume list --user hadoop
 {{< /highlight >}}
 
-上述命令会打印出 hadoop 用户拥有的所有卷。
+若 ACL 已启用，上述命令会打印出 hadoop 用户有 LIST 权限的所有卷。
+若 ACL 被禁用，上述命令会打印出 hadoop 用户拥有的所有卷。
 
 ### 更新
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -76,7 +76,7 @@ public final class OMConfigKeys {
       "ozone.om.db.cache.size.mb";
   public static final int OZONE_OM_DB_CACHE_SIZE_DEFAULT = 128;
 
-  public static final String OZONE_OM_USER_VOLUME_LISTALL_ALLOWED =
+  public static final String OZONE_OM_VOLUME_LISTALL_ALLOWED =
       "ozone.om.volume.listall.allowed";
   public static final boolean OZONE_OM_USER_VOLUME_LISTALL_ALLOWED_DEFAULT =
       true;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -76,6 +76,10 @@ public final class OMConfigKeys {
       "ozone.om.db.cache.size.mb";
   public static final int OZONE_OM_DB_CACHE_SIZE_DEFAULT = 128;
 
+  public static final String OZONE_OM_USER_VOLUME_LISTALL_ALLOWED =
+      "ozone.om.user.volume.listall.allowed";
+  public static final boolean OZONE_OM_USER_VOLUME_LISTALL_ALLOWED_DEFAULT =
+      true;
   public static final String OZONE_OM_USER_MAX_VOLUME =
       "ozone.om.user.max.volume";
   public static final int OZONE_OM_USER_MAX_VOLUME_DEFAULT = 1024;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -78,8 +78,7 @@ public final class OMConfigKeys {
 
   public static final String OZONE_OM_VOLUME_LISTALL_ALLOWED =
       "ozone.om.volume.listall.allowed";
-  public static final boolean OZONE_OM_USER_VOLUME_LISTALL_ALLOWED_DEFAULT =
-      true;
+  public static final boolean OZONE_OM_VOLUME_LISTALL_ALLOWED_DEFAULT = true;
   public static final String OZONE_OM_USER_MAX_VOLUME =
       "ozone.om.user.max.volume";
   public static final int OZONE_OM_USER_MAX_VOLUME_DEFAULT = 1024;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -77,7 +77,7 @@ public final class OMConfigKeys {
   public static final int OZONE_OM_DB_CACHE_SIZE_DEFAULT = 128;
 
   public static final String OZONE_OM_USER_VOLUME_LISTALL_ALLOWED =
-      "ozone.om.user.volume.listall.allowed";
+      "ozone.om.volume.listall.allowed";
   public static final boolean OZONE_OM_USER_VOLUME_LISTALL_ALLOWED_DEFAULT =
       true;
   public static final String OZONE_OM_USER_MAX_VOLUME =

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -118,7 +118,7 @@ public interface OzoneManagerProtocol
   void deleteVolume(String volume) throws IOException;
 
   /**
-   * Lists volume owned by a specific user.
+   * Lists volumes accessible by a specific user.
    * @param userName - user name
    * @param prefix  - Filter prefix -- Return only entries that match this.
    * @param prevKey - Previous key -- List starts from the next from the prevkey

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -573,7 +573,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   }
 
   /**
-   * Lists volume owned by a specific user.
+   * Lists volumes accessible by a specific user.
    *
    * @param userName - user name
    * @param prefix - Filter prefix -- Return only entries that match this.

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 CORE-SITE.XML_fs.o3fs.impl=org.apache.hadoop.fs.ozone.OzoneFileSystem
+OZONE-SITE.XML_ozone.om.user.volume.listall.allowed=false
 
 OZONE-SITE.XML_ozone.om.address=om
 OZONE-SITE.XML_ozone.om.http-address=om:9874

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 CORE-SITE.XML_fs.o3fs.impl=org.apache.hadoop.fs.ozone.OzoneFileSystem
-OZONE-SITE.XML_ozone.om.user.volume.listall.allowed=false
+OZONE-SITE.XML_ozone.om.volume.listall.allowed=false
 
 OZONE-SITE.XML_ozone.om.address=om
 OZONE-SITE.XML_ozone.om.http-address=om:9874

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
@@ -130,10 +130,6 @@ public class TestOzoneManagerListVolumes {
     ClientProtocol proxy = objectStore.getClientProxy();
     objectStore.createVolume(volumeName);
     proxy.setVolumeOwner(volumeName, ownerName);
-//    OzoneAcl acl1 = new OzoneAcl(IAccessAuthorizer.ACLIdentityType.USER,
-//        "johndoe", IAccessAuthorizer.ACLType.ALL, ACCESS);
-//    List<OzoneAcl> aclList = new ArrayList<>();
-//    aclList.add(acl1);
     setVolumeAcl(objectStore, volumeName, aclString);
   }
 
@@ -183,14 +179,10 @@ public class TestOzoneManagerListVolumes {
       try {
         objectStore.listVolumes("volume");
         Assert.fail("listAllVolumes should fail for " + user.getUserName());
-      } catch (OMException ex) {
-        // Expect PERMISSION_DENIED if user is not admin and listall disallowed
-        if (ex.getResult() != OMException.ResultCodes.PERMISSION_DENIED) {
-          throw ex;
-        }
       } catch (RuntimeException ex) {
         // Current listAllVolumes throws RuntimeException
         if (ex.getCause() instanceof OMException) {
+          // Expect PERMISSION_DENIED
           if (((OMException) ex.getCause()).getResult() !=
               OMException.ResultCodes.PERMISSION_DENIED) {
             throw ex;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
@@ -1,0 +1,215 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.UUID;
+
+import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneKey;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.test.GenericTestUtils;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_RATIS_PIPELINE_LIMIT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OPEN_KEY_EXPIRE_THRESHOLD_SECONDS;
+import org.junit.After;
+import org.junit.Assert;
+import static org.junit.Assert.fail;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+/**
+ * Test some client operations after cluster starts. And perform restart and
+ * then performs client operations and check the behavior is expected or not.
+ */
+@Ignore
+public class TestOzoneManagerListVolumes {
+  private MiniOzoneCluster cluster = null;
+  private OzoneConfiguration conf;
+  private String clusterId;
+  private String scmId;
+  private String omId;
+
+  @Rule
+  public Timeout timeout = new Timeout(60000);
+
+  /**
+   * Create a MiniDFSCluster for testing.
+   * <p>
+   * Ozone is made active by setting OZONE_ENABLED = true
+   *
+   * @throws IOException
+   */
+  @Before
+  public void init() throws Exception {
+    conf = new OzoneConfiguration();
+    clusterId = UUID.randomUUID().toString();
+    scmId = UUID.randomUUID().toString();
+    omId = UUID.randomUUID().toString();
+    conf.setBoolean(OZONE_ACL_ENABLED, true);
+    conf.setInt(OZONE_OPEN_KEY_EXPIRE_THRESHOLD_SECONDS, 2);
+    conf.set(OZONE_ADMINISTRATORS, OZONE_ADMINISTRATORS_WILDCARD);
+    conf.setInt(OZONE_SCM_RATIS_PIPELINE_LIMIT, 10);
+    cluster =  MiniOzoneCluster.newBuilder(conf)
+        .setClusterId(clusterId)
+        .setScmId(scmId)
+        .setOmId(omId)
+        .build();
+    cluster.waitForClusterToBeReady();
+
+  }
+
+  /**
+   * Shutdown MiniDFSCluster.
+   */
+  @After
+  public void shutdown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void testRestartOMWithVolumeOperation() throws Exception {
+    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
+
+    OzoneClient client = cluster.getClient();
+
+    ObjectStore objectStore = client.getObjectStore();
+
+    objectStore.createVolume(volumeName);
+
+    OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
+    Assert.assertTrue(ozoneVolume.getName().equals(volumeName));
+
+    cluster.restartOzoneManager();
+    cluster.restartStorageContainerManager(true);
+
+    // After restart, try to create same volume again, it should fail.
+    try {
+      objectStore.createVolume(volumeName);
+      fail("testRestartOM failed");
+    } catch (IOException ex) {
+      GenericTestUtils.assertExceptionContains("VOLUME_ALREADY_EXISTS", ex);
+    }
+
+    // Get Volume.
+    ozoneVolume = objectStore.getVolume(volumeName);
+    Assert.assertTrue(ozoneVolume.getName().equals(volumeName));
+
+  }
+
+
+  @Test
+  public void testRestartOMWithBucketOperation() throws Exception {
+    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
+    String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+
+    OzoneClient client = cluster.getClient();
+
+    ObjectStore objectStore = client.getObjectStore();
+
+    objectStore.createVolume(volumeName);
+
+    OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
+    Assert.assertTrue(ozoneVolume.getName().equals(volumeName));
+
+    ozoneVolume.createBucket(bucketName);
+
+    OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
+    Assert.assertTrue(ozoneBucket.getName().equals(bucketName));
+
+    cluster.restartOzoneManager();
+    cluster.restartStorageContainerManager(true);
+
+    // After restart, try to create same bucket again, it should fail.
+    try {
+      ozoneVolume.createBucket(bucketName);
+      fail("testRestartOMWithBucketOperation failed");
+    } catch (IOException ex) {
+      GenericTestUtils.assertExceptionContains("BUCKET_ALREADY_EXISTS", ex);
+    }
+
+    // Get bucket.
+    ozoneBucket = ozoneVolume.getBucket(bucketName);
+    Assert.assertTrue(ozoneBucket.getName().equals(bucketName));
+
+  }
+
+
+  @Test
+  public void testRestartOMWithKeyOperation() throws Exception {
+    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
+    String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+    String key = "key" + RandomStringUtils.randomNumeric(5);
+
+    OzoneClient client = cluster.getClient();
+
+    ObjectStore objectStore = client.getObjectStore();
+
+    objectStore.createVolume(volumeName);
+
+    OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
+    Assert.assertTrue(ozoneVolume.getName().equals(volumeName));
+
+    ozoneVolume.createBucket(bucketName);
+
+    OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
+    Assert.assertTrue(ozoneBucket.getName().equals(bucketName));
+
+    String data = "random data";
+    OzoneOutputStream ozoneOutputStream = ozoneBucket.createKey(key,
+        data.length(), ReplicationType.RATIS, ReplicationFactor.ONE,
+        new HashMap<>());
+
+    ozoneOutputStream.write(data.getBytes(), 0, data.length());
+    ozoneOutputStream.close();
+
+    cluster.restartOzoneManager();
+    cluster.restartStorageContainerManager(true);
+
+
+    // As we allow override of keys, not testing re-create key. We shall see
+    // after restart key exists or not.
+
+    // Get key.
+    OzoneKey ozoneKey = ozoneBucket.getKey(key);
+    Assert.assertTrue(ozoneKey.getName().equals(key));
+    Assert.assertTrue(ozoneKey.getReplicationType().equals(
+        ReplicationType.RATIS));
+  }
+
+
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
@@ -48,7 +48,6 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_AL
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.StoreType.OZONE;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -56,7 +55,6 @@ import org.junit.rules.Timeout;
 /**
  * Test OzoneManager list volume operation under combinations of configs.
  */
-@Ignore
 public class TestOzoneManagerListVolumes {
 
   @Rule

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -43,7 +43,6 @@ import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.conf.StorageUnit;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1844,12 +1844,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     try {
       metrics.incNumVolumeLists();
       if (isAclEnabled) {
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("ACL is enabled. Listing volumes accessible by user. "
-                  + "Principal: {}, keytab: {}",
-              configuration.get(OZONE_OM_KERBEROS_PRINCIPAL_KEY),
-              configuration.get(OZONE_OM_KERBEROS_KEYTAB_FILE_KEY));
-        }
         // List all volumes first
         List<OmVolumeArgs> listOfAllVolumes = volumeManager.listVolumes(
             null, prefix, prevKey, maxKeys);
@@ -1858,12 +1852,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
             .hasAccess(IAccessAuthorizer.ACLType.LIST, remoteUserUgi))
             .collect(Collectors.toList());
       } else {
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("ACL is disabled. Listing volumes owned by user. "
-                  + "Principal: {}, keytab: {}",
-              configuration.get(OZONE_OM_KERBEROS_PRINCIPAL_KEY),
-              configuration.get(OZONE_OM_KERBEROS_KEYTAB_FILE_KEY));
-        }
         // When ACL is not enabled, fallback to filter by owner
         return volumeManager.listVolumes(userName, prefix, prevKey, maxKeys);
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -203,7 +203,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_KEYTAB_F
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_METRICS_SAVE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_METRICS_SAVE_INTERVAL_DEFAULT;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_USER_VOLUME_LISTALL_ALLOWED;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_ALLOWED;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_USER_VOLUME_LISTALL_ALLOWED_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_USER_MAX_VOLUME;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_USER_MAX_VOLUME_DEFAULT;
@@ -345,8 +345,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     loginOMUserIfSecurityEnabled(conf);
 
-    this.allowListAllVolumes = conf.getBoolean(
-        OZONE_OM_USER_VOLUME_LISTALL_ALLOWED,
+    this.allowListAllVolumes = conf.getBoolean(OZONE_OM_VOLUME_LISTALL_ALLOWED,
         OZONE_OM_USER_VOLUME_LISTALL_ALLOWED_DEFAULT);
     this.maxUserVolumeCount = conf.getInt(OZONE_OM_USER_MAX_VOLUME,
         OZONE_OM_USER_MAX_VOLUME_DEFAULT);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -203,7 +203,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPA
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_METRICS_SAVE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_METRICS_SAVE_INTERVAL_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_ALLOWED;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_USER_VOLUME_LISTALL_ALLOWED_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_ALLOWED_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_USER_MAX_VOLUME;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_USER_MAX_VOLUME_DEFAULT;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_AUTH_METHOD;
@@ -345,7 +345,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     loginOMUserIfSecurityEnabled(conf);
 
     this.allowListAllVolumes = conf.getBoolean(OZONE_OM_VOLUME_LISTALL_ALLOWED,
-        OZONE_OM_USER_VOLUME_LISTALL_ALLOWED_DEFAULT);
+        OZONE_OM_VOLUME_LISTALL_ALLOWED_DEFAULT);
     this.maxUserVolumeCount = conf.getInt(OZONE_OM_USER_MAX_VOLUME,
         OZONE_OM_USER_MAX_VOLUME_DEFAULT);
     Preconditions.checkArgument(this.maxUserVolumeCount > 0,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1876,7 +1876,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     auditMap.put(OzoneConsts.USERNAME, null);
     try {
       metrics.incNumVolumeLists();
-      checkAdmin();
       return volumeManager.listVolumes(null, prefix, prevKey, maxKeys);
     } catch (Exception ex) {
       metrics.incNumVolumeListFails();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/VolumeManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/VolumeManagerImpl.java
@@ -453,23 +453,11 @@ public class VolumeManagerImpl implements VolumeManager {
   @Override
   public List<OmVolumeArgs> listVolumes(String userName,
       String prefix, String startKey, int maxKeys) throws IOException {
-    metadataManager.getLock().acquireLock(USER_LOCK, userName);
+    metadataManager.getLock().acquireWriteLock(USER_LOCK, userName);
     try {
-      List<OmVolumeArgs> volumes = metadataManager.listVolumes(
-          userName, prefix, startKey, maxKeys);
-      UserGroupInformation userUgi = ProtobufRpcEngine.Server.
-          getRemoteUser();
-      if (userUgi == null || !aclEnabled) {
-        return volumes;
-      }
-
-      List<OmVolumeArgs> filteredVolumes = volumes.stream().
-          filter(v -> v.getAclMap().
-              hasAccess(IAccessAuthorizer.ACLType.LIST, userUgi))
-          .collect(Collectors.toList());
-      return filteredVolumes;
+      return metadataManager.listVolumes(userName, prefix, startKey, maxKeys);
     } finally {
-      metadataManager.getLock().releaseLock(USER_LOCK, userName);
+      metadataManager.getLock().releaseWriteLock(USER_LOCK, userName);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/VolumeManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/VolumeManagerImpl.java
@@ -449,11 +449,11 @@ public class VolumeManagerImpl implements VolumeManager {
   @Override
   public List<OmVolumeArgs> listVolumes(String userName,
       String prefix, String startKey, int maxKeys) throws IOException {
-    metadataManager.getLock().acquireWriteLock(USER_LOCK, userName);
+    metadataManager.getLock().acquireReadLock(USER_LOCK, userName);
     try {
       return metadataManager.listVolumes(userName, prefix, startKey, maxKeys);
     } finally {
-      metadataManager.getLock().releaseWriteLock(USER_LOCK, userName);
+      metadataManager.getLock().releaseReadLock(USER_LOCK, userName);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/VolumeManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/VolumeManagerImpl.java
@@ -20,10 +20,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -32,10 +30,8 @@ import org.apache.hadoop.ozone.protocol.proto
     .OzoneManagerProtocolProtos.OzoneAclInfo;
 import org.apache.hadoop.ozone.protocol.proto
     .OzoneManagerProtocolProtos.UserVolumeInfo;
-import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.RequestContext;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
 import com.google.common.base.Preconditions;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/ListVolumeHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/ListVolumeHandler.java
@@ -55,6 +55,10 @@ public class ListVolumeHandler extends Handler {
       description = "Owner of the volumes to list.")
   private String userName;
 
+  @Option(names = {"--all", "-a"},
+      description = "List all volumes. This overrides --user option.")
+  private boolean listAllVolumes;
+
   @Override
   protected OzoneAddress getAddress() throws OzoneClientException {
     OzoneAddress address = new OzoneAddress(uri);
@@ -71,12 +75,12 @@ public class ListVolumeHandler extends Handler {
     }
 
     Iterator<? extends OzoneVolume> volumeIterator;
-    if (userName != null) {
+    if (userName != null && !listAllVolumes) {
       volumeIterator = client.getObjectStore().listVolumesByUser(userName,
           listOptions.getPrefix(), listOptions.getStartItem());
     } else {
       volumeIterator = client.getObjectStore().listVolumes(
-          listOptions.getPrefix());
+          listOptions.getPrefix(), listOptions.getStartItem());
     }
 
     int counter = 0;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/ListVolumeHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/ListVolumeHandler.java
@@ -52,11 +52,12 @@ public class ListVolumeHandler extends Handler {
   private ListOptions listOptions;
 
   @Option(names = {"--user", "-u"},
-      description = "Owner of the volumes to list.")
+      description = "List accessible volumes of the user. This will be ignored"
+          + " if list all volumes option is specified.")
   private String userName;
 
   @Option(names = {"--all", "-a"},
-      description = "List all volumes. This overrides --user option.")
+      description = "List all volumes.")
   private boolean listAllVolumes;
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Optionally allow non-admin users to list all volumes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3056

## How was this patch tested?

NOTE: The chunk below is out-dated. Will update once the patch is complete.

Tested manually in ozonesecure docker-compose.
`testuser` is an admin user (listed in `ozone.administrators`), `testuser2` is a non-admin user.

|                              | Before                          | After (ACL disabled)                                         | After (ACL enabled)                          |
| ---------------------------- | ------------------------------- | ------------------------------------------------------------ | -------------------------------------------- |
| `ozone sh volume list`       | Lists volumes **owned** by user | Lists volumes **owned** by user                              | Lists volumes that user has ACL **LIST** to. |
| `ozone sh volume list --all` | n/a                             | Lists all volumes if `ozone.om.volume.listall.allowed` is `true`; if `false`, only admins can list all volumes, non-admin will get `OmException` with `PERMISSION_DENIED`. | Same as ACL disabled.                        |


### After the patch (non-admin can list all volumes)

```bash
bash-4.2$ kinit -kt /etc/security/keytabs/testuser.keytab testuser/scm@EXAMPLE.COM
bash-4.2$ klist
Ticket cache: FILE:/tmp/krb5cc_1000
Default principal: testuser/scm@EXAMPLE.COM

Valid starting     Expires            Service principal
03/18/20 21:20:25  03/19/20 21:20:25  krbtgt/EXAMPLE.COM@EXAMPLE.COM
	renew until 03/25/20 21:20:25
bash-4.2$ ozone sh volume create vol1
bash-4.2$ ozone sh volume list
{
  "metadata" : { },
  "name" : "vol1",
  "admin" : "root",
  "owner" : "testuser/scm@EXAMPLE.COM",
...
bash-4.2$ kdestroy
bash-4.2$ kinit -kt /etc/security/keytabs/testuser2.keytab testuser2/scm@EXAMPLE.COM
bash-4.2$ ozone sh volume list --all
{
  "metadata" : { },
  "name" : "vol1",
  "admin" : "root",
  "owner" : "testuser/scm@EXAMPLE.COM",
  "creationTime" : "2020-03-18T21:20:35.370Z",
...
```

### For comparison, before the patch (non-admin can't list all volumes)

```bash
# kinit'ed as testuser2 (non-admin)
bash-4.2$ ozone sh volume list --all
PERMISSION_DENIED org.apache.hadoop.ozone.om.exceptions.OMException: Only admin users are authorized to create or list Ozone volumes.
bash-4.2$ klist
Ticket cache: FILE:/tmp/krb5cc_1000
Default principal: testuser2/scm@EXAMPLE.COM

Valid starting     Expires            Service principal
03/18/20 21:15:34  03/19/20 21:15:34  krbtgt/EXAMPLE.COM@EXAMPLE.COM
	renew until 03/25/20 21:15:34
```