### PR TITLE
HDDS-3347. PipelineActionHandler should handle unknown pipeline.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineActionHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineActionHandler.java
@@ -19,11 +19,16 @@ package org.apache.hadoop.hdds.scm.pipeline;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ClosePipelineInfo;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineAction;
+import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.PipelineActionsFromDatanode;
 
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.apache.hadoop.ozone.protocol.commands.ClosePipelineCommand;
+import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,25 +55,45 @@ public class PipelineActionHandler
   @Override
   public void onMessage(PipelineActionsFromDatanode report,
       EventPublisher publisher) {
-    for (PipelineAction action : report.getReport().getPipelineActionsList()) {
-      if (action.getAction() == PipelineAction.Action.CLOSE) {
-        PipelineID pipelineID = null;
-        try {
-          pipelineID = PipelineID.
-              getFromProtobuf(action.getClosePipeline().getPipelineID());
-          Pipeline pipeline = pipelineManager.getPipeline(pipelineID);
-          LOG.error("Received pipeline action {} for {} from datanode {}. " +
-                  "Reason : {}", action.getAction(), pipeline,
-              report.getDatanodeDetails(),
-              action.getClosePipeline().getDetailedReason());
-          pipelineManager.finalizeAndDestroyPipeline(pipeline, true);
-        } catch (IOException ioe) {
-          LOG.error("Could not execute pipeline action={} pipeline={} {}",
-              action, pipelineID, ioe);
-        }
+
+    report.getReport().getPipelineActionsList().forEach(action ->
+        processPipelineAction(report.getDatanodeDetails(), action, publisher));
+  }
+
+  /**
+   * Process the given PipelineAction.
+   *
+   * @param datanode the datanode which has sent the PipelineAction
+   * @param pipelineAction the PipelineAction
+   * @param publisher EventPublisher to fire new events if required
+   */
+  private void processPipelineAction(final DatanodeDetails datanode,
+                                     final PipelineAction pipelineAction,
+                                     final EventPublisher publisher) {
+    final ClosePipelineInfo info = pipelineAction.getClosePipeline();
+    final PipelineAction.Action action = pipelineAction.getAction();
+    final PipelineID pid = PipelineID.getFromProtobuf(info.getPipelineID());
+    try {
+      LOG.info("Received pipeline action {} for {} from datanode {}. " +
+          "Reason : {}", action, pid, datanode.getUuidString(),
+          info.getDetailedReason());
+
+      if (action == PipelineAction.Action.CLOSE) {
+        pipelineManager.finalizeAndDestroyPipeline(
+            pipelineManager.getPipeline(pid), true);
       } else {
-        LOG.error("unknown pipeline action:{}", action.getAction());
+        LOG.error("unknown pipeline action:{}", action);
       }
+    } catch (PipelineNotFoundException e) {
+      LOG.warn("Pipeline action {} received for unknown pipeline {}, " +
+          "firing close pipeline event.", action, pid);
+      publisher.fireEvent(SCMEvents.DATANODE_COMMAND,
+          new CommandForDatanode<>(datanode.getUuid(),
+              new ClosePipelineCommand(pid)));
+    } catch (IOException ioe) {
+      LOG.error("Could not execute pipeline action={} pipeline={}",
+          action, pid, ioe);
     }
   }
+
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineActionHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineActionHandler.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.hdds.scm.pipeline;
+
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ClosePipelineInfo;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineAction;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineActionsProto;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.PipelineActionsFromDatanode;
+import org.apache.hadoop.hdds.server.events.EventQueue;
+import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.UUID;
+
+/**
+ * Test-cases to verify the functionality of PipelineActionHandler.
+ */
+public class TestPipelineActionHandler {
+
+  @Test
+  public void testCloseActionForMissingPipeline()
+      throws PipelineNotFoundException {
+    final PipelineManager manager = Mockito.mock(PipelineManager.class);
+    final EventQueue queue = Mockito.mock(EventQueue.class);
+
+    Mockito.when(manager.getPipeline(Mockito.any(PipelineID.class)))
+        .thenThrow(new PipelineNotFoundException());
+
+    final PipelineActionHandler actionHandler =
+        new PipelineActionHandler(manager, null);
+
+    final PipelineActionsProto actionsProto = PipelineActionsProto.newBuilder()
+        .addPipelineActions(PipelineAction.newBuilder()
+        .setClosePipeline(ClosePipelineInfo.newBuilder()
+            .setPipelineID(HddsProtos.PipelineID.newBuilder()
+                .setId(UUID.randomUUID().toString()).build())
+            .setReason(ClosePipelineInfo.Reason.PIPELINE_FAILED))
+            .setAction(PipelineAction.Action.CLOSE).build())
+        .build();
+    final PipelineActionsFromDatanode pipelineActions =
+        new PipelineActionsFromDatanode(
+            MockDatanodeDetails.randomDatanodeDetails(), actionsProto);
+
+    actionHandler.onMessage(pipelineActions, queue);
+
+    Mockito.verify(queue, Mockito.times(1))
+        .fireEvent(Mockito.any(), Mockito.any(CommandForDatanode.class));
+
+  }
+
+}


### PR DESCRIPTION
PipelineActionHandler is not able to handle PipelineActions for pipelines which is not present in SCM (deleted pipelines)

After SCM sends out the close pipeline command to datanodes, it removes the pipeline information from the pipeline db. If a datanode sends PipelineAction for the deleted pipeline, PipelineActionHandler cannot handle it.
In such a situation SCM should fire ClosePipelineCommand.

https://issues.apache.org/jira/browse/HDDS-3347

## How was this patch tested?
Added a new unit test to cover the scenario.
