### PR TITLE
HDDS-3332. Upgrade Robot tests to Python 3

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
-    <docker.ozone-runner.version>20191107-1</docker.ozone-runner.version>
+    <docker.ozone-runner.version>20200403-1</docker.ozone-runner.version>
   </properties>
 
   <build>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade Robot tests to Python 3 by using a newer `ozone-runner` image, which has Python 3 installed.

https://issues.apache.org/jira/browse/HDDS-3332

## How was this patch tested?

CI: https://github.com/adoroszlai/hadoop-ozone/runs/558100142

Tested that runaway command is stopped after the specified timeout (10 seconds):

```
$ time docker run -it --rm -v $(pwd):/tmp apache/ozone-runner:20200403-1 robot /tmp/tmp.robot
To use Ozone please mount ozone folder to /opt/hadoop
==============================================================================
Tmp :: Timeout test
==============================================================================
Test timeout behavior with wait                                       | FAIL |
Test timeout 10 seconds exceeded.
------------------------------------------------------------------------------
Tmp :: Timeout test                                                   | FAIL |
1 critical test, 0 passed, 1 failed
1 test total, 0 passed, 1 failed
==============================================================================
Output:  /opt/hadoop/output.xml
Log:     /opt/hadoop/log.html
Report:  /opt/hadoop/report.html
docker run -it --rm -v $(pwd):/tmp apache/ozone-runner:20200403-1 robot   0.03s user 0.09s system 1% cpu 11.384 total
```

whereas previously it ran until completion (30 seconds):

```
$ time docker run -it --rm -v $(pwd):/tmp apache/ozone-runner:20191107-1 robot /tmp/tmp.robot
To use Ozone please mount ozone folder to /opt/hadoop
==============================================================================
Tmp :: Timeout test
==============================================================================
Test timeout behavior with wait                                       | FAIL |
Test timeout 10 seconds exceeded.
------------------------------------------------------------------------------
Tmp :: Timeout test                                                   | FAIL |
1 critical test, 0 passed, 1 failed
1 test total, 0 passed, 1 failed
==============================================================================
Output:  /opt/hadoop/output.xml
Log:     /opt/hadoop/log.html
Report:  /opt/hadoop/report.html
docker run -it --rm -v $(pwd):/tmp apache/ozone-runner:20191107-1 robot   0.03s user 0.07s system 0% cpu 31.267 total
```