### PR TITLE
HDDS-2945. Implement ofs://: Add robot tests for mkdir.

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs.robot
@@ -14,99 +14,128 @@
 # limitations under the License.
 
 *** Settings ***
-Documentation       Ozonefs test
+Documentation       Ozonefs test covering both o3fs and ofs
 Library             OperatingSystem
 Resource            ../commonlib.robot
 
 *** Variables ***
+${OfsBucket1}          om:9862/fstest/bucket1
+${O3fsBucket1}         bucket1.fstest/
+${O3Bucket1}           o3://om/fstest/bucket1
+${O3Bucket2}           o3://om/fstest/bucket2
+${O3Bucket3}           o3://om/fstest2/bucket3
 
+${OfsNonExistBucket}      om:9862/abc/def
+${O3fsNonExistBucket}     def.abc/
+${NonExistVolume}         abc
 
 *** Test Cases ***
-Create volume and bucket
+Create volume and bucket for Ozone file System test
     Execute             ozone sh volume create o3://om/fstest --quota 100TB
+    Execute             ozone sh bucket create ${O3Bucket1}
+    Execute             ozone sh bucket create ${O3Bucket2}
+
     Execute             ozone sh volume create o3://om/fstest2 --quota 100TB
-    Execute             ozone sh bucket create o3://om/fstest/bucket1
-    Execute             ozone sh bucket create o3://om/fstest/bucket2
-    Execute             ozone sh bucket create o3://om/fstest2/bucket3
+    Execute             ozone sh bucket create ${O3Bucket3}
 
-Check volume from ozonefs
-    ${result} =         Execute               ozone fs -ls o3fs://bucket1.fstest/
 
-Run ozoneFS tests
-                        Execute               ozone fs -mkdir -p o3fs://bucket1.fstest/testdir/deep
-    ${result} =         Execute               ozone sh key list o3://om/fstest/bucket1 | jq -r '.name'
+Check volume from o3fs
+    ${result} =         Execute               ozone fs -ls o3fs://${O3fsBucket1}
+
+Test ozone shell with ofs
+   Test ozone shell with scheme  ofs    om:9862/fstest/bucket1      om:9862/fstest/bucket2      om:9862/fstest2/bucket3      om:9862/abc/def
+
+Test ozone shell with o3fs
+   Test ozone shell with scheme  o3fs   bucket1.fstest/             bucket2.fstest/             bucket3.fstest2/             def.abc/
+
+*** Keywords ***
+Test ozone shell with scheme
+    [arguments]         ${scheme}             ${testBucket1}        ${testBucket2}      ${testBucket3}      ${nonExistBucket}
+
+    ${result} =         Execute               ozone fs -ls ${scheme}://${testBucket1}
+                        Execute               ozone fs -mkdir -p ${scheme}://${testBucket1}/testdir/deep
+    ${result} =         Execute               ozone sh key list ${O3Bucket1} | jq -r '.name'
                         Should contain    ${result}         testdir/deep
-                        Execute               ozone fs -copyFromLocal NOTICE.txt o3fs://bucket1.fstest/testdir/deep/
-    ${result} =         Execute               ozone sh key list o3://om/fstest/bucket1 | jq -r '.name'
+
+                        Execute               ozone fs -copyFromLocal NOTICE.txt ${scheme}://${testBucket1}/testdir/deep/
+    ${result} =         Execute               ozone sh key list ${O3Bucket1} | jq -r '.name'
                         Should contain    ${result}         NOTICE.txt
 
-                        Execute               ozone fs -put NOTICE.txt o3fs://bucket1.fstest/testdir/deep/PUTFILE.txt
-    ${result} =         Execute               ozone sh key list o3://om/fstest/bucket1 | jq -r '.name'
+                        Execute               ozone fs -put NOTICE.txt ${scheme}://${testBucket1}/testdir/deep/PUTFILE.txt
+    ${result} =         Execute               ozone sh key list ${O3Bucket1} | jq -r '.name'
                         Should contain    ${result}         PUTFILE.txt
 
-    ${result} =         Execute               ozone fs -ls o3fs://bucket1.fstest/testdir/deep/
+    ${result} =         Execute               ozone fs -ls ${scheme}://${testBucket1}/testdir/deep/
                         Should contain    ${result}         NOTICE.txt
                         Should contain    ${result}         PUTFILE.txt
 
