### PR TITLE
HDDS-3319. Handle HA for BasicOzoneClientAdapterImpl#renew/cancel().

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.ozone.client;
 
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.lang.reflect.Proxy;
 
@@ -173,7 +175,12 @@ public final class OzoneClientFactory {
   public static OzoneClient getOzoneClient(Configuration conf,
       Token<OzoneTokenIdentifier> token) throws IOException {
     Preconditions.checkNotNull(token, "Null token is not allowed");
-    String omServiceId = token.decodeIdentifier().getOmServiceId();
+    OzoneTokenIdentifier tokenId = new OzoneTokenIdentifier();
+    ByteArrayInputStream buf = new ByteArrayInputStream(
+        token.getIdentifier());
+    DataInputStream in = new DataInputStream(buf);
+    tokenId.readFields(in);
+    String omServiceId = tokenId.getOmServiceId();
     if (StringUtils.isNotEmpty(omServiceId)) {
       // new OM should always issue token with omServiceId
       if (!OmUtils.isServiceIdsDefined(conf)

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
@@ -184,10 +184,10 @@ public final class OzoneClientFactory {
         return OzoneClientFactory.getRpcClient(omServiceId, conf);
       } else {
         // HA with mismatched service id
-        throw new IOException("Service ID specified does not match" +
-            " with " + OZONE_OM_SERVICE_IDS_KEY + " defined in the " +
-            "configuration. Configured " + OZONE_OM_SERVICE_IDS_KEY +
-            " are" + conf.getTrimmedStringCollection(
+        throw new IOException("Service ID specified " + omServiceId +
+            " does not match" + " with " + OZONE_OM_SERVICE_IDS_KEY +
+            " defined in the " + "configuration. Configured " +
+            OZONE_OM_SERVICE_IDS_KEY + " are" + conf.getTrimmedStringCollection(
             OZONE_OM_SERVICE_IDS_KEY));
       }
     } else {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
@@ -176,8 +176,9 @@ public final class OzoneClientFactory {
     String omServiceId = token.decodeIdentifier().getOmServiceId();
     if (StringUtils.isNotEmpty(omServiceId)) {
       // new OM should always issue token with omServiceId
-      if (omServiceId.equals(OzoneConsts.OM_SERVICE_ID_DEFAULT)) {
-        // Non-HA
+      if (!OmUtils.isServiceIdsDefined(conf)
+          && omServiceId.equals(OzoneConsts.OM_SERVICE_ID_DEFAULT)) {
+        // Non-HA or single-node Ratis HA
         return OzoneClientFactory.getRpcClient(conf);
       } else if (OmUtils.isOmHAServiceId(conf, omServiceId)) {
         // HA with matching service id
@@ -196,10 +197,10 @@ public final class OzoneClientFactory {
       if (!OmUtils.isServiceIdsDefined(conf)) {
         return OzoneClientFactory.getRpcClient(conf);
       } else {
-        throw new IOException("Service ID must not"
-            + " be omitted when " + OZONE_OM_SERVICE_IDS_KEY + " is defined. " +
-            "Configured " + OZONE_OM_SERVICE_IDS_KEY + " are " +
-            conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY));
+        throw new IOException("OzoneToken with no service ID can't "
+            + "be renewed or canceled with local OM HA setup because we "
+            + "don't know if the token is issued from local OM HA cluster "
+            + "or not.");
       }
     }
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
@@ -21,9 +21,11 @@ package org.apache.hadoop.ozone.client;
 import java.io.IOException;
 import java.lang.reflect.Proxy;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.client.rpc.RpcClient;
 
@@ -31,6 +33,8 @@ import com.google.common.base.Preconditions;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 
+import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
+import org.apache.hadoop.security.token.Token;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -157,6 +161,47 @@ public final class OzoneClientFactory {
         OzoneClientInvocationHandler.class.getClassLoader(),
         new Class<?>[]{ClientProtocol.class}, clientHandler);
     return new OzoneClient(config, proxy);
+  }
+
+  /**
+   * Create OzoneClient for token renew/cancel operations.
+   * @param conf Configuration to be used for OzoneCient creation
+   * @param token ozone token is involved
+   * @return
+   * @throws IOException
+   */
+  public static OzoneClient getOzoneClient(Configuration conf,
+      Token<OzoneTokenIdentifier> token) throws IOException {
+    Preconditions.checkNotNull(token, "Null token is not allowed");
+    String omServiceId = token.decodeIdentifier().getOmServiceId();
+    if (StringUtils.isNotEmpty(omServiceId)) {
+      // new OM should always issue token with omServiceId
+      if (omServiceId.equals(OzoneConsts.OM_SERVICE_ID_DEFAULT)) {
+        // Non-HA
+        return OzoneClientFactory.getRpcClient(conf);
+      } else if (OmUtils.isOmHAServiceId(conf, omServiceId)) {
+        // HA with matching service id
+        return OzoneClientFactory.getRpcClient(omServiceId, conf);
+      } else {
+        // HA with mismatched service id
+        throw new IOException("Service ID specified does not match" +
+            " with " + OZONE_OM_SERVICE_IDS_KEY + " defined in the " +
+            "configuration. Configured " + OZONE_OM_SERVICE_IDS_KEY +
+            " are" + conf.getTrimmedStringCollection(
+            OZONE_OM_SERVICE_IDS_KEY));
+      }
+    } else {
+      // Old OM may issue token without omServiceId that should work
+      // with non-HA case
+      if (!OmUtils.isServiceIdsDefined(conf)) {
+        return OzoneClientFactory.getRpcClient(conf);
+      } else {
+        throw new IOException("Service ID must not"
+            + " be omitted when " + OZONE_OM_SERVICE_IDS_KEY + " is defined. " +
+            "Configured " + OZONE_OM_SERVICE_IDS_KEY + " are " +
+            conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY));
+      }
+    }
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneTokenIdentifier.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneTokenIdentifier.java
@@ -47,6 +47,7 @@ public class OzoneTokenIdentifier extends
   private String awsAccessId;
   private String signature;
   private String strToSign;
+  private String omServiceId;
 
   /**
    * Create an empty delegation token identifier.
@@ -102,6 +103,7 @@ public class OzoneTokenIdentifier extends
           .setStrToSign(getStrToSign());
     } else {
       builder.setOmCertSerialId(getOmCertSerialId());
+      builder.setOmServiceId(getOmServiceId());
     }
     OMTokenProto token = builder.build();
     out.write(token.toByteArray());
@@ -126,6 +128,7 @@ public class OzoneTokenIdentifier extends
     setSequenceNumber(token.getSequenceNumber());
     setMasterKeyId(token.getMasterKeyId());
     setOmCertSerialId(token.getOmCertSerialId());
+    setOmServiceId(token.getOmServiceId());
 
     // Set s3 specific fields.
     if (getTokenType().equals(S3AUTHINFO)) {
@@ -160,6 +163,7 @@ public class OzoneTokenIdentifier extends
       identifier.setMasterKeyId(token.getMasterKeyId());
     }
     identifier.setOmCertSerialId(token.getOmCertSerialId());
+    identifier.setOmServiceId(token.getOmServiceId());
     return identifier;
   }
 
@@ -210,6 +214,7 @@ public class OzoneTokenIdentifier extends
         .append(getRenewer(), that.getRenewer())
         .append(getKind(), that.getKind())
         .append(getSequenceNumber(), that.getSequenceNumber())
+        .append(getOmServiceId(), that.getOmServiceId())
         .build();
   }
 
@@ -264,6 +269,14 @@ public class OzoneTokenIdentifier extends
     this.omCertSerialId = omCertSerialId;
   }
 
+  public String getOmServiceId() {
+    return omServiceId;
+  }
+
+  public void setOmServiceId(String omServiceId) {
+    this.omServiceId = omServiceId;
+  }
+
   public Type getTokenType() {
     return tokenType;
   }
@@ -309,7 +322,8 @@ public class OzoneTokenIdentifier extends
         .append(", masterKeyId=").append(getMasterKeyId())
         .append(", strToSign=").append(getStrToSign())
         .append(", signature=").append(getSignature())
-        .append(", awsAccessKeyId=").append(getAwsAccessId());
+        .append(", awsAccessKeyId=").append(getAwsAccessId())
+        .append(", omServiceId=").append(getOmServiceId());
     return buffer.toString();
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneTokenIdentifier.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneTokenIdentifier.java
@@ -103,8 +103,11 @@ public class OzoneTokenIdentifier extends
           .setStrToSign(getStrToSign());
     } else {
       builder.setOmCertSerialId(getOmCertSerialId());
-      builder.setOmServiceId(getOmServiceId());
+      if (getOmServiceId() != null) {
+        builder.setOmServiceId(getOmServiceId());
+      }
     }
+
     OMTokenProto token = builder.build();
     out.write(token.toByteArray());
   }
@@ -128,13 +131,16 @@ public class OzoneTokenIdentifier extends
     setSequenceNumber(token.getSequenceNumber());
     setMasterKeyId(token.getMasterKeyId());
     setOmCertSerialId(token.getOmCertSerialId());
-    setOmServiceId(token.getOmServiceId());
 
     // Set s3 specific fields.
     if (getTokenType().equals(S3AUTHINFO)) {
       setAwsAccessId(token.getAccessKeyId());
       setSignature(token.getSignature());
       setStrToSign(token.getStrToSign());
+    }
+
+    if (token.hasOmServiceId()) {
+      setOmServiceId(token.getOmServiceId());
     }
   }
 

--- a/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
+++ b/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
@@ -895,6 +895,7 @@ message OMTokenProto {
     optional string accessKeyId    = 12;
     optional string signature      = 13;
     optional string strToSign      = 14;
+    optional string omServiceId    = 15;
 }
 
 message SecretKeyProto {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -658,9 +658,16 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
             OMConfigKeys.DELEGATION_TOKEN_RENEW_INTERVAL_DEFAULT,
             TimeUnit.MILLISECONDS);
 
-    return new OzoneDelegationTokenSecretManager(conf, tokenMaxLifetime,
-        tokenRenewInterval, tokenRemoverScanInterval, omRpcAddressTxt,
-        s3SecretManager, certClient);
+    return new OzoneDelegationTokenSecretManager.Builder()
+        .setConf(conf)
+        .setTokenMaxLifetime(tokenMaxLifetime)
+        .setTokenRenewInterval(tokenRenewInterval)
+        .setTokenRemoverScanInterval(tokenRemoverScanInterval)
+        .setService(omRpcAddressTxt)
+        .setS3SecretManager(s3SecretManager)
+        .setCertificateClient(certClient)
+        .setOmServiceId(omNodeDetails.getOMServiceId())
+        .build();
   }
 
   private OzoneBlockTokenSecretManager createBlockTokenSecretManager(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/Shell.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/Shell.java
@@ -30,8 +30,8 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 public abstract class Shell extends GenericCli {
 
   public static final String OZONE_URI_DESCRIPTION = "Ozone URI could start "
-      + "with o3:// or without prefix. URI may contain the host and port "
-      + "of the OM server. Both are optional. "
+      + "with o3:// or without prefix. URI may contain the host/serviceId "
+      + " and port of the OM server. Both are optional. "
       + "If they are not specified it will be identified from "
       + "the config files.";
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/token/CancelTokenHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/token/CancelTokenHandler.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.web.ozShell.token;
 
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientException;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.web.ozShell.Handler;
 import org.apache.hadoop.ozone.web.ozShell.OzoneAddress;
@@ -50,8 +51,11 @@ public class CancelTokenHandler extends Handler {
 
     if (securityEnabled("token cancel") && tokenFile.exists()) {
       Token<OzoneTokenIdentifier> token = tokenFile.decode();
-      client.getObjectStore().cancelDelegationToken(token);
+      try (OzoneClient ozoneClient = OzoneClientFactory.getOzoneClient(
+          getConf(), token)) {
+        ozoneClient.getObjectStore().cancelDelegationToken(token);
+        out().printf("Token canceled successfully.");
+      }
     }
   }
-
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/token/CancelTokenHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/token/CancelTokenHandler.java
@@ -54,7 +54,7 @@ public class CancelTokenHandler extends Handler {
       try (OzoneClient ozoneClient = OzoneClientFactory.getOzoneClient(
           getConf(), token)) {
         ozoneClient.getObjectStore().cancelDelegationToken(token);
-        out().printf("Token canceled successfully.");
+        out().printf("Token canceled successfully.%n");
       }
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/token/GetTokenHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/token/GetTokenHandler.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.ozone.client.OzoneClientException;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.web.ozShell.Handler;
 import org.apache.hadoop.ozone.web.ozShell.OzoneAddress;
+import org.apache.hadoop.ozone.web.ozShell.Shell;
 import org.apache.hadoop.security.token.Token;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -38,12 +39,16 @@ import java.util.Objects;
     description = "get a delegation token.")
 public class GetTokenHandler extends Handler {
 
+  @CommandLine.Parameters(arity = "1..1",
+      description = Shell.OZONE_URI_DESCRIPTION)
+  private String uri;
+
   @CommandLine.Mixin
   private RenewerOption renewer;
 
   @Override
   protected OzoneAddress getAddress() throws OzoneClientException {
-    return new OzoneAddress();
+    return new OzoneAddress(uri);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/token/RenewTokenHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/token/RenewTokenHandler.java
@@ -20,8 +20,11 @@ package org.apache.hadoop.ozone.web.ozShell.token;
 
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientException;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.web.ozShell.Handler;
 import org.apache.hadoop.ozone.web.ozShell.OzoneAddress;
+import org.apache.hadoop.security.token.Token;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -47,11 +50,14 @@ public class RenewTokenHandler extends Handler {
       throws IOException, OzoneClientException {
 
     if (securityEnabled("token renew") && tokenFile.exists()) {
-      long expiryTime = client.getObjectStore()
-          .renewDelegationToken(tokenFile.decode());
-
-      out().printf("Token renewed successfully, expiry time: %s",
-          expiryTime);
+      Token<OzoneTokenIdentifier> token = tokenFile.decode();
+      try (OzoneClient ozoneClient = OzoneClientFactory.getOzoneClient(
+          getConf(), token)) {
+        long expiryTime = ozoneClient.getObjectStore()
+            .renewDelegationToken(token);
+        out().printf("Token renewed successfully, expiry time: %s",
+            expiryTime);
+      }
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/token/RenewTokenHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/web/ozShell/token/RenewTokenHandler.java
@@ -55,7 +55,7 @@ public class RenewTokenHandler extends Handler {
           getConf(), token)) {
         long expiryTime = ozoneClient.getObjectStore()
             .renewDelegationToken(token);
-        out().printf("Token renewed successfully, expiry time: %s",
+        out().printf("Token renewed successfully, expiry time: %s.%n",
             expiryTime);
       }
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient
 import org.apache.hadoop.hdds.security.x509.certificate.client.OMCertificateClient;
 import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.S3SecretManager;
@@ -396,8 +397,15 @@ public class TestOzoneDelegationTokenSecretManager {
   private OzoneDelegationTokenSecretManager
       createSecretManager(OzoneConfiguration config, long tokenMaxLife,
       long expiry, long tokenRemoverScanTime) throws IOException {
-    return new OzoneDelegationTokenSecretManager(config, tokenMaxLife,
-        expiry, tokenRemoverScanTime, serviceRpcAdd, s3SecretManager,
-        certificateClient);
+    return new OzoneDelegationTokenSecretManager.Builder()
+        .setConf(config)
+        .setTokenMaxLifetime(tokenMaxLife)
+        .setTokenRenewInterval(expiryTime)
+        .setTokenRemoverScanInterval(tokenRemoverScanTime)
+        .setService(serviceRpcAdd)
+        .setS3SecretManager(s3SecretManager)
+        .setCertificateClient(certificateClient)
+        .setOmServiceId(OzoneConsts.OM_SERVICE_ID_DEFAULT)
+        .build();
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
@@ -400,7 +400,7 @@ public class TestOzoneDelegationTokenSecretManager {
     return new OzoneDelegationTokenSecretManager.Builder()
         .setConf(config)
         .setTokenMaxLifetime(tokenMaxLife)
-        .setTokenRenewInterval(expiryTime)
+        .setTokenRenewInterval(expiry)
         .setTokenRemoverScanInterval(tokenRemoverScanTime)
         .setService(serviceRpcAdd)
         .setS3SecretManager(s3SecretManager)

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -404,8 +404,8 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
         throws IOException, InterruptedException {
       Token<OzoneTokenIdentifier> ozoneDt =
           (Token<OzoneTokenIdentifier>) token;
-      OzoneClient ozoneClient =
-          OzoneClientFactory.getRpcClient(conf);
+      OzoneClient ozoneClient = OzoneClientFactory.getOzoneClient(conf,
+          ozoneDt);
       return ozoneClient.getObjectStore().renewDelegationToken(ozoneDt);
     }
 
@@ -414,8 +414,8 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
         throws IOException, InterruptedException {
       Token<OzoneTokenIdentifier> ozoneDt =
           (Token<OzoneTokenIdentifier>) token;
-      OzoneClient ozoneClient =
-          OzoneClientFactory.getRpcClient(conf);
+      OzoneClient ozoneClient = OzoneClientFactory.getOzoneClient(conf,
+          ozoneDt);
       ozoneClient.getObjectStore().cancelDelegationToken(ozoneDt);
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix the token renew and cancel logic in the Renewer class. By adding omserviceId into OzoneTokenIdentifier. This way, the renewer can renew and cancel the token without referring any additional ozone uri.
 
Fix the ozone token tool to support get/renew/cancel token in secure om ha setup.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3319

## How was this patch tested?
Test with the private build in real cluster using ozone token tool and the distcp. 
Before the fix, the YARN RM will stuck due to the omservice id is not being used to connect to the om proxy up job submit to renew the ozone token. After the fix, the distcp will be able to finish successfully. 

