### PR TITLE
HDDS-3235.Change to default of max retry count for Ozone client

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -143,7 +143,7 @@ public final class OzoneConfigKeys {
 
   public static final String OZONE_CLIENT_MAX_RETRIES =
       "ozone.client.max.retries";
-  public static final int OZONE_CLIENT_MAX_RETRIES_DEFAULT = 100;
+  public static final int OZONE_CLIENT_MAX_RETRIES_DEFAULT = 5;
   public static final String OZONE_CLIENT_RETRY_INTERVAL =
       "ozone.client.retry.interval";
   public static final TimeDuration OZONE_CLIENT_RETRY_INTERVAL_DEFAULT =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -412,7 +412,7 @@
   </property>
   <property>
     <name>ozone.client.max.retries</name>
-    <value>100</value>
+    <value>5</value>
     <tag>OZONE, CLIENT</tag>
     <description>Maximum number of retries by Ozone Client on encountering
       exception while writing a key.


### PR DESCRIPTION
## What changes were proposed in this pull request?
The change here is to limit the no of maxRetry count for ozone client retry to 5 or so.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3235

## How was this patch tested?
Only a config change.No tests required.