-                        Execute               ozone fs -mv o3fs://bucket1.fstest/testdir/deep/NOTICE.txt o3fs://bucket1.fstest/testdir/deep/MOVED.TXT
-    ${result} =         Execute               ozone sh key list o3://om/fstest/bucket1 | jq -r '.name'
+                        Execute               ozone fs -mv ${scheme}://${testBucket1}/testdir/deep/NOTICE.txt ${scheme}://${testBucket1}/testdir/deep/MOVED.TXT
+    ${result} =         Execute               ozone sh key list ${O3Bucket1} | jq -r '.name'
                         Should contain    ${result}         MOVED.TXT
                         Should not contain  ${result}       NOTICE.txt
 
-                        Execute               ozone fs -mkdir -p o3fs://bucket1.fstest/testdir/deep/subdir1
-                        Execute               ozone fs -cp o3fs://bucket1.fstest/testdir/deep/MOVED.TXT o3fs://bucket1.fstest/testdir/deep/subdir1/NOTICE.txt
-    ${result} =         Execute               ozone sh key list o3://om/fstest/bucket1 | jq -r '.name'
+                        Execute               ozone fs -mkdir -p ${scheme}://${testBucket1}/testdir/deep/subdir1
+                        Execute               ozone fs -cp ${scheme}://${testBucket1}/testdir/deep/MOVED.TXT ${scheme}://${testBucket1}/testdir/deep/subdir1/NOTICE.txt
+    ${result} =         Execute               ozone sh key list ${O3Bucket1} | jq -r '.name'
                         Should contain    ${result}         subdir1/NOTICE.txt
 
-    ${result} =         Execute               ozone fs -ls o3fs://bucket1.fstest/testdir/deep/subdir1/
+    ${result} =         Execute               ozone fs -ls ${scheme}://${testBucket1}/testdir/deep/subdir1/
                         Should contain    ${result}         NOTICE.txt
 
-                        Execute               ozone fs -cat o3fs://bucket1.fstest/testdir/deep/subdir1/NOTICE.txt
+                        Execute               ozone fs -cat ${scheme}://${testBucket1}/testdir/deep/subdir1/NOTICE.txt
                         Should not contain  ${result}       Failed
 
-                        Execute               ozone fs -rm o3fs://bucket1.fstest/testdir/deep/subdir1/NOTICE.txt
-    ${result} =         Execute               ozone sh key list o3://om/fstest/bucket1 | jq -r '.name'
+                        Execute               ozone fs -rm ${scheme}://${testBucket1}/testdir/deep/subdir1/NOTICE.txt
+    ${result} =         Execute               ozone sh key list ${O3Bucket1} | jq -r '.name'
                         Should not contain  ${result}       NOTICE.txt
 
-    ${result} =         Execute               ozone fs -rmdir o3fs://bucket1.fstest/testdir/deep/subdir1/
-    ${result} =         Execute               ozone sh key list o3://om/fstest/bucket1 | jq -r '.name'
+    ${result} =         Execute               ozone fs -rmdir ${scheme}://${testBucket1}/testdir/deep/subdir1/
+    ${result} =         Execute               ozone sh key list ${O3Bucket1} | jq -r '.name'
                         Should not contain  ${result}       subdir1
 
-                        Execute               ozone fs -touch o3fs://bucket1.fstest/testdir/TOUCHFILE.txt
-    ${result} =         Execute               ozone sh key list o3://om/fstest/bucket1 | jq -r '.name'
+                        Execute               ozone fs -touch ${scheme}://${testBucket1}/testdir/TOUCHFILE.txt
+    ${result} =         Execute               ozone sh key list ${O3Bucket1} | jq -r '.name'
                         Should contain  ${result}       TOUCHFILE.txt
 
-                        Execute               ozone fs -rm -r o3fs://bucket1.fstest/testdir/
-    ${result} =         Execute               ozone sh key list o3://om/fstest/bucket1 | jq -r '.name'
+                        Execute               ozone fs -rm -r ${scheme}://${testBucket1}/testdir/
+    ${result} =         Execute               ozone sh key list ${O3Bucket1} | jq -r '.name'
                         Should not contain  ${result}       testdir
 
                         Execute               rm -Rf /tmp/localdir1
                         Execute               mkdir /tmp/localdir1
                         Execute               cp NOTICE.txt /tmp/localdir1/LOCAL.txt
-                        Execute               ozone fs -mkdir -p o3fs://bucket1.fstest/testdir1
-                        Execute               ozone fs -copyFromLocal /tmp/localdir1 o3fs://bucket1.fstest/testdir1/
-                        Execute               ozone fs -put NOTICE.txt o3fs://bucket1.fstest/testdir1/NOTICE.txt
+                        Execute               ozone fs -mkdir -p ${scheme}://${testBucket1}/testdir1
+                        Execute               ozone fs -copyFromLocal /tmp/localdir1 ${scheme}://${testBucket1}/testdir1/
+                        Execute               ozone fs -put NOTICE.txt ${scheme}://${testBucket1}/testdir1/NOTICE.txt
 
