### PR TITLE
HDDS-3270. Allow safemode listeners to be notified when some precheck rules pass

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
@@ -361,7 +361,7 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
   @Override
   public void handleSafeModeTransition(
       SCMSafeModeManager.SafeModeStatus status) {
-    this.safeModePrecheck.setInSafeMode(status.getSafeModeStatus());
+    this.safeModePrecheck.setInSafeMode(status.isInSafeMode());
   }
   /**
    * Returns status of scm safe mode determined by SAFE_MODE_STATUS event.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -778,7 +778,7 @@ public class ReplicationManager implements MetricsSource, SafeModeNotification {
   @Override
   public void handleSafeModeTransition(
       SCMSafeModeManager.SafeModeStatus status) {
-    if (!status.getSafeModeStatus() && !this.isRunning()) {
+    if (!status.isInSafeMode() && !this.isRunning()) {
       this.start();
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreator.java
@@ -82,12 +82,9 @@ class BackgroundPipelineCreator {
   void triggerPipelineCreation() {
     // TODO: #CLUTIL introduce a better mechanism to not have more than one
     // job of a particular type running, probably via ratis.
-    LOG.info("Entered triggerPipelineCreation");
     if (!shouldSchedulePipelineCreator()) {
-      LOG.info("Not able to schedule the pipelineCreator");
       return;
     }
-    LOG.info("Scheduling the pipeline creation process");
     scheduler.schedule(this::createPipelines, 0, TimeUnit.MILLISECONDS);
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreator.java
@@ -82,9 +82,12 @@ class BackgroundPipelineCreator {
   void triggerPipelineCreation() {
     // TODO: #CLUTIL introduce a better mechanism to not have more than one
     // job of a particular type running, probably via ratis.
+    LOG.info("Entered triggerPipelineCreation");
     if (!shouldSchedulePipelineCreator()) {
+      LOG.info("Not able to schedule the pipelineCreator");
       return;
     }
+    LOG.info("Scheduling the pipeline creation process");
     scheduler.schedule(this::createPipelines, 0, TimeUnit.MILLISECONDS);
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -221,7 +221,7 @@ public class SCMPipelineManager implements PipelineManager {
   @Override
   public synchronized Pipeline createPipeline(ReplicationType type,
       ReplicationFactor factor) throws IOException {
-    if (!allowPipelineCreation.get()) {
+    if (!allowPipelineCreation.get() && factor != ReplicationFactor.ONE) {
       LOG.debug("Pipeline creation is not allowed until safe mode prechecks " +
           "complete");
       throw new IOException("Pipeline creation is not allowed as safe mode " +

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -88,6 +88,9 @@ public class SCMPipelineManager implements PipelineManager {
   private ObjectName pmInfoBean;
 
   private final AtomicBoolean isInSafeMode;
+  // Used to track if the safemode pre-checks have completed. This is designed
+  // to prevent pipelines being created until sufficient nodes have registered.
+  private final AtomicBoolean allowPipelineCreation;
 
   public SCMPipelineManager(Configuration conf, NodeManager nodeManager,
       EventPublisher eventPublisher)
@@ -134,6 +137,9 @@ public class SCMPipelineManager implements PipelineManager {
     this.isInSafeMode = new AtomicBoolean(conf.getBoolean(
         HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED,
         HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED_DEFAULT));
+    // Pipeline creation is only allowed after the safemode prechecks have
+    // passed, eg sufficient nodes have registered.
+    this.allowPipelineCreation = new AtomicBoolean(!this.isInSafeMode.get());
   }
 
   public PipelineStateManager getStateManager() {
@@ -144,6 +150,16 @@ public class SCMPipelineManager implements PipelineManager {
   public void setPipelineProvider(ReplicationType replicationType,
                                   PipelineProvider provider) {
     pipelineFactory.setProvider(replicationType, provider);
+  }
+
+  @VisibleForTesting
+  public void setAllowPipelineCreation(boolean newState) {
+    this.allowPipelineCreation.set(newState);
+  }
+
+  @VisibleForTesting
+  public boolean getAllowPipelineCreation() {
+    return allowPipelineCreation.get();
   }
 
   protected void initializePipelineState() throws IOException {
@@ -205,6 +221,12 @@ public class SCMPipelineManager implements PipelineManager {
   @Override
   public synchronized Pipeline createPipeline(ReplicationType type,
       ReplicationFactor factor) throws IOException {
+    if (!allowPipelineCreation.get()) {
+      LOG.debug("Pipeline creation is not allowed until safe mode prechecks " +
+          "complete");
+      throw new IOException("Pipeline creation is not allowed as safe mode " +
+          "prechecks have not yet passed");
+    }
     lock.writeLock().lock();
     try {
       Pipeline pipeline = pipelineFactory.create(type, factor);
@@ -641,13 +663,26 @@ public class SCMPipelineManager implements PipelineManager {
   }
 
   @Override
-  public void handleSafeModeTransition(
+  public synchronized void handleSafeModeTransition(
       SCMSafeModeManager.SafeModeStatus status) {
-    this.isInSafeMode.set(status.getSafeModeStatus());
-    if (!status.getSafeModeStatus()) {
-      // TODO: #CLUTIL if we reenter safe mode the fixed interval pipeline
-      // creation job needs to stop
+    // TODO: #CLUTIL - handle safemode getting re-enabled
+    boolean currentAllowPipelines =
+        allowPipelineCreation.getAndSet(status.isPreCheckComplete());
+    boolean currentlyInSafeMode =
+        isInSafeMode.getAndSet(status.isInSafeMode());
+    boolean triggerPipelines = false;
+
+    // Trigger pipeline creation only if the preCheck status has changed to
+    // complete.
+    if (allowPipelineCreation.get() && !currentAllowPipelines) {
+      triggerPipelines = true;
+    }
+    // Start the pipeline creation thread only when safemode switches off
+    if (!getSafeModeStatus() && currentlyInSafeMode) {
       startPipelineCreator();
+      triggerPipelines = true;
+    }
+    if (triggerPipelines) {
       triggerPipelineCreation();
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -221,10 +221,8 @@ public class SCMPipelineManager implements PipelineManager {
   @Override
   public synchronized Pipeline createPipeline(ReplicationType type,
       ReplicationFactor factor) throws IOException {
-    LOG.info("In createpipeline with type {} and factor {}. Allow creation is "+
-        " {}", type, factor, allowPipelineCreation);
     if (!allowPipelineCreation.get() && factor != ReplicationFactor.ONE) {
-      LOG.info("Pipeline creation is not allowed until safe mode prechecks " +
+      LOG.debug("Pipeline creation is not allowed until safe mode prechecks " +
           "complete");
       throw new IOException("Pipeline creation is not allowed as safe mode " +
           "prechecks have not yet passed");

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -221,8 +221,10 @@ public class SCMPipelineManager implements PipelineManager {
   @Override
   public synchronized Pipeline createPipeline(ReplicationType type,
       ReplicationFactor factor) throws IOException {
+    LOG.info("In createpipeline with type {} and factor {}. Allow creation is "+
+        " {}", type, factor, allowPipelineCreation);
     if (!allowPipelineCreation.get() && factor != ReplicationFactor.ONE) {
-      LOG.debug("Pipeline creation is not allowed until safe mode prechecks " +
+      LOG.info("Pipeline creation is not allowed until safe mode prechecks " +
           "complete");
       throw new IOException("Pipeline creation is not allowed as safe mode " +
           "prechecks have not yet passed");

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -670,20 +670,15 @@ public class SCMPipelineManager implements PipelineManager {
         pipelineCreationAllowed.getAndSet(status.isPreCheckComplete());
     boolean currentlyInSafeMode =
         isInSafeMode.getAndSet(status.isInSafeMode());
-    boolean triggerPipelines = false;
 
     // Trigger pipeline creation only if the preCheck status has changed to
     // complete.
     if (isPipelineCreationAllowed() && !currentAllowPipelines) {
-      triggerPipelines = true;
+      triggerPipelineCreation();
     }
     // Start the pipeline creation thread only when safemode switches off
     if (!getSafeModeStatus() && currentlyInSafeMode) {
       startPipelineCreator();
-      triggerPipelines = true;
-    }
-    if (triggerPipelines) {
-      triggerPipelineCreation();
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -138,13 +138,6 @@ public class SCMSafeModeManager implements SafeModeManager {
         exitRules.put(ATLEAST_ONE_DATANODE_REPORTED_PIPELINE_EXIT_RULE,
             oneReplicaPipelineSafeModeRule);
       }
-      boolean createPipelineInSafemode = conf.getBoolean(
-          HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION,
-          HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION_DEFAULT);
-
-      if (createPipelineInSafemode) {
-        pipelineManager.startPipelineCreator();
-      }
     } else {
       this.safeModeMetrics = null;
       exitSafeMode(eventQueue);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -138,6 +138,13 @@ public class SCMSafeModeManager implements SafeModeManager {
         exitRules.put(ATLEAST_ONE_DATANODE_REPORTED_PIPELINE_EXIT_RULE,
             oneReplicaPipelineSafeModeRule);
       }
+      boolean createPipelineInSafemode = conf.getBoolean(
+          HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION,
+          HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION_DEFAULT);
+
+      if (createPipelineInSafemode) {
+        pipelineManager.startPipelineCreator();
+      }
     } else {
       this.safeModeMetrics = null;
       exitSafeMode(eventQueue);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -604,6 +604,6 @@ public class SCMClientProtocolServer implements
   @Override
   public void handleSafeModeTransition(
       SCMSafeModeManager.SafeModeStatus status) {
-    safeModePrecheck.setInSafeMode(status.getSafeModeStatus());
+    safeModePrecheck.setInSafeMode(status.isInSafeMode());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -107,7 +107,7 @@ public class TestBlockManager {
     eventQueue = new EventQueue();
     pipelineManager =
         new SCMPipelineManager(conf, nodeManager, eventQueue);
-    pipelineManager.setAllowPipelineCreation(true);
+    pipelineManager.allowPipelineCreation();
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), conf, eventQueue);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -140,7 +140,7 @@ public class TestBlockManager {
     type = HddsProtos.ReplicationType.RATIS;
 
     blockManager.handleSafeModeTransition(
-        new SCMSafeModeManager.SafeModeStatus(false));
+        new SCMSafeModeManager.SafeModeStatus(false, false));
   }
 
   @After
@@ -235,7 +235,7 @@ public class TestBlockManager {
   @Test
   public void testAllocateBlockFailureInSafeMode() throws Exception {
     blockManager.handleSafeModeTransition(
-        new SCMSafeModeManager.SafeModeStatus(true));
+        new SCMSafeModeManager.SafeModeStatus(true, true));
     // Test1: In safe mode expect an SCMException.
     thrown.expectMessage("SafeModePrecheck failed for "
         + "allocateBlock");

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -107,6 +107,7 @@ public class TestBlockManager {
     eventQueue = new EventQueue();
     pipelineManager =
         new SCMPipelineManager(conf, nodeManager, eventQueue);
+    pipelineManager.setAllowPipelineCreation(true);
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), conf, eventQueue);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
@@ -73,6 +73,7 @@ public class TestCloseContainerEventHandler {
     eventQueue = new EventQueue();
     pipelineManager =
         new SCMPipelineManager(configuration, nodeManager, eventQueue);
+    pipelineManager.setAllowPipelineCreation(true);
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), configuration, eventQueue);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
@@ -73,7 +73,7 @@ public class TestCloseContainerEventHandler {
     eventQueue = new EventQueue();
     pipelineManager =
         new SCMPipelineManager(configuration, nodeManager, eventQueue);
-    pipelineManager.setAllowPipelineCreation(true);
+    pipelineManager.allowPipelineCreation();
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), configuration, eventQueue);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestSCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestSCMContainerManager.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
-import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.pipeline.SCMPipelineManager;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -67,7 +66,7 @@ import java.util.stream.IntStream;
 public class TestSCMContainerManager {
   private static SCMContainerManager containerManager;
   private static MockNodeManager nodeManager;
-  private static PipelineManager pipelineManager;
+  private static SCMPipelineManager pipelineManager;
   private static File testDir;
   private static XceiverClientManager xceiverClientManager;
   private static Random random;
@@ -97,6 +96,7 @@ public class TestSCMContainerManager {
     nodeManager = new MockNodeManager(true, 10);
     pipelineManager =
         new SCMPipelineManager(conf, nodeManager, new EventQueue());
+    pipelineManager.setAllowPipelineCreation(true);
     containerManager = new SCMContainerManager(conf, pipelineManager);
     xceiverClientManager = new XceiverClientManager(conf);
     replicationFactor = SCMTestUtils.getReplicationFactor(conf);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestSCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestSCMContainerManager.java
@@ -96,7 +96,7 @@ public class TestSCMContainerManager {
     nodeManager = new MockNodeManager(true, 10);
     pipelineManager =
         new SCMPipelineManager(conf, nodeManager, new EventQueue());
-    pipelineManager.setAllowPipelineCreation(true);
+    pipelineManager.allowPipelineCreation();
     containerManager = new SCMContainerManager(conf, pipelineManager);
     xceiverClientManager = new XceiverClientManager(conf);
     replicationFactor = SCMTestUtils.getReplicationFactor(conf);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -153,6 +153,11 @@ public class TestDeadNodeHandler {
     nodeManager.register(MockDatanodeDetails.randomDatanodeDetails(),
         TestUtils.createNodeReport(storageOne), null);
 
+    // The background pipline creation thread normally runs on a 2 minute
+    // heartbeat. Rather than wait potentially 2 minutes, we trigger it manually
+    // here.
+    pipelineManager.triggerPipelineCreation();
+
     LambdaTestUtils.await(120000, 10000,
         () -> pipelineManager.getPipelines(RATIS, THREE).size() == 3);
     TestUtils.openAllRatisPipelines(pipelineManager);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -95,6 +95,10 @@ public class TestDeadNodeHandler {
     pipelineManager =
         (SCMPipelineManager)scm.getPipelineManager();
     pipelineManager.setAllowPipelineCreation(true);
+    // This should be triggered by safemode preCheck rules passing, or safe
+    // mode exiting, but the relevant events to trigger safe mode exit are not
+    // fired by this test and hence we need to start the creator thread here.
+    pipelineManager.startPipelineCreator();
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), conf);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.fs.FileUtil;
@@ -86,6 +87,8 @@ public class TestDeadNodeHandler {
   @Before
   public void setup() throws IOException, AuthenticationException {
     OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setTimeDuration(HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT,
+        0, TimeUnit.SECONDS);
     storageDir = GenericTestUtils.getTempPath(
         TestDeadNodeHandler.class.getSimpleName() + UUID.randomUUID());
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, storageDir);
@@ -94,7 +97,6 @@ public class TestDeadNodeHandler {
     nodeManager = (SCMNodeManager) scm.getScmNodeManager();
     pipelineManager =
         (SCMPipelineManager)scm.getPipelineManager();
-    pipelineManager.setAllowPipelineCreation(true);
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), conf);
@@ -128,6 +130,10 @@ public class TestDeadNodeHandler {
     StorageReportProto storageOne = TestUtils.createStorageReport(
         datanode1.getUuid(), storagePath, 100, 10, 90, null);
 
+    // Exit safemode, as otherwise the safemode precheck will prevent pipelines
+    // from getting created. Due to how this test is wired up, safemode will
+    // not exit when the DNs are registered directly with the node manager.
+    scm.exitSafeMode();
     // Standalone pipeline now excludes the nodes which are already used,
     // is the a proper behavior. Adding 9 datanodes for now to make the
     // test case happy.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -153,13 +153,11 @@ public class TestDeadNodeHandler {
     nodeManager.register(MockDatanodeDetails.randomDatanodeDetails(),
         TestUtils.createNodeReport(storageOne), null);
 
-    // The background pipline creation thread normally runs on a 2 minute
-    // heartbeat. Rather than wait potentially 2 minutes, we trigger it manually
-    // here.
-    pipelineManager.triggerPipelineCreation();
-
-    LambdaTestUtils.await(120000, 10000,
-        () -> pipelineManager.getPipelines(RATIS, THREE).size() == 3);
+    LambdaTestUtils.await(120000, 1000,
+        () -> {
+          pipelineManager.triggerPipelineCreation();
+          return pipelineManager.getPipelines(RATIS, THREE).size() == 3;
+        });
     TestUtils.openAllRatisPipelines(pipelineManager);
 
     ContainerInfo container1 =

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -94,6 +94,7 @@ public class TestDeadNodeHandler {
     nodeManager = (SCMNodeManager) scm.getScmNodeManager();
     pipelineManager =
         (SCMPipelineManager)scm.getPipelineManager();
+    pipelineManager.setAllowPipelineCreation(true);
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), conf);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -95,10 +95,6 @@ public class TestDeadNodeHandler {
     pipelineManager =
         (SCMPipelineManager)scm.getPipelineManager();
     pipelineManager.setAllowPipelineCreation(true);
-    // This should be triggered by safemode preCheck rules passing, or safe
-    // mode exiting, but the relevant events to trigger safe mode exit are not
-    // fired by this test and hence we need to start the creator thread here.
-    pipelineManager.startPipelineCreator();
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), conf);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMPipelineManager.java
@@ -22,6 +22,8 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_L
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_ALLOCATED_TIMEOUT;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,8 +32,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Supplier;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.HddsConfigKeys;
@@ -85,6 +89,7 @@ public class TestSCMPipelineManager {
   public void testPipelineReload() throws IOException {
     SCMPipelineManager pipelineManager =
         new SCMPipelineManager(conf, nodeManager, new EventQueue());
+    pipelineManager.setAllowPipelineCreation(true);
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), conf);
@@ -104,6 +109,7 @@ public class TestSCMPipelineManager {
     // new pipeline manager should be able to load the pipelines from the db
     pipelineManager =
         new SCMPipelineManager(conf, nodeManager, new EventQueue());
+    pipelineManager.setAllowPipelineCreation(true);
     mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), conf);
@@ -134,6 +140,7 @@ public class TestSCMPipelineManager {
   public void testRemovePipeline() throws IOException {
     SCMPipelineManager pipelineManager =
         new SCMPipelineManager(conf, nodeManager, new EventQueue());
+    pipelineManager.setAllowPipelineCreation(true);
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), conf);
@@ -154,7 +161,7 @@ public class TestSCMPipelineManager {
         new SCMPipelineManager(conf, nodeManager, new EventQueue());
     try {
       pipelineManager.getPipeline(pipeline.getId());
-      Assert.fail("Pipeline should not have been retrieved");
+      fail("Pipeline should not have been retrieved");
     } catch (IOException e) {
       Assert.assertTrue(e.getMessage().contains("not found"));
     }
@@ -168,6 +175,7 @@ public class TestSCMPipelineManager {
     EventQueue eventQueue = new EventQueue();
     SCMPipelineManager pipelineManager =
         new SCMPipelineManager(conf, nodeManager, eventQueue);
+    pipelineManager.setAllowPipelineCreation(true);
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), conf);
@@ -218,7 +226,7 @@ public class TestSCMPipelineManager {
 
     try {
       pipelineManager.getPipeline(pipeline.getId());
-      Assert.fail("Pipeline should not have been retrieved");
+      fail("Pipeline should not have been retrieved");
     } catch (IOException e) {
       Assert.assertTrue(e.getMessage().contains("not found"));
     }
@@ -233,6 +241,7 @@ public class TestSCMPipelineManager {
         20);
     SCMPipelineManager pipelineManager =
         new SCMPipelineManager(conf, nodeManagerMock, new EventQueue());
+    pipelineManager.setAllowPipelineCreation(true);
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManagerMock,
             pipelineManager.getStateManager(), conf);
@@ -243,7 +252,7 @@ public class TestSCMPipelineManager {
         SCMPipelineMetrics.class.getSimpleName());
     long numPipelineAllocated = getLongCounter("NumPipelineAllocated",
         metrics);
-    Assert.assertTrue(numPipelineAllocated == 0);
+    Assert.assertEquals(0, numPipelineAllocated);
 
     // 3 DNs are unhealthy.
     // Create 5 pipelines (Use up 15 Datanodes)
@@ -267,7 +276,7 @@ public class TestSCMPipelineManager {
     try {
       pipelineManager.createPipeline(HddsProtos.ReplicationType.RATIS,
           HddsProtos.ReplicationFactor.THREE);
-      Assert.fail();
+      fail();
     } catch (SCMException ioe) {
       // pipeline creation failed this time.
       Assert.assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE,
@@ -291,6 +300,7 @@ public class TestSCMPipelineManager {
   public void testActivateDeactivatePipeline() throws IOException {
     final SCMPipelineManager pipelineManager =
         new SCMPipelineManager(conf, nodeManager, new EventQueue());
+    pipelineManager.setAllowPipelineCreation(true);
     final PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), conf);
@@ -338,11 +348,14 @@ public class TestSCMPipelineManager {
     EventQueue eventQueue = new EventQueue();
     SCMPipelineManager pipelineManager =
         new SCMPipelineManager(conf, nodeManager, eventQueue);
+    pipelineManager.setAllowPipelineCreation(true);
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), conf);
     pipelineManager.setPipelineProvider(HddsProtos.ReplicationType.RATIS,
         mockRatisProvider);
+    pipelineManager.handleSafeModeTransition(
+        new SCMSafeModeManager.SafeModeStatus(true, true));
     Pipeline pipeline = pipelineManager
         .createPipeline(HddsProtos.ReplicationType.RATIS,
             HddsProtos.ReplicationFactor.THREE);
@@ -396,6 +409,7 @@ public class TestSCMPipelineManager {
     EventQueue eventQueue = new EventQueue();
     final SCMPipelineManager pipelineManager =
         new SCMPipelineManager(conf, nodeManager, eventQueue);
+    pipelineManager.setAllowPipelineCreation(true);
     final PipelineProvider ratisProvider = new MockRatisPipelineProvider(
         nodeManager, pipelineManager.getStateManager(), conf, eventQueue,
         false);
@@ -424,6 +438,80 @@ public class TestSCMPipelineManager {
             HddsProtos.ReplicationFactor.THREE,
             Pipeline.PipelineState.ALLOCATED).contains(pipeline));
 
+    pipelineManager.close();
+  }
+
+  @Test
+  public void testPipelineNotCreatedUntilSafeModePrecheck()
+      throws IOException, TimeoutException, InterruptedException {
+    // No timeout for pipeline scrubber.
+    conf.setTimeDuration(
+        OZONE_SCM_PIPELINE_ALLOCATED_TIMEOUT, -1,
+        TimeUnit.MILLISECONDS);
+
+    EventQueue eventQueue = new EventQueue();
+    final SCMPipelineManager pipelineManager =
+        new SCMPipelineManager(conf, nodeManager, eventQueue);
+    final PipelineProvider ratisProvider = new MockRatisPipelineProvider(
+        nodeManager, pipelineManager.getStateManager(), conf, eventQueue,
+        false);
+
+    pipelineManager.setPipelineProvider(HddsProtos.ReplicationType.RATIS,
+        ratisProvider);
+
+    try {
+      Pipeline pipeline = pipelineManager
+          .createPipeline(HddsProtos.ReplicationType.RATIS,
+              HddsProtos.ReplicationFactor.THREE);
+      fail("Pipelines should not have been created");
+    } catch (IOException e) {
+      // expected
+    }
+
+    // Simulate safemode check exiting.
+    pipelineManager.handleSafeModeTransition(
+        new SCMSafeModeManager.SafeModeStatus(true, true));
+    GenericTestUtils.waitFor(new Supplier<Boolean>() {
+      @Override
+      public Boolean get() {
+        return pipelineManager.getPipelines().size() != 0;
+      }
+    }, 100, 10000);
+    pipelineManager.close();
+  }
+
+
+  @Test
+  public void testSafeModeUpdatedOnSafemodeExit()
+      throws IOException, TimeoutException, InterruptedException {
+    // No timeout for pipeline scrubber.
+    conf.setTimeDuration(
+        OZONE_SCM_PIPELINE_ALLOCATED_TIMEOUT, -1,
+        TimeUnit.MILLISECONDS);
+
+    EventQueue eventQueue = new EventQueue();
+    final SCMPipelineManager pipelineManager =
+        new SCMPipelineManager(conf, nodeManager, eventQueue);
+    final PipelineProvider ratisProvider = new MockRatisPipelineProvider(
+        nodeManager, pipelineManager.getStateManager(), conf, eventQueue,
+        false);
+
+    pipelineManager.setPipelineProvider(HddsProtos.ReplicationType.RATIS,
+        ratisProvider);
+
+    assertEquals(true, pipelineManager.getSafeModeStatus());
+    assertEquals(false, pipelineManager.getAllowPipelineCreation());
+    // First pass pre-check as true, but safemode still on
+    pipelineManager.handleSafeModeTransition(
+        new SCMSafeModeManager.SafeModeStatus(true, true));
+    assertEquals(true, pipelineManager.getSafeModeStatus());
+    assertEquals(true, pipelineManager.getAllowPipelineCreation());
+
+    // Then also turn safemode off
+    pipelineManager.handleSafeModeTransition(
+        new SCMSafeModeManager.SafeModeStatus(false, true));
+    assertEquals(false, pipelineManager.getSafeModeStatus());
+    assertEquals(true, pipelineManager.getAllowPipelineCreation());
     pipelineManager.close();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMPipelineManager.java
@@ -468,6 +468,12 @@ public class TestSCMPipelineManager {
       // expected
     }
 
+    // Ensure a pipeline of factor ONE can be created - no exceptions should be
+    // raised.
+    Pipeline pipeline = pipelineManager
+        .createPipeline(HddsProtos.ReplicationType.RATIS,
+            HddsProtos.ReplicationFactor.ONE);
+
     // Simulate safemode check exiting.
     pipelineManager.handleSafeModeTransition(
         new SCMSafeModeManager.SafeModeStatus(true, true));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMPipelineManager.java
@@ -89,7 +89,7 @@ public class TestSCMPipelineManager {
   public void testPipelineReload() throws IOException {
     SCMPipelineManager pipelineManager =
         new SCMPipelineManager(conf, nodeManager, new EventQueue());
-    pipelineManager.setAllowPipelineCreation(true);
+    pipelineManager.allowPipelineCreation();
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), conf);
@@ -109,7 +109,7 @@ public class TestSCMPipelineManager {
     // new pipeline manager should be able to load the pipelines from the db
     pipelineManager =
         new SCMPipelineManager(conf, nodeManager, new EventQueue());
-    pipelineManager.setAllowPipelineCreation(true);
+    pipelineManager.allowPipelineCreation();
     mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), conf);
@@ -140,7 +140,7 @@ public class TestSCMPipelineManager {
   public void testRemovePipeline() throws IOException {
     SCMPipelineManager pipelineManager =
         new SCMPipelineManager(conf, nodeManager, new EventQueue());
-    pipelineManager.setAllowPipelineCreation(true);
+    pipelineManager.allowPipelineCreation();
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), conf);
@@ -175,7 +175,7 @@ public class TestSCMPipelineManager {
     EventQueue eventQueue = new EventQueue();
     SCMPipelineManager pipelineManager =
         new SCMPipelineManager(conf, nodeManager, eventQueue);
-    pipelineManager.setAllowPipelineCreation(true);
+    pipelineManager.allowPipelineCreation();
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), conf);
@@ -241,7 +241,7 @@ public class TestSCMPipelineManager {
         20);
     SCMPipelineManager pipelineManager =
         new SCMPipelineManager(conf, nodeManagerMock, new EventQueue());
-    pipelineManager.setAllowPipelineCreation(true);
+    pipelineManager.allowPipelineCreation();
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManagerMock,
             pipelineManager.getStateManager(), conf);
@@ -300,7 +300,7 @@ public class TestSCMPipelineManager {
   public void testActivateDeactivatePipeline() throws IOException {
     final SCMPipelineManager pipelineManager =
         new SCMPipelineManager(conf, nodeManager, new EventQueue());
-    pipelineManager.setAllowPipelineCreation(true);
+    pipelineManager.allowPipelineCreation();
     final PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), conf);
@@ -348,7 +348,7 @@ public class TestSCMPipelineManager {
     EventQueue eventQueue = new EventQueue();
     SCMPipelineManager pipelineManager =
         new SCMPipelineManager(conf, nodeManager, eventQueue);
-    pipelineManager.setAllowPipelineCreation(true);
+    pipelineManager.allowPipelineCreation();
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(nodeManager,
             pipelineManager.getStateManager(), conf);
@@ -409,7 +409,7 @@ public class TestSCMPipelineManager {
     EventQueue eventQueue = new EventQueue();
     final SCMPipelineManager pipelineManager =
         new SCMPipelineManager(conf, nodeManager, eventQueue);
-    pipelineManager.setAllowPipelineCreation(true);
+    pipelineManager.allowPipelineCreation();
     final PipelineProvider ratisProvider = new MockRatisPipelineProvider(
         nodeManager, pipelineManager.getStateManager(), conf, eventQueue,
         false);
@@ -506,18 +506,18 @@ public class TestSCMPipelineManager {
         ratisProvider);
 
     assertEquals(true, pipelineManager.getSafeModeStatus());
-    assertEquals(false, pipelineManager.getAllowPipelineCreation());
+    assertEquals(false, pipelineManager.isPipelineCreationAllowed());
     // First pass pre-check as true, but safemode still on
     pipelineManager.handleSafeModeTransition(
         new SCMSafeModeManager.SafeModeStatus(true, true));
     assertEquals(true, pipelineManager.getSafeModeStatus());
-    assertEquals(true, pipelineManager.getAllowPipelineCreation());
+    assertEquals(true, pipelineManager.isPipelineCreationAllowed());
 
     // Then also turn safemode off
     pipelineManager.handleSafeModeTransition(
         new SCMSafeModeManager.SafeModeStatus(false, true));
     assertEquals(false, pipelineManager.getSafeModeStatus());
-    assertEquals(true, pipelineManager.getAllowPipelineCreation());
+    assertEquals(true, pipelineManager.isPipelineCreationAllowed());
     pipelineManager.close();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
@@ -111,6 +111,7 @@ public class TestHealthyPipelineSafeModeRule {
 
       SCMPipelineManager pipelineManager = new SCMPipelineManager(config,
           nodeManager, eventQueue);
+      pipelineManager.setAllowPipelineCreation(true);
 
       PipelineProvider mockRatisProvider =
           new MockRatisPipelineProvider(nodeManager,
@@ -184,6 +185,7 @@ public class TestHealthyPipelineSafeModeRule {
 
       SCMPipelineManager pipelineManager = new SCMPipelineManager(config,
           nodeManager, eventQueue);
+      pipelineManager.setAllowPipelineCreation(true);
       PipelineProvider mockRatisProvider =
           new MockRatisPipelineProvider(nodeManager,
               pipelineManager.getStateManager(), config, true);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
@@ -111,7 +111,7 @@ public class TestHealthyPipelineSafeModeRule {
 
       SCMPipelineManager pipelineManager = new SCMPipelineManager(config,
           nodeManager, eventQueue);
-      pipelineManager.setAllowPipelineCreation(true);
+      pipelineManager.allowPipelineCreation();
 
       PipelineProvider mockRatisProvider =
           new MockRatisPipelineProvider(nodeManager,
@@ -185,7 +185,7 @@ public class TestHealthyPipelineSafeModeRule {
 
       SCMPipelineManager pipelineManager = new SCMPipelineManager(config,
           nodeManager, eventQueue);
-      pipelineManager.setAllowPipelineCreation(true);
+      pipelineManager.allowPipelineCreation();
       PipelineProvider mockRatisProvider =
           new MockRatisPipelineProvider(nodeManager,
               pipelineManager.getStateManager(), config, true);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
@@ -69,6 +69,7 @@ public class TestOneReplicaPipelineSafeModeRule {
     pipelineManager =
         new SCMPipelineManager(ozoneConfiguration, mockNodeManager,
             eventQueue);
+    pipelineManager.setAllowPipelineCreation(true);
 
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(mockNodeManager,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
@@ -69,7 +69,7 @@ public class TestOneReplicaPipelineSafeModeRule {
     pipelineManager =
         new SCMPipelineManager(ozoneConfiguration, mockNodeManager,
             eventQueue);
-    pipelineManager.setAllowPipelineCreation(true);
+    pipelineManager.allowPipelineCreation();
 
     PipelineProvider mockRatisProvider =
         new MockRatisPipelineProvider(mockNodeManager,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -267,7 +267,7 @@ public class TestSCMSafeModeManager {
             pipelineManager.getStateManager(), config, true);
     pipelineManager.setPipelineProvider(HddsProtos.ReplicationType.RATIS,
         mockRatisProvider);
-    pipelineManager.setAllowPipelineCreation(true);
+    pipelineManager.allowPipelineCreation();
 
     for (int i=0; i < pipelineCount; i++) {
       pipelineManager.createPipeline(HddsProtos.ReplicationType.RATIS,
@@ -485,7 +485,7 @@ public class TestSCMSafeModeManager {
               pipelineManager.getStateManager(), config, true);
       pipelineManager.setPipelineProvider(HddsProtos.ReplicationType.RATIS,
           mockRatisProvider);
-      pipelineManager.setAllowPipelineCreation(true);
+      pipelineManager.allowPipelineCreation();
 
       Pipeline pipeline = pipelineManager.createPipeline(
           HddsProtos.ReplicationType.RATIS,
@@ -569,7 +569,7 @@ public class TestSCMSafeModeManager {
     Assert.assertEquals(true, smHandler.getIsInSafeMode());
 
     // Create a pipeline and ensure safemode is exited.
-    pipelineManager.setAllowPipelineCreation(true);
+    pipelineManager.allowPipelineCreation();
     Pipeline pipeline = pipelineManager.createPipeline(
         HddsProtos.ReplicationType.RATIS,
         HddsProtos.ReplicationFactor.THREE);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -48,7 +48,7 @@ import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -70,8 +70,8 @@ public class TestSCMSafeModeManager {
   @Rule
   public final TemporaryFolder tempDir = new TemporaryFolder();
 
-  @BeforeClass
-  public static void setUp() {
+  @Before
+  public void setUp() {
     queue = new EventQueue();
     config = new OzoneConfiguration();
     config.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
@@ -41,6 +43,8 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineProvider;
 import org.apache.hadoop.hdds.scm.pipeline.SCMPipelineManager;
+import org.apache.hadoop.hdds.server.events.EventHandler;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assert;
@@ -263,7 +267,7 @@ public class TestSCMSafeModeManager {
             pipelineManager.getStateManager(), config, true);
     pipelineManager.setPipelineProvider(HddsProtos.ReplicationType.RATIS,
         mockRatisProvider);
-
+    pipelineManager.setAllowPipelineCreation(true);
 
     for (int i=0; i < pipelineCount; i++) {
       pipelineManager.createPipeline(HddsProtos.ReplicationType.RATIS,
@@ -481,6 +485,7 @@ public class TestSCMSafeModeManager {
               pipelineManager.getStateManager(), config, true);
       pipelineManager.setPipelineProvider(HddsProtos.ReplicationType.RATIS,
           mockRatisProvider);
+      pipelineManager.setAllowPipelineCreation(true);
 
       Pipeline pipeline = pipelineManager.createPipeline(
           HddsProtos.ReplicationType.RATIS,
@@ -504,6 +509,103 @@ public class TestSCMSafeModeManager {
           HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_AVAILABILITY_CHECK,
           false);
       FileUtil.fullyDelete(new File(storageDir));
+    }
+  }
+
+  @Test
+  public void testPipelinesNotCreatedUntilPreCheckPasses()
+      throws Exception {
+    int numOfDns = 5;
+    // enable pipeline check
+    config.setBoolean(
+        HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_AVAILABILITY_CHECK, true);
+    config.setInt(HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE, numOfDns);
+    config.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION,
+        true);
+
+    MockNodeManager nodeManager = new MockNodeManager(true, numOfDns);
+    String storageDir = GenericTestUtils.getTempPath(
+        TestSCMSafeModeManager.class.getName() + UUID.randomUUID());
+    config.set(HddsConfigKeys.OZONE_METADATA_DIRS, storageDir);
+    // enable pipeline check
+    config.setBoolean(
+        HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_AVAILABILITY_CHECK, true);
+
+    SCMPipelineManager pipelineManager = new SCMPipelineManager(config,
+        nodeManager, queue);
+
+    PipelineProvider mockRatisProvider =
+        new MockRatisPipelineProvider(nodeManager,
+            pipelineManager.getStateManager(), config, true);
+    pipelineManager.setPipelineProvider(HddsProtos.ReplicationType.RATIS,
+        mockRatisProvider);
+
+    SafeModeEventHandler smHandler = new SafeModeEventHandler();
+    queue.addHandler(SCMEvents.SAFE_MODE_STATUS, smHandler);
+    scmSafeModeManager = new SCMSafeModeManager(
+        config, containers, pipelineManager, queue);
+
+    // Assert SCM is in Safe mode.
+    assertTrue(scmSafeModeManager.getInSafeMode());
+
+    // Register all DataNodes except last one and assert SCM is in safe mode.
+    for (int i = 0; i < numOfDns - 1; i++) {
+      queue.fireEvent(SCMEvents.NODE_REGISTRATION_CONT_REPORT,
+          HddsTestUtils.createNodeRegistrationContainerReport(containers));
+      assertTrue(scmSafeModeManager.getInSafeMode());
+      assertFalse(scmSafeModeManager.getPreCheckComplete());
+    }
+    queue.processAll(5000);
+    Assert.assertEquals(0, smHandler.getInvokedCount());
+
+    // Register last DataNode and check that the SafeModeEvent gets fired, but
+    // safemode is still enabled with preCheck completed.
+    queue.fireEvent(SCMEvents.NODE_REGISTRATION_CONT_REPORT,
+        HddsTestUtils.createNodeRegistrationContainerReport(containers));
+    queue.processAll(5000);
+
+    Assert.assertEquals(1, smHandler.getInvokedCount());
+    Assert.assertEquals(true, smHandler.getPreCheckComplete());
+    Assert.assertEquals(true, smHandler.getIsInSafeMode());
+
+    // Create a pipeline and ensure safemode is exited.
+    pipelineManager.setAllowPipelineCreation(true);
+    Pipeline pipeline = pipelineManager.createPipeline(
+        HddsProtos.ReplicationType.RATIS,
+        HddsProtos.ReplicationFactor.THREE);
+    firePipelineEvent(pipelineManager, pipeline);
+
+    queue.processAll(5000);
+    Assert.assertEquals(2, smHandler.getInvokedCount());
+    Assert.assertEquals(true, smHandler.getPreCheckComplete());
+    Assert.assertEquals(false, smHandler.getIsInSafeMode());
+  }
+
+  private static class SafeModeEventHandler
+      implements EventHandler<SCMSafeModeManager.SafeModeStatus> {
+
+    private AtomicInteger invokedCount = new AtomicInteger(0);
+    private AtomicBoolean preCheckComplete = new AtomicBoolean(false);
+    private AtomicBoolean isInSafeMode = new AtomicBoolean(true);
+
+    public int getInvokedCount() {
+      return invokedCount.get();
+    }
+
+    public boolean getPreCheckComplete() {
+      return preCheckComplete.get();
+    }
+
+    public boolean getIsInSafeMode() {
+      return isInSafeMode.get();
+    }
+
+    @Override
+    public void onMessage(SCMSafeModeManager.SafeModeStatus safeModeStatus,
+        EventPublisher publisher) {
+      invokedCount.incrementAndGet();
+      preCheckComplete.set(safeModeStatus.isPreCheckComplete());
+      isInSafeMode.set(safeModeStatus.isInSafeMode());
     }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestScmSafeMode.java
@@ -317,7 +317,7 @@ public class TestScmSafeMode {
     final List<ContainerInfo> containers = scm.getContainerManager()
         .getContainers();
     scm.getEventQueue().fireEvent(SCMEvents.SAFE_MODE_STATUS,
-        new SCMSafeModeManager.SafeModeStatus(true));
+        new SCMSafeModeManager.SafeModeStatus(true, true));
     GenericTestUtils.waitFor(() -> {
       return clientProtocolServer.getSafeModeStatus();
     }, 50, 1000 * 30);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkOzoneManager.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkOzoneManager.java
@@ -104,7 +104,7 @@ public class BenchMarkOzoneManager {
           pipelineManager.openPipeline(pipeline.getId());
         }
         scm.getEventQueue().fireEvent(SCMEvents.SAFE_MODE_STATUS,
-            new SCMSafeModeManager.SafeModeStatus(false));
+            new SCMSafeModeManager.SafeModeStatus(false, false));
         Thread.sleep(1000);
 
         // prepare OM

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkSCM.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkSCM.java
@@ -92,7 +92,7 @@ public class BenchMarkSCM {
           pipelineManager.openPipeline(pipeline.getId());
         }
         scm.getEventQueue().fireEvent(SCMEvents.SAFE_MODE_STATUS,
-            new SCMSafeModeManager.SafeModeStatus(false));
+            new SCMSafeModeManager.SafeModeStatus(false, false));
         Thread.sleep(1000);
       }
     } finally {


### PR DESCRIPTION
## What changes were proposed in this pull request?

As part of the SCM safemode process, there are some rules which must pass before safemode can be exited.

One of these rules is the number of registered datanodes and another is that at least one pipeline must be created and open.

Currently, pipeline creation is attempted each time a node registers. As soon as the 3rd node registers, pipelines will be created.

There are two issue with this:

1. With network topology, if the first 3 nodes are all from the same rack, a non-rackaware pipeline will get created.

2. With multi-raft, it would be better if more nodes are registered to allow the multiple pipelines per node to be spread across all the available nodes.

The proposal here, is to introduce a new sub-state into the safemode process, call "preCheckComplete". When adding rules to the Safemode Manager, some rules can be tagged as "preCheck" (eg number of datanodes registered). When all all the pre-check rules have passed a notification will be sent to all safemode listeners:
```
  safeModeIsOn -> true
  preCheckComplete -> true
```
That will allow the listener to take action on this first stage completing. In the case of PipelineManager, it will then allow pipelines to be created.

After the remaining rules have been passed, safemode will exit as normal, by sending a second event:
```
  safeModeIsOn -> false
  preCheckComplete -> true
```


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3270

## How was this patch tested?

New unit tests added and existing tests modified.
