### PR TITLE
HDDS-3324. OM Client fails with StringIndexOutOfBoundsException.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -204,7 +204,13 @@ public class OMFailoverProxyProvider implements
       }
     }
 
-    return new Text(rpcAddress.toString().substring(1));
+    if (!rpcAddress.toString().isEmpty()) {
+      return new Text(rpcAddress.toString().substring(1));
+    } else {
+      // If all OM addresses are unresolvable, set dt service to null. Let
+      // this fail in later step when during connection setup.
+      return null;
+    }
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix Ozone Client failing with StringIndexOutOfBoundsException.

The fix is done in such a way it will fail later when it is setting up the connection, so that in future when getProxy is called we will retry to create socket, and set dtService accordingly. That fix will be later handled by https://issues.apache.org/jira/browse/HDDS-3233. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3324

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?
Right now for HA tests are disabled, once we get them in, we can add more tests later.
Tested this behavior on the docker-compose cluster, now with the fix we don't see error StringOutOfBoundException, Later when it is trying to set up a connection it will fail, after retries.


```
2020-04-02 18:49:46,856 [main] ERROR OMFailoverProxyProvider:285 - Failed to connect to OMs: [nodeId=om1,nodeAddress=om1:9862, nodeId=om3,nodeAddress=om3:9862, nodeId=om2,nodeAddress=om2:9862]. Attempted 15 failovers.
2020-04-02 18:49:46,857 [main] ERROR OzoneClientFactory:195 - Couldn't create RpcClient protocol exception:
java.net.UnknownHostException: Invalid host name: local host is: (unknown); destination host is: "om2":9862; java.net.UnknownHostException; For more details see:  http://wiki.apache.org/hadoop/UnknownHost
        at java.base/jdk.internal.reflect.GeneratedConstructorAccessor8.newInstance(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
        at org.apache.hadoop.net.NetUtils.wrapWithMessage(NetUtils.java:831)
        at org.apache.hadoop.net.NetUtils.wrapException(NetUtils.java:768)
        at org.apache.hadoop.ipc.Client$Connection.<init>(Client.java:449)
        at org.apache.hadoop.ipc.Client.getConnection(Client.java:1552)
        at org.apache.hadoop.ipc.Client.call(Client.java:1403)
        at org.apache.hadoop.ipc.Client.call(Client.java:1367)
        at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:228)
        at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:116)
        at com.sun.proxy.$Proxy19.submitRequest(Unknown Source)
        at jdk.internal.reflect.GeneratedMethodAccessor6.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:422)
        at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invokeMethod(RetryInvocationHandler.java:165)
        at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invoke(RetryInvocationHandler.java:157)
        at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invokeOnce(RetryInvocationHandler.java:95)
        at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:359)
        at com.sun.proxy.$Proxy19.submitRequest(Unknown Source)
        at org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB.submitRequest(OzoneManagerProtocolClientSideTranslatorPB.java:407)
        at org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB.getServiceInfo(OzoneManagerProtocolClientSideTranslatorPB.java:1296)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.apache.hadoop.hdds.tracing.TraceAllMethod.invoke(TraceAllMethod.java:71)
        at com.sun.proxy.$Proxy20.getServiceInfo(Unknown Source)
        at org.apache.hadoop.ozone.client.rpc.RpcClient.<init>(RpcClient.java:158)
        at org.apache.hadoop.ozone.client.OzoneClientFactory.getClientProtocol(OzoneClientFactory.java:192)
        at org.apache.hadoop.ozone.client.OzoneClientFactory.getRpcClient(OzoneClientFactory.java:107)
        at org.apache.hadoop.ozone.web.ozShell.OzoneAddress.createClient(OzoneAddress.java:106)
        at org.apache.hadoop.ozone.web.ozShell.volume.CreateVolumeHandler.call(CreateVolumeHandler.java:70)
        at org.apache.hadoop.ozone.web.ozShell.volume.CreateVolumeHandler.call(CreateVolumeHandler.java:37)
        at picocli.CommandLine.execute(CommandLine.java:1173)
        at picocli.CommandLine.access$800(CommandLine.java:141)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:1367)
```


