### PR TITLE
HDDS-3348. scmcli container info command shows the wrong container state.

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -22,8 +22,6 @@ import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
-    .ContainerDataProto;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.container.common.helpers
     .ContainerWithPipeline;
@@ -57,26 +55,13 @@ public class InfoSubcommand implements Callable<Void> {
   @Override
   public Void call() throws Exception {
     try (ScmClient scmClient = parent.getParent().createScmClient()) {
-      ContainerWithPipeline container = scmClient.
+      final ContainerWithPipeline container = scmClient.
           getContainerWithPipeline(containerID);
       Preconditions.checkNotNull(container, "Container cannot be null");
 
-      ContainerDataProto containerData = scmClient.readContainer(container
-          .getContainerInfo().getContainerID(), container.getPipeline());
-
       // Print container report info.
       LOG.info("Container id: {}", containerID);
-      String openStatus =
-          containerData.getState() == ContainerDataProto.State.OPEN ? "OPEN" :
-              "CLOSED";
-      LOG.info("Container State: {}", openStatus);
-      LOG.info("Container Path: {}", containerData.getContainerPath());
-
-      // Output meta data.
-      String metadataStr = containerData.getMetadataList().stream().map(
-          p -> p.getKey() + ":" + p.getValue())
-          .collect(Collectors.joining(", "));
-      LOG.info("Container Metadata: {}", metadataStr);
+      LOG.info("Container State: {}", container.getContainerInfo().getState());
 
       // Print pipeline of an existing container.
       String machinesStr = container.getPipeline().getNodes().stream().map(

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -61,6 +61,7 @@ public class InfoSubcommand implements Callable<Void> {
 
       // Print container report info.
       LOG.info("Container id: {}", containerID);
+      LOG.info("Pipeline id: {}", container.getPipeline().getId().getId());
       LOG.info("Container State: {}", container.getContainerInfo().getState());
 
       // Print pipeline of an existing container.


### PR DESCRIPTION
## What changes were proposed in this pull request?
Container State from SCM is displayed in output of `scmcli container info` command

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3348

## How was this patch tested?
The output was manually checked.
