### PR TITLE
HDDS-3281. Add timeouts to all robot tests

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/auditparser/auditparser.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/auditparser/auditparser.robot
@@ -18,6 +18,7 @@ Documentation       Smoketest ozone cluster startup
 Library             OperatingSystem
 Library             BuiltIn
 Resource            ../commonlib.robot
+Test Timeout        5 minutes
 
 *** Variables ***
 ${user}              hadoop

--- a/hadoop-ozone/dist/src/main/smoketest/basic/basic.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/basic.robot
@@ -17,6 +17,7 @@
 Documentation       Smoketest ozone cluster startup
 Library             OperatingSystem
 Resource            ../commonlib.robot
+Test Timeout        5 minutes
 
 *** Variables ***
 ${DATANODE_HOST}        datanode

--- a/hadoop-ozone/dist/src/main/smoketest/env-compose.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/env-compose.robot
@@ -16,7 +16,7 @@
 *** Settings ***
 Documentation       High level utilities to execute commands and tests in docker-compose based environments.
 Resource            commonlib.robot
-
+Test Timeout        5 minutes
 
 *** Keywords ***
 

--- a/hadoop-ozone/dist/src/main/smoketest/freon/freon.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/freon/freon.robot
@@ -17,6 +17,7 @@
 Documentation       Smoketest ozone cluster startup
 Library             OperatingSystem
 Resource            ../commonlib.robot
+Test Timeout        5 minutes
 
 *** Test Cases ***
 Freon Randomkey Generator

--- a/hadoop-ozone/dist/src/main/smoketest/gdpr/gdpr.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/gdpr/gdpr.robot
@@ -19,6 +19,7 @@ Library             OperatingSystem
 Library             BuiltIn
 Library             String
 Resource            ../commonlib.robot
+Test Timeout        5 minutes
 Suite Setup         Generate volume
 
 *** Variables ***

--- a/hadoop-ozone/dist/src/main/smoketest/om-ratis/testOMAdminCmd.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/om-ratis/testOMAdminCmd.robot
@@ -17,7 +17,7 @@
 Documentation       Smoketest ozone cluster startup
 Library             OperatingSystem
 Resource            ../commonlib.robot
-
+Test Timeout        5 minutes
 
 *** Test Cases ***
 

--- a/hadoop-ozone/dist/src/main/smoketest/omha/testOMHA.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/omha/testOMHA.robot
@@ -19,6 +19,7 @@ Library             OperatingSystem
 Library             SSHLibrary
 Library             Collections
 Resource            ../commonlib.robot
+Test Timeout        8 minutes
 
 *** Variables ***
 ${SECURITY_ENABLED}                 false

--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/hadoopo3fs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/hadoopo3fs.robot
@@ -18,6 +18,7 @@ Documentation       Test ozone fs with hadoopfs
 Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
+Test Timeout        5 minutes
 
 *** Variables ***
 ${DATANODE_HOST}        datanode

--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs.robot
@@ -17,6 +17,7 @@
 Documentation       Ozonefs test
 Library             OperatingSystem
 Resource            ../commonlib.robot
+Test Timeout        5 minutes
 
 *** Variables ***
 

--- a/hadoop-ozone/dist/src/main/smoketest/recon/recon-api.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/recon/recon-api.robot
@@ -19,6 +19,7 @@ Library             OperatingSystem
 Library             String
 Library             BuiltIn
 Resource            ../commonlib.robot
+Test Timeout        5 minutes
 
 *** Variables ***
 ${ENDPOINT_URL}       http://recon:9888

--- a/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
@@ -19,6 +19,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            commonawslib.robot
+Test Timeout        5 minutes
 Suite Setup         Setup s3 tests
 
 *** Keywords ***

--- a/hadoop-ozone/dist/src/main/smoketest/s3/awss3.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/awss3.robot
@@ -19,6 +19,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            ./commonawslib.robot
+Test Timeout        5 minutes
 Suite Setup         Setup s3 tests
 
 *** Variables ***

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
@@ -19,6 +19,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            commonawslib.robot
+Test Timeout        5 minutes
 Suite Setup         Setup s3 tests
 
 *** Variables ***

--- a/hadoop-ozone/dist/src/main/smoketest/s3/buckethead.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/buckethead.robot
@@ -19,6 +19,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            commonawslib.robot
+Test Timeout        5 minutes
 Suite Setup         Setup s3 tests
 
 *** Variables ***

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
@@ -19,6 +19,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            commonawslib.robot
+Test Timeout        5 minutes
 Suite Setup         Setup s3 tests
 
 *** Variables ***

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectcopy.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectcopy.robot
@@ -19,6 +19,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            commonawslib.robot
+Test Timeout        5 minutes
 Suite Setup         Setup s3 tests
 
 *** Variables ***

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectdelete.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectdelete.robot
@@ -19,6 +19,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            commonawslib.robot
+Test Timeout        5 minutes
 Suite Setup         Setup s3 tests
 
 *** Variables ***

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectmultidelete.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectmultidelete.robot
@@ -19,6 +19,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            commonawslib.robot
+Test Timeout        5 minutes
 Suite Setup         Setup s3 tests
 
 *** Variables ***

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectputget.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectputget.robot
@@ -19,6 +19,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            commonawslib.robot
+Test Timeout        5 minutes
 Suite Setup         Setup s3 tests
 
 *** Variables ***

--- a/hadoop-ozone/dist/src/main/smoketest/s3/webui.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/webui.robot
@@ -19,6 +19,7 @@ Library             OperatingSystem
 Library             String
 Resource            ../commonlib.robot
 Resource            ./commonawslib.robot
+Test Timeout        5 minutes
 Suite Setup         Setup s3 tests
 
 *** Variables ***

--- a/hadoop-ozone/dist/src/main/smoketest/scmcli/datanode.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/scmcli/datanode.robot
@@ -18,6 +18,7 @@ Documentation       Smoketest ozone cluster startup
 Library             OperatingSystem
 Library             BuiltIn
 Resource            ../commonlib.robot
+Test Timeout        5 minutes
 
 *** Variables ***
 

--- a/hadoop-ozone/dist/src/main/smoketest/scmcli/pipeline.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/scmcli/pipeline.robot
@@ -18,6 +18,7 @@ Documentation       Smoketest ozone cluster startup
 Library             OperatingSystem
 Library             BuiltIn
 Resource            ../commonlib.robot
+Test Timeout        5 minutes
 
 *** Variables ***
 

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
@@ -19,6 +19,7 @@ Library             OperatingSystem
 Library             String
 Library             BuiltIn
 Resource            ../commonlib.robot
+Test Timeout        5 minutes
 
 *** Variables ***
 ${ENDPOINT_URL}    http://s3g:9878

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-s3.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-s3.robot
@@ -20,6 +20,7 @@ Library             String
 Library             BuiltIn
 Resource            ../commonlib.robot
 Resource            ../s3/commonawslib.robot
+Test Timeout        5 minutes
 
 *** Variables ***
 ${ENDPOINT_URL}     http://s3g:9878


### PR DESCRIPTION
## What changes were proposed in this pull request?

We have seen in some CI runs that the acceptance test suit is getting cancelled as it runs for more than 6 hours. Because of this, the test results and logs are also not saved. 

This Jira aims to add a 5 minute timeout to all robot tests. In case some tests require more time, we can update the timeout. This would help to isolate the test which could be causing the whole acceptance test suit to time out.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3281

## How was this patch tested?

CI acceptance test suit can test this change as it only adds a timeout to robot tests.