### PR TITLE
HDDS-3250. Create a separate log file for Warnings and Errors in MiniOzoneChaosCluster.

### DIFF
--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/bin/start-chaos.sh
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/bin/start-chaos.sh
@@ -19,6 +19,7 @@ date=$(date +"%Y-%m-%d-%H-%M-%S-%Z")
 logfiledirectory="/tmp/chaos-${date}/"
 completesuffix="complete.log"
 chaossuffix="chaos.log"
+errorsuffix="error.log"
 compilesuffix="compile.log"
 heapformat="dump.hprof"
 
@@ -30,6 +31,8 @@ chaosfilename="${logfiledirectory}${chaossuffix}"
 compilefilename="${logfiledirectory}${compilesuffix}"
 #log goes to something like /tmp/2019-12-04--00-01-26-IST/dump.hprof
 heapdumpfile="${logfiledirectory}${heapformat}"
+#log goes to something like /tmp/2019-12-04--00-01-26-IST/error.log
+errorfilename="${logfiledirectory}${errorsuffix}"
 
 #TODO: add gc log file details as well
 MVN_OPTS="-XX:+HeapDumpOnOutOfMemoryError "
@@ -46,6 +49,7 @@ mvn exec:java \
   -Dexec.mainClass="org.apache.hadoop.ozone.TestMiniChaosOzoneCluster" \
   -Dexec.classpathScope=test \
   -Dchaoslogfilename=${chaosfilename} \
+  -Derrorlogfilename=${errorfilename} \
   -Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false \
   -Dio.netty.leakDetection.level=advanced \
   -Dio.netty.leakDetectionLevel=advanced \

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/bin/start-chaos.sh
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/bin/start-chaos.sh
@@ -19,7 +19,7 @@ date=$(date +"%Y-%m-%d-%H-%M-%S-%Z")
 logfiledirectory="/tmp/chaos-${date}/"
 completesuffix="complete.log"
 chaossuffix="chaos.log"
-errorsuffix="error.log"
+problemsuffix="problem.log"
 compilesuffix="compile.log"
 heapformat="dump.hprof"
 
@@ -31,8 +31,8 @@ chaosfilename="${logfiledirectory}${chaossuffix}"
 compilefilename="${logfiledirectory}${compilesuffix}"
 #log goes to something like /tmp/2019-12-04--00-01-26-IST/dump.hprof
 heapdumpfile="${logfiledirectory}${heapformat}"
-#log goes to something like /tmp/2019-12-04--00-01-26-IST/error.log
-errorfilename="${logfiledirectory}${errorsuffix}"
+#log goes to something like /tmp/2019-12-04--00-01-26-IST/problem.log
+problemfilename="${logfiledirectory}${problemsuffix}"
 
 #TODO: add gc log file details as well
 MVN_OPTS="-XX:+HeapDumpOnOutOfMemoryError "
@@ -49,7 +49,7 @@ mvn exec:java \
   -Dexec.mainClass="org.apache.hadoop.ozone.TestMiniChaosOzoneCluster" \
   -Dexec.classpathScope=test \
   -Dchaoslogfilename=${chaosfilename} \
-  -Derrorlogfilename=${errorfilename} \
+  -Dproblemlogfilename=${problemfilename} \
   -Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false \
   -Dio.netty.leakDetection.level=advanced \
   -Dio.netty.leakDetectionLevel=advanced \

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/resources/log4j.properties
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/resources/log4j.properties
@@ -11,7 +11,7 @@
 #   limitations under the License.
 # log4j configuration used during build and unit tests
 
-log4j.rootLogger=INFO,stdout,TEST
+log4j.rootLogger=INFO,stdout,PROBLEM
 log4j.threshold=ALL
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
@@ -29,10 +29,10 @@ log4j.appender.CHAOS=org.apache.log4j.FileAppender
 log4j.appender.CHAOS.layout=org.apache.log4j.PatternLayout
 log4j.appender.CHAOS.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M(%L)) - %m%n
 
-log4j.appender.TEST.File=${errorlogfilename}
-log4j.appender.TEST.Threshold=WARN
-log4j.appender.TEST=org.apache.log4j.FileAppender
-log4j.appender.TEST.layout=org.apache.log4j.PatternLayout
-log4j.appender.TEST.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M(%L)) - %m%n
+log4j.appender.PROBLEM.File=${problemlogfilename}
+log4j.appender.PROBLEM.Threshold=WARN
+log4j.appender.PROBLEM=org.apache.log4j.FileAppender
+log4j.appender.PROBLEM.layout=org.apache.log4j.PatternLayout
+log4j.appender.PROBLEM.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M(%L)) - %m%n
 
 log4j.additivity.org.apache.hadoop.ozone.utils=false

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/resources/log4j.properties
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/resources/log4j.properties
@@ -11,7 +11,7 @@
 #   limitations under the License.
 # log4j configuration used during build and unit tests
 
-log4j.rootLogger=INFO,stdout
+log4j.rootLogger=INFO,stdout,TEST
 log4j.threshold=ALL
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
@@ -28,4 +28,11 @@ log4j.appender.CHAOS.File=${chaoslogfilename}
 log4j.appender.CHAOS=org.apache.log4j.FileAppender
 log4j.appender.CHAOS.layout=org.apache.log4j.PatternLayout
 log4j.appender.CHAOS.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M(%L)) - %m%n
+
+log4j.appender.TEST.File=${errorlogfilename}
+log4j.appender.TEST.Threshold=WARN
+log4j.appender.TEST=org.apache.log4j.FileAppender
+log4j.appender.TEST.layout=org.apache.log4j.PatternLayout
+log4j.appender.TEST.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{2} (%F:%M(%L)) - %m%n
+
 log4j.additivity.org.apache.hadoop.ozone.utils=false


### PR DESCRIPTION
## What changes were proposed in this pull request?
Adding a new log file for just the error while running MiniOzoneChaosCluster

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3250

## How was this patch tested?
Ran MiniOzoneChaosCluster
