### PR TITLE
HDDS-3483. Handle unhealthy replica state of an open container.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -252,9 +252,14 @@ public class ReplicationManager implements MetricsSource, SafeModeNotification {
       final LifeCycleState state = container.getState();
 
       /*
-       * We don't take any action if the container is in OPEN state.
+       * We don't take any action if the container is in OPEN state and
+       * the container is healthy. If the container is not healthy, i.e.
+       * the replicas are not in OPEN state, send CLOSE_CONTAINER command.
        */
       if (state == LifeCycleState.OPEN) {
+        if (!isContainerHealthy(container, replicas)) {
+          eventPublisher.fireEvent(SCMEvents.CLOSE_CONTAINER, id);
+        }
         return;
       }
 


### PR DESCRIPTION
HDDS-3483. Handle unhealthy replica state of an open container.

It was assumed that when a container is in OPEN state SCM doesn't have to take any action on it and the Ratis pipeline in datanode should handle the consistency of that container.

But, there are cases where a replica of a container which is in OPEN state can be marked as UNHEALTHY in datanode. This should be handled in SCM.

## How was this patch tested?

Added unit test to verify the new functionality.
