### PR TITLE
HDDS-3364. Increase test timeout for ozonesecure-security robot tests

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
@@ -19,7 +19,7 @@ Library             OperatingSystem
 Library             String
 Library             BuiltIn
 Resource            ../commonlib.robot
-Test Timeout        5 minutes
+Test Timeout        15 minutes
 
 *** Variables ***
 ${ENDPOINT_URL}    http://s3g:9878

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-s3.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-s3.robot
@@ -20,7 +20,7 @@ Library             String
 Library             BuiltIn
 Resource            ../commonlib.robot
 Resource            ../s3/commonawslib.robot
-Test Timeout        5 minutes
+Test Timeout        15 minutes
 
 *** Variables ***
 ${ENDPOINT_URL}     http://s3g:9878


### PR DESCRIPTION
## What changes were proposed in this pull request?

In few CI runs, ozone-security robot tests are timing out at 5 minutes. 
https://github.com/apache/hadoop-ozone/pull/784/checks?check_run_id=569548444

We should increase the timeout to avoid this.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3364

## How was this patch tested?

CI Acceptance test suit. This patch just increases the timeout.