### PR TITLE
HDDS-3375. S3A failing complete multipart upload with Ozone S3.

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequest.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequest.java
@@ -30,7 +30,8 @@ import java.util.List;
  * Request for Complete Multipart Upload request.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlRootElement(name = "CompleteMultipartUpload")
+@XmlRootElement(name = "CompleteMultipartUpload", namespace =
+    "http://s3.amazonaws.com/doc/2006-03-01/")
 public class CompleteMultipartUploadRequest {
 
   @XmlElement(name = "Part")

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequestUnmarshaller.java
@@ -1,0 +1,67 @@
+package org.apache.hadoop.ozone.s3.endpoint;
+
+import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.xml.XMLConstants;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.UnmarshallerHandler;
+import javax.xml.parsers.SAXParserFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import static org.apache.hadoop.ozone.s3.util.S3Consts.S3_XML_NAMESPACE;
+
+/**
+ * Custom unmarshaller to read CompleteMultipartUploadRequest wo namespace.
+ */
+
+public class CompleteMultipartUploadRequestUnmarshaller
+    implements MessageBodyReader<CompleteMultipartUploadRequest> {
+
+  private final JAXBContext context;
+  private final XMLReader xmlReader;
+
+  public CompleteMultipartUploadRequestUnmarshaller() {
+    try {
+      context = JAXBContext.newInstance(CompleteMultipartUploadRequest.class);
+      SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
+      saxParserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      xmlReader = saxParserFactory.newSAXParser().getXMLReader();
+    } catch (Exception ex) {
+      throw new AssertionError("Can not instantiate " +
+          "CompleteMultipartUploadRequest parser", ex);
+    }
+  }
+  @Override
+  public boolean isReadable(Class<?> aClass, Type type,
+      Annotation[] annotations, MediaType mediaType) {
+    return type.equals(CompleteMultipartUploadRequest.class);
+  }
+
+  @Override
+  public CompleteMultipartUploadRequest readFrom(
+      Class<CompleteMultipartUploadRequest> aClass, Type type,
+      Annotation[] annotations, MediaType mediaType,
+      MultivaluedMap<String, String> multivaluedMap,
+      InputStream inputStream) throws IOException, WebApplicationException {
+    try {
+      UnmarshallerHandler unmarshallerHandler =
+          context.createUnmarshaller().getUnmarshallerHandler();
+      XmlNamespaceFilter filter =
+          new XmlNamespaceFilter(S3_XML_NAMESPACE);
+      filter.setContentHandler(unmarshallerHandler);
+      filter.setParent(xmlReader);
+      filter.parse(new InputSource(inputStream));
+      return (CompleteMultipartUploadRequest) unmarshallerHandler.getResult();
+    } catch (Exception e) {
+      throw new WebApplicationException("Can't parse request body to XML.", e);
+    }
+  }
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequestUnmarshaller.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.ozone.s3.endpoint;
 
 import org.xml.sax.InputSource;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/BadRequestExceptionMapper.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/BadRequestExceptionMapper.java
@@ -1,0 +1,27 @@
+package org.apache.hadoop.ozone.s3.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * Class that represents BadRequestException.
+ */
+public class BadRequestExceptionMapper implements
+    ExceptionMapper<BadRequestException> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(BadRequestExceptionMapper.class);
+  @Override
+  public Response toResponse(BadRequestException exception) {
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Returning exception. ex: {}", exception.toString());
+    }
+
+    return Response.status(Response.Status.BAD_REQUEST)
+        .entity(exception.getMessage()).build();
+  }
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/BadRequestExceptionMapper.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/BadRequestExceptionMapper.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.ozone.s3.exception;
 
 import org.slf4j.Logger;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Consts.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/S3Consts.java
@@ -52,4 +52,7 @@ public final class S3Consts {
   //Error code 416 is Range Not Satisfiable
   public static final int RANGE_NOT_SATISFIABLE = 416;
 
+  public static final String S3_XML_NAMESPACE = "http://s3.amazonaws" +
+      ".com/doc/2006-03-01/";
+
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestCompleteMultipartUploadRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestCompleteMultipartUploadRequestUnmarshaller.java
@@ -1,0 +1,77 @@
+package org.apache.hadoop.ozone.s3.endpoint;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Class tests Unmarshall logic of {@link CompleteMultipartUploadRequest}.
+ */
+public class TestCompleteMultipartUploadRequestUnmarshaller {
+
+  private static String part1 = UUID.randomUUID().toString();
+  private static String part2 = UUID.randomUUID().toString();
+  @Test
+  public void fromStreamWithNamespace() throws IOException {
+    //GIVEN
+    ByteArrayInputStream inputBody =
+        new ByteArrayInputStream(
+            ("<CompleteMultipartUpload xmlns=\"http://s3.amazonaws" +
+                ".com/doc/2006-03-01/\">" +
+                "<Part><ETag>" + part1 + "</ETag><PartNumber>1" +
+                "</PartNumber></Part><Part><ETag>" + part2 +
+                "</ETag><PartNumber>2</PartNumber></Part>" +
+                "</CompleteMultipartUpload>")
+                .getBytes(UTF_8));
+
+    //WHEN
+    CompleteMultipartUploadRequest completeMultipartUploadRequest =
+        unmarshall(inputBody);
+
+    //THEN
+    checkContent(completeMultipartUploadRequest);
+  }
+
+  @Test
+  public void fromStreamWithoutNamespace() throws IOException {
+    //GIVEN
+    ByteArrayInputStream inputBody =
+        new ByteArrayInputStream(
+            ("<CompleteMultipartUpload>" +
+                "<Part><ETag>" + part1 + "</ETag><PartNumber>1</PartNumber" +
+                "></Part><Part><ETag>" + part2 + "</ETag><PartNumber>2" +
+                "</PartNumber></Part></CompleteMultipartUpload>")
+                .getBytes(UTF_8));
+
+    //WHEN
+    CompleteMultipartUploadRequest completeMultipartUploadRequest =
+        unmarshall(inputBody);
+
+    //THEN
+    checkContent(completeMultipartUploadRequest);
+  }
+
+  private void checkContent(CompleteMultipartUploadRequest completeMultipartUploadRequest) {
+    Assert.assertEquals(2, completeMultipartUploadRequest.getPartList().size());
+
+    List<CompleteMultipartUploadRequest.Part> parts =
+        completeMultipartUploadRequest.getPartList();
+
+    Assert.assertEquals(part1,
+        parts.get(0).geteTag());
+    Assert.assertEquals(part2,
+        completeMultipartUploadRequest.getPartList().get(1).geteTag());
+  }
+
+  private CompleteMultipartUploadRequest unmarshall(
+      ByteArrayInputStream inputBody) throws IOException {
+    return new CompleteMultipartUploadRequestUnmarshaller()
+        .readFrom(null, null, null, null, null, inputBody);
+  }
+}

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestCompleteMultipartUploadRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestCompleteMultipartUploadRequestUnmarshaller.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.ozone.s3.endpoint;
 
 import org.junit.Assert;
@@ -57,16 +75,14 @@ public class TestCompleteMultipartUploadRequestUnmarshaller {
     checkContent(completeMultipartUploadRequest);
   }
 
-  private void checkContent(CompleteMultipartUploadRequest completeMultipartUploadRequest) {
-    Assert.assertEquals(2, completeMultipartUploadRequest.getPartList().size());
+  private void checkContent(CompleteMultipartUploadRequest request) {
+    Assert.assertEquals(2, request.getPartList().size());
 
     List<CompleteMultipartUploadRequest.Part> parts =
-        completeMultipartUploadRequest.getPartList();
+        request.getPartList();
 
-    Assert.assertEquals(part1,
-        parts.get(0).geteTag());
-    Assert.assertEquals(part2,
-        completeMultipartUploadRequest.getPartList().get(1).geteTag());
+    Assert.assertEquals(part1, parts.get(0).geteTag());
+    Assert.assertEquals(part2, parts.get(1).geteTag());
   }
 
   private CompleteMultipartUploadRequest unmarshall(


### PR DESCRIPTION
## What changes were proposed in this pull request?

S3A failing complete multipart upload request due to namespace missing in the request.

S3 documentation also shows the namespace in the request, in response namespace is set, only missing in the request.

Thank You @ChenSammi for reporting this issue.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3375

## How was this patch tested?

Existing tests should cover this.
