### PR TITLE
HDDS-3290. REVERT: Disable all the freon integration tests.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -106,6 +106,21 @@ jobs:
           with:
             name: acceptance
             path: target/acceptance
+  it-freon:
+    name: it-freon
+    runs-on: ubuntu-18.04
+    needs:
+        - build
+    steps:
+        - uses: actions/checkout@master
+        - uses: ./.github/buildenv
+          with:
+             args: ./hadoop-ozone/dev-support/checks/integration.sh -Pfreon
+        - uses: actions/upload-artifact@master
+          if: always()
+          with:
+            name: it-freon
+            path: target/integration
   it-filesystem:
     name: it-filesystem
     runs-on: ubuntu-18.04


### PR DESCRIPTION
## What changes were proposed in this pull request?

This reverts commit a66aae8613c20171fa78cfa434282bcaf28691ed.

We disabled the it-freon tests for pull requests due to the flakiness, but it seems to be rock-solid on the master: couldn't see any it-freon failures in the last 25 builds.

Let's try to re-enable for the Prs.

(HDDS-3290 is still valid. I think they should be removed / rewritten, but until that we can run them...)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3356

## How was this patch tested?

We should have multiple (let's say, at least 5) green builds, before commit it.