### PR TITLE
HDDS-3314. FIx ContainerOperationClient#readContainer to use Grpc Client to read from datanode

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -382,7 +382,7 @@ public class ContainerOperationClient implements ScmClient {
       Pipeline pipeline) throws IOException {
     XceiverClientSpi client = null;
     try {
-      client = xceiverClientManager.acquireClient(pipeline);
+      client = xceiverClientManager.acquireClientForReadData(pipeline);
       ReadContainerResponseProto response =
           ContainerProtocolCalls.readContainer(client, containerID, null);
       if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Ozone debug chunkinfo <key uri> command fails intermittently on killing  a datanode in a multinode setup as it uses the ratis pipeline.This was because the query happens only on the leader node.The change is that the scm now queries different datanodes in case of failure through the grpcClient.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3314

## How was this patch tested?
Manual test