### PR TITLE
HDDS-3165. Integrate Recon missing containers UI with endpoint.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeysResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/KeysResponse.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.recon.api.types;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.ArrayList;
 import java.util.Collection;
 
 /**
@@ -26,57 +25,27 @@ import java.util.Collection;
  */
 public class KeysResponse {
   /**
-   * Contains a map with total count of keys inside the given container and a
-   * list of keys with metadata.
+   * Total count of the keys.
    */
-  @JsonProperty("data")
-  private KeysResponseData keysResponseData;
-
-  public KeysResponse() {
-    this(0, new ArrayList<>());
-  }
-
-  public KeysResponse(long totalCount,
-                      Collection<KeyMetadata> keys) {
-    this.keysResponseData =
-        new KeysResponseData(totalCount, keys);
-  }
-
-  public KeysResponseData getKeysResponseData() {
-    return keysResponseData;
-  }
-
-  public void setKeysResponseData(KeysResponseData keysResponseData) {
-    this.keysResponseData = keysResponseData;
-  }
+  @JsonProperty("totalCount")
+  private long totalCount;
 
   /**
-   * Class that encapsulates the data presented in Keys API Response.
+   * An array of keys.
    */
-  public static class KeysResponseData {
-    /**
-     * Total count of the keys.
-     */
-    @JsonProperty("totalCount")
-    private long totalCount;
+  @JsonProperty("keys")
+  private Collection<KeyMetadata> keys;
 
-    /**
-     * An array of keys.
-     */
-    @JsonProperty("keys")
-    private Collection<KeyMetadata> keys;
+  public KeysResponse(long totalCount, Collection<KeyMetadata> keys) {
+    this.totalCount = totalCount;
+    this.keys = keys;
+  }
 
-    KeysResponseData(long totalCount, Collection<KeyMetadata> keys) {
-      this.totalCount = totalCount;
-      this.keys = keys;
-    }
+  public long getTotalCount() {
+    return totalCount;
+  }
 
-    public long getTotalCount() {
-      return totalCount;
-    }
-
-    public Collection<KeyMetadata> getKeys() {
-      return keys;
-    }
+  public Collection<KeyMetadata> getKeys() {
+    return keys;
   }
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/routes.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/routes.json
@@ -1,4 +1,5 @@
 {
   "/api/v1/*": "/$1",
-  "/containers/:id/keys": "/keys"
+  "/containers/:id/keys": "/keys",
+  "/containers/missing": "/missingContainers"
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/Overview/Overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/Overview/Overview.tsx
@@ -23,6 +23,7 @@ import axios from 'axios';
 import prettyBytes from 'pretty-bytes';
 import './Overview.less';
 import {StorageReport} from "types/datanode.types";
+import {MissingContainersResponse} from "../MissingContainers/MissingContainers";
 
 interface ClusterStateResponse {
   totalDatanodes: number;
@@ -73,9 +74,12 @@ export class Overview extends React.Component<any, OverviewState> {
       loading: true
     });
     axios.all([
-        axios.get('/api/v1/clusterState')
-    ]).then(axios.spread((clusterStateResponse) => {
+        axios.get('/api/v1/clusterState'),
+        axios.get('/api/v1/containers/missing')
+    ]).then(axios.spread((clusterStateResponse, missingContainersResponse) => {
       const clusterState: ClusterStateResponse = clusterStateResponse.data;
+      const missingContainers: MissingContainersResponse = missingContainersResponse.data;
+      const missingContainersCount = missingContainers.totalCount;
       this.setState({
         loading: false,
         datanodes: `${clusterState.healthyDatanodes}/${clusterState.totalDatanodes}`,
@@ -85,7 +89,7 @@ export class Overview extends React.Component<any, OverviewState> {
         volumes: clusterState.volumes,
         buckets: clusterState.buckets,
         keys: clusterState.keys,
-        missingContainersCount: 0
+        missingContainersCount
       });
     }));
   }
@@ -103,7 +107,7 @@ export class Overview extends React.Component<any, OverviewState> {
           <Tooltip placement="bottom" title={`${missingContainersCount} ${containersTooltip}`}>
             <Icon type="exclamation-circle" theme="filled" className="icon-failure icon-small"/>
           </Tooltip>
-          <span className="padded-text">{containers}</span>
+          <span className="padded-text">{containers-missingContainersCount}/{containers}</span>
         </span>
         : containers.toString();
     const clusterCapacity = `${prettyBytes(storageReport.capacity - storageReport.remaining)}/${prettyBytes(storageReport.capacity)}`;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -244,8 +244,7 @@ public class TestContainerEndpoint extends AbstractOMMetadataManagerTest {
 
     Response response = containerEndpoint.getKeysForContainer(1L, -1, "");
 
-    KeysResponse responseObject = (KeysResponse) response.getEntity();
-    KeysResponse.KeysResponseData data = responseObject.getKeysResponseData();
+    KeysResponse data = (KeysResponse) response.getEntity();
     Collection<KeyMetadata> keyMetadataList = data.getKeys();
 
     assertEquals(3, data.getTotalCount());
@@ -272,16 +271,14 @@ public class TestContainerEndpoint extends AbstractOMMetadataManagerTest {
     assertEquals(104, blockIds.get(1L).iterator().next().getLocalID());
 
     response = containerEndpoint.getKeysForContainer(3L, -1, "");
-    responseObject = (KeysResponse) response.getEntity();
-    data = responseObject.getKeysResponseData();
+    data = (KeysResponse) response.getEntity();
     keyMetadataList = data.getKeys();
     assertTrue(keyMetadataList.isEmpty());
     assertEquals(0, data.getTotalCount());
 
     // test if limit works as expected
     response = containerEndpoint.getKeysForContainer(1L, 1, "");
-    responseObject = (KeysResponse) response.getEntity();
-    data = responseObject.getKeysResponseData();
+    data = (KeysResponse) response.getEntity();
     keyMetadataList = data.getKeys();
     assertEquals(1, keyMetadataList.size());
     assertEquals(3, data.getTotalCount());
@@ -293,11 +290,9 @@ public class TestContainerEndpoint extends AbstractOMMetadataManagerTest {
     Response response = containerEndpoint.getKeysForContainer(
         1L, -1, "/sampleVol/bucketOne/key_one");
 
-    KeysResponse responseObject =
+    KeysResponse data =
         (KeysResponse) response.getEntity();
 
-    KeysResponse.KeysResponseData data =
-        responseObject.getKeysResponseData();
     assertEquals(3, data.getTotalCount());
 
     Collection<KeyMetadata> keyMetadataList = data.getKeys();
@@ -312,8 +307,7 @@ public class TestContainerEndpoint extends AbstractOMMetadataManagerTest {
 
     response = containerEndpoint.getKeysForContainer(
         1L, -1, StringUtils.EMPTY);
-    responseObject = (KeysResponse) response.getEntity();
-    data = responseObject.getKeysResponseData();
+    data = (KeysResponse) response.getEntity();
     keyMetadataList = data.getKeys();
 
     assertEquals(3, data.getTotalCount());
@@ -325,16 +319,14 @@ public class TestContainerEndpoint extends AbstractOMMetadataManagerTest {
     // test for negative cases
     response = containerEndpoint.getKeysForContainer(
         1L, -1, "/sampleVol/bucketOne/invalid_key");
-    responseObject = (KeysResponse) response.getEntity();
-    data = responseObject.getKeysResponseData();
+    data = (KeysResponse) response.getEntity();
     keyMetadataList = data.getKeys();
     assertEquals(3, data.getTotalCount());
     assertEquals(0, keyMetadataList.size());
 
     response = containerEndpoint.getKeysForContainer(
         5L, -1, "");
-    responseObject = (KeysResponse) response.getEntity();
-    data = responseObject.getKeysResponseData();
+    data = (KeysResponse) response.getEntity();
     keyMetadataList = data.getKeys();
     assertEquals(0, keyMetadataList.size());
     assertEquals(0, data.getTotalCount());


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Integrate Recon missing containers UI with endpoint (/api/v1/containers/missing)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3165

## How was this patch tested?

- Tested manually via docker-compose. Generated random keys with freon, killed one datanode and verified that the missing container alert is shown in the UI with keys in the container.

<img width="1680" alt="Screen Shot 2020-03-29 at 2 43 23 AM" src="https://user-images.githubusercontent.com/1051198/77845916-40be3980-7167-11ea-8a89-5fc812c7c659.png">
<img width="1680" alt="Screen Shot 2020-03-29 at 2 43 40 AM" src="https://user-images.githubusercontent.com/1051198/77845917-4451c080-7167-11ea-9cce-b17cd04b1b17.png">

