### PR TITLE
HDDS-3455. Change MiniLoadGenerator to a pluggable model.

### DIFF
--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneLoadGenerator.java
@@ -109,23 +109,23 @@ public class MiniOzoneLoadGenerator {
       return this;
     }
 
-    public Builder setConf(OzoneConfiguration conf) {
-      this.conf = conf;
+    public Builder setConf(OzoneConfiguration configuration) {
+      this.conf = configuration;
       return this;
     }
 
-    public Builder setNumBuffers(int numBuffers) {
-      this.numBuffers = numBuffers;
+    public Builder setNumBuffers(int buffers) {
+      this.numBuffers = buffers;
       return this;
     }
 
-    public Builder setNumThreads(int numThreads) {
-      this.numThreads = numThreads;
+    public Builder setNumThreads(int threads) {
+      this.numThreads = threads;
       return this;
     }
 
-    public Builder setVolume(OzoneVolume volume) {
-      this.volume = volume;
+    public Builder setVolume(OzoneVolume vol) {
+      this.volume = vol;
       return this;
     }
 

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneLoadGenerator.java
@@ -20,10 +20,6 @@ package org.apache.hadoop.ozone;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.client.OzoneVolume;
-import org.apache.hadoop.ozone.loadgenerators.FilesystemLoadGenerator;
-import org.apache.hadoop.ozone.loadgenerators.AgedLoadGenerator;
-import org.apache.hadoop.ozone.loadgenerators.RandomLoadGenerator;
-import org.apache.hadoop.ozone.loadgenerators.ReadOnlyLoadGenerator;
 import org.apache.hadoop.ozone.loadgenerators.DataBuffer;
 import org.apache.hadoop.ozone.loadgenerators.LoadExecutors;
 import org.apache.hadoop.ozone.loadgenerators.LoadGenerator;
@@ -33,7 +29,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -44,66 +39,99 @@ public class MiniOzoneLoadGenerator {
   private static final Logger LOG =
       LoggerFactory.getLogger(MiniOzoneLoadGenerator.class);
 
-  private final List<LoadExecutors> loadExecutors;
+  private final List<LoadGenerator> loadGenerators;
+  private final LoadExecutors loadExecutor;
 
   private final OzoneVolume volume;
   private final OzoneConfiguration conf;
   private final String omServiceID;
 
-  MiniOzoneLoadGenerator(OzoneVolume volume, int numClients, int numThreads,
-      int numBuffers, OzoneConfiguration conf, String omServiceId)
+  MiniOzoneLoadGenerator(OzoneVolume volume, int numThreads,
+      int numBuffers, OzoneConfiguration conf, String omServiceId,
+      List<Class<? extends LoadGenerator>> loadGenratorClazzes)
       throws Exception {
     DataBuffer buffer = new DataBuffer(numBuffers);
-    loadExecutors = new ArrayList<>();
+    loadGenerators = new ArrayList<>();
     this.volume = volume;
     this.conf = conf;
     this.omServiceID = omServiceId;
 
-    // Random Load
-    String mixBucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
-    volume.createBucket(mixBucketName);
-    List<LoadBucket> ozoneBuckets = new ArrayList<>(numClients);
-    for (int i = 0; i < numClients; i++) {
-      ozoneBuckets.add(new LoadBucket(volume.getBucket(mixBucketName),
-          conf, omServiceId));
+    for(Class<? extends LoadGenerator> clazz : loadGenratorClazzes) {
+      addLoads(clazz, buffer);
     }
-    RandomLoadGenerator loadGenerator =
-        new RandomLoadGenerator(buffer, ozoneBuckets);
-    loadExecutors.add(new LoadExecutors(numThreads, loadGenerator));
 
-    // Aged Load
-    addLoads(numThreads,
-        bucket -> new AgedLoadGenerator(buffer, bucket));
-
-    //Filesystem Load
-    addLoads(numThreads,
-        bucket -> new FilesystemLoadGenerator(buffer, bucket));
-
-    //Repl Load
-    addLoads(numThreads,
-        bucket -> new ReadOnlyLoadGenerator(buffer, bucket, 20));
+    this.loadExecutor = new LoadExecutors(numThreads, loadGenerators);
   }
 
-  private void addLoads(int numThreads,
-                        Function<LoadBucket, LoadGenerator> function)
-      throws Exception {
+  private void addLoads(Class<? extends LoadGenerator> clazz,
+                        DataBuffer buffer) throws Exception {
     String bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
     volume.createBucket(bucketName);
-    LoadBucket bucket = new LoadBucket(volume.getBucket(bucketName), conf,
-        omServiceID);
-    LoadGenerator loadGenerator = function.apply(bucket);
-    loadExecutors.add(new LoadExecutors(numThreads, loadGenerator));
+    LoadBucket ozoneBucket = new LoadBucket(volume.getBucket(bucketName),
+        conf, omServiceID);
+
+    LoadGenerator loadGenerator = clazz
+        .getConstructor(DataBuffer.class, LoadBucket.class)
+        .newInstance(buffer, ozoneBucket);
+    loadGenerators.add(loadGenerator);
   }
 
   void startIO(long time, TimeUnit timeUnit) {
     LOG.info("Starting MiniOzoneLoadGenerator for time {}:{}", time, timeUnit);
     long runTime = timeUnit.toMillis(time);
     // start and wait for executors to finish
-    loadExecutors.forEach(le -> le.startLoad(runTime));
-    loadExecutors.forEach(LoadExecutors::waitForCompletion);
+    loadExecutor.startLoad(runTime);
+    loadExecutor.waitForCompletion();
   }
 
   void shutdownLoadGenerator() {
-    loadExecutors.forEach(LoadExecutors::shutdown);
+    loadExecutor.shutdown();
+  }
+
+  /**
+   * Builder to create Ozone load generator.
+   */
+  public static class Builder {
+    private List<Class<? extends LoadGenerator>> clazzes = new ArrayList<>();
+    private String omServiceId;
+    private OzoneConfiguration conf;
+    private int numBuffers;
+    private int numThreads;
+    private OzoneVolume volume;
+
+    public Builder addLoadGenerator(Class<? extends LoadGenerator> clazz) {
+      clazzes.add(clazz);
+      return this;
+    }
+
+    public Builder setOMServiceId(String serviceId) {
+      omServiceId = serviceId;
+      return this;
+    }
+
+    public Builder setConf(OzoneConfiguration conf) {
+      this.conf = conf;
+      return this;
+    }
+
+    public Builder setNumBuffers(int numBuffers) {
+      this.numBuffers = numBuffers;
+      return this;
+    }
+
+    public Builder setNumThreads(int numThreads) {
+      this.numThreads = numThreads;
+      return this;
+    }
+
+    public Builder setVolume(OzoneVolume volume) {
+      this.volume = volume;
+      return this;
+    }
+
+    public MiniOzoneLoadGenerator build() throws Exception {
+      return new MiniOzoneLoadGenerator(volume, numThreads, numBuffers,
+          conf, omServiceId, clazzes);
+    }
   }
 }

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneLoadGenerator.java
@@ -76,7 +76,7 @@ public class MiniOzoneLoadGenerator {
     loadGenerators.add(loadGenerator);
   }
 
-  void startIO(long time, TimeUnit timeUnit) {
+  void startIO(long time, TimeUnit timeUnit) throws Exception {
     LOG.info("Starting MiniOzoneLoadGenerator for time {}:{}", time, timeUnit);
     long runTime = timeUnit.toMillis(time);
     // start and wait for executors to finish

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
@@ -151,7 +151,7 @@ public class TestMiniChaosOzoneCluster extends GenericCli {
   }
 
   @Test
-  public void testReadWriteWithChaosCluster() {
+  public void testReadWriteWithChaosCluster() throws Exception {
     cluster.startChaos(5, 10, TimeUnit.SECONDS);
     loadGenerator.startIO(120, TimeUnit.SECONDS);
   }

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
@@ -23,6 +23,10 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.MiniOzoneChaosCluster.FailureService;
+import org.apache.hadoop.ozone.loadgenerators.RandomLoadGenerator;
+import org.apache.hadoop.ozone.loadgenerators.ReadOnlyLoadGenerator;
+import org.apache.hadoop.ozone.loadgenerators.FilesystemLoadGenerator;
+import org.apache.hadoop.ozone.loadgenerators.AgedLoadGenerator;
 import org.junit.BeforeClass;
 import org.junit.AfterClass;
 import org.junit.Ignore;
@@ -69,10 +73,6 @@ public class TestMiniChaosOzoneCluster extends GenericCli {
       description = "total run time")
   private static int numMinutes = 1440; // 1 day by default
 
-  @Option(names = {"-n", "--numClients"},
-      description = "no of clients writing to OM")
-  private static int numClients = 3;
-
   @Option(names = {"-v", "--numDataVolume"},
       description = "number of datanode volumes to create")
   private static int numDataVolumes = 3;
@@ -107,9 +107,17 @@ public class TestMiniChaosOzoneCluster extends GenericCli {
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
 
-    loadGenerator =
-        new MiniOzoneLoadGenerator(volume, numClients, numThreads,
-            numBuffers, configuration, omServiceID);
+    loadGenerator = new MiniOzoneLoadGenerator.Builder()
+        .setVolume(volume)
+        .setConf(configuration)
+        .setNumBuffers(numBuffers)
+        .setNumThreads(numThreads)
+        .setOMServiceId(omServiceID)
+        .addLoadGenerator(RandomLoadGenerator.class)
+        .addLoadGenerator(AgedLoadGenerator.class)
+        .addLoadGenerator(FilesystemLoadGenerator.class)
+        .addLoadGenerator(ReadOnlyLoadGenerator.class)
+        .build();
   }
 
   /**

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/LoadExecutors.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/LoadExecutors.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.loadgenerators;
 
+import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
@@ -38,30 +39,32 @@ public class LoadExecutors {
   private static final Logger LOG =
       LoggerFactory.getLogger(LoadExecutors.class);
 
-  private final LoadGenerator generator;
+  private final List<LoadGenerator> generators;
   private final int numThreads;
   private final ExecutorService executor;
+  private final int numGenerators;
   private final List<CompletableFuture<Void>> futures = new ArrayList<>();
 
-  public LoadExecutors(int numThreads, LoadGenerator generator) {
+  public LoadExecutors(int numThreads,  List<LoadGenerator> generators) {
     this.numThreads = numThreads;
-    this.generator = generator;
+    this.generators = generators;
+    this.numGenerators = generators.size();
     this.executor = Executors.newFixedThreadPool(numThreads);
   }
 
   private void load(long runTimeMillis) {
     long threadID = Thread.currentThread().getId();
-    LOG.info("{} LOADGEN: Started {} IO Thread:{}.",
-        generator, threadID);
+    LOG.info("LOADGEN: Started IO Thread:{}.", threadID);
     long startTime = Time.monotonicNow();
 
     while (Time.monotonicNow() - startTime < runTimeMillis) {
+      LoadGenerator gen =
+          generators.get(RandomUtils.nextInt(0, numGenerators));
 
       try {
-        generator.generateLoad();
+        gen.generateLoad();
       } catch (Throwable t) {
-        LOG.error("{} LOADGEN: Exiting due to exception",
-            generator, t);
+        LOG.error("{} LOADGEN: Exiting due to exception", gen, t);
         ExitUtil.terminate(new ExitUtil.ExitException(1, t));
         break;
       }
@@ -70,15 +73,19 @@ public class LoadExecutors {
 
 
   public void startLoad(long time) {
-    LOG.info("Starting {} threads for {}", numThreads, generator);
-    try {
-      generator.initialize();
-      for (int i = 0; i < numThreads; i++) {
-        futures.add(CompletableFuture.runAsync(
-            () -> load(time), executor));
+    LOG.info("Starting {} threads for {} genrators", numThreads,
+        generators.size());
+    for (LoadGenerator gen : generators) {
+      try {
+        LOG.info("Initializing {} generator", gen);
+        gen.initialize();
+      } catch (Throwable t) {
+        LOG.error("Failed to initialize loadgen:{}", gen, t);
       }
-    } catch (Throwable t) {
-      LOG.error("Failed to initialize loadgen:{}", generator, t);
+    }
+
+    for (int i = 0; i < numThreads; i++) {
+      futures.add(CompletableFuture.runAsync(() -> load(time), executor));
     }
   }
 

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/LoadExecutors.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/LoadExecutors.java
@@ -72,7 +72,7 @@ public class LoadExecutors {
   }
 
 
-  public void startLoad(long time) {
+  public void startLoad(long time) throws Exception {
     LOG.info("Starting {} threads for {} genrators", numThreads,
         generators.size());
     for (LoadGenerator gen : generators) {
@@ -81,6 +81,7 @@ public class LoadExecutors {
         gen.initialize();
       } catch (Throwable t) {
         LOG.error("Failed to initialize loadgen:{}", gen, t);
+        throw t;
       }
     }
 

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/LoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/LoadGenerator.java
@@ -22,6 +22,16 @@ package org.apache.hadoop.ozone.loadgenerators;
  * Interface for load generator.
  */
 public abstract class LoadGenerator {
+  /**
+   * The implemented LoadGenerators constructors should have the
+   * constructor with the signature as following
+   * class NewLoadGen implements LoadGenerator {
+   *
+   *   NewLoadGen(DataBuffer buffer, LoadBucket bucket) {
+   *     // Add code here
+   *   }
+   * }
+   */
 
   private final String keyNameDelimiter = "_";
 

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/LoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/LoadGenerator.java
@@ -22,7 +22,7 @@ package org.apache.hadoop.ozone.loadgenerators;
  * Interface for load generator.
  */
 public abstract class LoadGenerator {
-  /**
+  /*
    * The implemented LoadGenerators constructors should have the
    * constructor with the signature as following
    * class NewLoadGen implements LoadGenerator {

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/RandomLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/RandomLoadGenerator.java
@@ -24,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
-import java.util.List;
 
 /**
  * Random load generator which writes, read and deletes keys from

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/RandomLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/RandomLoadGenerator.java
@@ -34,26 +34,24 @@ public class RandomLoadGenerator extends LoadGenerator {
   private static final Logger LOG =
       LoggerFactory.getLogger(RandomLoadGenerator.class);
 
-  private final List<LoadBucket> ozoneBuckets;
+  private final LoadBucket ozoneBucket;
   private final DataBuffer dataBuffer;
 
-  public RandomLoadGenerator(DataBuffer dataBuffer, List<LoadBucket> buckets) {
-    this.ozoneBuckets = buckets;
+  public RandomLoadGenerator(DataBuffer dataBuffer, LoadBucket bucket) {
+    this.ozoneBucket = bucket;
     this.dataBuffer = dataBuffer;
   }
 
   @Override
   public void generateLoad() throws Exception {
-    LoadBucket bucket =
-        ozoneBuckets.get((int) (Math.random() * ozoneBuckets.size()));
     int index = RandomUtils.nextInt();
     ByteBuffer buffer = dataBuffer.getBuffer(index);
     String keyName = getKeyName(index);
-    bucket.writeKey(buffer, keyName);
+    ozoneBucket.writeKey(buffer, keyName);
 
-    bucket.readKey(buffer, keyName);
+    ozoneBucket.readKey(buffer, keyName);
 
-    bucket.deleteKey(keyName);
+    ozoneBucket.deleteKey(keyName);
   }
 
   public void initialize() {

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/ReadOnlyLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/ReadOnlyLoadGenerator.java
@@ -28,7 +28,7 @@ import java.nio.ByteBuffer;
 public class ReadOnlyLoadGenerator extends LoadGenerator {
   private final LoadBucket replBucket;
   private final DataBuffer dataBuffer;
-  private final static int numKeys = 10;
+  private final static int NUM_KEYS = 10;
 
   public ReadOnlyLoadGenerator(DataBuffer dataBuffer, LoadBucket replBucket) {
     this.dataBuffer = dataBuffer;
@@ -37,7 +37,7 @@ public class ReadOnlyLoadGenerator extends LoadGenerator {
 
   @Override
   public void generateLoad() throws Exception {
-    int index = RandomUtils.nextInt(0, numKeys);
+    int index = RandomUtils.nextInt(0, NUM_KEYS);
     ByteBuffer buffer = dataBuffer.getBuffer(index);
     String keyName = getKeyName(index);
     replBucket.readKey(buffer, keyName);
@@ -45,7 +45,7 @@ public class ReadOnlyLoadGenerator extends LoadGenerator {
 
 
   public void initialize() throws Exception {
-    for (int index = 0; index < numKeys; index++) {
+    for (int index = 0; index < NUM_KEYS; index++) {
       ByteBuffer buffer = dataBuffer.getBuffer(index);
       String keyName = getKeyName(index);
       replBucket.writeKey(buffer, keyName);

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/ReadOnlyLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/ReadOnlyLoadGenerator.java
@@ -28,13 +28,11 @@ import java.nio.ByteBuffer;
 public class ReadOnlyLoadGenerator extends LoadGenerator {
   private final LoadBucket replBucket;
   private final DataBuffer dataBuffer;
-  private final int numKeys;
+  private final static int numKeys = 10;
 
-  public ReadOnlyLoadGenerator(DataBuffer dataBuffer, LoadBucket replBucket,
-                               int numKeys) {
+  public ReadOnlyLoadGenerator(DataBuffer dataBuffer, LoadBucket replBucket) {
     this.dataBuffer = dataBuffer;
     this.replBucket = replBucket;
-    this.numKeys = numKeys;
   }
 
   @Override

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/resources/log4j.properties
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/resources/log4j.properties
@@ -24,7 +24,7 @@ log4j.logger.org.apache.hadoop.util.NativeCodeLoader=ERROR
 log4j.logger.org.apache.ratis.grpc.client.GrpcClientProtocolClient=WARN
 
 log4j.logger.org.apache.hadoop.ozone.utils=DEBUG,stdout,CHAOS
-log4j.logger.org.apache.hadoop.ozone.loadgenerator=DEBUG,stdout,CHAOS
+log4j.logger.org.apache.hadoop.ozone.loadgenerators=DEBUG,stdout,CHAOS
 log4j.appender.CHAOS.File=${chaoslogfilename}
 log4j.appender.CHAOS=org.apache.log4j.FileAppender
 log4j.appender.CHAOS.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
## What changes were proposed in this pull request?
This jira proposes to change MiniOzoneLoadGenerator to a pluggable model, this allows different tests to specify different load generators to be used in the test.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3455

## How was this patch tested?
Ran MiniOzoneChaosCluster
