### PR TITLE
HDDS-3249: remove unrelated assert in ContainerCache

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestContainerCache.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestContainerCache.java
@@ -93,8 +93,6 @@ public class TestContainerCache {
     db3.close();
     Assert.assertEquals(0, db3.getReferenceCount());
 
-    Assert.assertTrue(cache.isFull());
-
     // add one more reference to ContainerCache and verify that it will not
     // evict the least recent entry as it has reference.
     ReferenceCountedDB db4 = cache.getDB(3, "RocksDB",


### PR DESCRIPTION
## What changes were proposed in this pull request?
As described in #705,  Assert.assertTrue(cache.isFull()) check the functionality of LRUMap instead of ContainerCache and it's irrelevant, so I remove it.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3249

## How was this patch tested?
mvn clean package