### PR TITLE
HDDS-3244. Improve write efficiency by opening RocksDB only once

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -52,8 +52,6 @@ import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis
     .DispatcherContext;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
-import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
-import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
     .ContainerCommandRequestProto;
@@ -165,20 +163,6 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
     }
   }
 
-  private void createRocksDBAndPutCache(Container container)
-      throws IOException {
-    if (container == null) {
-      return;
-    }
-
-    KeyValueContainerData kvContainerData =
-        (KeyValueContainerData)container.getContainerData();
-    if (!BlockUtils.isDBExist(kvContainerData, conf)) {
-      BlockUtils.createDBAndPutCache(kvContainerData.getContainerDBType(),
-          kvContainerData.getDbFile().getAbsolutePath(), conf);
-    }
-  }
-
   @SuppressWarnings("methodlength")
   private ContainerCommandResponseProto dispatchRequest(
       ContainerCommandRequestProto msg, DispatcherContext dispatcherContext) {
@@ -229,15 +213,6 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
       container2BCSIDMap = dispatcherContext.getContainer2BCSIDMap();
     }
     if (isWriteCommitStage) {
-      try {
-        createRocksDBAndPutCache(container);
-      } catch (IOException ioe) {
-        StorageContainerException sce = new StorageContainerException(
-            "Create RocksDB failed. " + ioe.getMessage(), ioe,
-            Result.UNABLE_TO_READ_METADATA_DB);
-        return ContainerUtils.logAndReturnError(LOG, sce, msg);
-      }
-
       //  check if the container Id exist in the loaded snapshot file. if
       // it does not , it infers that , this is a restart of dn where
       // the we are reapplying the transaction which was not captured in the

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java
@@ -160,4 +160,33 @@ public final class ContainerCache extends LRUMap {
       lock.unlock();
     }
   }
