### PR TITLE
HDDS-3284. ozonesecure-mr test fails due to lack of disk space

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
@@ -99,6 +99,8 @@ YARN-SITE.XML_yarn.resourcemanager.system.metrics.publisher.enabled=true
 YARN-SITE.XML_yarn.log-aggregation-enable=true
 YARN-SITE.XML_yarn.nodemanager.log-aggregation.roll-monitoring-interval-seconds=3600
 YARN-SITE.XML_yarn.nodemanager.delete.debug-delay-sec=600
+YARN-SITE.XML_yarn.nodemanager.disk-health-checker.max-disk-utilization-per-disk-percentage=99
+YARN-SITE.XML_yarn.nodemanager.disk-health-checker.enable=false
 
 # Yarn LinuxContainer requires the /opt/hadoop/etc/hadoop to be owned by root and not modifiable by other users,
 # which prevents start.sh from changing the configurations based on docker-config


### PR DESCRIPTION
## What changes were proposed in this pull request?

Disable YARN disk utilization check in `ozonesecure-mr` acceptance test.

Plenty of disk space is available in CI, but more than 90% of the disk is used:

```
Filesystem      Size  Used Avail Use% Mounted on
...
/dev/sda1        84G   75G  8.3G  91% /
```

Thus directory checker marks it as invalid:

```
WARN  DirectoryCollection:418 - Directory /tmp/hadoop-hadoop/nm-local-dir error, used space above threshold of 90.0%, removing from list of valid directories
WARN  DirectoryCollection:418 - Directory /opt/hadoop/logs/userlogs error, used space above threshold of 90.0%, removing from list of valid directories
```

https://issues.apache.org/jira/browse/HDDS-3284

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/535925282

```
==============================================================================
Execute PI calculation                                                | PASS |
------------------------------------------------------------------------------
Execute WordCount                                                     | PASS |
------------------------------------------------------------------------------
ozonesecure-mr-mapreduce :: Execute MR jobs                           | PASS |
```