### PR TITLE
Revert "HDDS-3291. Write operation when both OM followers are shutdown."

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1696,17 +1696,6 @@
   </property>
 
   <property>
-    <name>ipc.client.rpc-timeout.ms</name>
-    <value>900000</value>
-    <description>
-      RpcClient timeout on waiting response from server. The default value is
-      set to 15 minutes. If ipc.client.ping is set to true and this rpc-timeout
-      is greater than the value of ipc.ping.interval, the effective value of
-      the rpc-timeout is rounded up to multiple of ipc.ping.interval.
-    </description>
-  </property>
-
-  <property>
     <name>ozone.om.ratis.snapshot.dir</name>
     <value/>
     <tag>OZONE, OM, STORAGE, MANAGEMENT, RATIS</tag>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -44,7 +44,6 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
     errorIfMissingXmlProps = true;
     xmlPropsToSkipCompare.add("hadoop.tags.custom");
     xmlPropsToSkipCompare.add("ozone.om.nodes.EXAMPLEOMSERVICEID");
-    xmlPrefixToSkipCompare.add("ipc.client.rpc-timeout.ms");
     addPropertiesNotInXml();
   }
 


### PR DESCRIPTION
Reverts apache/hadoop-ozone#733

Reverting this as this causes other Hadoop application in the cluster to use the new IPC timeout values.