### PR TITLE
HDDS-2576. Handle InterruptedException in OzoneManagerDoubleBuffer

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -278,7 +278,7 @@ public class OzoneManagerDoubleBuffer {
         // Wait for daemon thread to exit
         daemon.join();
       } catch (InterruptedException e) {
-        LOG.error("Interrupted while waiting for daemon to exit.", e);
+        LOG.debug("Interrupted while waiting for daemon to exit.", e);
       }
 
       // stop metrics.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -275,7 +275,8 @@ public class OzoneManagerDoubleBuffer {
         // Wait for daemon thread to exit
         daemon.join();
       } catch (InterruptedException e) {
-        LOG.error("Interrupted while waiting for daemon to exit.");
+        LOG.error("Interrupted while waiting for daemon to exit.", e);
+        Thread.currentThread().interrupt();
       }
 
       // stop metrics.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -267,6 +267,9 @@ public class OzoneManagerDoubleBuffer {
   /**
    * Stop OM DoubleBuffer flush thread.
    */
+  // Ignore the sonar false positive on the InterruptedException issue
+  // as this a normal flow of a shutdown.
+  @SuppressWarnings("squid:S2142")
   public void stop() {
     if (isRunning.compareAndSet(true, false)) {
       LOG.info("Stopping OMDoubleBuffer flush thread");
@@ -276,7 +279,6 @@ public class OzoneManagerDoubleBuffer {
         daemon.join();
       } catch (InterruptedException e) {
         LOG.error("Interrupted while waiting for daemon to exit.", e);
-        Thread.currentThread().interrupt();
       }
 
       // stop metrics.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Handle InterruptedException in ratis related files:
* OzoneManagerDoubleBuffer: https://sonarcloud.io/project/issues?id=hadoop-ozone&issues=AW5md-VxKcVY8lQ4Zrtu&open=AW5md-VxKcVY8lQ4Zrtu
* ~~OzoneManagerRatisClient~~: removed in [HDDS-1991](https://issues.apache.org/jira/browse/HDDS-1991)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2576

## How was this patch tested?

Compiles successfully without any errors in local.
