### PR TITLE
HDDS-3355. Add wait time between client retries to OM

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -392,14 +392,10 @@ public final class OzoneConfigKeys {
       "ozone.client.failover.max.attempts";
   public static final int OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_DEFAULT =
       15;
-  public static final String OZONE_CLIENT_FAILOVER_SLEEP_BASE_MILLIS_KEY =
-      "ozone.client.failover.sleep.base.millis";
-  public static final int OZONE_CLIENT_FAILOVER_SLEEP_BASE_MILLIS_DEFAULT =
-      500;
-  public static final String OZONE_CLIENT_FAILOVER_SLEEP_MAX_MILLIS_KEY =
-      "ozone.client.failover.sleep.max.millis";
-  public static final int OZONE_CLIENT_FAILOVER_SLEEP_MAX_MILLIS_DEFAULT =
-      15000;
+  public static final String OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_KEY =
+      "ozone.client.wait.between.retries.millis";
+  public static final long OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_DEFAULT =
+      2000;
 
   public static final String OZONE_FREON_HTTP_ENABLED_KEY =
       "ozone.freon.http.enabled";

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2149,29 +2149,13 @@
     </description>
   </property>
   <property>
-    <name>ozone.client.failover.sleep.base.millis</name>
-    <value>500</value>
+    <name>ozone.client.wait.between.retries.millis</name>
+    <value>2000</value>
     <description>
-      Expert only. The time to wait, in milliseconds, between failover
-      attempts increases exponentially as a function of the number of
-      attempts made so far, with a random factor of +/- 50%. This option
-      specifies the base value used in the failover calculation. The
-      first failover will retry immediately. The 2nd failover attempt
-      will delay at least ozone.client.failover.sleep.base.millis
-      milliseconds. And so on.
-    </description>
-  </property>
-  <property>
-    <name>ozone.client.failover.sleep.max.millis</name>
-    <value>15000</value>
-    <description>
-      Expert only. The time to wait, in milliseconds, between failover
-      attempts increases exponentially as a function of the number of
-      attempts made so far, with a random factor of +/- 50%. This option
-      specifies the maximum value to wait between failovers.
-      Specifically, the time between two failover attempts will not
-      exceed +/- 50% of ozone.client.failover.sleep.max.millis
-      milliseconds.
+      Expert only. The time to wait, in milliseconds, between retry attempts
+      to contact OM. Wait time increases linearly if same OM is retried
+      again. If retrying on multiple OMs proxies in round robin fashion, the
+      wait time is introduced after all the OM proxies have been attempted once.
     </description>
   </property>
   <property>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
@@ -43,8 +44,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 
@@ -74,6 +77,16 @@ public class OMFailoverProxyProvider implements
 
   private final String omServiceId;
 
+  // OMFailoverProxyProvider, on encountering certain exception, tries each OM
+  // once in a round robin fashion. After that it waits for configured time
+  // before attempting to contact all the OMs again. For other exceptions
+  // such as LeaderNotReadyException, the same OM is contacted again with a
+  // linearly increasing wait time.
+  private Set<String> attemptedOMs = new HashSet<>();
+  private String lastAttemptedOM;
+  private int numAttemptsOnSameOM = 0;
+  private final long waitBetweenRetries;
+
   public OMFailoverProxyProvider(OzoneConfiguration configuration,
       UserGroupInformation ugi, String omServiceId) throws IOException {
     this.conf = configuration;
@@ -85,6 +98,10 @@ public class OMFailoverProxyProvider implements
 
     currentProxyIndex = 0;
     currentProxyOMNodeId = omNodeIDList.get(currentProxyIndex);
+
+    waitBetweenRetries = conf.getLong(
+        OzoneConfigKeys.OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_KEY,
+        OzoneConfigKeys.OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_DEFAULT);
   }
 
   public OMFailoverProxyProvider(OzoneConfiguration configuration,
@@ -261,10 +278,16 @@ public class OMFailoverProxyProvider implements
   }
 
   /**
-   * Performs failover if the leaderOMNodeId returned through OMReponse does
+   * Performs failover if the leaderOMNodeId returned through OMResponse does
    * not match the current leaderOMNodeId cached by the proxy provider.
    */
   public void performFailoverToNextProxy() {
+
+    // Before failing over to next proxy, add the proxy OM (which has
+    // returned an exception) to the list of attemptedOMs.
+    lastAttemptedOM = currentProxyOMNodeId;
+    attemptedOMs.add(currentProxyOMNodeId);
+
     int newProxyIndex = incrementProxyIndex();
     if (LOG.isDebugEnabled()) {
       LOG.debug("Incrementing OM proxy index to {}, nodeId: {}",
@@ -300,6 +323,32 @@ public class OMFailoverProxyProvider implements
 
   private synchronized int getCurrentProxyIndex() {
     return currentProxyIndex;
+  }
+
+  public long getWaitTime() {
+    if (currentProxyOMNodeId.equals(lastAttemptedOM)) {
+      // Clear attemptedOMs list as round robin has been broken. Add only the
+      attemptedOMs.clear();
+
+      // The same OM will be contacted again. So wait and then retry.
+      numAttemptsOnSameOM++;
+      return (waitBetweenRetries * numAttemptsOnSameOM);
+    }
+    // Reset numAttemptsOnSameOM as we failed over to a different OM.
+    numAttemptsOnSameOM = 0;
+
+    // OMs are being contacted in round robin way. Check if all the OMs have
+    // been contacted in this attempt.
+    for (String omNodeID : omProxyInfos.keySet()) {
+      if (!attemptedOMs.contains(omNodeID)) {
+        return 0;
+      }
+    }
+    // This implies all the OMs have been contacted once. Return true and
+    // clear the list as we are going to inject a wait and the next check
+    // should not include these atttempts again.
+    attemptedOMs.clear();
+    return waitBetweenRetries;
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -282,12 +282,6 @@ public class OMFailoverProxyProvider implements
    * not match the current leaderOMNodeId cached by the proxy provider.
    */
   public void performFailoverToNextProxy() {
-
-    // Before failing over to next proxy, add the proxy OM (which has
-    // returned an exception) to the list of attemptedOMs.
-    lastAttemptedOM = currentProxyOMNodeId;
-    attemptedOMs.add(currentProxyOMNodeId);
-
     int newProxyIndex = incrementProxyIndex();
     if (LOG.isDebugEnabled()) {
       LOG.debug("Incrementing OM proxy index to {}, nodeId: {}",
@@ -300,6 +294,11 @@ public class OMFailoverProxyProvider implements
    * @return the new proxy index
    */
   private synchronized int incrementProxyIndex() {
+    // Before failing over to next proxy, add the proxy OM (which has
+    // returned an exception) to the list of attemptedOMs.
+    lastAttemptedOM = currentProxyOMNodeId;
+    attemptedOMs.add(currentProxyOMNodeId);
+
     currentProxyIndex = (currentProxyIndex + 1) % omProxies.size();
     currentProxyOMNodeId = omNodeIDList.get(currentProxyIndex);
     return currentProxyIndex;
@@ -325,7 +324,7 @@ public class OMFailoverProxyProvider implements
     return currentProxyIndex;
   }
 
-  public long getWaitTime() {
+  public synchronized long getWaitTime() {
     if (currentProxyOMNodeId.equals(lastAttemptedOM)) {
       // Clear attemptedOMs list as round robin has been broken. Add only the
       attemptedOMs.clear();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -159,7 +159,7 @@ import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
-import static org.apache.hadoop.io.retry.RetryPolicy.RetryAction.FAILOVER_AND_RETRY;
+import static org.apache.hadoop.io.retry.RetryPolicy.RetryAction.RetryDecision;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TOKEN_ERROR_OTHER;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.ACCESS_DENIED;
@@ -209,15 +209,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     int maxFailovers = conf.getInt(
         OzoneConfigKeys.OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY,
         OzoneConfigKeys.OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_DEFAULT);
-    int sleepBase = conf.getInt(
-        OzoneConfigKeys.OZONE_CLIENT_FAILOVER_SLEEP_BASE_MILLIS_KEY,
-        OzoneConfigKeys.OZONE_CLIENT_FAILOVER_SLEEP_BASE_MILLIS_DEFAULT);
-    int sleepMax = conf.getInt(
-        OzoneConfigKeys.OZONE_CLIENT_FAILOVER_SLEEP_MAX_MILLIS_KEY,
-        OzoneConfigKeys.OZONE_CLIENT_FAILOVER_SLEEP_MAX_MILLIS_DEFAULT);
 
-    this.rpcProxy = createRetryProxy(omFailoverProxyProvider, maxFailovers,
-        sleepBase, sleepMax);
+    this.rpcProxy = createRetryProxy(omFailoverProxyProvider, maxFailovers);
     this.clientID = clientId;
   }
 
@@ -227,8 +220,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
    * exception or if the current proxy is not the leader OM.
    */
   private OzoneManagerProtocolPB createRetryProxy(
-      OMFailoverProxyProvider failoverProxyProvider,
-      int maxFailovers, int delayMillis, int maxDelayBase) {
+      OMFailoverProxyProvider failoverProxyProvider, int maxFailovers) {
 
     // Client attempts contacting each OM ipc.client.connect.max.retries
     // (default = 10) times before failing over to the next OM, if
@@ -255,7 +247,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
             // OMFailoverProxyProvider#performFailover() is a dummy call and
             // does not perform any failover. Failover manually to the next OM.
             omFailoverProxyProvider.performFailoverToNextProxy();
-            return getRetryAction(FAILOVER_AND_RETRY, failovers);
+            return getRetryAction(RetryDecision.FAILOVER_AND_RETRY, failovers);
           }
 
           OMLeaderNotReadyException leaderNotReadyException =
@@ -265,7 +257,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
           // does not perform any failover.
           // So Just retry with same OM node.
           if (leaderNotReadyException != null) {
-            return getRetryAction(FAILOVER_AND_RETRY, failovers);
+            return getRetryAction(RetryDecision.FAILOVER_AND_RETRY, failovers);
           }
         }
 
@@ -274,13 +266,14 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         // OMFailoverProxyProvider#performFailover() is a dummy call and
         // does not perform any failover.
         omFailoverProxyProvider.performFailoverToNextProxy();
-        return getRetryAction(FAILOVER_AND_RETRY, failovers);
+        return getRetryAction(RetryDecision.FAILOVER_AND_RETRY, failovers);
       }
 
-      private RetryAction getRetryAction(RetryAction fallbackAction,
+      private RetryAction getRetryAction(RetryDecision fallbackAction,
           int failovers) {
         if (failovers <= maxFailovers) {
-          return fallbackAction;
+          return new RetryAction(fallbackAction,
+              omFailoverProxyProvider.getWaitTime());
         } else {
           FAILOVER_PROXY_PROVIDER_LOG.error("Failed to connect to OMs: {}. " +
               "Attempted {} failovers.",

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -90,7 +90,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDC
 import static org.apache.hadoop.ozone.OzoneConfigKeys
     .OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys
-    .OZONE_CLIENT_FAILOVER_SLEEP_BASE_MILLIS_DEFAULT;
+    .OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys
     .OZONE_OPEN_KEY_EXPIRE_THRESHOLD_SECONDS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_ALREADY_EXISTS;
@@ -684,11 +684,11 @@ public class TestOzoneManagerHA {
     // On stopping the current OM Proxy, the next connection attempt should
     // failover to a another OM proxy.
     cluster.stopOzoneManager(firstProxyNodeId);
-    Thread.sleep(OZONE_CLIENT_FAILOVER_SLEEP_BASE_MILLIS_DEFAULT * 4);
+    Thread.sleep(OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_DEFAULT * 4);
 
     // Next request to the proxy provider should result in a failover
     createVolumeTest(true);
-    Thread.sleep(OZONE_CLIENT_FAILOVER_SLEEP_BASE_MILLIS_DEFAULT);
+    Thread.sleep(OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_DEFAULT);
 
     // Get the new OM Proxy NodeId
     String newProxyNodeId = omFailoverProxyProvider.getCurrentProxyOMNodeId();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, client keeps retrying to connect to leader OM in a tight loop and fails after configured number of retires/ failovers.
If the Leader OM is not ready, the client can timeout quickly. So, we should instead try each OM once, and then wait before retrying again. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3355

## How was this patch tested?

Will add unit test in next commit.