### PR TITLE
HDDS-2682: OM File create request does not check for existing directory with the same name

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -24,6 +24,8 @@ import java.util.TreeSet;
 
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -42,6 +44,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.junit.After;
@@ -65,6 +68,110 @@ public class TestOzoneFileSystem {
   private int rootItemCount;
 
   @Test(timeout = 300_000)
+  public void testCreateFileShouldCheckTheExistenceOfDirWithSameName() throws Exception {
+    /*
+     * Op 1. create file -> /d1/d2/d3/d4/key2
+     * Op 2. create dir -> /d1/d2/d3/d4/key2
+     *
+     * Reverse of the above steps
+     * Op 2. create dir -> /d1/d2/d3/d4/key3
+     * Op 1. create file -> /d1/d2/d3/d4/key3
+     *
+     * Op 3. create file -> /d1/d2/d3 (d3 as a file inside /d1/d2)
+     */
+    OzoneConfiguration conf = new OzoneConfiguration();
+    cluster = MiniOzoneCluster.newBuilder(conf)
+            .setNumDatanodes(3)
+            .build();
+    cluster.waitForClusterToBeReady();
+    // create a volume and a bucket to be used by OzoneFileSystem
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
+    volumeName = bucket.getVolumeName();
+    bucketName = bucket.getName();
+
+    String rootPath = String.format("%s://%s.%s/",
+            OzoneConsts.OZONE_URI_SCHEME, bucket.getName(), bucket.getVolumeName());
+
+    // Set the fs.defaultFS and start the filesystem
+    conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+    fs = FileSystem.get(conf);
+
+    Path parent = new Path("/d1/d2/d3/d4/");
+    Path file1 = new Path(parent, "key1");
+    try (FSDataOutputStream outputStream = fs.create(file1, false)) {
+      assertNotNull("Should be able to create file1", outputStream);
+    }
+
+    Path dir1 = new Path("/d1/d2/d3/d4/key2");
+    fs.mkdirs(dir1);
+    try (FSDataOutputStream outputStream1 = fs.create(dir1, false)) {
+      fail("Should throw FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException fae){
+      // ignore as its expected
+    }
+
+    Path file2 = new Path("/d1/d2/d3/d4/key3");
+    try (FSDataOutputStream outputStream2 = fs.create(file2, false)) {
+    }
+    try {
+      fs.mkdirs(file2);
+      fail("Should throw FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException fae) {
+      // ignore as its expected
+    }
+
+    // Op 3. create file -> /d1/d2/d3 (d3 as a file inside /d1/d2)
+    Path file3 = new Path("/d1/d2/d3");
+    try (FSDataOutputStream outputStream2 = fs.create(file3, false)) {
+      fail("Should throw FileAlreadyExistsException");
+    } catch (FileAlreadyExistsException fae) {
+      // ignore as its expected
+    }
+  }
+
+  /**
+   * Make the given file and all non-existent parents into
+   * directories. Has roughly the semantics of Unix @{code mkdir -p}.
+   * {@link FileSystem#mkdirs(Path)}
+   */
+  @Test(timeout = 300_000)
+  public void testMakeDirsWithAnExistingDirectoryPath() throws Exception {
+    /*
+    * Op 1. create file -> /d1/d2/d3/d4/k1 (d3 implicitly is a sub-directory inside /d1/d2)
+    * Op 2. create dir -> /d1/d2
+    */
+    OzoneConfiguration conf = new OzoneConfiguration();
+    cluster = MiniOzoneCluster.newBuilder(conf)
+            .setNumDatanodes(3)
+            .build();
+    cluster.waitForClusterToBeReady();
+    // create a volume and a bucket to be used by OzoneFileSystem
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
+    volumeName = bucket.getVolumeName();
+    bucketName = bucket.getName();
+
+    String rootPath = String.format("%s://%s.%s/",
+            OzoneConsts.OZONE_URI_SCHEME, bucket.getName(), bucket.getVolumeName());
+
+    // Set the fs.defaultFS and start the filesystem
+    conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+    fs = FileSystem.get(conf);
+
+    Path parent = new Path("/d1/d2/d3/d4/");
+    Path file1 = new Path(parent, "key1");
+    try (FSDataOutputStream outputStream = fs.create(file1, false)) {
+      assertNotNull("Should create file1", outputStream);
+    }
+
+    Path subdir = new Path("/d1/d2/");
+    boolean status = fs.mkdirs(subdir);
+    /**
+     * Has roughly the semantics of Unix @{code mkdir -p}.
+     */
+    assertTrue("Shouldn't send error if dir exists", status);
+  }
+
+    @Test(timeout = 300_000)
   public void testFileSystem() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     cluster = MiniOzoneCluster.newBuilder(conf)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Verified the behavior in the latest code. This issue has been already taken care as part of some of the Ozone FS namespace optimisation changes.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-2682

## How was this patch tested?
Added unit test case to validate this.
