### PR TITLE
HDDS-3289. Add a freon generator to create nested directories.

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
@@ -42,7 +42,7 @@ import picocli.CommandLine.Option;
         OmKeyGenerator.class,
         OmBucketGenerator.class,
         HadoopFsGenerator.class,
-        HadoopDirGenerator.class,
+        HadoopNestedDirGenerator.class,
         HadoopFsValidator.class,
         SameKeyReader.class,
         S3KeyGenerator.class,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
@@ -42,6 +42,7 @@ import picocli.CommandLine.Option;
         OmKeyGenerator.class,
         OmBucketGenerator.class,
         HadoopFsGenerator.class,
+        HadoopDirGenerator.class,
         HadoopFsValidator.class,
         SameKeyReader.class,
         S3KeyGenerator.class,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirGenerator.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.freon;
+
+import java.net.URI;
+import java.util.concurrent.Callable;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+
+import com.codahale.metrics.Timer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Directory generator tool test om performance.
+ */
+@Command(name = "ddsg",
+    aliases = "dfs-directory-generator",
+    description = "Create random directories to the any dfs compatible file system.",
+    versionProvider = HddsVersionProvider.class,
+    mixinStandardHelpOptions = true,
+    showDefaultValues = true)
+public class HadoopDirGenerator extends BaseFreonGenerator
+    implements Callable<Void> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(HadoopDirGenerator.class);
+
+  @Option(names = {"--dpath"},
+      description = "Hadoop FS directory system path",
+      defaultValue = "o3fs://bucket2.vol2")
+  private String rootPath;
+
+
+  @Option(names = {"-d", "--depth"},
+      description = "Number of directories to be generated recursively",
+      defaultValue = "5")
+  private int depth;
+
+  @Option(names = {"--span"},
+      description = "Number of child directories to be created inside leaf directory.",
+      defaultValue = "10")
+  private int span;
+
+  @Option(names = {"--nameLen"},
+      description = "Length of the random name of directory you want to create.",
+      defaultValue = "10")
+  private int n;
+
+  private FileSystem fileSystem;
+
+  @Override
+  public Void call() throws Exception {
+
+    init();
+    OzoneConfiguration configuration = createOzoneConfiguration();
+    fileSystem = FileSystem.get(URI.create(rootPath), configuration);
+    runTests(this::createDir);
+    return null;
+
+  }
+
+  private void createDir(long counter) throws Exception {
+    String dirString = RandomStringUtils.randomAlphanumeric(n);
+      for(int i = 1; i <= depth; i++) {
+        dirString = dirString + "/" + RandomStringUtils.randomAlphanumeric(n);
+      }
+      Path file = new Path(rootPath + "/" + dirString);
+      fileSystem.mkdirs(file.getParent());
+
+      String leafDir = dirString.substring(0, dirString.length() - n);
+      String tmp = "/0";
+      for(int i = 1; i <= span; i++) {
+        String childDir = leafDir + Integer.toString(i) + tmp;
+        Path dir = new Path(rootPath + "/" + childDir);
+        fileSystem.mkdirs(dir.getParent());
+      }
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirGenerator.java
@@ -19,13 +19,11 @@ package org.apache.hadoop.ozone.freon;
 import java.net.URI;
 import java.util.concurrent.Callable;
 
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
-import com.codahale.metrics.Timer;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +35,8 @@ import picocli.CommandLine.Option;
  */
 @Command(name = "ddsg",
     aliases = "dfs-directory-generator",
-    description = "Create random directories to the any dfs compatible file system.",
+    description =
+            "Create random directories to the any dfs compatible file system.",
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true,
     showDefaultValues = true)
@@ -59,12 +58,14 @@ public class HadoopDirGenerator extends BaseFreonGenerator
   private int depth;
 
   @Option(names = {"--span"},
-      description = "Number of child directories to be created inside leaf directory.",
+      description =
+              "Number of child directories to be created in leaf directory.",
       defaultValue = "10")
   private int span;
 
   @Option(names = {"--nameLen"},
-      description = "Length of the random name of directory you want to create.",
+      description =
+              "Length of the random name of directory you want to create.",
       defaultValue = "10")
   private int n;
 
@@ -83,18 +84,18 @@ public class HadoopDirGenerator extends BaseFreonGenerator
 
   private void createDir(long counter) throws Exception {
     String dirString = RandomStringUtils.randomAlphanumeric(n);
-      for(int i = 1; i <= depth; i++) {
-        dirString = dirString + "/" + RandomStringUtils.randomAlphanumeric(n);
-      }
-      Path file = new Path(rootPath + "/" + dirString);
-      fileSystem.mkdirs(file.getParent());
-
-      String leafDir = dirString.substring(0, dirString.length() - n);
-      String tmp = "/0";
-      for(int i = 1; i <= span; i++) {
-        String childDir = leafDir + Integer.toString(i) + tmp;
-        Path dir = new Path(rootPath + "/" + childDir);
-        fileSystem.mkdirs(dir.getParent());
-      }
+    for(int i = 1; i <= depth; i++) {
+      dirString = dirString.concat("/").concat(RandomStringUtils.
+              randomAlphanumeric(n));
+    }
+    Path file = new Path(rootPath.concat("/").concat(dirString));
+    fileSystem.mkdirs(file.getParent());
+    String leafDir = dirString.substring(0, dirString.length() - n);
+    String tmp = "/0";
+    for(int i = 1; i <= span; i++) {
+      String childDir = leafDir.concat(Integer.toString(i)).concat(tmp);
+      Path dir = new Path(rootPath.concat("/").concat(childDir));
+      fileSystem.mkdirs(dir.getParent());
+    }
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopNestedDirGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopNestedDirGenerator.java
@@ -40,11 +40,11 @@ import picocli.CommandLine.Option;
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true,
     showDefaultValues = true)
-public class HadoopDirGenerator extends BaseFreonGenerator
+public class HadoopNestedDirGenerator extends BaseFreonGenerator
     implements Callable<Void> {
 
   private static final Logger LOG =
-      LoggerFactory.getLogger(HadoopDirGenerator.class);
+      LoggerFactory.getLogger(HadoopNestedDirGenerator.class);
 
   @Option(names = {"--dpath"},
       description = "Hadoop FS directory system path",
@@ -81,7 +81,19 @@ public class HadoopDirGenerator extends BaseFreonGenerator
     return null;
 
   }
+  /*
+      Nested directories will be created like this,
+      suppose you pass depth=3, span=3 and number of tests=2
 
+              Dir11                               Dir12
+                |                                   |
+              Dir21                               Dir22
+                |                                   |
+              Dir31                               Dir32
+            /   |   \                           /   |   \
+      Dir311 Dir312 Dir313                 Dir321 Dir322 Dir323
+
+   */
   private void createDir(long counter) throws Exception {
     String dirString = RandomStringUtils.randomAlphanumeric(n);
     for(int i = 1; i <= depth; i++) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopNestedDirGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopNestedDirGenerator.java
@@ -36,7 +36,7 @@ import picocli.CommandLine.Option;
 @Command(name = "ddsg",
     aliases = "dfs-directory-generator",
     description =
-            "Create random directories to the any dfs compatible file system.",
+            "Create nested directories to the any dfs compatible file system.",
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true,
     showDefaultValues = true)
@@ -46,7 +46,7 @@ public class HadoopNestedDirGenerator extends BaseFreonGenerator
   private static final Logger LOG =
       LoggerFactory.getLogger(HadoopNestedDirGenerator.class);
 
-  @Option(names = {"--dpath"},
+  @Option(names = {"-r","--rpath"},
       description = "Hadoop FS directory system path",
       defaultValue = "o3fs://bucket2.vol2")
   private String rootPath;
@@ -57,17 +57,17 @@ public class HadoopNestedDirGenerator extends BaseFreonGenerator
       defaultValue = "5")
   private int depth;
 
-  @Option(names = {"--span"},
+  @Option(names = {"-s","--span"},
       description =
               "Number of child directories to be created in leaf directory.",
       defaultValue = "10")
   private int span;
 
-  @Option(names = {"--nameLen"},
+  @Option(names = {"-l","--nameLen"},
       description =
               "Length of the random name of directory you want to create.",
       defaultValue = "10")
-  private int n;
+  private int length;
 
   private FileSystem fileSystem;
 
@@ -95,14 +95,14 @@ public class HadoopNestedDirGenerator extends BaseFreonGenerator
 
    */
   private void createDir(long counter) throws Exception {
-    String dirString = RandomStringUtils.randomAlphanumeric(n);
+    String dirString = RandomStringUtils.randomAlphanumeric(length);
     for(int i = 1; i <= depth; i++) {
       dirString = dirString.concat("/").concat(RandomStringUtils.
-              randomAlphanumeric(n));
+              randomAlphanumeric(length));
     }
     Path file = new Path(rootPath.concat("/").concat(dirString));
     fileSystem.mkdirs(file.getParent());
-    String leafDir = dirString.substring(0, dirString.length() - n);
+    String leafDir = dirString.substring(0, dirString.length() - length);
     String tmp = "/0";
     for(int i = 1; i <= span; i++) {
       String childDir = leafDir.concat(Integer.toString(i)).concat(tmp);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopNestedDirGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopNestedDirGenerator.java
@@ -31,7 +31,7 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 /**
- * Directory generator tool test om performance.
+ *  Directory Generator tool to test OM performance.
  */
 @Command(name = "ddsg",
     aliases = "dfs-directory-generator",


### PR DESCRIPTION
## What changes were proposed in this pull request?

This Jira proposes to add a functionality to freon to create nested directories. Also, multiple child directories can be created inside the leaf directory and also multiple top level directories can be created. 
This functionality will help to determine the scalability of ozone by creating nested directories(may be in millions) and also it will allow to control nested directories properties, just by passing appropriate parameters. This all can be done just by executing a single command.
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3289

## How was this patch tested?

Tested manually by running Freon Directory Generator.