+
+  /**
+   * Check whether a DB handler exists in cache.
+   *
+   * @param containerDBPath - DB path of the container.
+   */
+  public boolean isDBExist(String containerDBPath) {
+    lock.lock();
+    try {
+      return this.get(containerDBPath) != null;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * Add a DB handler into cache.
+   *
+   * @param containerDBPath - DB path of the container.
+   * @param db - DB handler
+   */
+  public void addDB(String containerDBPath, ReferenceCountedDB db) {
+    lock.lock();
+    try {
+      this.putIfAbsent(containerDBPath, db);
+    } finally {
+      lock.unlock();
+    }
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java
@@ -162,20 +162,6 @@ public final class ContainerCache extends LRUMap {
   }
 
   /**
-   * Check whether a DB handler exists in cache.
-   *
-   * @param containerDBPath - DB path of the container.
-   */
-  public boolean isDBExist(String containerDBPath) {
-    lock.lock();
-    try {
-      return this.get(containerDBPath) != null;
-    } finally {
-      lock.unlock();
-    }
-  }
-
-  /**
    * Add a DB handler into cache.
    *
    * @param containerDBPath - DB path of the container.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/BlockUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/BlockUtils.java
@@ -22,14 +22,11 @@ import com.google.common.base.Preconditions;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
-import org.apache.hadoop.hdds.utils.MetadataStore;
-import org.apache.hadoop.hdds.utils.MetadataStoreBuilder;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.common.utils.ContainerCache;
 import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
 
-import java.io.File;
 import java.io.IOException;
 
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
@@ -99,41 +96,16 @@ public final class BlockUtils {
   }
 
   /**
-   * Check whether a DB handler exists in cache.
+   * Add a DB handler into cache.
    *
-   * @param containerData containerData.
-   * @param conf configuration.
-   */
-  public static boolean isDBExist(KeyValueContainerData containerData,
-      Configuration conf) {
-    Preconditions.checkNotNull(containerData);
-    ContainerCache cache = ContainerCache.getInstance(conf);
-    Preconditions.checkNotNull(cache);
-    Preconditions.checkNotNull(containerData.getDbFile());
-    return cache.isDBExist(containerData.getDbFile().getAbsolutePath());
-  }
-
-  /**
-   * Create a DB handler and put it into cache.
-   *
-   * @param containerDBType - DB type of the container.
+   * @param db - DB handler.
    * @param containerDBPath - DB path of the container.
    * @param conf configuration.
    */
-  public static void createDBAndPutCache(String containerDBType,
-      String containerDBPath, Configuration conf) throws IOException {
+  public static void addDB(ReferenceCountedDB db, String containerDBPath,
+      Configuration conf) {
     ContainerCache cache = ContainerCache.getInstance(conf);
     Preconditions.checkNotNull(cache);
-
-    MetadataStore metadataStore =
-        MetadataStoreBuilder.newBuilder()
-        .setDbFile(new File(containerDBPath))
-        .setCreateIfMissing(true)
-        .setConf(conf)
-        .setDBType(containerDBType)
-        .build();
-    ReferenceCountedDB db =
-        new ReferenceCountedDB(metadataStore, containerDBPath);
     cache.addDB(containerDBPath, db);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -32,6 +32,8 @@ import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
+import org.apache.hadoop.hdds.utils.MetadataStore;
+import org.apache.hadoop.hdds.utils.MetadataStoreBuilder;
 
 import com.google.common.base.Preconditions;
 import org.apache.commons.io.FileUtils;
@@ -71,6 +73,13 @@ public final class KeyValueContainerUtil {
       throw new IOException("Unable to create directory for metadata storage." +
           " Path: " + containerMetaDataPath);
     }
+
+    MetadataStore store = MetadataStoreBuilder.newBuilder().setConf(conf)
+        .setCreateIfMissing(true).setDbFile(dbFile).build();
+    ReferenceCountedDB db =
+        new ReferenceCountedDB(store, dbFile.getAbsolutePath());
+    //add db handler into cache
+    BlockUtils.addDB(db, dbFile.getAbsolutePath(), conf);
 
     if (!chunksPath.mkdirs()) {
       LOG.error("Unable to create chunks directory Container {}",

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -32,8 +32,6 @@ import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
-import org.apache.hadoop.hdds.utils.MetadataStore;
-import org.apache.hadoop.hdds.utils.MetadataStoreBuilder;
 
 import com.google.common.base.Preconditions;
 import org.apache.commons.io.FileUtils;
@@ -73,14 +71,6 @@ public final class KeyValueContainerUtil {
       throw new IOException("Unable to create directory for metadata storage." +
           " Path: " + containerMetaDataPath);
     }
-    MetadataStore store = MetadataStoreBuilder.newBuilder().setConf(conf)
-        .setCreateIfMissing(true).setDbFile(dbFile).build();
-
-    // we close since the SCM pre-creates containers.
-    // we will open and put Db handle into a cache when keys are being created
-    // in a container.
-
-    store.close();
 
     if (!chunksPath.mkdirs()) {
       LOG.error("Unable to create chunks directory Container {}",

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -74,13 +74,6 @@ public final class KeyValueContainerUtil {
           " Path: " + containerMetaDataPath);
     }
 
-    MetadataStore store = MetadataStoreBuilder.newBuilder().setConf(conf)
-        .setCreateIfMissing(true).setDbFile(dbFile).build();
-    ReferenceCountedDB db =
-        new ReferenceCountedDB(store, dbFile.getAbsolutePath());
-    //add db handler into cache
-    BlockUtils.addDB(db, dbFile.getAbsolutePath(), conf);
-
     if (!chunksPath.mkdirs()) {
       LOG.error("Unable to create chunks directory Container {}",
           chunksPath);
@@ -90,6 +83,13 @@ public final class KeyValueContainerUtil {
       throw new IOException("Unable to create directory for data storage." +
           " Path: " + chunksPath);
     }
+
+    MetadataStore store = MetadataStoreBuilder.newBuilder().setConf(conf)
+        .setCreateIfMissing(true).setDbFile(dbFile).build();
+    ReferenceCountedDB db =
+        new ReferenceCountedDB(store, dbFile.getAbsolutePath());
+    //add db handler into cache
+    BlockUtils.addDB(db, dbFile.getAbsolutePath(), conf);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

**What's the problem ?**

1. when datanode create a new container, a new RocksDB instance will be 
[created](https://github.com/apache/hadoop-ozone/blob/master/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java#L76) in `HddsDispatcher.WriteChunk` , but then the created RocksDB was  [closed](https://github.com/apache/hadoop-ozone/blob/master/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java#L83), until `HddsDispatcher.PutBlock` the RocsDB will be [opend](https://github.com/apache/hadoop-ozone/blob/master/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java#L123) again and then put it into cache, so the RocksDB was open twice in each datanode.  Becase RocksDB.open cost about 200ms, so open it twice is a waste.
 

**How to fix it ?**

1. Put the RocksDB handler into cache when open it the first time , to avoid open it again in `HddsDispatcher.PutBlock`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-3244

## How was this patch tested?

Existed UT and IT.
