### PR TITLE
HDDS-3341. Checkstyle fails for new modules/versions

### DIFF
--- a/hadoop-hdds/dev-support/checkstyle/checkstyle.xml
+++ b/hadoop-hdds/dev-support/checkstyle/checkstyle.xml
@@ -49,6 +49,10 @@
 
 <module name="Checker">
 
+    <module name="BeforeExecutionExclusionFileFilter">
+      <property name="fileNamePattern" value=".*/target/generated.*"/>
+    </module>
+
     <module name="SuppressWarningsFilter"/>
 
     <!-- Checks that a package.html file exists for each package.     -->
@@ -192,5 +196,4 @@
         <module name="UpperEll"/>
 
     </module>
-
 </module>

--- a/hadoop-ozone/dev-support/checks/checkstyle.sh
+++ b/hadoop-ozone/dev-support/checks/checkstyle.sh
@@ -21,9 +21,15 @@ REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/checkstyle"}
 mkdir -p "$REPORT_DIR"
 REPORT_FILE="$REPORT_DIR/summary.txt"
 
-set -e
-mvn -B checkstyle:check -D checkstyle.failOnViolation=false
-set +e
+declare -i rc
+mvn -B checkstyle:check -Dcheckstyle.failOnViolation=false > "${REPORT_DIR}/output.log"
+rc=$?
+if [[ ${rc} -ne 0 ]]; then
+  mvn -B test-compile checkstyle:check -Dcheckstyle.failOnViolation=false
+  rc=$?
+else
+  cat "${REPORT_DIR}/output.log"
+fi
 
 #Print out the exact violations with parsing XML results with sed
 find "." -name checkstyle-errors.xml -print0 \
@@ -43,3 +49,4 @@ grep -c ':' "$REPORT_FILE" > "$REPORT_DIR/failures"
 if [[ -s "${REPORT_FILE}" ]]; then
    exit 1
 fi
+exit ${rc}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make `checkstyle.sh` work with new modules/versions:

1. first attempt to run the check only
2. if it fails due to anything other than style violation, try to compile sources, too.

Ignore violations on Protobuf generated sources.

Output from the first attempt is only printed with some delay only if and when it completes successfully, to avoid duplicate Maven logs.  This may be a bit annoying when run manually.  Please let me know if duplicated but immediate output is preferred.

https://issues.apache.org/jira/browse/HDDS-3341

## How was this patch tested?

1. Tested on HDDS-3312, which introduces a new `hadoop-hdds-hadoop-dependency-client` module and [fails](https://github.com/apache/hadoop-ozone/pull/744/checks?check_run_id=558258406) with `Could not find artifact org.apache.hadoop:hadoop-hdds-hadoop-dependency-client:jar:0.6.0-SNAPSHOT in apache.snapshots.https`.  With this change the check passes:

```
$ hadoop-ozone/dev-support/checks/checkstyle.sh
...
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:55 min
...
$ echo $?
0
```

2. Tested on `master`, where all modules are available, so no compilation is needed:

```
$ hadoop-ozone/dev-support/checks/checkstyle.sh
...
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  14.093 s
...
$ echo $?
0
```

3. Introduced an unused import, verified that violation is reported:

```
$ hadoop-ozone/dev-support/checks/checkstyle.sh
...
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.226 s
...
hadoop-ozone/common/src/main/java/org/apache/hadoop/hdds/protocol/StorageType.java
 20: Unused import - java.util.List.
$ echo $?
1
```

https://github.com/adoroszlai/hadoop-ozone/runs/558999926