### PR TITLE
HDDS-3236. Fix Dropwizard metrics mapping for latest Ratis metrics.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/RatisNameRewriteSampleBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/RatisNameRewriteSampleBuilder.java
@@ -61,11 +61,11 @@ public class RatisNameRewriteSampleBuilder extends DefaultSampleBuilder {
       List<String> values = new ArrayList<>(additionalLabelValues);
       String name = normalizeRatisMetric(dropwizardName, names, values);
 
-      //      if (LOG.isTraceEnabled()) {
-      LOG.info(
+      if (LOG.isTraceEnabled()) {
+        LOG.trace(
           "Ratis dropwizard {} metrics are converted to {} with tag "
               + "keys/values {},{}", dropwizardName, name, names, values);
-      //      }
+      }
       return super
           .createSample(name, nameSuffix,
               names,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/RatisNameRewriteSampleBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/RatisNameRewriteSampleBuilder.java
@@ -27,11 +27,16 @@ import io.prometheus.client.Collector.MetricFamilySamples.Sample;
 import io.prometheus.client.dropwizard.samplebuilder.DefaultSampleBuilder;
 import org.apache.logging.log4j.util.Strings;
 import static org.apache.ratis.server.metrics.RatisMetrics.RATIS_APPLICATION_NAME_METRICS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Collect Dropwizard metrics and rename ratis specific metrics.
  */
 public class RatisNameRewriteSampleBuilder extends DefaultSampleBuilder {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(RatisNameRewriteSampleBuilder.class);
 
   private List<Pattern> followerPatterns = new ArrayList<>();
 
@@ -41,8 +46,8 @@ public class RatisNameRewriteSampleBuilder extends DefaultSampleBuilder {
             "grpc_log_appender_follower_(.*)_(latency|success|inconsistency)"
                 + ".*"));
     followerPatterns
-        .add(Pattern.compile("follower_(.*)_lastHeartbeatElapsedTime"));
-    followerPatterns.add(Pattern.compile("(.*)_peerCommitIndex"));
+        .add(Pattern.compile("follower_([^_]*)_.*"));
+    followerPatterns.add(Pattern.compile("([^_]*)_peerCommitIndex"));
 
   }
 
@@ -51,12 +56,16 @@ public class RatisNameRewriteSampleBuilder extends DefaultSampleBuilder {
       List<String> additionalLabelNames, List<String> additionalLabelValues,
       double value) {
     //this is a ratis metrics, where the second part is an instance id.
-    if (dropwizardName.startsWith(RATIS_APPLICATION_NAME_METRICS)
-        || (dropwizardName.startsWith("ratis_grpc"))) {
+    if (dropwizardName.startsWith(RATIS_APPLICATION_NAME_METRICS)) {
       List<String> names = new ArrayList<>(additionalLabelNames);
       List<String> values = new ArrayList<>(additionalLabelValues);
       String name = normalizeRatisMetric(dropwizardName, names, values);
 
+      //      if (LOG.isTraceEnabled()) {
+      LOG.info(
+          "Ratis dropwizard {} metrics are converted to {} with tag "
+              + "keys/values {},{}", dropwizardName, name, names, values);
+      //      }
       return super
           .createSample(name, nameSuffix,
               names,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/RatisNameRewriteSampleBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/RatisNameRewriteSampleBuilder.java
@@ -63,8 +63,8 @@ public class RatisNameRewriteSampleBuilder extends DefaultSampleBuilder {
 
       if (LOG.isTraceEnabled()) {
         LOG.trace(
-          "Ratis dropwizard {} metrics are converted to {} with tag "
-              + "keys/values {},{}", dropwizardName, name, names, values);
+            "Ratis dropwizard {} metrics are converted to {} with tag "
+                + "keys/values {},{}", dropwizardName, name, names, values);
       }
       return super
           .createSample(name, nameSuffix,

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisNameRewrite.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisNameRewrite.java
@@ -45,6 +45,16 @@ public class TestRatisNameRewrite {
   public static List<Object[]> parameters() {
     return Arrays.asList(
         new Object[] {
+            "ratis.log_appender"
+                + ".851cb00a-af97-455a-b079-d94a77d2a936@group-C14654DE8C2C"
+                + ".follower_65f881ea-8794-403d-be77-a030ed79c341_match_index",
+            "ratis.log_appender.follower_match_index",
+            new String[] {"instance", "group", "follower"},
+            new String[] {"851cb00a-af97-455a-b079-d94a77d2a936",
+                "group-C14654DE8C2C",
+                "65f881ea-8794-403d-be77-a030ed79c341"}
+        },
+        new Object[] {
             "ratis_grpc.log_appender.72caaf3a-fb1c-4da4-9cc0-a2ce21bb8e67@group"
                 + "-72caaf3a-fb1c-4da4-9cc0-a2ce21bb8e67"
                 + ".grpc_log_appender_follower_75fa730a-59f0-4547"

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>0.6.0-a320ae0-SNAPSHOT</ratis.version>
+    <ratis.version>0.6.0-SNAPSHOT</ratis.version>
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>
     <distMgmtSnapshotsUrl>https://repository.apache.org/content/repositories/snapshots</distMgmtSnapshotsUrl>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>0.6.0-SNAPSHOT</ratis.version>
+    <ratis.version>0.6.0-a320ae0-SNAPSHOT</ratis.version>
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>
     <distMgmtSnapshotsUrl>https://repository.apache.org/content/repositories/snapshots</distMgmtSnapshotsUrl>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ratis use dropwizard metrics where the key parameters of the metrics (like group name or instance id) are part of the name of the metrics instead of using a tag.

For example

```
ratis.log_appender.851cb00a-af97-455a-b079-d94a77d2a936@group-C14654DE8C2C.follower_65f881ea-8794-403d-be77-a030ed79c341_match_index 
```

Instead of

```
ratis.log_appender_match_index{group="group-C14654DE8C2C",...} 
```

It makes hard to combine the same metrics (match_index) from different sources.

HDDS-2950 implemented a regexp based workaround, but the regexp doesn't match for the latest Ratis metrics.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3236

## How was this patch tested?

Tested with kubernetes cluster generation ~200M keys.

An easier way to test is to start a docker compose cluster and check the `/prom` endpoint of one datanode:

```
docker-compose exec datanoe bash
curl localhost:9882/prom | grep index
```