### PR TITLE
HDDS-3223. Improve s3g read 1GB object efficiency by 100 times

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
@@ -292,6 +292,15 @@ public class XceiverClientManager implements Closeable {
   }
 
   /**
+   * Reset xceiver client metric.
+   */
+  public static synchronized void resetXceiverClientMetrics() {
+    if (metrics != null) {
+      metrics.reset();
+    }
+  }
+
+  /**
    * Configuration for HDDS client.
    */
   @ConfigGroup(prefix = "scm.container.client")

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientMetrics.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientMetrics.java
@@ -45,6 +45,10 @@ public class XceiverClientMetrics {
   private MetricsRegistry registry;
 
   public XceiverClientMetrics() {
+    init();
+  }
+
+  public void init() {
     int numEnumEntries = ContainerProtos.Type.values().length;
     this.registry = new MetricsRegistry(SOURCE_NAME);
 
@@ -104,6 +108,11 @@ public class XceiverClientMetrics {
   @VisibleForTesting
   public long getContainerOpCountMetrics(ContainerProtos.Type type) {
     return opsArray[type.ordinal()].value();
+  }
+
+  @VisibleForTesting
+  public void reset() {
+    init();
   }
 
   public void unRegister() {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyInputStream.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.client.io;
 import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.FSExceptionMessages;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.hadoop.hdds.client.BlockID;
@@ -34,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -321,5 +323,64 @@ public class KeyInputStream extends InputStream implements Seekable {
   @VisibleForTesting
   public long getRemainingOfIndex(int index) throws IOException {
     return blockStreams.get(index).getRemaining();
+  }
+
+  /**
+   * Copies some or all bytes from a large (over 2GB) <code>InputStream</code>
+   * to an <code>OutputStream</code>, optionally skipping input bytes.
+   * <p>
+   * Copy the method from IOUtils of commons-io to reimplement skip by seek
+   * rather than read. The reason why IOUtils of commons-io implement skip
+   * by read can be found at
+   * <a href="https://issues.apache.org/jira/browse/IO-203">IO-203</a>.
+   * </p>
+   * <p>
+   * This method uses the provided buffer, so there is no need to use a
+   * <code>BufferedInputStream</code>.
+   * </p>
+   *
+   * @param output the <code>OutputStream</code> to write to
+   * @param inputOffset : number of bytes to skip from input before copying
+   * -ve values are ignored
+   * @param length : number of bytes to copy. -ve means all
+   * @param buffer the buffer to use for the copy
+   * @return the number of bytes copied
+   * @throws NullPointerException if the input or output is null
+   * @throws IOException          if an I/O error occurs
+   */
+  public long copyLarge(final OutputStream output,
+      final long inputOffset, final long len, final byte[] buffer)
+      throws IOException {
+    if (inputOffset > 0) {
+      seek(inputOffset);
+    }
+
+    if (len == 0) {
+      return 0;
+    }
+
+    final int bufferLength = buffer.length;
+    int bytesToRead = bufferLength;
+    if (len > 0 && len < bufferLength) {
+      bytesToRead = (int) len;
+    }
+
+    int read;
+    long totalRead = 0;
+    while (bytesToRead > 0) {
+      read = read(buffer, 0, bytesToRead);
+      if (read == IOUtils.EOF) {
+        break;
+      }
+
+      output.write(buffer, 0, read);
+      totalRead += read;
+      if (len > 0) { // only adjust len if not reading to the end
+        // Note the cast must work because buffer.length is an integer
+        bytesToRead = (int) Math.min(len - totalRead, bufferLength);
+      }
+    }
+
+    return totalRead;
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -533,10 +533,16 @@ public class ObjectEndpoint extends EndpointBase {
             if (range != null) {
               RangeHeader rangeHeader =
                   RangeHeaderParserUtil.parseRangeHeader(range, 0);
-              IOUtils.copyLarge(sourceObject, ozoneOutputStream,
-                  rangeHeader.getStartOffset(),
-                  rangeHeader.getEndOffset() - rangeHeader.getStartOffset());
 
+              long copyLength = rangeHeader.getEndOffset() -
+                  rangeHeader.getStartOffset();
+
+              try (S3WrapperInputStream s3WrapperInputStream =
+                  new S3WrapperInputStream(
+                  sourceObject.getInputStream())) {
+                s3WrapperInputStream.copyLarge(ozoneOutputStream,
+                    rangeHeader.getStartOffset(), copyLength);
+              }
             } else {
               IOUtils.copy(sourceObject, ozoneOutputStream);
             }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -259,8 +259,7 @@ public class ObjectEndpoint extends EndpointBase {
           try (S3WrapperInputStream s3WrapperInputStream =
               new S3WrapperInputStream(
                   key.getInputStream())) {
-            IOUtils.copyLarge(s3WrapperInputStream, dest, startOffset,
-                copyLength);
+            s3WrapperInputStream.copyLarge(dest, startOffset, copyLength);
           }
         };
         responseBuilder = Response

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/io/S3WrapperInputStream.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/io/S3WrapperInputStream.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.s3.io;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.FSInputStream;
 import org.apache.hadoop.ozone.client.io.KeyInputStream;
 
@@ -105,61 +104,7 @@ public class S3WrapperInputStream extends FSInputStream {
    */
   public long copyLarge(final OutputStream output, final long inputOffset,
       final long length) throws IOException {
-    return copyLarge(output, inputOffset, length,
+    return inputStream.copyLarge(output, inputOffset, length,
         new byte[DEFAULT_BUFFER_SIZE]);
-  }
-
-  /**
-   * Copies some or all bytes from a large (over 2GB) <code>InputStream</code>
-   * to an <code>OutputStream</code>, optionally skipping input bytes.
-   * <p>
-   * Copy the method from IOUtils of commons-io to reimplement skip by seek
-   * rather than read. The reason why IOUtils of commons-io implement skip
-   * by read can be found at
-   * <a href="https://issues.apache.org/jira/browse/IO-203">IO-203</a>.
-   * </p>
-   * <p>
-   * This method uses the provided buffer, so there is no need to use a
-   * <code>BufferedInputStream</code>.
-   * </p>
-   *
-   * @param output the <code>OutputStream</code> to write to
-   * @param inputOffset : number of bytes to skip from input before copying
-   * -ve values are ignored
-   * @param length : number of bytes to copy. -ve means all
-   * @param buffer the buffer to use for the copy
-   * @return the number of bytes copied
-   * @throws NullPointerException if the input or output is null
-   * @throws IOException          if an I/O error occurs
-   */
-  public long copyLarge(final OutputStream output,
-      final long inputOffset, final long length, final byte[] buffer)
-      throws IOException {
-    if (inputOffset > 0) {
-      seek(inputOffset);
-    }
-    if (length == 0) {
-      return 0;
-    }
-    final int bufferLength = buffer.length;
-    int bytesToRead = bufferLength;
-    if (length > 0 && length < bufferLength) {
-      bytesToRead = (int) length;
-    }
-    int read;
-    long totalRead = 0;
-    while (bytesToRead > 0) {
-      read = inputStream.read(buffer, 0, bytesToRead);
-      if (read == IOUtils.EOF) {
-        break;
-      }
-      output.write(buffer, 0, read);
-      totalRead += read;
-      if (length > 0) { // only adjust length if not reading to the end
-        // Note the cast must work because buffer.length is an integer
-        bytesToRead = (int) Math.min(length - totalRead, bufferLength);
-      }
-    }
-    return totalRead;
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadWithCopy.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadWithCopy.java
@@ -111,13 +111,6 @@ public class TestMultipartUploadWithCopy {
             OzoneConsts.S3_BUCKET + "/" + EXISTING_KEY, null);
     partsList.add(part2);
 
-    partNumber = 3;
-    Part part3 =
-        uploadPartWithCopy(KEY, uploadID, partNumber,
-            OzoneConsts.S3_BUCKET + "/" + EXISTING_KEY,
-            "bytes=" + RANGE_FROM + "-" + RANGE_TO);
-    partsList.add(part3);
-
     // complete multipart upload
     CompleteMultipartUploadRequest completeMultipartUploadRequest = new
         CompleteMultipartUploadRequest();
@@ -130,8 +123,7 @@ public class TestMultipartUploadWithCopy {
         OzoneConsts.S3_BUCKET);
     try (InputStream is = bucket.readKey(KEY)) {
       String keyContent = new Scanner(is).useDelimiter("\\A").next();
-      Assert.assertEquals(content + EXISTING_KEY_CONTENT + EXISTING_KEY_CONTENT
-          .substring(RANGE_FROM, RANGE_TO), keyContent);
+      Assert.assertEquals(content + EXISTING_KEY_CONTENT, keyContent);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
**What's the problem ?**

Use dd to read 1000M object from ozone bucket mounted by goofys, it cost about 470 seconds, i.e. 2.2M/s, which is too slow. 
![image](https://user-images.githubusercontent.com/51938049/79706793-028ee280-82ed-11ea-8bea-ce34e712ff70.png)

I also use tcpdump to capture the packet when I  read 200M object. As the image shows, the 1st GET request cost about 1 second, but the 10th GET request cost about 22 seconds. The GET request become slower and slower.
![image](https://user-images.githubusercontent.com/51938049/79739152-5b339f00-8330-11ea-8892-4422b2380f98.png)


**What's the reason ?**
When read 1000M object, there are 50 GET requests, each GET request read 20M. When do GET, the stack is: [IOUtils::copyLarge](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java#L262) -> [IOUtils::skipFully](https://github.com/apache/commons-io/blob/master/src/main/java/org/apache/commons/io/IOUtils.java#L1190) -> [IOUtils::skip](https://github.com/apache/commons-io/blob/master/src/main/java/org/apache/commons/io/IOUtils.java#L2064) -> [InputStream::read](https://github.com/apache/commons-io/blob/master/src/main/java/org/apache/commons/io/IOUtils.java#L1957).

It means, the 50th GET request which should read 980M-1000M, but to skip 0-980M, it also [InputStream::read](https://github.com/apache/commons-io/blob/master/src/main/java/org/apache/commons/io/IOUtils.java#L1957) 0-980M. So the 1st GET request read 0-20M, the 2nd GET request read 0-40M, the 3rd GET request read 0-60M, ..., the 50th GET request read 0-1000M. So the GET  request from 1st-50th become slower and slower.

You can also refer [IO-203](https://issues.apache.org/jira/browse/IO-203) and [IO-355](https://issues.apache.org/jira/browse/IO-355) why IOUtils implement skip by read rather than real skip, e.g. seek.
![image](https://user-images.githubusercontent.com/51938049/79708164-4388f600-82f1-11ea-83ab-97177638069e.png)


**How to improve ?**
Copy IOUtils::copyLarge to S3WrapperInputStream, and replace [IOUtils::skipFully](https://github.com/apache/commons-io/blob/master/src/main/java/org/apache/commons/io/IOUtils.java#L1190)  with [S3WrapperInputStream::seek](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/io/S3WrapperInputStream.java#L67).  No other changes of IOUtils::copyLarge.
After improving, read 1000M object cost 4.79 seconds, i.e. 219M/s, about 100 times faster.
![image](https://user-images.githubusercontent.com/51938049/79707421-01f74b80-82ef-11ea-9ae4-7bc7bde784e3.png)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3223

## How was this patch tested?

Existed UT and IT.
