### PR TITLE
HDDS-3456. Fix Acceptance test failures due to disk out of space.

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -112,6 +112,8 @@ jobs:
         - run: sudo chown runner -R .
         - run: cd ./hadoop-ozone/dist/target/ozone-*/ && mkdir .aws && sudo chown 1000 .aws
         - run: ./hadoop-ozone/dev-support/checks/acceptance.sh
+          env:
+            KEEP_IMAGE: false
         - uses: actions/upload-artifact@master
           if: always()
           with:

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -104,6 +104,10 @@ jobs:
         - uses: ./.github/buildenv
           with:
             args: ./hadoop-ozone/dev-support/checks/build.sh
+        # remove image created for 'buildenv'
+        - run: docker image rm $(docker images -a -q | head -1) || true
+        # remove its big parent build image
+        - run: docker image rm apache/ozone-build || true
         - run: sudo pip install robotframework
         - run: sudo chown runner -R .
         - run: cd ./hadoop-ozone/dist/target/ozone-*/ && mkdir .aws && sudo chown 1000 .aws

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -97,6 +97,10 @@ jobs:
         - uses: ./.github/buildenv
           with:
             args: ./hadoop-ozone/dev-support/checks/build.sh
+        # remove image created for 'buildenv'
+        - run: docker image rm $(docker images -a -q | head -1) || true
+        # remove its big parent build image
+        - run: docker image rm apache/ozone-build || true
         - run: sudo pip install robotframework
         - run: sudo chown runner -R .
         - run: cd ./hadoop-ozone/dist/target/ozone-*/ && mkdir .aws && sudo chown 1000 .aws

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -105,6 +105,8 @@ jobs:
         - run: sudo chown runner -R .
         - run: cd ./hadoop-ozone/dist/target/ozone-*/ && mkdir .aws && sudo chown 1000 .aws
         - run: ./hadoop-ozone/dev-support/checks/acceptance.sh
+          env:
+            KEEP_IMAGE: false
         - uses: actions/upload-artifact@master
           if: always()
           with:

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/test.sh
@@ -19,6 +19,7 @@ COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 
 # shellcheck source=/dev/null
+source "$COMPOSE_DIR/.env"
 source "$COMPOSE_DIR/../../testlib.sh"
 
 start_docker_env
@@ -35,9 +36,10 @@ source "$COMPOSE_DIR/../../testlib.sh"
 
 execute_robot_test rm ozonefs/hadoopo3fs.robot
 
-execute_robot_test rm  -v hadoop.version:3.1.2 mapreduce.robot
-
+execute_robot_test rm  -v "hadoop.version:${HADOOP_VERSION}" mapreduce.robot
 
 stop_docker_env
 
 generate_report
+
+cleanup_docker_images "${HADOOP_IMAGE}:${HADOOP_VERSION}"

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -192,6 +192,13 @@ stop_docker_env(){
   fi
 }
 
+## @description  Removes the given docker images if configured not to keep them (via KEEP_IMAGE=false)
+cleanup_docker_images() {
+  if [[ "${KEEP_IMAGE:-true}" == false ]]; then
+    docker image rm "$@"
+  fi
+}
+
 ## @description  Generate robot framework reports based on the saved results.
 generate_report(){
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Remove the docker images `ozone-build` and its temporary child image after completion of Maven build for acceptance test.
2. Remove `apache/hadoop:3.1.2` image after `hadoop31` test.  `hadoop:3` (for `hadoop32`) is used later for secure tests, too.

https://issues.apache.org/jira/browse/HDDS-3456

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/602389143

```
Dockerfile for action: '/home/runner/work/hadoop-ozone/hadoop-ozone/./.github/buildenv/Dockerfile'.
##[command]/usr/bin/docker build -t 430c1a:5eb4503f65695cb5f3b88870f564260e "/home/runner/work/hadoop-ozone/hadoop-ozone/.github/buildenv"
...
Run docker image rm $(docker images -a -q | head -1) || true
Untagged: 430c1a:5eb4503f65695cb5f3b88870f564260e
Deleted: sha256:35a79ac289f9198f022d949e34bf10a36de0230c4016ee2c05c0348f66dd0acc
...
Run docker image rm apache/ozone-build || true
Untagged: apache/ozone-build:latest
Untagged: apache/ozone-build@sha256:1bb0075ead1b4a78e53860a21b7613ffbab7f317e1fb304ebdeb7fbbfda11db4
Deleted: sha256:ce5cb3e6669c11ecfb36a079aab583c5f8c9eaaa23a91128c170a1cfadcc4968
...
```