### PR TITLE
HDDS-2569. Handle InterruptedException in LogStreamServlet

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/LogStreamServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/LogStreamServlet.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.server.http;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -37,7 +36,7 @@ public class LogStreamServlet extends HttpServlet {
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp)
-      throws ServletException, IOException {
+      throws IOException {
 
     WriterAppender appender =
         new WriterAppender(new PatternLayout(PATTERN), resp.getWriter());
@@ -48,7 +47,7 @@ public class LogStreamServlet extends HttpServlet {
       try {
         Thread.sleep(Integer.MAX_VALUE);
       } catch (InterruptedException e) {
-        //interrupted
+        Thread.currentThread().interrupt();
       }
     } finally {
       Logger.getRootLogger().removeAppender(appender);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Address sonar issue in LogStreamServlet https://sonarcloud.io/project/issues?id=hadoop-ozone&issues=AW5md-yJKcVY8lQ4ZsIf&open=AW5md-yJKcVY8lQ4ZsIf

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2569

## How was this patch tested?

Compiles successfully without any errors in local.
