### PR TITLE
HDDS-3373. Intermittent failure in TestDnRatisLogParser and TestOMRatisLogParser

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/ratis/TestDnRatisLogParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/ratis/TestDnRatisLogParser.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.segmentparser.DatanodeRatisLogParser;
 
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -62,7 +63,7 @@ public class TestDnRatisLogParser {
   }
 
   @Test
-  public void testRatisLogParsing() {
+  public void testRatisLogParsing() throws Exception {
     cluster.stop();
     OzoneConfiguration conf = cluster.getHddsDatanodes().get(0).getConf();
     String path =
@@ -72,7 +73,7 @@ public class TestDnRatisLogParser {
     File pipelineDir = new File(path, pid.toString());
     File currentDir = new File(pipelineDir, "current");
     File logFile = new File(currentDir, "log_inprogress_0");
-    Assert.assertTrue(logFile.exists());
+    GenericTestUtils.waitFor(logFile::exists, 100, 15000);
     Assert.assertTrue(logFile.isFile());
 
     DatanodeRatisLogParser datanodeRatisLogParser =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/parser/TestOMRatisLogParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/parser/TestOMRatisLogParser.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.segmentparser.OMRatisLogParser;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -83,7 +84,7 @@ public class TestOMRatisLogParser {
   }
 
   @Test
-  public void testRatisLogParsing() {
+  public void testRatisLogParsing() throws Exception {
     OzoneConfiguration ozoneConfiguration =
         cluster.getOMLeader().getConfiguration();
 
@@ -109,7 +110,7 @@ public class TestOMRatisLogParser {
     Assert.assertTrue(groupDir.isDirectory());
     File currentDir = new File(groupDir, "current");
     File logFile = new File(currentDir, "log_inprogress_0");
-    Assert.assertTrue(logFile.exists());
+    GenericTestUtils.waitFor(logFile::exists, 100, 15000);
     Assert.assertTrue(logFile.isFile());
 
     OMRatisLogParser omRatisLogParser = new OMRatisLogParser();


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Attempt to) fix intermittent failure in TestDnRatisLogParser and TestOMRatisLogParser.

https://issues.apache.org/jira/browse/HDDS-3373

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/runs/608442447

50x repetition with these two tests (in progress):
https://github.com/adoroszlai/hadoop-ozone/runs/608916570