### PR TITLE
HDDS-3288: Update default RPC handler SCM/OM count to 100

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -221,7 +221,7 @@ public final class ScmConfigKeys {
 
   public static final String OZONE_SCM_HANDLER_COUNT_KEY =
       "ozone.scm.handler.count.key";
-  public static final int OZONE_SCM_HANDLER_COUNT_DEFAULT = 10;
+  public static final int OZONE_SCM_HANDLER_COUNT_DEFAULT = 100;
 
   public static final String OZONE_SCM_SECURITY_HANDLER_COUNT_KEY =
       "ozone.scm.security.handler.count.key";

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -505,7 +505,7 @@
   </property>
   <property>
     <name>ozone.om.handler.count.key</name>
-    <value>20</value>
+    <value>100</value>
     <tag>OM, PERFORMANCE</tag>
     <description>
       The number of RPC handler threads for OM service endpoints.
@@ -918,7 +918,7 @@
   </property>
   <property>
     <name>ozone.scm.handler.count.key</name>
-    <value>10</value>
+    <value>100</value>
     <tag>OZONE, MANAGEMENT, PERFORMANCE</tag>
     <description>
       The number of RPC handler threads for each SCM service

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -37,7 +37,7 @@ public final class OMConfigKeys {
 
   public static final String OZONE_OM_HANDLER_COUNT_KEY =
       "ozone.om.handler.count.key";
-  public static final int OZONE_OM_HANDLER_COUNT_DEFAULT = 20;
+  public static final int OZONE_OM_HANDLER_COUNT_DEFAULT = 100;
 
   public static final String OZONE_OM_INTERNAL_SERVICE_ID =
       "ozone.om.internal.service.id";


### PR DESCRIPTION
## What changes were proposed in this pull request?

Presently, default RPC handler count of ozone.scm.handler.count.key=10 and ozone.om.handler.count.key=20 are too small values and its good to increase the default values to a realistic value.

```
ozone.om.handler.count.key=100
ozone.scm.handler.count.key=100
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3288

## How was this patch tested?

Config changes and no UTs added.