### PR TITLE
HDDS-3291. Write operation when both OM followers are shutdown.

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1686,6 +1686,17 @@
   </property>
 
   <property>
+    <name>ipc.client.rpc-timeout.ms</name>
+    <value>900000</value>
+    <description>
+      RpcClient timeout on waiting response from server. The default value is
+      set to 15 minutes. If ipc.client.ping is set to true and this rpc-timeout
+      is greater than the value of ipc.ping.interval, the effective value of
+      the rpc-timeout is rounded up to multiple of ipc.ping.interval.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.om.ratis.snapshot.dir</name>
     <value/>
     <tag>OZONE, OM, STORAGE, MANAGEMENT, RATIS</tag>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -44,6 +44,7 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
     errorIfMissingXmlProps = true;
     xmlPropsToSkipCompare.add("hadoop.tags.custom");
     xmlPropsToSkipCompare.add("ozone.om.nodes.EXAMPLEOMSERVICEID");
+    xmlPrefixToSkipCompare.add("ipc.client.rpc-timeout.ms");
     addPropertiesNotInXml();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add IPC client time out, so that the client will fail with socket time out exception in cases of 2 OM node failures.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3291

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

Tested it in docker compose cluster with 1 minute, and see that it failed finally, instead of hanging.

To repro this test, we need to change leader.election.time.out value also to large value, as we need this request to be submitted to ratis, and as ratis server keeps on retry then only we will see this issue.

2020-03-27 16:25:27,625 [main] INFO  RetryInvocationHandler:411 - com.google.protobuf.ServiceException: java.net.SocketTimeoutException: Call From c5263a1df1ad/172.22.0.3 to om2:9862 failed on socket timeout exception: java.net.SocketTimeoutException: 60000 millis timeout while waiting for channel to be ready for read. ch : java.nio.channels.SocketChannel[connected local=/172.22.0.3:56460 remote=om2/172.22.0.4:9862]; For more details see:  http://wiki.apache.org/hadoop/SocketTimeout, while invoking $Proxy19.submitRequest over nodeId=om2,nodeAddress=om2:9862 after 15 failover attempts. Trying to failover immediately.
2020-03-27 16:25:27,626 [main] ERROR OMFailoverProxyProvider:285 - Failed to connect to OMs: [nodeId=om1,nodeAddress=om1:9862, nodeId=om3,nodeAddress=om3:9862, nodeId=om2,nodeAddress=om2:9862]. Attempted 15 failovers.

For now, the changed config affects all rpc clients in the system, in the future if we want to add a new RPC client time out, we can add a new config. For now, using the same config of ipc client.
