### PR TITLE
HDDS-2575. Handle InterruptedException in LogSubcommand

### DIFF
--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/LogSubcommand.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/LogSubcommand.java
@@ -110,6 +110,7 @@ public class LogSubcommand extends BaseInsightSubCommand
       try {
         thread.join();
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         e.printStackTrace();
       }
     }

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/LogSubcommand.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/LogSubcommand.java
@@ -110,6 +110,7 @@ public class LogSubcommand extends BaseInsightSubCommand
       try {
         thread.join();
       } catch (InterruptedException e) {
+        // restore thread interrupted state
         Thread.currentThread().interrupt();
         e.printStackTrace();
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Address sonar lint issue int LogSubcommand: https://sonarcloud.io/project/issues?id=hadoop-ozone&issues=AW5md-mpKcVY8lQ4ZsAH&open=AW5md-mpKcVY8lQ4ZsAH

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2575

## How was this patch tested?

Compiles successfully without any errors in local.