### PR TITLE
HDDS-2976. Recon throws error while trying to get snapshot over https

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -34,6 +34,8 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.zip.GZIPOutputStream;
+import java.net.URLConnection;
+import java.net.URL;
 
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
@@ -225,33 +227,12 @@ public class ReconUtils {
    * @return Inputstream to the response of the HTTP call.
    * @throws IOException While reading the response.
    */
-  public InputStream makeHttpCall(CloseableHttpClient httpClient, String url)
-      throws IOException {
-
-    HttpGet httpGet = new HttpGet(url);
-    HttpResponse response = httpClient.execute(httpGet);
-    int errorCode = response.getStatusLine().getStatusCode();
-    HttpEntity entity = response.getEntity();
-
-    if ((errorCode == HTTP_OK) || (errorCode == HTTP_CREATED)) {
-      return entity.getContent();
-    }
-
-    if (entity != null) {
-      throw new IOException("Unexpected exception when trying to reach Ozone " +
-          "Manager, " + EntityUtils.toString(entity));
-    } else {
-      throw new IOException("Unexpected null in http payload," +
-          " while processing request");
-    }
-  }
-
   public InputStream makeHttpCall(URLConnectionFactory connectionFactory,
                                   String url)
       throws IOException {
 
-    java.net.URLConnection urlConnection =
-          connectionFactory.openConnection(new java.net.URL(url));
+    URLConnection urlConnection =
+          connectionFactory.openConnection(new URL(url));
      urlConnection.connect();
      return urlConnection.getInputStream();
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -51,6 +51,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 
 /**
  * Recon Utility class.
@@ -243,6 +244,16 @@ public class ReconUtils {
       throw new IOException("Unexpected null in http payload," +
           " while processing request");
     }
+  }
+
+  public InputStream makeHttpCall(URLConnectionFactory connectionFactory,
+                                  String url)
+      throws IOException {
+
+    java.net.URLConnection urlConnection =
+          connectionFactory.openConnection(new java.net.URL(url));
+     urlConnection.connect();
+     return urlConnection.getInputStream();
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.ozone.recon;
 
-import static java.net.HttpURLConnection.HTTP_CREATED;
-import static java.net.HttpURLConnection.HTTP_OK;
 import static org.apache.hadoop.hdds.server.ServerUtils.getDirectoryFromConfig;
 import static org.apache.hadoop.hdds.server.ServerUtils.getOzoneMetaDirPath;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_DB_DIR;
@@ -45,12 +43,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.io.IOUtils;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
 
-import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
@@ -233,8 +226,8 @@ public class ReconUtils {
 
     URLConnection urlConnection =
           connectionFactory.openConnection(new URL(url));
-     urlConnection.connect();
-     return urlConnection.getInputStream();
+    urlConnection.connect();
+    return urlConnection.getInputStream();
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -30,6 +30,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.server.http.HttpConfig;
@@ -89,6 +91,7 @@ public class OzoneManagerServiceProviderImpl
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OzoneManagerServiceProviderImpl.class);
+  private static URLConnectionFactory connectionFactory;
 
   private final CloseableHttpClient httpClient;
   private File omSnapshotDBParentDir = null;
@@ -119,6 +122,8 @@ public class OzoneManagerServiceProviderImpl
       ReconUtils reconUtils,
       OzoneManagerProtocol ozoneManagerClient) {
 
+    connectionFactory =
+        URLConnectionFactory.newDefaultURLConnectionFactory(configuration);
     String ozoneManagerHttpAddress = configuration.get(OMConfigKeys
         .OZONE_OM_HTTP_ADDRESS_KEY);
 
@@ -278,7 +283,7 @@ public class OzoneManagerServiceProviderImpl
     File targetFile = new File(omSnapshotDBParentDir, snapshotFileName +
         ".tar.gz");
     try {
-      try (InputStream inputStream = reconUtils.makeHttpCall(httpClient,
+      try (InputStream inputStream = reconUtils.makeHttpCall(connectionFactory,
           getOzoneManagerSnapshotUrl())) {
         FileUtils.copyInputStreamToFile(inputStream, targetFile);
       }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -30,7 +30,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -91,7 +90,7 @@ public class OzoneManagerServiceProviderImpl
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OzoneManagerServiceProviderImpl.class);
-  private static URLConnectionFactory connectionFactory;
+  private URLConnectionFactory connectionFactory;
 
   private final CloseableHttpClient httpClient;
   private File omSnapshotDBParentDir = null;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
@@ -37,7 +37,9 @@ import java.nio.file.Paths;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import org.apache.http.HttpEntity;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -166,9 +168,11 @@ public class TestReconUtils {
       }
     });
 
-    InputStream inputStream = new ReconUtils()
-        .makeHttpCall(httpClientMock, url);
-    String contents = IOUtils.toString(inputStream, Charset.defaultCharset());
+    String contents;
+    try (InputStream inputStream = new ReconUtils()
+        .makeHttpCall(httpClientMock, url)) {
+      contents = IOUtils.toString(inputStream, Charset.defaultCharset());
+    }
 
     assertEquals("File 1 Contents", contents);
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
@@ -34,6 +34,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Paths;
+import java.net.URLConnection;
+import java.net.URL;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -49,7 +51,6 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
 /**
  * Test Recon Utility methods.
  */
@@ -169,12 +170,20 @@ public class TestReconUtils {
     });
 
     String contents;
+    URLConnectionFactory connectionFactoryMock =
+        mock(URLConnectionFactory.class);
+    URLConnection urlConnectionMock = mock(URLConnection.class);
+    // when(urlConnectionMock.connect()).thenReturn();
+    when(urlConnectionMock.getInputStream()).thenReturn(fileInputStream);
+    when(connectionFactoryMock.openConnection(any(URL.class)))
+        .thenReturn(urlConnectionMock);
     try (InputStream inputStream = new ReconUtils()
-        .makeHttpCall(httpClientMock, url)) {
+        .makeHttpCall(connectionFactoryMock, url)) {
       contents = IOUtils.toString(inputStream, Charset.defaultCharset());
     }
 
     assertEquals("File 1 Contents", contents);
+
   }
 
   @Test

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
@@ -140,20 +140,7 @@ public class TestReconUtils {
 
   @Test
   public void testMakeHttpCall() throws Exception {
-
-    CloseableHttpClient httpClientMock = mock(CloseableHttpClient.class);
     String url = "http://localhost:9874/dbCheckpoint";
-
-    CloseableHttpResponse httpResponseMock = mock(CloseableHttpResponse.class);
-    when(httpClientMock.execute(any(HttpGet.class)))
-        .thenReturn(httpResponseMock);
-
-    StatusLine statusLineMock = mock(StatusLine.class);
-    when(statusLineMock.getStatusCode()).thenReturn(200);
-    when(httpResponseMock.getStatusLine()).thenReturn(statusLineMock);
-
-    HttpEntity httpEntityMock = mock(HttpEntity.class);
-    when(httpResponseMock.getEntity()).thenReturn(httpEntityMock);
     File file1 = Paths.get(folder.getRoot().getPath(), "file1")
         .toFile();
     BufferedWriter writer = new BufferedWriter(new FileWriter(
@@ -162,18 +149,10 @@ public class TestReconUtils {
     writer.close();
     InputStream fileInputStream = new FileInputStream(file1);
 
-    when(httpEntityMock.getContent()).thenReturn(new InputStream() {
-      @Override
-      public int read() throws IOException {
-        return fileInputStream.read();
-      }
-    });
-
     String contents;
     URLConnectionFactory connectionFactoryMock =
         mock(URLConnectionFactory.class);
     URLConnection urlConnectionMock = mock(URLConnection.class);
-    // when(urlConnectionMock.connect()).thenReturn();
     when(urlConnectionMock.getInputStream()).thenReturn(fileInputStream);
     when(connectionFactoryMock.openConnection(any(URL.class)))
         .thenReturn(urlConnectionMock);
@@ -183,7 +162,6 @@ public class TestReconUtils {
     }
 
     assertEquals("File 1 Contents", contents);
-
   }
 
   @Test

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/TestReconUtils.java
@@ -39,14 +39,8 @@ import java.net.URL;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
-import org.apache.http.HttpEntity;
-import org.apache.http.StatusLine;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Making getOzoneManagerDBSnapshot work over https.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2976

## How was this patch tested?
- Manual Test in a secure environment
- Unit Tests