### PR TITLE
HDDS-3337. Export the IPC port of OM in docker-compose

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-hdfs/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-hdfs/docker-compose.yaml
@@ -42,6 +42,7 @@ services:
          - ../..:/opt/hadoop
       ports:
          - 9874:9874
+         - 9862:9862
       environment:
          ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
       env_file:

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/docker-compose.yaml
@@ -33,6 +33,7 @@ services:
       - ../../..:/opt/hadoop
     ports:
       - 9874:9874
+      - 9862:9862
     environment:
       WAITFOR: scm:9876
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/docker-compose.yaml
@@ -33,6 +33,7 @@ services:
       - ../../..:/opt/hadoop
     ports:
       - 9874:9874
+      - 9862:9862
     environment:
       WAITFOR: scm:9876
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/docker-compose.yaml
@@ -33,6 +33,7 @@ services:
       - ../../..:/opt/hadoop
     ports:
       - 9874:9874
+      - 9862:9862
     environment:
       WAITFOR: scm:9876
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION

--- a/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-compose.yaml
@@ -107,6 +107,7 @@ services:
          - ../..:/opt/hadoop
       ports:
          - 9874:9874
+         - 9862:9862
       environment:
          ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
       env_file:

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
@@ -45,6 +45,7 @@ services:
       <<: *replication
     ports:
       - 9874:9874
+      - 9862:9862
     command: ["ozone","om"]
   scm:
     <<: *common-config

--- a/hadoop-ozone/dist/src/main/compose/ozoneblockade/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozoneblockade/docker-compose.yaml
@@ -31,6 +31,7 @@ services:
          - ../..:/opt/hadoop
       ports:
          - 9874:9874
+         - 9862:9862
       environment:
          ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
       env_file:

--- a/hadoop-ozone/dist/src/main/compose/ozones3-haproxy/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozones3-haproxy/docker-compose.yaml
@@ -38,6 +38,7 @@ services:
          - ../..:/opt/hadoop
       ports:
          - 9874:9874
+         - 9862:9862
       environment:
          ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
       env_file:

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-compose.yaml
@@ -38,6 +38,7 @@ services:
          - ../..:/opt/hadoop
       ports:
          - 9874:9874
+         - 9862:9862
       env_file:
           - ./docker-config
    scm:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
@@ -57,6 +57,7 @@ services:
       - ../..:/opt/hadoop
     ports:
       - 9874:9874
+      - 9862:9862
     environment:
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
       KERBEROS_KEYTABS: om HTTP testuser

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -50,6 +50,7 @@ services:
       - ../..:/opt/hadoop
     ports:
       - 9874:9874
+      - 9862:9862
     environment:
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
       KERBEROS_KEYTABS: om HTTP


### PR DESCRIPTION
## What changes were proposed in this pull request?

Export the IPC port of OM in docker-compose, so that we can use the ozone service inside the docker container while execute command at docker host.

## What is the link to the Apache JIRA

HDDS-3337

## How was this patch tested?

See the `docker ps` result, you can see the port 9862 of OM container is exported after execute ```bash
hadoop-ozone/hadoop-ozone/dist/target/ozone-0.6.0-SNAPSHOT/compose/ozone/run.sh
```
