### PR TITLE
HDDS-3328. List design docs as part of the documentation page.

### DIFF
--- a/hadoop-hdds/docs/archetypes/design.md
+++ b/hadoop-hdds/docs/archetypes/design.md
@@ -1,0 +1,60 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+menu: main
+jira: HDDS-XXX
+summary: One sentence summary. Will be displayed at the main design doc table.
+status: current
+author: Your Name
+
+---
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+
+This the proposed template to document any proposal. It's recommended but not required the use exactly the some structure. Some proposal may require different structure, but we need the following information.
+
+## Summary
+
+> Give a one sentence summary, like the jira title. It will be displayed on the documentation page. Should be enough to understand
+
+## Problem statement (Motivation / Abstract)
+
+> What is the problem and how would you solve it? Think about an abstract of a paper: one paragraph overview. Why will the world better with this change?
+
+## Non-goals
+
+ > Very important to define what is outside of the scope of this proposal
+
+##   Technical Description (Architecture and implementation details)
+
+ > Explain the problem in more details. How can it be reproduced? What is the current solution? What is the limitation of the current solution?
+
+ > How the new proposed solution would solve the problem? Architectural design.
+
+ > Implementation details. What should be changed in the code. Is it a huge change? Do we need to change wire protocol? Backward compatibility?
+
+## Alternatives
+
+ > What are the other alternatives you considered and why do yoy prefer the proposed solution The goal of this section is to help people understand why this is the best solution now, and also to prevent churn in the future when old alternatives are reconsidered.
+
+Note: In some cases 4/5 can be combined. For example if you have multiple proposals, the first version may include multiple solutions. At the end ot the discussion we can move the alternatives to 5. and explain why the community is decided to use the selected option.
+
+## Implementation plan
+
+ > Planning to implement the feature. Estimated size of the work? Do we need feature branch? Any migration plan, dependency? If it's not a big new feature it can be one sentence or optiona;.
+
+## References

--- a/hadoop-hdds/docs/content/design/configless.md
+++ b/hadoop-hdds/docs/content/design/configless.md
@@ -1,0 +1,31 @@
+---
+title: Configless Ozone service management
+summary: Distribute only minimal configuration and download all the remaining before start
+date: 2019-05-25
+jira: HDDS-1467
+status: accepted
+author: Márton Elek, Anu Engineer
+---
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+# Abstract
+
+ Configuration keys are partitioned to two parts: runtime settings and environment settings.
+ 
+ Environment settings (hosts, ports) can be downloaded at start.
+ 
+# Link
+
+  * https://issues.apache.org/jira/secure/attachment/12966992/configless.pdf

--- a/hadoop-hdds/docs/content/design/decommissioning.md
+++ b/hadoop-hdds/docs/content/design/decommissioning.md
@@ -1,3 +1,11 @@
+---
+title: Decommissioning in Ozone
+summary: Formal process to shut down machines in a safe way after the required replications.
+date: 2019-07-31
+jira: HDDS-1881
+status: implementing
+author: Anu Engineer, Marton Elek, Stephen O'Donnell
+---
 <!--
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -11,15 +19,6 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-
----
-title: Decommissioning in Ozone
-summary: Formal process to shut down machines in a safe way after the required replications.
-date: 2019-07-31
-jira: HDDS-1881
-status: current
-author: Anu Engineer, Marton Elek, Stephen O'Donnell
----
 
 # Abstract
 

--- a/hadoop-hdds/docs/content/design/gdpr.md
+++ b/hadoop-hdds/docs/content/design/gdpr.md
@@ -1,0 +1,31 @@
+---
+title: Ozone GDPR framework 
+summary: Crypto key management to handle GDPR "right to be forgotten" feature
+date: 2019-06-20
+jira: HDDS-2012
+status: implemented
+author: Dinesh Chitlangia 
+---
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+# Abstract
+
+ Encrypt all the key and delete only the encryption key if the deletion is requested. Without the key any remaining data can't be read any more.
+  
+# Link
+
+  https://issues.apache.org/jira/secure/attachment/12978992/Ozone%20GDPR%20Framework.pdf
+
+  https://issues.apache.org/jira/secure/attachment/12987528/Ozone%20GDPR%20Framework_updated.pdf

