### PR TITLE
HDDS-3316. Checkstyle check fails silently in case of mvn related errors

### DIFF
--- a/hadoop-ozone/dev-support/checks/checkstyle.sh
+++ b/hadoop-ozone/dev-support/checks/checkstyle.sh
@@ -21,7 +21,9 @@ REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/checkstyle"}
 mkdir -p "$REPORT_DIR"
 REPORT_FILE="$REPORT_DIR/summary.txt"
 
-mvn -B -fn checkstyle:check
+set -e
+mvn -B checkstyle:check -D checkstyle.failOnViolation=false
+set +e
 
 #Print out the exact violations with parsing XML results with sed
 find "." -name checkstyle-errors.xml -print0 \


### PR DESCRIPTION
## What changes were proposed in this pull request?

rom the last master build:

https://github.com/apache/hadoop-ozone/runs/550746880?check_suite_focus=true

Checkstyle is failed due to a maven error:

```
[ERROR] Failed to execute goal on project hadoop-hdds-common: Could not resolve dependencies for project org.apache.hadoop:hadoop-hdds-common:jar:0.6.0-SNAPSHOT: Could not find artifact org.apache.hadoop:hadoop-hdds-config:jar:0.6.0-SNAPSHOT in apache.snapshots.https (https://repository.apache.org/content/repositories/snapshots) -> [Help 1]
[ERROR] Failed to execute goal on project hadoop-hdds-client: Could not resolve dependencies for project org.apache.hadoop:hadoop-hdds-client:jar:0.6.0-SNAPSHOT: The following artifacts could not be resolved: org.apache.hadoop:hadoop-hdds-common:jar:0.6.0-SNAPSHOT, org.apache.hadoop:hadoop-hdds-config:jar:0.6.0-SNAPSHOT: Could not find artifact org.apache.hadoop:hadoop-hdds-common:jar:0.6.0-SNAPSHOT in apache.snapshots.https (https://repository.apache.org/content/repositories/snapshots) -> [Help 1]
```

But it remained green.

We should fail the check if the maven run couldn't succeed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3316

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

```
hadoop-ozone/dev-support/checks/checkstyle.sh
echo $?
```

 1. Create a syntax error in your pom.xml (expected: exit code 1, without the patch: 0)
 2. Create a checkstyle error (expected: exit code 1)
 3. Fix the checkstyle error (expected: exit code 0)