### PR TITLE
HDDS-3273. getConf does not return all OM addresses.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -112,6 +112,9 @@ public final class OmUtils {
             addKeySuffixes(OZONE_OM_ADDRESS_KEY, serviceId, nodeId));
         if (rpcAddr != null) {
           result.get(serviceId).add(NetUtils.createSocketAddr(rpcAddr));
+        } else {
+          LOG.warn("Address undefined for nodeId: {} for service {}", nodeId,
+              serviceId);
         }
       }
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -29,8 +29,12 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.stream.Collectors;
@@ -87,6 +91,31 @@ public final class OmUtils {
    */
   public static InetSocketAddress getOmAddress(Configuration conf) {
     return NetUtils.createSocketAddr(getOmRpcAddress(conf));
+  }
+
+  /**
+   * Return list of OM addresses by service ids - when HA is enabled.
+   *
+   * @param conf {@link Configuration}
+   * @return {service.id -> [{@link InetSocketAddress}]}
+   */
+  public static Map<String, List<InetSocketAddress>> getOmHAAddressesById(
+      Configuration conf) {
+    Map<String, List<InetSocketAddress>> result = new HashMap<>();
+    for (String serviceId : conf.getTrimmedStringCollection(
+        OZONE_OM_SERVICE_IDS_KEY)) {
+      if (!result.containsKey(serviceId)) {
+        result.put(serviceId, new ArrayList<>());
+      }
+      for (String nodeId : getOMNodeIds(conf, serviceId)) {
+        String rpcAddr = getOmRpcAddress(conf,
+            addKeySuffixes(OZONE_OM_ADDRESS_KEY, serviceId, nodeId));
+        if (rpcAddr != null) {
+          result.get(serviceId).add(NetUtils.createSocketAddr(rpcAddr));
+        }
+      }
+    }
+    return result;
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/freon/OzoneGetConf.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/freon/OzoneGetConf.java
@@ -253,7 +253,11 @@ public class OzoneGetConf extends Configured implements Tool {
     @Override
     public int doWorkInternal(OzoneGetConf tool, String[] args)
         throws IOException {
-      tool.printOut(OmUtils.getOmAddress(tool.getConf()).getHostName());
+      if (OmUtils.isServiceIdsDefined(tool.getConf())) {
+        tool.printOut(OmUtils.getOmHAAddressesById(tool.getConf()).toString());
+      } else {
+        tool.printOut(OmUtils.getOmAddress(tool.getConf()).getHostName());
+      }
       return 0;
     }
   }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.io.IOUtils;
 import org.junit.Rule;
@@ -31,9 +32,14 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
 
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -113,6 +119,26 @@ public class TestOmUtils {
     // expecting exception
   }
 
+  @Test
+  public void testGetOmHAAddressesById() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OZONE_OM_SERVICE_IDS_KEY, "ozone1");
+    conf.set("ozone.om.nodes.ozone1", "node1,node2,node3");
+    conf.set("ozone.om.address.ozone1.node1", "1.1.1.1");
+    conf.set("ozone.om.address.ozone1.node2", "1.1.1.2");
+    conf.set("ozone.om.address.ozone1.node3", "1.1.1.3");
+    Map<String, List<InetSocketAddress>> addresses =
+        OmUtils.getOmHAAddressesById(conf);
+    assertFalse(addresses.isEmpty());
+    List<InetSocketAddress> rpcAddrs = addresses.get("ozone1");
+    assertFalse(rpcAddrs.isEmpty());
+    assertTrue(rpcAddrs.stream().anyMatch(
+        a -> a.getAddress().getHostAddress().equals("1.1.1.1")));
+    assertTrue(rpcAddrs.stream().anyMatch(
+        a -> a.getAddress().getHostAddress().equals("1.1.1.2")));
+    assertTrue(rpcAddrs.stream().anyMatch(
+        a -> a.getAddress().getHostAddress().equals("1.1.1.3")));
+  }
 }
 
 class TestDBCheckpoint implements DBCheckpoint {

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added a new utility method to return a list of addresses keyed by serviceId. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3273

## How was this patch tested?
Added a unit test and verified via docker:

`bash-4.2$ /opt/hadoop/bin/ozone getconf -ozonemanagers`
`{omservice=[om1/172.22.0.6:9862, om2/172.22.0.4:9862, om3/172.22.0.2:9862]}`

`bash-4.2$ /opt/hadoop/bin/ozone getconf -ozonemanagers`
`om`