--- a/hadoop-hdds/docs/content/design/locks.md
+++ b/hadoop-hdds/docs/content/design/locks.md
@@ -1,0 +1,29 @@
+---
+title: Ozone locks in OM 
+summary: Hierarchical locking structure for OM elements (volumes/keys/buckets)
+date: 2019-06-20
+jira: HDDS-1672
+status: implemented
+author: Bharat Viswanadham
+---
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+# Abstract
+
+ Fine grained locking hierarchy for Ozone specific resources (volumes, buckets, keys...)
+  
+# Link
+
+ https://issues.apache.org/jira/secure/attachment/12972275/Ozone%20Locks%20in%20OM.pdf

--- a/hadoop-hdds/docs/content/design/multiraft.md
+++ b/hadoop-hdds/docs/content/design/multiraft.md
@@ -1,0 +1,31 @@
+---
+title: Ozone multi-raft support 
+summary: Datanodes can be part of multiple independent RAFT groups / pipelines
+date: 2019-05-21
+jira: HDDS-1564
+status: implemented
+author:  
+---
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+# Abstract
+
+ Without multiraft support one datanode could be part of one RAFT group. With multiraft one datanode can be part of multiple independent RAFT ring.
+  
+# Link
+
+ https://issues.apache.org/jira/secure/attachment/12990694/multiraft_performance_brief.pdf
+
+ https://issues.apache.org/jira/secure/attachment/12969227/Ozone%20Multi-Raft%20Support.pdf

--- a/hadoop-hdds/docs/content/design/namespace-support.md
+++ b/hadoop-hdds/docs/content/design/namespace-support.md
@@ -1,0 +1,29 @@
+---
+title: Ozone Manager HA
+summary: Support HA for Ozone Manager with the help of RATIS
+date: 2020-01-20
+jira: HDDS-2939
+status: accepted
+author: Supratim Deka, Anu Engineer
+---
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+# Abstract
+
+ Flat namespace (like key -> key info) is not efficient for retrieveing directories. (Large segments should be scanned, the whole sub-hierarchy)
+
+# Link
+
+ * https://issues.apache.org/jira/secure/attachment/12991926/Ozone%20FS%20Namespace%20Proposal%20v1.0.docx

--- a/hadoop-hdds/docs/content/design/nfs.md
+++ b/hadoop-hdds/docs/content/design/nfs.md
@@ -1,0 +1,31 @@
+---
+title: NFS support Ozone
+summary: Adopt NFS gateway of HDFS and provide NFS file system view
+date: 2020-03-25
+jira: HDDS-3001
+status: draft
+author: Prashant Pogde
+---
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+# Abstract
+
+ 1. Use NFS server of HDFS and adopt it
+ 2. Support unique ID for each Ozone object
+ 3. Support Random Write
+  
+# Link
+  
+ * https://issues.apache.org/jira/secure/attachment/12997790/NFS%20Support%20for%20Ozone.pdf

--- a/hadoop-hdds/docs/content/design/ofs.md
+++ b/hadoop-hdds/docs/content/design/ofs.md
@@ -1,0 +1,33 @@
+---
+title: Implement new Ozone FileSystem scheme ofs:// 
+summary: A new schema structure for Hadoop compatible file system
+date: 2019-12-05
+jira: HDDS-2665
+status: implementing
+author: Siyao Meng 
+---
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+# Abstract
+
+  Existing scheme: o3fs://bucket.volume/key/../...
+
+  Proposed scheme: ofs://omhost/volume/bucket/key/../...
+  
+# Link
+
+Design doc is uploaded to the JIRA:
+
+https://issues.apache.org/jira/secure/attachment/12987636/Design%20ofs%20v1.pdf

