### PR TITLE
HDDS-3381. OzoneManager starts 2 OzoneManagerDoubleBuffer for HA cluster.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -106,6 +106,12 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   private final OzoneManager impl;
   private OzoneManagerDoubleBuffer ozoneManagerDoubleBuffer;
 
+
+  public OzoneManagerRequestHandler(OzoneManager om) {
+    this.impl = om;
+    this.ozoneManagerDoubleBuffer = null;
+  }
+
   public OzoneManagerRequestHandler(OzoneManager om,
       OzoneManagerDoubleBuffer ozoneManagerDoubleBuffer) {
     this.impl = om;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removed initialization of doubleBuffer when ratis is enabled in OzoneManagerProtocolServerSideTranslatorPB.java. As doubleBuffer is only needed in StateMachine when ratis is enabled.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3381

## How was this patch tested?

Existing tests should cover this.
