### PR TITLE
HDDS-3321. Prometheus endpoint should have an option to be configured with Token based authentication.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/HddsPrometheusConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/HddsPrometheusConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.conf;
+
+/**
+ * The configuration class for the Prometheus endpoint.
+ */
+@ConfigGroup(prefix = "hdds.prometheus.")
+public class HddsPrometheusConfig {
+
+  @Config(key = "endpoint.token",
+      type = ConfigType.STRING,
+      defaultValue = "",
+      tags = { ConfigTag.SECURITY, ConfigTag.MANAGEMENT },
+      description = "Allowed authorization token while using prometheus " +
+          "servlet endpoint. This will disable SPNEGO based authentication on" +
+          " the endpoint."
+  )
+  private String prometheusEndpointToken;
+
+  public String getPrometheusEndpointToken() {
+    return prometheusEndpointToken;
+  }
+
+  public void setPrometheusEndpointToken(String prometheusEndpointToken) {
+    this.prometheusEndpointToken = prometheusEndpointToken;
+  }
+}


### PR DESCRIPTION
…enabled on it.

## What changes were proposed in this pull request?
Prometheus does not support targets which have Kerberos SPNEGO based authentication. Hence, on a secure cluster, if we have prometheus endpoint enabled, it makes sense to skip the authentication filter for it.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3321

## How was this patch tested?
Manually tested.