### PR TITLE
HDDS-3291. Write operation when both OM followers are shutdown.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -34,8 +34,10 @@ import java.util.Optional;
 import java.util.OptionalInt;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.ozone.conf.OMClientConfig;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
@@ -494,4 +496,11 @@ public final class OmUtils {
     }
   }
 
+  /**
+   * Return OM Client Rpc Time out.
+   */
+  public static long getOMClientRpcTimeOut(Configuration configuration) {
+    return OzoneConfiguration.of(configuration)
+        .getObject(OMClientConfig.class).getRpcTimeOut();
+  }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/conf/OMClientConfig.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/conf/OMClientConfig.java
@@ -23,6 +23,8 @@ import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigType;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.apache.hadoop.hdds.conf.ConfigTag.CLIENT;
 import static org.apache.hadoop.hdds.conf.ConfigTag.OM;
 import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
@@ -39,6 +41,7 @@ public class OMClientConfig {
       defaultValue = "15m",
       type = ConfigType.TIME,
       tags = {OZONE, OM, CLIENT},
+      timeUnit = TimeUnit.MILLISECONDS,
       description = "RpcClient timeout on waiting for the response from " +
           "OzoneManager. The default value is set to 15 minutes. " +
           "If ipc.client.ping is set to true and this rpc-timeout " +

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/conf/OMClientConfig.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/conf/OMClientConfig.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.hadoop.ozone.conf;
+
+import org.apache.hadoop.hdds.conf.Config;
+import org.apache.hadoop.hdds.conf.ConfigGroup;
+import org.apache.hadoop.hdds.conf.ConfigType;
+
+import static org.apache.hadoop.hdds.conf.ConfigTag.CLIENT;
+import static org.apache.hadoop.hdds.conf.ConfigTag.OM;
+import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
+
+/**
+ * Config for OM Client.
+ */
+@ConfigGroup(prefix = "ozone.om.client")
+public class OMClientConfig {
+
+  public static final String OM_CLIENT_RPC_TIME_OUT = "rpc.timeout";
+
+  @Config(key = OM_CLIENT_RPC_TIME_OUT,
+      defaultValue = "15m",
+      type = ConfigType.TIME,
+      tags = {OZONE, OM, CLIENT},
+      description = "RpcClient timeout on waiting for the response from " +
+          "OzoneManager. The default value is set to 15 minutes. " +
+          "If ipc.client.ping is set to true and this rpc-timeout " +
+          "is greater than the value of ipc.ping.interval, the effective " +
+          "value of the rpc-timeout is rounded up to multiple of " +
+          "ipc.ping.interval."
+  )
+  private long rpcTimeOut = 15 * 60 * 1000;
+
+
+  public long getRpcTimeOut() {
+    return rpcTimeOut;
+  }
+
+  public void setRpcTimeOut(long timeOut) {
+    // As at the end this value should not exceed MAX_VALUE, as underlying
+    // Rpc layer SocketTimeout parameter is int.
+    if (rpcTimeOut > Integer.MAX_VALUE) {
+      this.rpcTimeOut = Integer.MAX_VALUE;
+    }
+    this.rpcTimeOut = timeOut;
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/conf/package-info.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/conf/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Package contains classes related to ozone configuration.
+ */

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -153,7 +153,7 @@ public class OMFailoverProxyProvider implements
         ProtobufRpcEngine.class);
     return RPC.getProxy(OzoneManagerProtocolPB.class, omVersion, omAddress, ugi,
         conf, NetUtils.getDefaultSocketFactory(conf),
-        Client.getRpcTimeout(conf));
+        (int) OmUtils.getOMClientRpcTimeOut(conf));
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.retry.FailoverProxyProvider;
 import org.apache.hadoop.io.retry.RetryInvocationHandler;
-import org.apache.hadoop.ipc.Client;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.net.NetUtils;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -434,9 +434,5 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
 
       conf.set(omNodesKey, omNodesKeyValue.substring(1));
     }
-
-    public void setHandlers(int count) {
-      this.numOfOmHandlers = count;
-    }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -434,5 +434,9 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
 
       conf.set(omNodesKey, omNodesKeyValue.substring(1));
     }
+
+    public void setHandlers(int count) {
+      this.numOfOmHandlers = count;
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a new parameter for om rpc client time out. In this way, it will only affect OM Rpc Client.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3291

## How was this patch tested?

Tested this on a docker cluster with the below settings. We should increase the timeout duration to a larger value so that OM will think it is the leader for a longer period even though it is not, and the request will be accepted by leader, and it will retry forever.
OZONE-SITE.XML_ozone.om.client.rpc.timeout=30s
OZONE-SITE.XML_ozone.om.leader.election.minimum.timeout.duration=1m

Now with this patch, request fails after 15 retries. And for OM Server which it thinks it is leader, we get SocketTimeOutException, and move to next OM.

Logs:
```
2020-04-13 21:59:44,667 [main] INFO  RetryInvocationHandler:411 - com.google.protobuf.ServiceException: java.net.UnknownHostException: Invalid host name: local host is: (unknown); destination host is: "om3":9862; java.net.UnknownHostException; For more details see:  http://wiki.apache.org/hadoop/UnknownHost, while invoking $Proxy20.submitRequest over nodeId=om3,nodeAddress=om3:9862 after 13 failover attempts. Trying to failover immediately.
2020-04-13 21:59:44,667 [main] INFO  RetryInvocationHandler:411 - com.google.protobuf.ServiceException: java.net.UnknownHostException: Invalid host name: local host is: (unknown); destination host is: "om1":9862; java.net.UnknownHostException; For more details see:  http://wiki.apache.org/hadoop/UnknownHost, while invoking $Proxy20.submitRequest over nodeId=om1,nodeAddress=om1:9862 after 14 failover attempts. Trying to failover immediately.
2020-04-13 22:00:14,677 [main] INFO  RetryInvocationHandler:411 - com.google.protobuf.ServiceException: java.net.SocketTimeoutException: Call From 531e9bfac0d9/172.24.0.4 to om2:9862 failed on socket timeout exception: java.net.SocketTimeoutException: 30000 millis timeout while waiting for channel to be ready for read. ch : java.nio.channels.SocketChannel[connected local=/172.24.0.4:47798 remote=om2/172.24.0.7:9862]; For more details see:  http://wiki.apache.org/hadoop/SocketTimeout, while invoking $Proxy20.submitRequest over nodeId=om2,nodeAddress=om2:9862 after 15 failover attempts. Trying to failover immediately.
2020-04-13 22:00:14,678 [main] ERROR OMFailoverProxyProvider:286 - Failed to connect to OMs: [nodeId=om1,nodeAddress=om1:9862, nodeId=om3,nodeAddress=om3:9862, nodeId=om2,nodeAddress=om2:9862]. Attempted 15 failover
```
