### PR TITLE
HDDS-3400. Extract test utilities to separate module

### DIFF
--- a/hadoop-hdds/client/pom.xml
+++ b/hadoop-hdds/client/pom.xml
@@ -32,6 +32,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-common</artifactId>
     </dependency>
 

--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -72,6 +72,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-config</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>javax.annotation</groupId>

--- a/hadoop-hdds/config/pom.xml
+++ b/hadoop-hdds/config/pom.xml
@@ -35,6 +35,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <dependencies>
 
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -34,6 +34,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>hadoop-hdds-common</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
     </dependency>

--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -32,6 +32,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-common</artifactId>
     </dependency>
     <dependency>

--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -41,6 +41,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <module>tools</module>
     <module>docs</module>
     <module>config</module>
+    <module>test-utils</module>
   </modules>
 
   <properties>
@@ -132,6 +133,13 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-hdds-config</artifactId>
         <version>${hdds.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-hdds-test-utils</artifactId>
+        <version>${hdds.version}</version>
+        <scope>test</scope>
       </dependency>
 
       <dependency>

--- a/hadoop-hdds/server-scm/pom.xml
+++ b/hadoop-hdds/server-scm/pom.xml
@@ -31,6 +31,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-common</artifactId>
     </dependency>
 

--- a/hadoop-hdds/test-utils/pom.xml
+++ b/hadoop-hdds/test-utils/pom.xml
@@ -19,29 +19,54 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.hadoop</groupId>
-    <artifactId>hadoop-ozone</artifactId>
+    <artifactId>hadoop-hdds</artifactId>
     <version>0.6.0-SNAPSHOT</version>
   </parent>
-  <artifactId>hadoop-ozone-client</artifactId>
+  <artifactId>hadoop-hdds-test-utils</artifactId>
   <version>0.6.0-SNAPSHOT</version>
-  <description>Apache Hadoop Ozone Client</description>
-  <name>Apache Hadoop Ozone Client</name>
+  <description>Apache Hadoop Distributed Data Store Test Utils</description>
+  <name>Apache Hadoop HDDS Test Utils</name>
   <packaging>jar</packaging>
+
+  <properties>
+
+  </properties>
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-hdds-test-utils</artifactId>
-      <scope>test</scope>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-ozone-common</artifactId>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
   </dependencies>
+
 </project>

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/hadoop/test/LambdaTestUtils.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/hadoop/test/LambdaTestUtils.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.hadoop.util.Time;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import com.google.common.base.Preconditions;
 import org.junit.Assert;
@@ -117,7 +117,7 @@ public final class LambdaTestUtils {
         "timeoutMillis must be >= 0");
     Preconditions.checkNotNull(timeoutHandler);
 
-    long endTime = Time.now() + timeoutMillis;
+    final long endTime = System.currentTimeMillis() + timeoutMillis;
     Throwable ex = null;
     boolean running = true;
     int iterations = 0;
@@ -138,7 +138,7 @@ public final class LambdaTestUtils {
         LOG.debug("eventually() iteration {}", iterations, e);
         ex = e;
       }
-      running = Time.now() < endTime;
+      running = System.currentTimeMillis() < endTime;
       if (running) {
         int sleeptime = retry.call();
         if (sleeptime >= 0) {
@@ -228,15 +228,15 @@ public final class LambdaTestUtils {
    * @throws InterruptedException if interrupted during the sleep operation.
    * @throws OutOfMemoryError you've run out of memory.
    */
+  @SuppressFBWarnings("DLS_DEAD_LOCAL_STORE")
   public static <T> T eventually(int timeoutMillis,
       Callable<T> eval,
       Callable<Integer> retry) throws Exception {
     Preconditions.checkArgument(timeoutMillis >= 0,
         "timeoutMillis must be >= 0");
-    long endTime = Time.now() + timeoutMillis;
+    final long endTime = System.currentTimeMillis() + timeoutMillis;
     Throwable ex;
     boolean running;
-    int sleeptime;
     int iterations = 0;
     do {
       iterations++;
@@ -250,11 +250,11 @@ public final class LambdaTestUtils {
       } catch (Throwable e) {
         LOG.debug("evaluate() iteration {}", iterations, e);
         ex = e;
-      }
-      running = Time.now() < endTime;
-      sleeptime = retry.call();
-      if (running && sleeptime >= 0) {
-        Thread.sleep(sleeptime);
+        running = System.currentTimeMillis() < endTime;
+        int sleeptime = retry.call();
+        if (running && sleeptime >= 0) {
+          Thread.sleep(sleeptime);
+        }
       }
     } while (running);
     // timeout. Throw the last exception raised
@@ -597,7 +597,6 @@ public final class LambdaTestUtils {
    * Assert that an optional value matches an expected one;
    * checks include null and empty on the actual value.
    * @param message message text
-   * @param expected expected value
    * @param actual actual optional value
    * @param <T> type
    */

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/hadoop/test/TimedOutTestsListener.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/hadoop/test/TimedOutTestsListener.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.test;
 
+import java.io.BufferedWriter;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.management.LockInfo;
@@ -27,12 +29,13 @@ import java.lang.management.ThreadMXBean;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Map;
-
-import org.apache.hadoop.util.StringUtils;
 
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * JUnit run listener which prints full thread dump into System.err
@@ -40,14 +43,15 @@ import org.junit.runner.notification.RunListener;
  */
 public class TimedOutTestsListener extends RunListener {
 
-  static final String TEST_TIMED_OUT_PREFIX = "test timed out after";
+  private static final String TEST_TIMED_OUT_PREFIX = "test timed out after";
 
   private static final String INDENT = "    ";
 
   private final PrintWriter output;
   
   public TimedOutTestsListener() {
-    this.output = new PrintWriter(System.err);
+    this(new PrintWriter(new BufferedWriter(new OutputStreamWriter(
+        System.err, UTF_8))));
   }
   
   public TimedOutTestsListener(PrintWriter output) {
@@ -56,7 +60,7 @@ public class TimedOutTestsListener extends RunListener {
 
   @Override
   public void testFailure(Failure failure) throws Exception {
-    if (failure != null && failure.getMessage() != null 
+    if (failure != null && failure.getMessage() != null
         && failure.getMessage().startsWith(TEST_TIMED_OUT_PREFIX)) {
       output.println("====> TEST TIMED OUT. PRINTING THREAD DUMP. <====");
       output.println();
@@ -90,14 +94,14 @@ public class TimedOutTestsListener extends RunListener {
     for (Map.Entry<Thread, StackTraceElement[]> e : stackTraces.entrySet()) {
       Thread thread = e.getKey();
       dump.append(String.format(
-          "\"%s\" %s prio=%d tid=%d %s\njava.lang.Thread.State: %s",
+          "\"%s\" %s prio=%d tid=%d %s%njava.lang.Thread.State: %s",
           thread.getName(),
           (thread.isDaemon() ? "daemon" : ""),
           thread.getPriority(),
           thread.getId(),
           Thread.State.WAITING.equals(thread.getState()) ? 
               "in Object.wait()" :
-              StringUtils.toLowerCase(thread.getState().name()),
+              thread.getState().name().toLowerCase(Locale.ENGLISH),
           Thread.State.WAITING.equals(thread.getState()) ?
               "WAITING (on object monitor)" : thread.getState()));
       for (StackTraceElement stackTraceElement : e.getValue()) {

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/hadoop/test/package-info.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/hadoop/test/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utilities for tests.
+ */
+package org.apache.hadoop.test;

--- a/hadoop-hdds/tools/pom.xml
+++ b/hadoop-hdds/tools/pom.xml
@@ -32,6 +32,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-common</artifactId>
     </dependency>
     <dependency>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -36,6 +36,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-common</artifactId>
     </dependency>
     <dependency>

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/pom.xml
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/pom.xml
@@ -35,6 +35,11 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-ozone-filesystem</artifactId>
     </dependency>
     <dependency>

--- a/hadoop-ozone/insight/pom.xml
+++ b/hadoop-ozone/insight/pom.xml
@@ -37,6 +37,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-ozone-common</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- Genesis requires server side components -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/hadoop-ozone/integration-test/pom.xml
+++ b/hadoop-ozone/integration-test/pom.xml
@@ -36,6 +36,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-server-scm</artifactId>
     </dependency>
     <dependency>

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -47,6 +47,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-server-framework</artifactId>
     </dependency>
     <dependency>

--- a/hadoop-ozone/ozonefs/pom.xml
+++ b/hadoop-ozone/ozonefs/pom.xml
@@ -82,6 +82,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-common</artifactId>
     </dependency>
     <dependency>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -112,6 +112,12 @@
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-hdds-test-utils</artifactId>
+        <version>${hdds.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-hdds-hadoop-dependency-client</artifactId>
         <version>${hdds.version}</version>
       </dependency>

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -197,6 +197,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- visible only for ContainerOperationClient -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/hadoop-ozone/s3gateway/pom.xml
+++ b/hadoop-ozone/s3gateway/pom.xml
@@ -38,6 +38,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-server-framework</artifactId>
     </dependency>
     <dependency>

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -37,6 +37,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-ozone-common</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- Genesis requires server side components -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/hadoop-ozone/upgrade/pom.xml
+++ b/hadoop-ozone/upgrade/pom.xml
@@ -31,6 +31,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-common</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1221,6 +1221,12 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <scope>provided</scope>
       </dependency>
       <dependency>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-annotations</artifactId>
+        <version>${spotbugs.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>${findbugs.version}</version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Create `hadoop-hdds/test-utils` module for test utilities (eg. `GenericTestUtils` and `LambdaTestUtils`).  This should not depend on any other HDDS/Ozone modules: the goal is to be able to use test listeners defined in this module (currently only `TimedOutTestsListener`) in all other modules.

https://issues.apache.org/jira/browse/HDDS-3400

## How was this patch tested?

CI:
https://github.com/adoroszlai/hadoop-ozone/runs/592403416

Applied the addition of listener from #813, [verified](https://github.com/adoroszlai/hadoop-ozone/runs/592999817) that no [`ClassNotFoundException`](https://github.com/apache/hadoop-ozone/pull/813/checks?check_run_id=589621137) happens.