### PR TITLE
HDDS-3307. Improve write efficiency by avoiding reverse DNS lookup

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.protocolPB;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -386,13 +387,18 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
    * @param cmdType type of the request
    */
   private OMRequest.Builder createOMRequest(Type cmdType) {
-    UserInfo.Builder userInfo = UserInfo.newBuilder();
-    userInfo.setHostName(InetAddress.getLocalHost().getHostName());
-
-    return OMRequest.newBuilder()
+    OMRequest.Builder request = OMRequest
+        .newBuilder()
         .setCmdType(cmdType)
-        .setClientId(clientID)
-        .setUserInfo(userInfo);
+        .setClientId(clientID);
+
+    try {
+      UserInfo.Builder userInfo = UserInfo.newBuilder();
+      userInfo.setHostName(InetAddress.getLocalHost().getHostName());
+      return request.setUserInfo(userInfo);
+    } catch (UnknownHostException e) {
+      return request;
+    }
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.om.protocolPB;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -142,6 +143,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetAclR
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetBucketPropertyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetVolumePropertyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.UserInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.VolumeInfo;
 import org.apache.hadoop.ozone.protocolPB.OMPBHelper;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
@@ -384,10 +386,13 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
    * @param cmdType type of the request
    */
   private OMRequest.Builder createOMRequest(Type cmdType) {
+    UserInfo.Builder userInfo = UserInfo.newBuilder();
+    userInfo.setHostName(InetAddress.getLocalHost().getHostName());
 
     return OMRequest.newBuilder()
         .setCmdType(cmdType)
-        .setClientId(clientID);
+        .setClientId(clientID)
+        .setUserInfo(userInfo);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -130,7 +130,7 @@ public abstract class OMClientRequest implements RequestAuditor {
       OzoneManagerProtocolProtos.UserInfo userInfoInProtocol = getOmRequest()
           .toBuilder().getUserInfo();
       if (userInfoInProtocol.getHostName().isEmpty()) {
-        userInfo.setHostName(remoteAddress.getHostAddress());
+        userInfo.setHostName(remoteAddress.getHostName());
       } else {
         userInfo.setHostName(userInfoInProtocol.getHostName());
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -128,7 +128,7 @@ public abstract class OMClientRequest implements RequestAuditor {
 
     if (remoteAddress != null) {
       OzoneManagerProtocolProtos.UserInfo userInfoInProtocol = getOmRequest()
-          .toBuilder().getUserInfo();
+          .getUserInfo();
       if (userInfoInProtocol.getHostName().isEmpty()) {
         userInfo.setHostName(remoteAddress.getHostName());
       } else {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -127,7 +127,14 @@ public abstract class OMClientRequest implements RequestAuditor {
     }
 
     if (remoteAddress != null) {
-      userInfo.setHostName(remoteAddress.getHostName());
+      OzoneManagerProtocolProtos.UserInfo userInfoInProtocol = getOmRequest()
+          .toBuilder().getUserInfo();
+      if (userInfoInProtocol.getHostName().isEmpty()) {
+        userInfo.setHostName(remoteAddress.getHostAddress());
+      } else {
+        userInfo.setHostName(userInfoInProtocol.getHostName());
+      }
+
       userInfo.setRemoteAddress(remoteAddress.getHostAddress()).build();
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

**What's the problem ?**
1. When create key, [getHostName()](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java#L130) by IP need reverse DNS lookup, cost about 15ms. It's also reported in [JDK-6450279](https://bugs.openjdk.java.net/browse/JDK-6450279) and [ZOOKEEPER-1666](https://issues.apache.org/jira/browse/ZOOKEEPER-1666). 

2. Besides there is addressCache  in JDK for getting IP from Hostname, but there is no cache for getting Hostname from IP. So getting hostname from ip is slow, and maybe should avoid it.

**How to fix ?**
client getLocalHost().getHostName() and add it in request, server get hostname from request.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3307

## How was this patch tested?

Existed UT and IT.
