### PR TITLE
HDDS-3387. Fix ContainerOperationClient#createContainer

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -239,8 +239,6 @@ public class ContainerOperationClient implements ScmClient {
           storageContainerLocationClient.allocateContainer(type, factor,
               owner);
       Pipeline pipeline = containerWithPipeline.getPipeline();
-      client = xceiverClientManager.acquireClient(pipeline);
-
       // connect to pipeline leader and allocate container on leader datanode.
       client = xceiverClientManager.acquireClient(pipeline);
       createContainer(client,


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the createContainer method of  ContainerOperationClient, the xceiverClient instance was acquired twice but released once. The change is made so that it acquires it once.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3387

## How was this patch tested?
Just a clean up patch .No tests required.
