### PR TITLE
HDDS-3393. Recon throws NPE in clusterState endpoint

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ClusterStateEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ClusterStateEndpoint.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
-import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.recon.api.types.ClusterStateResponse;
 import org.apache.hadoop.ozone.recon.api.types.DatanodeStorageReport;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
@@ -81,29 +80,25 @@ public class ClusterStateEndpoint {
         new DatanodeStorageReport(stats.getCapacity().get(),
             stats.getScmUsed().get(), stats.getRemaining().get());
     ClusterStateResponse.Builder builder = ClusterStateResponse.newBuilder();
-    try {
-      Table volumeTable = omMetadataManager.getVolumeTable();
-      if (volumeTable != null) {
-        builder.setVolumes(volumeTable.getEstimatedKeyCount());
+    if (omMetadataManager.isOmTablesInitialized()) {
+      try {
+        builder.setVolumes(
+            omMetadataManager.getVolumeTable().getEstimatedKeyCount());
+      } catch (Exception ex) {
+        LOG.error("Unable to get Volumes count in ClusterStateResponse.", ex);
       }
-    } catch (Exception ex) {
-      LOG.error("Unable to get Volumes count in ClusterStateResponse.", ex);
-    }
-    try {
-      Table bucketTable = omMetadataManager.getBucketTable();
-      if (bucketTable != null) {
-        builder.setBuckets(bucketTable.getEstimatedKeyCount());
+      try {
+        builder.setBuckets(
+            omMetadataManager.getBucketTable().getEstimatedKeyCount());
+      } catch (Exception ex) {
+        LOG.error("Unable to get Buckets count in ClusterStateResponse.", ex);
       }
-    } catch (Exception ex) {
-      LOG.error("Unable to get Buckets count in ClusterStateResponse.", ex);
-    }
-    try {
-      Table keyTable = omMetadataManager.getKeyTable();
-      if (keyTable != null) {
-        builder.setKeys(keyTable.getEstimatedKeyCount());
+      try {
+        builder.setKeys(
+            omMetadataManager.getKeyTable().getEstimatedKeyCount());
+      } catch (Exception ex) {
+        LOG.error("Unable to get Keys count in ClusterStateResponse.", ex);
       }
-    } catch (Exception ex) {
-      LOG.error("Unable to get Keys count in ClusterStateResponse.", ex);
     }
     ClusterStateResponse response = builder
         .setStorageReport(storageReport)

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ClusterStateEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ClusterStateEndpoint.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
+import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.recon.api.types.ClusterStateResponse;
 import org.apache.hadoop.ozone.recon.api.types.DatanodeStorageReport;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
@@ -81,20 +82,26 @@ public class ClusterStateEndpoint {
             stats.getScmUsed().get(), stats.getRemaining().get());
     ClusterStateResponse.Builder builder = ClusterStateResponse.newBuilder();
     try {
-      builder.setVolumes(
-          omMetadataManager.getVolumeTable().getEstimatedKeyCount());
+      Table volumeTable = omMetadataManager.getVolumeTable();
+      if (volumeTable != null) {
+        builder.setVolumes(volumeTable.getEstimatedKeyCount());
+      }
     } catch (Exception ex) {
       LOG.error("Unable to get Volumes count in ClusterStateResponse.", ex);
     }
     try {
-      builder.setBuckets(
-          omMetadataManager.getBucketTable().getEstimatedKeyCount());
+      Table bucketTable = omMetadataManager.getBucketTable();
+      if (bucketTable != null) {
+        builder.setBuckets(bucketTable.getEstimatedKeyCount());
+      }
     } catch (Exception ex) {
       LOG.error("Unable to get Buckets count in ClusterStateResponse.", ex);
     }
     try {
-      builder.setKeys(
-          omMetadataManager.getKeyTable().getEstimatedKeyCount());
+      Table keyTable = omMetadataManager.getKeyTable();
+      if (keyTable != null) {
+        builder.setKeys(keyTable.getEstimatedKeyCount());
+      }
     } catch (Exception ex) {
       LOG.error("Unable to get Keys count in ClusterStateResponse.", ex);
     }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOMMetadataManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOMMetadataManager.java
@@ -44,7 +44,7 @@ public interface ReconOMMetadataManager extends OMMetadataManager {
 
   /**
    * Check if OM tables are initialized.
-   * @return if OM Tables are initialized
+   * @return true if OM Tables are initialized, otherwise false.
    */
   boolean isOmTablesInitialized();
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOMMetadataManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOMMetadataManager.java
@@ -41,4 +41,10 @@ public interface ReconOMMetadataManager extends OMMetadataManager {
    * Database.
    */
   long getLastSequenceNumberFromDB();
+
+  /**
+   * Check if OM tables are initialized.
+   * @return if OM Tables are initialized
+   */
+  boolean isOmTablesInitialized();
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
@@ -51,6 +51,7 @@ public class ReconOmMetadataManagerImpl extends OmMetadataManagerImpl
 
   private OzoneConfiguration ozoneConfiguration;
   private ReconUtils reconUtils;
+  private boolean omTablesInitialized = false;
 
   @Inject
   public ReconOmMetadataManagerImpl(OzoneConfiguration configuration,
@@ -94,6 +95,7 @@ public class ReconOmMetadataManagerImpl extends OmMetadataManagerImpl
     }
     if (getStore() != null) {
       initializeOmTables();
+      omTablesInitialized = true;
     }
   }
 
@@ -120,4 +122,11 @@ public class ReconOmMetadataManagerImpl extends OmMetadataManagerImpl
     }
   }
 
+  /**
+   * Check if OM tables are initialized.
+   * @return if OM Tables are initialized
+   */
+  public boolean isOmTablesInitialized() {
+    return omTablesInitialized;
+  }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
@@ -124,8 +124,9 @@ public class ReconOmMetadataManagerImpl extends OmMetadataManagerImpl
 
   /**
    * Check if OM tables are initialized.
-   * @return if OM Tables are initialized
+   * @return true if OM Tables are initialized, otherwise false.
    */
+  @Override
   public boolean isOmTablesInitialized() {
     return omTablesInitialized;
   }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -1,16 +1,16 @@
 {
   "clusterState": {
-    "totalDatanodes": 10,
-    "healthyDatanodes": 9,
-    "pipelines": 3,
+    "totalDatanodes": 24,
+    "healthyDatanodes": 24,
+    "pipelines": 32,
     "storageReport": {
-      "capacity": 1099511627778,
-      "used": 681826058240,
-      "remaining": 391915765760
+      "capacity": 32985348833280,
+      "used": 15942918602752,
+      "remaining": 12094627905536
     },
-    "containers": 54,
+    "containers": 3230,
     "volumes": 5,
-    "buckets": 100,
+    "buckets": 156,
     "keys": 253000
   },
   "datanodes": {
@@ -355,8 +355,8 @@
     "totalCount": 2,
     "containers": [
       {
-        "id": 1,
-        "keys": 3876,
+        "containerID": 1,
+        "keys": 1235,
         "replicas": [
           {
             "containerId": 1,
@@ -378,11 +378,11 @@
           }
         ],
         "missingSince": 1578491371528,
-        "pipelineId": "05e3d908-ff01-4ce6-ad75-f3ec79bcc7982"
+        "pipelineID": "05e3d908-ff01-4ce6-ad75-f3ec79bcc7982"
       },
       {
-        "id": 2,
-        "keys": 5943,
+        "containerID": 2,
+        "keys": 1356,
         "replicas": [
           {
             "containerId": 1,
@@ -404,7 +404,7 @@
           }
         ],
         "missingSince": 1578491471528,
-        "pipelineId": "04a5d908-ff01-4ce6-ad75-f3ec73dfc8a2"
+        "pipelineID": "04a5d908-ff01-4ce6-ad75-f3ec73dfc8a2"
       }
     ]
   },


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Perform a null check on tables before calling getEstimatedKeyCount() on them.
- Update mock api response to match the expected json structure.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3393

## How was this patch tested?

Patch was tested with docker-compose and verified that there is no NPE thrown in Recon logs after hitting the clusterState endpoint before first snapshot from OM. 
