### PR TITLE
HDDS-3322. StandAlone Pipelines are created in an infinite loop

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreator.java
@@ -91,8 +91,13 @@ class BackgroundPipelineCreator {
   private boolean skipCreation(HddsProtos.ReplicationFactor factor,
                                HddsProtos.ReplicationType type,
                                boolean autoCreate) {
-    return factor == HddsProtos.ReplicationFactor.ONE &&
-        type == HddsProtos.ReplicationType.RATIS && (!autoCreate);
+    if (type == HddsProtos.ReplicationType.RATIS) {
+      return factor == HddsProtos.ReplicationFactor.ONE && (!autoCreate);
+    } else {
+      // For STAND_ALONE Replication Type, Replication Factor 3 should not be
+      // used.
+      return factor == HddsProtos.ReplicationFactor.THREE;
+    }
   }
 
   private void createPipelines() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineFactory.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineFactory.java
@@ -43,7 +43,7 @@ public class PipelineFactory {
       Configuration conf, EventPublisher eventPublisher) {
     providers = new HashMap<>();
     providers.put(ReplicationType.STAND_ALONE,
-        new SimplePipelineProvider(nodeManager));
+        new SimplePipelineProvider(nodeManager, stateManager));
     providers.put(ReplicationType.RATIS,
         new RatisPipelineProvider(nodeManager, stateManager, conf,
             eventPublisher));

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineProvider.java
@@ -18,22 +18,67 @@
 
 package org.apache.hadoop.hdds.scm.pipeline;
 
-import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
-
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
+import org.apache.hadoop.hdds.scm.exceptions.SCMException;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
 
 /**
  * Interface for creating pipelines.
  */
-public interface PipelineProvider {
+public abstract class PipelineProvider {
 
-  Pipeline create(ReplicationFactor factor) throws IOException;
+  final NodeManager nodeManager;
+  final PipelineStateManager stateManager;
 
-  Pipeline create(ReplicationFactor factor, List<DatanodeDetails> nodes);
+  public PipelineProvider(NodeManager nodeManager,
+      PipelineStateManager stateManager) {
+    this.nodeManager = nodeManager;
+    this.stateManager = stateManager;
+  }
 
-  void close(Pipeline pipeline) throws IOException;
+  protected abstract Pipeline create(ReplicationFactor factor) throws IOException;
 
-  void shutdown();
+  protected abstract Pipeline create(ReplicationFactor factor,
+      List<DatanodeDetails> nodes);
+
+  protected abstract void close(Pipeline pipeline) throws IOException;
+
+  protected abstract void shutdown();
+
+  List<DatanodeDetails> pickNodesNeverUsed(ReplicationType type,
+      ReplicationFactor factor) throws SCMException {
+    Set<DatanodeDetails> dnsUsed = new HashSet<>();
+    stateManager.getPipelines(type, factor).stream().filter(
+        p -> p.getPipelineState().equals(Pipeline.PipelineState.OPEN) ||
+            p.getPipelineState().equals(Pipeline.PipelineState.DORMANT) ||
+            p.getPipelineState().equals(Pipeline.PipelineState.ALLOCATED))
+        .forEach(p -> dnsUsed.addAll(p.getNodes()));
+
+    // Get list of healthy nodes
+    List<DatanodeDetails> dns = nodeManager
+        .getNodes(HddsProtos.NodeState.HEALTHY)
+        .parallelStream()
+        .filter(dn -> !dnsUsed.contains(dn))
+        .limit(factor.getNumber())
+        .collect(Collectors.toList());
+    if (dns.size() < factor.getNumber()) {
+      String e = String
+          .format("Cannot create pipeline of factor %d using %d nodes." +
+                  " Used %d nodes. Healthy nodes %d", factor.getNumber(),
+              dns.size(), dnsUsed.size(),
+              nodeManager.getNodes(HddsProtos.NodeState.HEALTHY).size());
+      throw new SCMException(e,
+          SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
+    }
+    return dns;
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineProvider.java
@@ -36,8 +36,8 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
  */
 public abstract class PipelineProvider {
 
-  final NodeManager nodeManager;
-  final PipelineStateManager stateManager;
+  private final NodeManager nodeManager;
+  private final PipelineStateManager stateManager;
 
   public PipelineProvider(NodeManager nodeManager,
       PipelineStateManager stateManager) {
@@ -45,7 +45,21 @@ public abstract class PipelineProvider {
     this.stateManager = stateManager;
   }
 
-  protected abstract Pipeline create(ReplicationFactor factor) throws IOException;
+  public PipelineProvider() {
+    this.nodeManager = null;
+    this.stateManager = null;
+  }
+
+  public NodeManager getNodeManager() {
+    return nodeManager;
+  }
+
+  public PipelineStateManager getPipelineStateManager() {
+    return stateManager;
+  }
+
+  protected abstract Pipeline create(ReplicationFactor factor)
+      throws IOException;
 
   protected abstract Pipeline create(ReplicationFactor factor,
       List<DatanodeDetails> nodes);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -36,10 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Implements Api for creating ratis pipelines.
@@ -78,20 +75,22 @@ public class RatisPipelineProvider extends PipelineProvider {
     }
     // Per datanode limit
     if (maxPipelinePerDatanode > 0) {
-      return (stateManager.getPipelines(ReplicationType.RATIS, factor).size() -
-          stateManager.getPipelines(ReplicationType.RATIS, factor,
-              Pipeline.PipelineState.CLOSED).size()) > maxPipelinePerDatanode *
-          nodeManager.getNodeCount(HddsProtos.NodeState.HEALTHY) /
+      return (getPipelineStateManager().getPipelines(
+          ReplicationType.RATIS, factor).size() -
+          getPipelineStateManager().getPipelines(ReplicationType.RATIS, factor,
+              PipelineState.CLOSED).size()) > maxPipelinePerDatanode *
+          getNodeManager().getNodeCount(HddsProtos.NodeState.HEALTHY) /
           factor.getNumber();
     }
 
     // Global limit
     if (pipelineNumberLimit > 0) {
-      return (stateManager.getPipelines(ReplicationType.RATIS,
-          ReplicationFactor.THREE).size() - stateManager.getPipelines(
-          ReplicationType.RATIS, ReplicationFactor.THREE,
-          Pipeline.PipelineState.CLOSED).size()) >
-          (pipelineNumberLimit - stateManager.getPipelines(
+      return (getPipelineStateManager().getPipelines(ReplicationType.RATIS,
+          ReplicationFactor.THREE).size() -
+          getPipelineStateManager().getPipelines(
+              ReplicationType.RATIS, ReplicationFactor.THREE,
+              PipelineState.CLOSED).size()) >
+          (pipelineNumberLimit - getPipelineStateManager().getPipelines(
               ReplicationType.RATIS, ReplicationFactor.ONE).size());
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -237,6 +237,8 @@ public class SCMPipelineManager implements PipelineManager {
       recordMetricsForPipeline(pipeline);
       return pipeline;
     } catch (IOException ex) {
+      LOG.error("Failed to create pipeline of type {} and factor {}. " +
+          "Exception: {}", type, factor, ex.getMessage());
       metrics.incNumPipelineCreationFailed();
       throw ex;
     } finally {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SimplePipelineProvider.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hdds.scm.pipeline;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState;
 
@@ -32,18 +31,18 @@ import java.util.List;
 /**
  * Implements Api for creating stand alone pipelines.
  */
-public class SimplePipelineProvider implements PipelineProvider {
+public class SimplePipelineProvider extends PipelineProvider {
 
-  private final NodeManager nodeManager;
-
-  public SimplePipelineProvider(NodeManager nodeManager) {
-    this.nodeManager = nodeManager;
+  public SimplePipelineProvider(NodeManager nodeManager,
+      PipelineStateManager stateManager) {
+    super(nodeManager, stateManager);
   }
 
   @Override
   public Pipeline create(ReplicationFactor factor) throws IOException {
-    List<DatanodeDetails> dns =
-        nodeManager.getNodes(NodeState.HEALTHY);
+    List<DatanodeDetails> dns = pickNodesNeverUsed(ReplicationType.STAND_ALONE,
+        factor);
+
     if (dns.size() < factor.getNumber()) {
       String e = String
           .format("Cannot create pipeline of factor %d using %d nodes.",

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
@@ -44,7 +44,7 @@ public class TestSimplePipelineProvider {
   public void init() throws Exception {
     nodeManager = new MockNodeManager(true, 10);
     stateManager = new PipelineStateManager();
-    provider = new SimplePipelineProvider(nodeManager);
+    provider = new SimplePipelineProvider(nodeManager, stateManager);
   }
 
   @Test

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineFactory.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineFactory.java
@@ -41,10 +41,6 @@ public class ReconPipelineFactory extends PipelineFactory {
 
   static class ReconPipelineProvider extends PipelineProvider {
 
-    public ReconPipelineProvider() {
-      super(null, null);
-    }
-
     @Override
     public Pipeline create(HddsProtos.ReplicationFactor factor){
       // We don't expect this to be called at all. But adding this as a red

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineFactory.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineFactory.java
@@ -39,7 +39,11 @@ public class ReconPipelineFactory extends PipelineFactory {
     setProviders(new DefaultedMap(reconMockPipelineProvider));
   }
 
-  static class ReconPipelineProvider implements PipelineProvider {
+  static class ReconPipelineProvider extends PipelineProvider {
+
+    public ReconPipelineProvider() {
+      super(null, null);
+    }
 
     @Override
     public Pipeline create(HddsProtos.ReplicationFactor factor){
@@ -63,7 +67,7 @@ public class ReconPipelineFactory extends PipelineFactory {
 
     @Override
     public void shutdown() {
-
+      // Do nothing
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

BackgroundPipelineCreator keeps creating pipelines of configured Replication type and all available Replication factors until some exception occurs while creating the pipeline such as no more available nodes.

When Replication Type is set to STAND_ALONE, we do not check if a DN has already been used to create a pipeline of same factor or not and keep reusing the same DNs to create new pipelines. This causes the pipeline creation to happen in an infinite loop.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3322

## How was this patch tested?

Tested on a real cluster.