### PR TITLE
HDDS-3377. Remove guava 26.0-android jar.

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -167,11 +167,6 @@
                   <artifactId>protobuf-java</artifactId>
                   <version>3.5.1</version>
                 </artifactItem>
-                <artifactItem>
-                  <groupId>com.google.guava</groupId>
-                  <artifactId>guava</artifactId>
-                  <version>26.0-android</version>
-                </artifactItem>
               </artifactItems>
             </configuration>
           </execution>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Do not explicitly copy guava 26.0-jre to the lib/ directory, because we already depend on guava-28.2.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3377

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
