### PR TITLE
HDDS-3472. Remove redundant hdds.version from hadoop-hdds/common/pom.xml

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -29,10 +29,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <packaging>jar</packaging>
 
   <properties>
-    <hdds.version>0.6.0-SNAPSHOT</hdds.version>
     <log4j2.version>2.11.0</log4j2.version>
     <disruptor.version>3.4.2</disruptor.version>
-    <declared.hdds.version>${hdds.version}</declared.hdds.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Remove redundant hdds.version from hadoop-hdds/common/pom.xml

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3472

## How was this patch tested?
Build the project.
