### PR TITLE
HDDS-3401. Ozone audit entries could be consistent among volume creation with quota and update quota

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -239,7 +239,6 @@ public final class OzoneConsts {
   public static final String KEY = "key";
   public static final String SRC_KEY = "srcKey";
   public static final String DST_KEY = "dstKey";
-  public static final String QUOTA = "quota";
   public static final String QUOTA_IN_BYTES = "quotaInBytes";
   public static final String OBJECT_ID = "objectID";
   public static final String UPDATE_ID = "updateID";

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1699,7 +1699,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     }
 
     Map<String, String> auditMap = buildAuditMap(volume);
-    auditMap.put(OzoneConsts.QUOTA, String.valueOf(quota));
+    auditMap.put(OzoneConsts.QUOTA_IN_BYTES, String.valueOf(quota));
     try {
       metrics.incNumVolumeUpdates();
       volumeManager.setQuota(volume, quota);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetQuotaRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetQuotaRequest.java
@@ -93,7 +93,7 @@ public class OMVolumeSetQuotaRequest extends OMVolumeRequest {
     AuditLogger auditLogger = ozoneManager.getAuditLogger();
     OzoneManagerProtocolProtos.UserInfo userInfo = getOmRequest().getUserInfo();
     Map<String, String> auditMap = buildVolumeAuditMap(volume);
-    auditMap.put(OzoneConsts.QUOTA,
+    auditMap.put(OzoneConsts.QUOTA_IN_BYTES,
         String.valueOf(setVolumePropertyRequest.getQuotaInBytes()));
 
     OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();


### PR DESCRIPTION
Use QUOTA_IN_BYTES for setVolumeRequest.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## What is the link to the Apache JIRA



## How was this patch tested?

Existing tests. This is just a naming change in the Audit log.
