### PR TITLE
HDDS-3155. Improved ozone client flush implementation to make it faster.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -452,7 +452,7 @@ public class BlockOutputStream extends OutputStream {
   }
 
   private boolean whetherDoFlush() {
-    if (streamBufferFlushDelay == true  &&
+    if (streamBufferFlushDelay &&
         (writtenDataLength - totalDataFlushedLength) < streamBufferSize) {
       return false;
     } else {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -438,7 +438,9 @@ public class BlockOutputStream extends OutputStream {
   @Override
   public void flush() throws IOException {
     if (xceiverClientManager != null && xceiverClient != null
-        && bufferPool != null && bufferPool.getSize() > 0 && whetherDoFlush()) {
+        && bufferPool != null && bufferPool.getSize() > 0
+        && (!streamBufferFlushDelay ||
+            writtenDataLength - totalDataFlushedLength >= streamBufferSize)) {
       try {
         handleFlush(false);
       } catch (InterruptedException | ExecutionException e) {
@@ -448,15 +450,6 @@ public class BlockOutputStream extends OutputStream {
         adjustBuffersOnException();
         throw getIoException();
       }
-    }
-  }
-
-  private boolean whetherDoFlush() {
-    if (streamBufferFlushDelay &&
-        (writtenDataLength - totalDataFlushedLength) < streamBufferSize) {
-      return false;
-    } else {
-      return true;
     }
   }
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -85,7 +85,9 @@ public class BlockOutputStream extends OutputStream {
   private final int bytesPerChecksum;
   private int chunkIndex;
   private final AtomicLong chunkOffset = new AtomicLong();
+  private final int streamBufferSize;
   private final long streamBufferFlushSize;
+  private final boolean streamBufferFlushDelay;
   private final long streamBufferMaxSize;
   private final BufferPool bufferPool;
   // The IOException will be set by response handling thread in case there is an
@@ -131,10 +133,10 @@ public class BlockOutputStream extends OutputStream {
   @SuppressWarnings("parameternumber")
   public BlockOutputStream(BlockID blockID,
       XceiverClientManager xceiverClientManager, Pipeline pipeline,
-      long streamBufferFlushSize, long streamBufferMaxSize,
+      int streamBufferSize, long streamBufferFlushSize,
+      boolean streamBufferFlushDelay, long streamBufferMaxSize,
       BufferPool bufferPool, ChecksumType checksumType,
-      int bytesPerChecksum)
-      throws IOException {
+      int bytesPerChecksum) throws IOException {
     this.blockID = new AtomicReference<>(blockID);
     KeyValue keyValue =
         KeyValue.newBuilder().setKey("TYPE").setValue("KEY").build();
@@ -143,8 +145,10 @@ public class BlockOutputStream extends OutputStream {
             .addMetadata(keyValue);
     this.xceiverClientManager = xceiverClientManager;
     this.xceiverClient = xceiverClientManager.acquireClient(pipeline);
+    this.streamBufferSize = streamBufferSize;
     this.streamBufferFlushSize = streamBufferFlushSize;
     this.streamBufferMaxSize = streamBufferMaxSize;
+    this.streamBufferFlushDelay = streamBufferFlushDelay;
     this.bufferPool = bufferPool;
     this.bytesPerChecksum = bytesPerChecksum;
 
@@ -434,7 +438,7 @@ public class BlockOutputStream extends OutputStream {
   @Override
   public void flush() throws IOException {
     if (xceiverClientManager != null && xceiverClient != null
-        && bufferPool != null && bufferPool.getSize() > 0) {
+        && bufferPool != null && bufferPool.getSize() > 0 && whetherDoFlush()) {
       try {
         handleFlush(false);
       } catch (InterruptedException | ExecutionException e) {
@@ -447,6 +451,14 @@ public class BlockOutputStream extends OutputStream {
     }
   }
 
+  private boolean whetherDoFlush() {
+    if (streamBufferFlushDelay == true  &&
+        (writtenDataLength - totalDataFlushedLength) < streamBufferSize) {
+      return false;
+    } else {
+      return true;
+    }
+  }
 
   private void writeChunk(ChunkBuffer buffer)
       throws IOException {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -151,7 +151,7 @@ public final class OzoneConfigKeys {
 
   /**
    * If this value is true, when the client calls the flush() method,
-   * we will checks whether the data in the buffer is greater than
+   * it checks whether the data in the buffer is greater than
    * OZONE_CLIENT_STREAM_BUFFER_SIZE_DEFAULT. If greater than,
    * send the data in the buffer to the datanode.
    * */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -149,6 +149,17 @@ public final class OzoneConfigKeys {
   public static final TimeDuration OZONE_CLIENT_RETRY_INTERVAL_DEFAULT =
       TimeDuration.valueOf(0, TimeUnit.MILLISECONDS);
 
+  /**
+   * If this value is true, when the client calls the flush() method,
+   * we will checks whether the data in the buffer is greater than
+   * OZONE_CLIENT_STREAM_BUFFER_SIZE_DEFAULT. If greater than,
+   * send the data in the buffer to the datanode.
+   * */
+  public static final String OZONE_CLIENT_STREAM_BUFFER_FLUSH_DELAY =
+      "ozone.client.stream.buffer.flush.delay";
+  public static final boolean OOZONE_CLIENT_STREAM_BUFFER_FLUSH_DELAY_DEFAULT =
+      false;
+
   // This defines the overall connection limit for the connection pool used in
   // RestClient.
   public static final String OZONE_REST_CLIENT_HTTP_CONNECTION_MAX =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -390,9 +390,9 @@
     <name>ozone.client.stream.buffer.flush.delay</name>
     <value>false</value>
     <tag>OZONE, CLIENT</tag>
-    <description>If set true, when call flush()，we'll determine whether the
+    <description>If set true, when call flush() and determine whether the
       data in the current buffer is greater than ozone.client.stream.buffer.size.
-      if greater than it we'll sent buffer to the datanode.
+      if greater than then send buffer to the datanode.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -387,6 +387,15 @@
     </description>
   </property>
   <property>
+    <name>ozone.client.stream.buffer.flush.delay</name>
+    <value>false</value>
+    <tag>OZONE, CLIENT</tag>
+    <description>If set true, when call flush()，we'll determine whether the
+      data in the current buffer is greater than ozone.client.stream.buffer.size.
+      if greater than it we'll sent buffer to the datanode.
+    </description>
+  </property>
+  <property>
     <name>ozone.client.stream.buffer.size</name>
     <value>4MB</value>
     <tag>OZONE, CLIENT</tag>

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
@@ -55,7 +55,9 @@ public final class BlockOutputStreamEntry extends OutputStream {
   private long currentPosition;
   private Token<OzoneBlockTokenIdentifier> token;
 
+  private final int streamBufferSize;
   private final long streamBufferFlushSize;
+  private final boolean streamBufferFlushDelay;
   private final long streamBufferMaxSize;
   private final long watchTimeout;
   private BufferPool bufferPool;
@@ -64,7 +66,8 @@ public final class BlockOutputStreamEntry extends OutputStream {
   private BlockOutputStreamEntry(BlockID blockID, String key,
       XceiverClientManager xceiverClientManager,
       Pipeline pipeline, String requestId, int chunkSize,
-      long length, long streamBufferFlushSize, long streamBufferMaxSize,
+      long length, int streamBufferSize, long streamBufferFlushSize, boolean streamBufferFlushDelay,
+      long streamBufferMaxSize,
       long watchTimeout, BufferPool bufferPool,
       ChecksumType checksumType, int bytesPerChecksum,
       Token<OzoneBlockTokenIdentifier> token) {
@@ -77,7 +80,9 @@ public final class BlockOutputStreamEntry extends OutputStream {
     this.token = token;
     this.length = length;
     this.currentPosition = 0;
+    this.streamBufferSize = streamBufferSize;
     this.streamBufferFlushSize = streamBufferFlushSize;
+    this.streamBufferFlushDelay = streamBufferFlushDelay;
     this.streamBufferMaxSize = streamBufferMaxSize;
     this.watchTimeout = watchTimeout;
     this.bufferPool = bufferPool;
@@ -110,9 +115,9 @@ public final class BlockOutputStreamEntry extends OutputStream {
       }
       this.outputStream =
           new BlockOutputStream(blockID, xceiverClientManager,
-              pipeline, streamBufferFlushSize,
-              streamBufferMaxSize, bufferPool, checksumType,
-              bytesPerChecksum);
+              pipeline, streamBufferSize, streamBufferFlushSize,
+              streamBufferFlushDelay, streamBufferMaxSize, bufferPool,
+              checksumType, bytesPerChecksum);
     }
   }
 
@@ -215,7 +220,9 @@ public final class BlockOutputStreamEntry extends OutputStream {
     private String requestId;
     private int chunkSize;
     private long length;
+    private int  streamBufferSize;
     private long streamBufferFlushSize;
+    private boolean streamBufferFlushDelay;
     private long streamBufferMaxSize;
     private long watchTimeout;
     private BufferPool bufferPool;
@@ -269,8 +276,18 @@ public final class BlockOutputStreamEntry extends OutputStream {
       return this;
     }
 
+    public Builder setStreamBufferSize(int bufferSize) {
+      this.streamBufferSize = bufferSize;
+      return this;
+    }
+
     public Builder setStreamBufferFlushSize(long bufferFlushSize) {
       this.streamBufferFlushSize = bufferFlushSize;
+      return this;
+    }
+
+    public Builder setStreamBufferFlushDelay(boolean bufferFlushDelay) {
+      this.streamBufferFlushDelay = bufferFlushDelay;
       return this;
     }
 
@@ -297,7 +314,8 @@ public final class BlockOutputStreamEntry extends OutputStream {
     public BlockOutputStreamEntry build() {
       return new BlockOutputStreamEntry(blockID, key,
           xceiverClientManager, pipeline, requestId, chunkSize,
-          length, streamBufferFlushSize, streamBufferMaxSize, watchTimeout,
+          length, streamBufferSize, streamBufferFlushSize,
+          streamBufferFlushDelay, streamBufferMaxSize, watchTimeout,
           bufferPool, checksumType, bytesPerChecksum, token);
     }
   }
@@ -331,8 +349,16 @@ public final class BlockOutputStreamEntry extends OutputStream {
     return currentPosition;
   }
 
+  public int getStreamBufferSize() {
+    return streamBufferSize;
+  }
+
   public long getStreamBufferFlushSize() {
     return streamBufferFlushSize;
+  }
+
+  public boolean getStreamBufferFlushDelay() {
+    return streamBufferFlushDelay;
   }
 
   public long getStreamBufferMaxSize() {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntry.java
@@ -66,8 +66,8 @@ public final class BlockOutputStreamEntry extends OutputStream {
   private BlockOutputStreamEntry(BlockID blockID, String key,
       XceiverClientManager xceiverClientManager,
       Pipeline pipeline, String requestId, int chunkSize,
-      long length, int streamBufferSize, long streamBufferFlushSize, boolean streamBufferFlushDelay,
-      long streamBufferMaxSize,
+      long length, int streamBufferSize, long streamBufferFlushSize,
+      boolean streamBufferFlushDelay, long streamBufferMaxSize,
       long watchTimeout, BufferPool bufferPool,
       ChecksumType checksumType, int bytesPerChecksum,
       Token<OzoneBlockTokenIdentifier> token) {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
@@ -77,7 +77,7 @@ public class BlockOutputStreamEntryPool {
       int chunkSize, String requestId, HddsProtos.ReplicationFactor factor,
       HddsProtos.ReplicationType type,
       int bufferSize, long bufferFlushSize,
-      boolean bufferFlushDelay,long bufferMaxSize,
+      boolean bufferFlushDelay, long bufferMaxSize,
       long size, long watchTimeout, ContainerProtos.ChecksumType checksumType,
       int bytesPerChecksum, String uploadID, int partNumber,
       boolean isMultipart, OmKeyInfo info,

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
@@ -61,6 +61,7 @@ public class BlockOutputStreamEntryPool {
   private final String requestID;
   private final int streamBufferSize;
   private final long streamBufferFlushSize;
+  private final boolean streamBufferFlushDelay;
   private final long streamBufferMaxSize;
   private final long watchTimeout;
   private final long blockSize;
@@ -75,7 +76,8 @@ public class BlockOutputStreamEntryPool {
   public BlockOutputStreamEntryPool(OzoneManagerProtocol omClient,
       int chunkSize, String requestId, HddsProtos.ReplicationFactor factor,
       HddsProtos.ReplicationType type,
-      int bufferSize, long bufferFlushSize, long bufferMaxSize,
+      int bufferSize, long bufferFlushSize,
+      boolean bufferFlushDelay,long bufferMaxSize,
       long size, long watchTimeout, ContainerProtos.ChecksumType checksumType,
       int bytesPerChecksum, String uploadID, int partNumber,
       boolean isMultipart, OmKeyInfo info,
@@ -93,6 +95,7 @@ public class BlockOutputStreamEntryPool {
     this.requestID = requestId;
     this.streamBufferSize = bufferSize;
     this.streamBufferFlushSize = bufferFlushSize;
+    this.streamBufferFlushDelay = bufferFlushDelay;
     this.streamBufferMaxSize = bufferMaxSize;
     this.blockSize = size;
     this.watchTimeout = watchTimeout;
@@ -137,6 +140,7 @@ public class BlockOutputStreamEntryPool {
     requestID = null;
     streamBufferSize = 0;
     streamBufferFlushSize = 0;
+    streamBufferFlushDelay = false;
     streamBufferMaxSize = 0;
     bufferPool = new BufferPool(chunkSize, 1);
     watchTimeout = 0;
@@ -188,7 +192,9 @@ public class BlockOutputStreamEntryPool {
             .setRequestId(requestID)
             .setChunkSize(chunkSize)
             .setLength(subKeyInfo.getLength())
+            .setStreamBufferSize(streamBufferSize)
             .setStreamBufferFlushSize(streamBufferFlushSize)
+            .setStreamBufferFlushDelay(streamBufferFlushDelay)
             .setStreamBufferMaxSize(streamBufferMaxSize)
             .setWatchTimeout(watchTimeout)
             .setbufferPool(bufferPool)

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyOutputStream.java
@@ -124,15 +124,16 @@ public class KeyOutputStream extends OutputStream {
       XceiverClientManager xceiverClientManager,
       OzoneManagerProtocol omClient, int chunkSize,
       String requestId, ReplicationFactor factor, ReplicationType type,
-      int bufferSize, long bufferFlushSize, long bufferMaxSize,
-      long size, long watchTimeout,
+      int bufferSize, long bufferFlushSize, boolean isBufferFlushDelay,
+      long bufferMaxSize, long size, long watchTimeout,
       ChecksumType checksumType, int bytesPerChecksum,
       String uploadID, int partNumber, boolean isMultipart,
       int maxRetryCount, long retryInterval) {
     OmKeyInfo info = handler.getKeyInfo();
     blockOutputStreamEntryPool =
         new BlockOutputStreamEntryPool(omClient, chunkSize, requestId, factor,
-            type, bufferSize, bufferFlushSize, bufferMaxSize, size,
+            type, bufferSize, bufferFlushSize, isBufferFlushDelay,
+            bufferMaxSize, size,
             watchTimeout, checksumType, bytesPerChecksum, uploadID, partNumber,
             isMultipart, info, xceiverClientManager, handler.getId());
     // Retrieve the file encryption key info, null if file is not in
@@ -542,6 +543,7 @@ public class KeyOutputStream extends OutputStream {
     private ReplicationFactor factor;
     private int streamBufferSize;
     private long streamBufferFlushSize;
+    private boolean streamBufferFlushDelay;
     private long streamBufferMaxSize;
     private long blockSize;
     private long watchTimeout;
@@ -608,6 +610,11 @@ public class KeyOutputStream extends OutputStream {
       return this;
     }
 
+    public Builder setStreamBufferFlushDelay(boolean isDelay) {
+      this.streamBufferFlushDelay = isDelay;
+      return this;
+    }
+
     public Builder setStreamBufferMaxSize(long size) {
       this.streamBufferMaxSize = size;
       return this;
@@ -646,7 +653,8 @@ public class KeyOutputStream extends OutputStream {
     public KeyOutputStream build() {
       return new KeyOutputStream(openHandler, xceiverManager, omClient,
           chunkSize, requestID, factor, type,
-          streamBufferSize, streamBufferFlushSize, streamBufferMaxSize,
+          streamBufferSize, streamBufferFlushSize, streamBufferFlushDelay,
+          streamBufferMaxSize,
           blockSize, watchTimeout, checksumType,
           bytesPerChecksum, multipartUploadID, multipartNumber, isMultipartKey,
           maxRetryCount, retryInterval);

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -126,6 +126,7 @@ public class RpcClient implements ClientProtocol {
   private final ACLType groupRights;
   private final int streamBufferSize;
   private final long streamBufferFlushSize;
+  private boolean streamBufferFlushDelay;
   private final long streamBufferMaxSize;
   private final long blockSize;
   private final ClientId clientId = ClientId.randomId();
@@ -185,6 +186,9 @@ public class RpcClient implements ClientProtocol {
         .getStorageSize(OzoneConfigKeys.OZONE_CLIENT_STREAM_BUFFER_FLUSH_SIZE,
             OzoneConfigKeys.OZONE_CLIENT_STREAM_BUFFER_FLUSH_SIZE_DEFAULT,
             StorageUnit.BYTES);
+    streamBufferFlushDelay = conf.getBoolean(
+        OzoneConfigKeys.OZONE_CLIENT_STREAM_BUFFER_FLUSH_DELAY,
+        OzoneConfigKeys.OOZONE_CLIENT_STREAM_BUFFER_FLUSH_DELAY_DEFAULT);
     streamBufferMaxSize = (long) conf
         .getStorageSize(OzoneConfigKeys.OZONE_CLIENT_STREAM_BUFFER_MAX_SIZE,
             OzoneConfigKeys.OZONE_CLIENT_STREAM_BUFFER_MAX_SIZE_DEFAULT,
@@ -1192,6 +1196,7 @@ public class RpcClient implements ClientProtocol {
             .setFactor(HddsProtos.ReplicationFactor.valueOf(factor.getValue()))
             .setStreamBufferSize(streamBufferSize)
             .setStreamBufferFlushSize(streamBufferFlushSize)
+            .setStreamBufferFlushDelay(streamBufferFlushDelay)
             .setStreamBufferMaxSize(streamBufferMaxSize)
             .setBlockSize(blockSize)
             .setChecksumType(checksumType)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/Test2BlockOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/Test2BlockOutputStream.java
@@ -148,7 +148,7 @@ public class Test2BlockOutputStream {
 
     // we have just written data(length 10) less than chunk Size,
     // at this time we call flush will not  sync data.
-    Assert.assertEquals(0, blockOutputStream.getWrittenDataLength());
+    Assert.assertEquals(0, blockOutputStream.getTotalDataFlushedLength());
     key1.close();
     validateData(keyName1, data1);
 
@@ -169,8 +169,8 @@ public class Test2BlockOutputStream {
     // we have just written data(length 110) greater than chunk Size,
     // at this time we call flush will sync data.
     Assert.assertEquals(data2.length,
-            blockOutputStream.getWrittenDataLength());
-    key2.close();;
+            blockOutputStream.getTotalDataFlushedLength());
+    key2.close();
     validateData(keyName2, data2);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/Test2BlockOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/Test2BlockOutputStream.java
@@ -1,0 +1,187 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.client.rpc;
+
+import org.apache.hadoop.conf.StorageUnit;
+import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.scm.XceiverClientManager;
+import org.apache.hadoop.hdds.scm.XceiverClientMetrics;
+import org.apache.hadoop.hdds.scm.storage.BlockOutputStream;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.io.KeyOutputStream;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.container.ContainerTestHelper;
+import org.apache.hadoop.ozone.container.TestHelper;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_SCM_WATCHER_TIMEOUT;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_STREAM_BUFFER_FLUSH_DELAY;
+
+/**
+ * Tests BlockOutputStream class.
+ */
+public class Test2BlockOutputStream {
+  private static MiniOzoneCluster cluster;
+  private static OzoneConfiguration conf = new OzoneConfiguration();
+  private static OzoneClient client;
+  private static ObjectStore objectStore;
+  private static int chunkSize;
+  private static int flushSize;
+  private static int maxFlushSize;
+  private static int blockSize;
+  private static String volumeName;
+  private static String bucketName;
+  private static String keyString;
+
+  /**
+   * Create a MiniDFSCluster for testing.
+   * <p>
+   * Ozone is made active by setting OZONE_ENABLED = true
+   *
+   * @throws IOException
+   */
+  @BeforeClass
+  public static void init() throws Exception {
+    chunkSize = 100;
+    flushSize = 2 * chunkSize;
+    maxFlushSize = 2 * flushSize;
+    blockSize = 2 * maxFlushSize;
+    conf.setTimeDuration(HDDS_SCM_WATCHER_TIMEOUT, 1000, TimeUnit.MILLISECONDS);
+    conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
+    conf.set(OzoneConfigKeys.OZONE_CLIENT_CHECKSUM_TYPE, "NONE");
+    conf.setQuietMode(false);
+    conf.setStorageSize(OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE, 4,
+        StorageUnit.MB);
+    conf.setBoolean(OZONE_CLIENT_STREAM_BUFFER_FLUSH_DELAY, true);
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(7)
+        .setTotalPipelineNumLimit(10)
+        .setBlockSize(blockSize)
+        .setChunkSize(chunkSize)
+        .setStreamBufferFlushSize(flushSize)
+        .setStreamBufferMaxSize(maxFlushSize)
+        .setStreamBufferSizeUnit(StorageUnit.BYTES)
+        .build();
+    cluster.waitForClusterToBeReady();
+    //the easiest way to create an open container is creating a key
+    client = OzoneClientFactory.getRpcClient(conf);
+    objectStore = client.getObjectStore();
+    keyString = UUID.randomUUID().toString();
+    volumeName = "testblockoutputstream";
+    bucketName = volumeName;
+    objectStore.createVolume(volumeName);
+    objectStore.getVolume(volumeName).createBucket(bucketName);
+  }
+
+  private String getKeyName() {
+    return UUID.randomUUID().toString();
+  }
+
+  /**
+   * Shutdown MiniDFSCluster.
+   */
+  @AfterClass
+  public static void shutdown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void testFlushChunkDelay() throws Exception {
+    XceiverClientMetrics metrics =
+        XceiverClientManager.getXceiverClientMetrics();
+    long writeChunkCount = metrics.getContainerOpCountMetrics(
+        ContainerProtos.Type.WriteChunk);
+    long putBlockCount = metrics.getContainerOpCountMetrics(
+        ContainerProtos.Type.PutBlock);
+    long pendingWriteChunkCount =  metrics.getContainerOpsMetrics(
+        ContainerProtos.Type.WriteChunk);
+    long pendingPutBlockCount = metrics.getContainerOpsMetrics(
+        ContainerProtos.Type.PutBlock);
+    long totalOpCount = metrics.getTotalOpCount();
+    String keyName1 = getKeyName();
+    OzoneOutputStream key1 = createKey(keyName1, ReplicationType.RATIS, 0);
+
+    byte[] data1 =
+        ContainerTestHelper.getFixedLengthString(keyString, 10)
+            .getBytes(UTF_8);
+    key1.write(data1);
+    key1.flush();
+    KeyOutputStream keyOutputStream = (KeyOutputStream)key1.getOutputStream();
+    Assert.assertTrue(keyOutputStream.getStreamEntries().size() == 1);
+    OutputStream stream = keyOutputStream.getStreamEntries().get(0)
+        .getOutputStream();
+    Assert.assertTrue(stream instanceof BlockOutputStream);
+    BlockOutputStream blockOutputStream = (BlockOutputStream) stream;
+
+    // we have just written data(length 10) less than chunk Size,
+    // at this time we call flush will not  sync data.
+    Assert.assertEquals(0, blockOutputStream.getWrittenDataLength());
+    key1.close();
+    validateData(keyName1, data1);
+
+    String keyName2 = getKeyName();
+    OzoneOutputStream key2 = createKey(keyName2, ReplicationType.RATIS, 0);
+    byte[] data2 =
+            ContainerTestHelper.getFixedLengthString(keyString, 110)
+                    .getBytes(UTF_8);
+    key2.write(data2);
+    key2.flush();
+    keyOutputStream = (KeyOutputStream)key2.getOutputStream();
+    Assert.assertTrue(keyOutputStream.getStreamEntries().size() == 1);
+    stream = keyOutputStream.getStreamEntries().get(0)
+            .getOutputStream();
+    Assert.assertTrue(stream instanceof BlockOutputStream);
+    blockOutputStream = (BlockOutputStream) stream;
+
+    // we have just written data(length 110) greater than chunk Size,
+    // at this time we call flush will sync data.
+    Assert.assertEquals(data2.length,
+            blockOutputStream.getWrittenDataLength());
+    key2.close();;
+    validateData(keyName2, data2);
+  }
+
+  private OzoneOutputStream createKey(String keyName, ReplicationType type,
+      long size) throws Exception {
+    return TestHelper
+        .createKey(keyName, type, size, objectStore, volumeName, bucketName);
+  }
+  private void validateData(String keyName, byte[] data) throws Exception {
+    TestHelper
+        .validateData(keyName, data, objectStore, volumeName, bucketName);
+  }
+
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/Test2BlockOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/Test2BlockOutputStream.java
@@ -20,9 +20,6 @@ package org.apache.hadoop.ozone.client.rpc;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
-import org.apache.hadoop.hdds.scm.XceiverClientManager;
-import org.apache.hadoop.hdds.scm.XceiverClientMetrics;
 import org.apache.hadoop.hdds.scm.storage.BlockOutputStream;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
@@ -120,17 +117,6 @@ public class Test2BlockOutputStream {
 
   @Test
   public void testFlushChunkDelay() throws Exception {
-    XceiverClientMetrics metrics =
-        XceiverClientManager.getXceiverClientMetrics();
-    long writeChunkCount = metrics.getContainerOpCountMetrics(
-        ContainerProtos.Type.WriteChunk);
-    long putBlockCount = metrics.getContainerOpCountMetrics(
-        ContainerProtos.Type.PutBlock);
-    long pendingWriteChunkCount =  metrics.getContainerOpsMetrics(
-        ContainerProtos.Type.WriteChunk);
-    long pendingPutBlockCount = metrics.getContainerOpsMetrics(
-        ContainerProtos.Type.PutBlock);
-    long totalOpCount = metrics.getTotalOpCount();
     String keyName1 = getKeyName();
     OzoneOutputStream key1 = createKey(keyName1, ReplicationType.RATIS, 0);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we run MR Job (with 1000 maps)  based on OzoneFileSystem. After the map and reduce has finished 100%, the appmaster pauses More than 40 minutes .
`20/03/05 14:43:33 INFO mapreduce.Job: map 100% reduce 100% `
`20/03/05 15:29:52 INFO mapreduce.Job: Job job_1583385253878_0002 completed successfully`
It turns out that the appmaster writes all the task events to the log one by one, calling flush once for each one. This operation is very time consuming in ozone.

HDFS currently has two flush ports, flush () and hflush ().
flush() : flush the data from client  buffer to the client package (dfs.write.packet.size default 64k). If the package is not full, it will not be sent to the datanode.
hflush(): each invocation sends the data in the buffer to the datanode.

Now, ozone's flush is more similar to HDFS's hflush. This PR adds an implementation of flush similar to HDFS‘s flush. Using ozone.client.stream.buffer.flush.delay to control whether to enable(not enabled by default). If we enabled it, when we call the flush() method, we will determine whether the data in the current buffer is greater than ozone.client.stream.buffer.size. If greater than, we will send it to the datanode. Otherwise, we will not send it.

The flush performance has been significantly improved through testing. The job is no longer blocked, It will take 1 second to exit after MR finished.
`20/03/25 11:04:04 INFO mapreduce.Job:  map 100% reduce 100%`
`20/03/25 11:04:05 INFO mapreduce.Job: Job job_1585104739905_0002 completed successfully`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3155

## How was this patch tested?

Run yarn on the ozone, perform the testdfsio job below, start a thousand maps. And see the exit time after map and reduce 100%.
`hadoop jar  /path/of/hadoop-mapreduce-client-jobclient-2.8.5-tests.jar TestDFSIO -write -nrFiles 1000 -fileSize 1KB  -resFile /tmp/dfsio-write.out`

Add the following configuration in ozone-site.xml and repeat the above command to see the execution.
`<property>`
 `   <name>ozone.client.stream.buffer.flush.delay</name>`
 `   <value>true</value>`
 `</property>`