### PR TITLE
HDDS-2568. Handle InterruptedException in OzoneContainer

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -178,7 +178,8 @@ public class OzoneContainer {
         volumeThreads.get(i).join();
       }
     } catch (InterruptedException ex) {
-      LOG.info("Volume Threads Interrupted exception", ex);
+      LOG.error("Volume Threads Interrupted exception", ex);
+      Thread.currentThread().interrupt();
     }
 
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Address sonar lint issue: https://sonarcloud.io/project/issues?id=hadoop-ozone&issues=AW5md-9sKcVY8lQ4ZsUh&open=AW5md-9sKcVY8lQ4ZsUh

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2568

## How was this patch tested?

Compiles successfully without any errors in local.
