### PR TITLE
HDDS-3334. OM Client failover to next OM on NotLeaderException

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -250,11 +250,13 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
               getNotLeaderException(exception);
           if (notLeaderException != null &&
               notLeaderException.getSuggestedLeaderNodeId() != null) {
-            // We need to failover manually to the suggested Leader OM Node.
+            // TODO: NotLeaderException should include the host
+            //  address of the suggested leader along with the nodeID.
+            //  Failing over just based on nodeID is not very robust.
+
             // OMFailoverProxyProvider#performFailover() is a dummy call and
-            // does not perform any failover.
-            omFailoverProxyProvider.performFailoverIfRequired(
-                notLeaderException.getSuggestedLeaderNodeId());
+            // does not perform any failover. Failover manually to the next OM.
+            omFailoverProxyProvider.performFailoverToNextProxy();
             return getRetryAction(FAILOVER_AND_RETRY, failovers);
           }
 
@@ -263,7 +265,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
           // As in this case, current OM node is leader, but it is not ready.
           // OMFailoverProxyProvider#performFailover() is a dummy call and
           // does not perform any failover.
-          // So Just retry with same ON node.
+          // So Just retry with same OM node.
           if (leaderNotReadyException != null) {
             return getRetryAction(FAILOVER_AND_RETRY, failovers);
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?

On receiving NotLeaderException from OM server, we should failover to the next OM in the list instead of the suggested Leader. This will ensure that all the OMs are contacted in a round robin way. Failing always to the suggested leader is not robust.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3334

## How was this patch tested?

TestOzoneManagerHA#testOMProxyProviderFailoverToCurrentLeader already covers this test.