-    ${result} =         Execute               ozone fs -ls -R o3fs://bucket1.fstest/testdir1/
+    ${result} =         Execute               ozone fs -ls -R ${scheme}://${testBucket1}/testdir1/
                         Should contain    ${result}         localdir1/LOCAL.txt
                         Should contain    ${result}         testdir1/NOTICE.txt
 
-                        Execute               ozone fs -mkdir -p o3fs://bucket2.fstest/testdir2
-                        Execute               ozone fs -mkdir -p o3fs://bucket3.fstest2/testdir3
+                        Execute               ozone fs -mkdir -p ${scheme}://${testBucket2}/testdir2
+                        Execute               ozone fs -mkdir -p ${scheme}://${testBucket3}/testdir3
 
-                        Execute               ozone fs -cp o3fs://bucket1.fstest/testdir1/localdir1 o3fs://bucket2.fstest/testdir2/
+                        Execute               ozone fs -cp ${scheme}://${testBucket1}/testdir1/localdir1 ${scheme}://${testBucket2}/testdir2/
+                        Execute               ozone fs -cp ${scheme}://${testBucket1}/testdir1/localdir1 ${scheme}://${testBucket3}/testdir3/
 
-                        Execute               ozone fs -cp o3fs://bucket1.fstest/testdir1/localdir1 o3fs://bucket3.fstest2/testdir3/
-
-                        Execute               ozone sh key put o3://om/fstest/bucket1/KEY.txt NOTICE.txt
-    ${result} =         Execute               ozone fs -ls o3fs://bucket1.fstest/KEY.txt
+                        Execute               ozone sh key put ${O3Bucket1}/KEY.txt NOTICE.txt
+    ${result} =         Execute               ozone fs -ls ${scheme}://${testBucket1}/KEY.txt
                         Should contain    ${result}         KEY.txt
-    ${rc}  ${result} =  Run And Return Rc And Output        ozone fs -copyFromLocal NOTICE.txt o3fs://bucket1.fstest/KEY.txt
+
+    ${rc}  ${result} =  Run And Return Rc And Output        ozone fs -copyFromLocal NOTICE.txt ${scheme}://${testBucket1}/KEY.txt
                         Should Be Equal As Integers     ${rc}                1
                         Should contain    ${result}         File exists
+
                         Execute               rm -Rf /tmp/GET.txt
-                        Execute               ozone fs -get o3fs://bucket1.fstest/KEY.txt /tmp/GET.txt
+                        Execute               ozone fs -get ${scheme}://${testBucket1}/KEY.txt /tmp/GET.txt
                         Execute               ls -l /tmp/GET.txt
-    ${rc}  ${result} =  Run And Return Rc And Output        ozone fs -ls o3fs://abcde.pqrs/
+
+    ${rc}  ${result} =  Run And Return Rc And Output        ozone fs -ls ${scheme}://${nonExistBucket}
                         Should Be Equal As Integers     ${rc}                1
-                        Should Match Regexp    ${result}         (Check access operation failed)|(Volume pqrs is not found)
+                        Should Match Regexp    ${result}         (Check access operation failed)|(Volume ${nonExistVolume} is not found)|(No such file or directory)
+
+# Final clean up before next run
+                        Execute               ozone fs -rm -r ${scheme}://${testBucket1}/testdir1/
+                        Execute               ozone fs -rm -r ${scheme}://${testBucket2}/testdir2/
+                        Execute               ozone fs -rm -r ${scheme}://${testBucket3}/testdir3/
+                        Execute               ozone fs -rm -r ${scheme}://${testBucket1}/*


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refactor existing ozone file system tests to cover both o3fs and ofs.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2945

## How was this patch tested?

Run acceptance test locally. 

`==============================================================================
ozone-ozonefs :: Ozonefs test covering both o3fs and ofs
==============================================================================
Create volume and bucket for Ozone file System test                   | PASS |
------------------------------------------------------------------------------
Check volume from o3fs                                                | PASS |
------------------------------------------------------------------------------
Test ozone shell with ofs                                             | PASS |
------------------------------------------------------------------------------
Test ozone shell with o3fs                                            | PASS |
------------------------------------------------------------------------------
ozone-ozonefs :: Ozonefs test covering both o3fs and ofs              | PASS |
4 critical tests, 4 passed, 0 failed
4 tests total, 4 passed, 0 failed`