### PR TITLE
HDDS-3074. Make the configuration of container scrub consistent.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScrubberConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScrubberConfiguration.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.hdds.conf.ConfigType;
 /**
  * This class defines configuration parameters for container scrubber.
  **/
-@ConfigGroup(prefix = "hdds.containerscrub")
+@ConfigGroup(prefix = "hdds.container.scrub")
 public class ContainerScrubberConfiguration {
 
   @Config(key = "enabled",


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we set `hdds.container.scrub.enabled` (in ozone-site.xml) to true, container scrub didn't work because the [prefix of the configuration](https://github.com/apache/hadoop-ozone/blob/f6be7660a52ac0e7ebfa3818989c30c0b9f977ed/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScrubberConfiguration.java#L28) is incorrect, like this:

![ds1](https://user-images.githubusercontent.com/14295594/77563517-5845ba00-6efc-11ea-8895-f57b8a994402.png)

So I fixed the prefix of the configuration (replace it with **hdds.container.scrub**), it did work.

![ds2](https://user-images.githubusercontent.com/14295594/77563533-5e3b9b00-6efc-11ea-9df2-f1d1a6ed3c0b.png)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-3074

## How was this patch tested?

Check logs on Ozone Single Cluster.
