### PR TITLE
HDDS-3368. Ozone filesystem jar should not include webapps folder

### DIFF
--- a/hadoop-ozone/ozonefs-lib-current/pom.xml
+++ b/hadoop-ozone/ozonefs-lib-current/pom.xml
@@ -181,6 +181,14 @@
         </exclusion>
         <exclusion>
           <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdds-server-framework</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdds-container-service</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-hdfs</artifactId>
         </exclusion>
         <exclusion>


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Exclude the unwanted server dependencies from filesystem jar

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3368

## How was this patch tested?

Tested the filesystem jar in a cluster with Hive on Tez and verified that hive was successfully able to write to Ozone bucket using o3fs uri. 

