### PR TITLE
HDDS-3357. Add check for import from shaded package

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
@@ -33,9 +33,9 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.DiskChecker.DiskErrorException;
 import org.apache.hadoop.util.Timer;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.apache.commons.io.FileUtils;
-import org.apache.curator.shaded.com.google.common.collect.ImmutableSet;
 import static org.hamcrest.CoreMatchers.is;
 import org.junit.After;
 import static org.junit.Assert.assertEquals;

--- a/hadoop-hdds/dev-support/checkstyle/checkstyle.xml
+++ b/hadoop-hdds/dev-support/checkstyle/checkstyle.xml
@@ -119,7 +119,10 @@
 
         <!-- Checks for imports                              -->
         <!-- See http://checkstyle.sf.net/config_import.html -->
-        <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
+        <module name="IllegalImport">
+          <property name="regexp" value="true"/>
+          <property name="illegalPkgs" value="^sun\..*, ^.*\.relocated\..*, ^.*\.shaded\..*"/>
+        </module>
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>
 

--- a/hadoop-ozone/dev-support/checks/checkstyle.sh
+++ b/hadoop-ozone/dev-support/checks/checkstyle.sh
@@ -21,11 +21,13 @@ REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/checkstyle"}
 mkdir -p "$REPORT_DIR"
 REPORT_FILE="$REPORT_DIR/summary.txt"
 
+MAVEN_OPTIONS='-B -fae -Dskip.yarn -Dskip.installyarn -Dcheckstyle.failOnViolation=false'
+
 declare -i rc
-mvn -B checkstyle:check -Dcheckstyle.failOnViolation=false > "${REPORT_DIR}/output.log"
+mvn ${MAVEN_OPTIONS} checkstyle:check > "${REPORT_DIR}/output.log"
 rc=$?
 if [[ ${rc} -ne 0 ]]; then
-  mvn -B test-compile checkstyle:check -Dcheckstyle.failOnViolation=false
+  mvn ${MAVEN_OPTIONS} test-compile checkstyle:check
   rc=$?
 else
   cat "${REPORT_DIR}/output.log"

--- a/hadoop-ozone/dev-support/checks/checkstyle.sh
+++ b/hadoop-ozone/dev-support/checks/checkstyle.sh
@@ -27,8 +27,9 @@ declare -i rc
 mvn ${MAVEN_OPTIONS} checkstyle:check > "${REPORT_DIR}/output.log"
 rc=$?
 if [[ ${rc} -ne 0 ]]; then
-  mvn ${MAVEN_OPTIONS} test-compile checkstyle:check
+  mvn ${MAVEN_OPTIONS} clean test-compile checkstyle:check
   rc=$?
+  mkdir -p "$REPORT_DIR" # removed by mvn clean
 else
   cat "${REPORT_DIR}/output.log"
 fi


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a checkstyle rule to reject import from shaded packages.  This helps avoid accidentally using shaded transitive dependencies instead of direct, unshaded dependencies, eg. `org.apache.curator.shaded.com.google.common.collect.ImmutableSet` instead of `com.google.common.collect.ImmutableSet`.

Also skip frontend install/compile for Recon (as checkstyle only applies to Java code) similarly to ac93176a0.

https://issues.apache.org/jira/browse/HDDS-3357

## How was this patch tested?

Temporarily added an import from a `sun.*` package, verified that it is flagged (along with the only current import from shaded package):

```
$ hadoop-ozone/dev-support/checks/checkstyle.sh
...
hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
 21: Illegal import - sun.security.ec.ECKeyFactory.
hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
 38: Illegal import - org.apache.curator.shaded.com.google.common.collect.ImmutableSet.
$ echo $?
1
```

Failed check due to import from shaded package:
https://github.com/adoroszlai/hadoop-ozone/runs/570614153

Successful check after removing offender:
https://github.com/adoroszlai/hadoop-ozone/runs/570825882