### PR TITLE
HDDS-3403. Generate ozone specific version from type in FSProto.proto

### DIFF
--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -116,6 +116,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               <source>
                 <directory>${basedir}/src/main/proto</directory>
                 <includes>
+                  <include>FSProtos.proto</include>
                   <include>OzoneManagerProtocol.proto</include>
                 </includes>
               </source>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFileStatus.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFileStatus.java
@@ -24,8 +24,8 @@ import java.net.URI;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.ozone.fs.FSProtos;
-import org.apache.hadoop.ozone.fs.FSProtos.FileStatusProto;
+import org.apache.hadoop.ozone.protocol.proto.FSProtos;
+import org.apache.hadoop.ozone.protocol.proto.FSProtos.FileStatusProto;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneFileStatusProto;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFileStatus.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFileStatus.java
@@ -18,14 +18,15 @@
 
 package org.apache.hadoop.ozone.om.helpers;
 
+import java.io.IOException;
+import java.net.URI;
+
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.fs.protocolPB.PBHelper;
+import org.apache.hadoop.ozone.fs.FSProtos;
+import org.apache.hadoop.ozone.fs.FSProtos.FileStatusProto;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneFileStatusProto;
-
-import java.io.IOException;
-import java.net.URI;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 
@@ -56,7 +57,7 @@ public class OzoneFileStatus extends FileStatus {
 
   public OzoneFileStatusProto getProtobuf() throws IOException {
     OzoneFileStatusProto.Builder builder = OzoneFileStatusProto.newBuilder()
-        .setStatus(PBHelper.convert(this));
+        .setStatus(convert(this));
     if (keyInfo != null) {
       builder.setKeyInfo(keyInfo.getProtobuf());
     }
@@ -65,7 +66,7 @@ public class OzoneFileStatus extends FileStatus {
 
   public static OzoneFileStatus getFromProtobuf(OzoneFileStatusProto response)
       throws IOException {
-    return new OzoneFileStatus(PBHelper.convert(response.getStatus()),
+    return new OzoneFileStatus(convert(response.getStatus()),
         OmKeyInfo.getFromProtobuf(response.getKeyInfo()));
   }
 
@@ -118,5 +119,106 @@ public class OzoneFileStatus extends FileStatus {
   @Override
   public int hashCode() {
     return super.hashCode();
+  }
+
+  private static FileStatus convert(FileStatusProto proto) throws IOException {
+    final Path path;
+    final long length;
+    final boolean isdir;
+    final short blockReplication;
+    final long blocksize;
+    final long mtime;
+    final long atime;
+    final String owner;
+    final String group;
+    final FsPermission permission;
+    final Path symlink;
+    switch (proto.getFileType()) {
+    case FT_DIR:
+      isdir = true;
+      symlink = null;
+      blocksize = 0;
+      length = 0;
+      blockReplication = 0;
+      break;
+    case FT_SYMLINK:
+      isdir = false;
+      symlink = new Path(proto.getSymlink());
+      blocksize = 0;
+      length = 0;
+      blockReplication = 0;
+      break;
+    case FT_FILE:
+      isdir = false;
+      symlink = null;
+      blocksize = proto.getBlockSize();
+      length = proto.getLength();
+      int brep = proto.getBlockReplication();
+      if ((brep & 0xffff0000) != 0) {
+        throw new IOException(String.format("Block replication 0x%08x " +
+            "doesn't fit in 16 bits.", brep));
+      }
+      blockReplication = (short) brep;
+      break;
+    default:
+      throw new IllegalStateException("Unknown type: " + proto.getFileType());
+    }
+    path = new Path(proto.getPath());
+    mtime = proto.getModificationTime();
+    atime = proto.getAccessTime();
+    permission = convertPermission(proto.getPermission());
+    owner = proto.getOwner();
+    group = proto.getGroup();
+    int flags = proto.getFlags();
+    FileStatus fileStatus = new FileStatus(length, isdir, blockReplication,
+        blocksize, mtime, atime, permission, owner, group, symlink, path,
+        FileStatus.attributes(
+            (flags & FileStatusProto.Flags.HAS_ACL_VALUE) != 0,
+            (flags & FileStatusProto.Flags.HAS_CRYPT_VALUE) != 0,
+            (flags & FileStatusProto.Flags.HAS_EC_VALUE) != 0,
+            (flags & FileStatusProto.Flags.SNAPSHOT_ENABLED_VALUE) != 0));
+    return fileStatus;
+  }
+
+  private static FileStatusProto convert(FileStatus stat) throws IOException {
+    FileStatusProto.Builder bld = FileStatusProto.newBuilder();
+    bld.setPath(stat.getPath().toString());
+    if (stat.isDirectory()) {
+      bld.setFileType(FileStatusProto.FileType.FT_DIR);
+    } else if (stat.isSymlink()) {
+      bld.setFileType(FileStatusProto.FileType.FT_SYMLINK)
+          .setSymlink(stat.getSymlink().toString());
+    } else {
+      bld.setFileType(FileStatusProto.FileType.FT_FILE)
+          .setLength(stat.getLen())
+          .setBlockReplication(stat.getReplication())
+          .setBlockSize(stat.getBlockSize());
+    }
+    bld.setAccessTime(stat.getAccessTime())
+        .setModificationTime(stat.getModificationTime())
+        .setOwner(stat.getOwner())
+        .setGroup(stat.getGroup())
+        .setPermission(convertPermission(stat.getPermission()));
+    int flags = 0;
+    flags |= stat.hasAcl() ? FileStatusProto.Flags.HAS_ACL_VALUE : 0;
+    flags |= stat.isEncrypted() ? FileStatusProto.Flags.HAS_CRYPT_VALUE : 0;
+    flags |= stat.isErasureCoded() ? FileStatusProto.Flags.HAS_EC_VALUE : 0;
+    flags |= stat.isSnapshotEnabled() ? FileStatusProto.Flags
+        .SNAPSHOT_ENABLED_VALUE : 0;
+    bld.setFlags(flags);
+    return bld.build();
+  }
+
+  private static FSProtos.FsPermissionProto convertPermission(FsPermission p)
+      throws IOException {
+    FSProtos.FsPermissionProto.Builder bld =
+        FSProtos.FsPermissionProto.newBuilder();
+    bld.setPerm(p.toShort());
+    return bld.build();
+  }
+
+  private static FsPermission
+      convertPermission(FSProtos.FsPermissionProto proto) throws IOException {
+    return new FsPermission((short) proto.getPerm());
   }
 }

--- a/hadoop-ozone/common/src/main/proto/FSProtos.proto
+++ b/hadoop-ozone/common/src/main/proto/FSProtos.proto
@@ -22,7 +22,7 @@
  * for what changes are allowed for a *stable* .proto interface.
  */
 
-option java_package = "org.apache.hadoop.fs";
+option java_package = "org.apache.hadoop.ozone.fs";
 option java_outer_classname = "FSProtos";
 option java_generic_services = true;
 option java_generate_equals_and_hash = true;

--- a/hadoop-ozone/common/src/main/proto/FSProtos.proto
+++ b/hadoop-ozone/common/src/main/proto/FSProtos.proto
@@ -22,7 +22,7 @@
  * for what changes are allowed for a *stable* .proto interface.
  */
 
-option java_package = "org.apache.hadoop.ozone.fs";
+option java_package = "org.apache.hadoop.ozone.protocol.proto";
 option java_outer_classname = "FSProtos";
 option java_generic_services = true;
 option java_generate_equals_and_hash = true;


### PR DESCRIPTION
## What changes were proposed in this pull request?

FSProtos.proto is copied from the Hadoop and used during the proto file generation *BUT* the types defined in FSProtos.proto are generated by Hadoop subproject.

This makes it hard to use Ozone with older Hadoop versions as the types of FSProtos are available only from Hadoop 3.x.

An easy fix is to generate our own version based on the existing FSProtos.proto

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3403

## How was this patch tested?

CI tests.