--- a/hadoop-hdds/docs/content/design/omha.md
+++ b/hadoop-hdds/docs/content/design/omha.md
@@ -1,0 +1,33 @@
+---
+title: Ozone Manager HA
+summary: Support HA for Ozone Manager with the help of RATIS
+date: 2018-09-18
+jira: HDDS-505
+status: implemented
+author: Bharat Viswanadham
+---
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+# Abstract
+
+ HA for Ozone Manager with the help of Ratis. High performance operation with caching and double-buffer (separated doc).
+ 
+# Link
+
+ * https://issues.apache.org/jira/secure/attachment/12940314/OzoneManager%20HA.pdf
+
+ * https://issues.apache.org/jira/secure/attachment/12990063/OM%20HA%20Cache%20Design.pdf
+
+ * https://issues.apache.org/jira/secure/attachment/12973260/Handling%20Write%20Requests%20with%20OM%20HA.pdf

--- a/hadoop-hdds/docs/content/design/ozone-enhancement-proposals.md
+++ b/hadoop-hdds/docs/content/design/ozone-enhancement-proposals.md
@@ -129,7 +129,7 @@ This the proposed template to document any proposal. It's recommended but not re
 
 Defined in the markdown header. Proposed statuses:
 
- * `accepted`: (Use this as by default. If not accapted, won't be merged)
+ * `accepted`: (Use this as by default. If not accepted, won't be merged)
 
  * `implemented`: The discussed technical solution is implemented (maybe with some minor implementation difference)
 

--- a/hadoop-hdds/docs/content/design/recon1.md
+++ b/hadoop-hdds/docs/content/design/recon1.md
@@ -1,0 +1,32 @@
+---
+title: Recon server 1
+summary: Second phase of Recon development. Recon acts as a passive SCM.
+date: 2019-02-19
+jira: HDDS-1084
+status: implemented
+author: Sid Wagle, Vivek Subramanian and Aravindan
+---
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+# Abstract
+
+ Recon is a monitoring and analytics server for Ozone. It can retrieve data from 
+ other components and store it and do historical queries (eg. out-of-disk-space time estimation).
+ 
+> Ozone Recon (short for reconnaissance) Service is, as the name suggests, meant to be eyes and ears of Ozone for the user. The first resort in understanding what is happening with Ozone.
+
+# Link
+
+ * https://issues.apache.org/jira/secure/attachment/12960258/Ozone_Recon_Design_V1_Draft.pdf

--- a/hadoop-hdds/docs/content/design/recon2.md
+++ b/hadoop-hdds/docs/content/design/recon2.md
@@ -1,0 +1,29 @@
+---
+title: Recon server v2
+summary: Second phase of Recon development. Recon acts as a passive SCM.
+date: 2019-08-19
+jira: HDDS-1996
+status: implementing
+author: Aravindan Vijayan, Vivek Ratnavel Subramanian, Sid Wagle
+---
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+# Abstract
+
+ The second phase of Recon development. The biggest change is that Recon can act as a passive SCM, collect HB from Datanode and analyze the data.
+ 
+# Link
+
+ * https://issues.apache.org/jira/secure/attachment/12986596/Recon%20v0.2.pdf

--- a/hadoop-hdds/docs/content/design/s3gateway.md
+++ b/hadoop-hdds/docs/content/design/s3gateway.md
@@ -1,0 +1,31 @@
+---
+title: S3 protocol support for Ozone
+summary: Support any AWS S3 compatible client with dedicated REST endpoint
+date: 2018-09-27
+jira: HDDS-434
+status: implemented
+author: Marton Elek, Jitendra Pandey, Bharat Viswanadham & Anu Engineer
+---
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+# Abstract
+
+Introduction of a stateless separated daemon which acts as an S3 endpoint and transform calls to Ozone RPC calls.
+
+This document is still valid but since the first implementation, more and more features are added.
+ 
+# Link
+
+ * https://issues.apache.org/jira/secure/attachment/12941573/S3Gateway.pdf

--- a/hadoop-hdds/docs/content/design/scmha.md
+++ b/hadoop-hdds/docs/content/design/scmha.md
@@ -1,0 +1,29 @@
+---
+title: SCM HA support
+summary: HA for Storage Container Manager using Ratis to replicate data
+date: 2020-03-05
+jira: HDDS-2823
+status: draft
+author: Li Cheng
+---
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+# Abstract
+
+ Proposal to implement HA similar to the OM HA: Using Apache Ratis to propagate the 
+ 
+# Link
+
+ * https://docs.google.com/document/d/1vr_z6mQgtS1dtI0nANoJlzvF1oLV-AtnNJnxAgg69rM/edit?usp=sharing

--- a/hadoop-hdds/docs/content/design/tde.md
+++ b/hadoop-hdds/docs/content/design/tde.md
@@ -1,0 +1,29 @@
+---
+title: Ozone Encryption At Rest
+summary: Transparent Data Encryption encrypts the data before store it
+date: 2019-02-08
+jira: HDDS-1041
+status: implemented
+author: Xiaoyu Yao
+---
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+# Abstract
+
+Design is very similar to HDFS TDE feature. Using KMS encrypts the data before store and decrypt it after reading.
+ 
+# Link
+
+ https://issues.apache.org/jira/secure/attachment/12957995/Ozone%20Encryption%20At-Rest%20-%20V2019.2.7.pdf

--- a/hadoop-hdds/docs/content/design/token.md
+++ b/hadoop-hdds/docs/content/design/token.md
@@ -1,0 +1,25 @@
+---
+title: Generic Extensible Token support for Ozone 
+summary: Extend existing token architecture to all entities of Ozone
+date: 2020-01-09
+jira: HDDS-2867
+status: accepted
+author:  Xiaoyu Yao  
+---
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+  
+# Link
+
+https://issues.apache.org/jira/secure/attachment/12990459/Generic%20Extensible%20Tokens%20for%20Ozone.pdf

--- a/hadoop-hdds/docs/content/design/trash.md
+++ b/hadoop-hdds/docs/content/design/trash.md
@@ -1,0 +1,25 @@
+---
+title: Ozone Trash Feature
+summary: Feature provides a user with the ability to recover keys that may have been deleted accidentally. (similar to the HDFS trash feature).
+date: 2019-11-07
+jira: HDDS-2416
+status: implementing
+author: Matthew Sharp
+---
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+The design doc is uploaded to the JIRA: 
+
+https://issues.apache.org/jira/secure/attachment/12985273/Ozone_Trash_Feature.docx

--- a/hadoop-hdds/docs/content/design/typesafeconfig.md
+++ b/hadoop-hdds/docs/content/design/typesafeconfig.md
@@ -1,0 +1,33 @@
+---
+title: Type-safe configuration API
+summary: Inject configuration values based on annotations instead of using constants and Hadoop API
+date: 2019-04-25
+jira: HDDS-505
+status: implemented
+author: Anu Engineer, Marton Elek
+---
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+# Abstract
+
+ HA for Ozone Manager with the help of Ratis. High performance operation with caching and double-buffer.
+ 
+# Link
+
+ * https://issues.apache.org/jira/secure/attachment/12940314/OzoneManager%20HA.pdf
+
+ * https://issues.apache.org/jira/secure/attachment/12990063/OM%20HA%20Cache%20Design.pdf
+
+ * https://issues.apache.org/jira/secure/attachment/12973260/Handling%20Write%20Requests%20with%20OM%20HA.pdf

--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/_default/baseof.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/_default/baseof.html
@@ -1,0 +1,41 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+{{ partial "header.html" . }}
+
+<body>
+
+{{ partial "navbar.html" . }}
+
+<div class="container-fluid">
+    <div class="row">
+        {{ partial "sidebar.html" . }}
+        <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
+
+            <main>
+                {{ block "main" .}}
+                {{end}}
+            </main>
+
+        </div>
+    </div>
+</div>
+</div>
+
+{{ partial "footer.html" . }}
+
+</body>
+</html>

--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/design/section.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/design/section.html
@@ -1,0 +1,68 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+{{ partial "header.html" . }}
+
+<body>
+
+{{ partial "navbar.html" . }}
+
+<div class="container-fluid">
+    <div class="row">
+        {{ partial "sidebar.html" . }}
+        <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
+
+            <main>
+                <main>
+                    <h1>Available design docs</h1>
+                    {{ .Content }}
+                    <table class="table">
+                        <thead>
+                        <tr>
+                            <td>Date</td>
+                            <td>JIRA</td>
+                            <td>Title</td>
+                            <td>Summary</td>
+                            <td>Status</td>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {{ range .Pages }}
+                        <tr>
+                            <td>{{.Params.date | dateFormat "2006-01-02"}}</td>
+                            <td>
+                                <a href="https://issues.apache.org/jira/browse/{{.Params.jira}}">{{.Params.jira}}</a>
+                            </td>
+                            <td><a href="{{.URL}}">{{.Title}}</a></td>
+                            <td>{{.Summary}}</td>
+                            <td>{{.Params.status}}</td>
+                        </tr>
+                        {{ end }}
+                        </tbody>
+                    </table>
+                </main>
+            </main>
+
+        </div>
+    </div>
+</div>
+</div>
+
+{{ partial "footer.html" . }}
+
+</body>
+</html>
+

--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/design/single.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/design/single.html
@@ -1,0 +1,47 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+{{ partial "header.html" . }}
+
+  <body>
+{{ partial "navbar.html" . }}
+    <div class="container-fluid">
+      <div class="row">
+        {{ partial "sidebar.html" . }}
+        <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
+            <div class="col-md-9">
+                <h1><a href="https://issues.apache.org/jira/browse/{{.Params.jira}}">[{{.Params.jira}}]</a> {{ .Title }} ({{.Params.status}}) </h1>
+                <div><i>Authors: {{.Params.author}}</i><div class="pull-right">{{.Params.date | dateFormat "2006-01-02"}}</div></div>
+                <p>&nbsp</p>
+
+                <div class="panel panel-success">
+                    <div class="panel-heading">Summary</div>
+                    <div class="panel-body">
+                        {{.Summary}}
+                    </div>
+                </div>
+
+              {{ .Content }}
+            </div>
+
+        </div>
+      </div>
+    </div>
+
+{{ partial "footer.html" . }}
+
+  </body>
+</html>

--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/sidebar.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/sidebar.html
@@ -60,6 +60,7 @@
             </li>
         {{ end }}
     {{ end }}
+    <li><a href="{{ "design.html" | relURL }}"><span><b>Design docs</b></span></a></li>
     <li class="visible-xs"><a href="#">References</a>
     <ul class="nav">
         <li><a href="https://github.com/apache/hadoop"><span class="glyphicon glyphicon-new-window" aria-hidden="true"></span> Source</a></li>


### PR DESCRIPTION
## What changes were proposed in this pull request?



In HDDS-1659 a new generic way was introduced to make the design docs more public (collect them as part of the documentation whether they are written as part of the docs or as separated pdf/google docs).

This patch:

    List the design doc as part of the documentation
    Adds link to some of the existing / earlier design docs

I believe that this can be a good extension to the documentation page as some of the low level internals are discussed only in design docs.

![image](https://user-images.githubusercontent.com/170549/78252600-66df3300-74f3-11ea-832f-e1b7d10ed563.png)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3328

## How was this patch tested?

```
cd hadoop-hdds/docs
hugo serve
firefox http://localhost:1313
```