### PR TITLE
HDDS-3405.Tool for Listing keys from the OpenKeyTable

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -32,10 +32,7 @@ import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
-import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
-import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
-import org.apache.hadoop.ozone.om.helpers.WithMetadata;
+import org.apache.hadoop.ozone.om.helpers.*;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 
@@ -373,6 +370,9 @@ public class OzoneBucket extends WithMetadata {
     return new KeyIterator(keyPrefix, prevKey);
   }
 
+  public List<OzoneKey> listOpenKeys() throws IOException {
+    return proxy.listOpenKeys(volumeName,this.name);
+  }
   /**
    * Deletes key from the bucket.
    * @param key Name of the key to be deleted.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -315,6 +315,9 @@ public interface ClientProtocol {
                           String keyPrefix, String prevKey, int maxListResult)
       throws IOException;
 
+  List<OzoneKey> listOpenKeys(String volumeName, String bucketName)
+          throws IOException;
+
   /**
    * List trash allows the user to list the keys that were marked as deleted,
    * but not actually deleted by Ozone Manager. This allows a user to recover

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -710,6 +710,25 @@ public class RpcClient implements ClientProtocol {
   }
 
   @Override
+  public List<OzoneKey> listOpenKeys(String volumeName, String bucketName) throws IOException {
+    Preconditions.checkNotNull(volumeName);
+    Preconditions.checkNotNull(bucketName);
+    List<OmKeyInfo> keys = ozoneManagerClient.listOpenKeys(
+            volumeName, bucketName);
+    return keys.stream().map(key -> new OzoneKey(
+            key.getVolumeName(),
+            key.getBucketName(),
+            key.getKeyName(),
+            key.getDataSize(),
+            key.getCreationTime(),
+            key.getModificationTime(),
+            ReplicationType.valueOf(key.getType().toString()),
+            key.getFactor().getNumber()))
+            .collect(Collectors.toList());
+
+  }
+
+  @Override
   public List<RepeatedOmKeyInfo> listTrash(String volumeName, String bucketName,
       String startKeyName, String keyPrefix, int maxKeys) throws IOException {
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -223,6 +223,7 @@ public final class OmUtils {
     case ListBuckets:
     case LookupKey:
     case ListKeys:
+    case ListOpenKeys:
     case ListTrash:
     case RecoverTrash:
     case InfoS3Bucket:

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -279,6 +279,7 @@ public interface OzoneManagerProtocol
       String bucketName, String startKeyName, String keyPrefix, int maxKeys)
       throws IOException;
 
+  List<OmKeyInfo> listOpenKeys(String volumeName, String bucketName) throws  IOException;
   /**
    * Returns list of Ozone services with its configuration details.
    *
@@ -554,5 +555,4 @@ public interface OzoneManagerProtocol
    */
   boolean recoverTrash(String volumeName, String bucketName, String keyName,
       String destinationBucket) throws IOException;
-
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -61,6 +61,7 @@ import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AddAclRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AddAclResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AllocateBlockRequest;
@@ -980,6 +981,28 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
             .collect(Collectors.toList()));
     return keys;
 
+  }
+
+  @Override
+  public List<OmKeyInfo> listOpenKeys(String volumeName, String bucketName) throws  IOException{
+    List<OmKeyInfo> keys = new ArrayList<>();
+   OzoneManagerProtocolProtos.ListOpenKeysRequest.Builder reqBuilder =
+            OzoneManagerProtocolProtos.ListOpenKeysRequest.newBuilder();
+    reqBuilder.setVolumeName(volumeName);
+    reqBuilder.setBucketName(bucketName);
+
+    OzoneManagerProtocolProtos.ListOpenKeysRequest req  = reqBuilder.build();
+    OMRequest omRequest = createOMRequest(Type.ListOpenKeys)
+            .setListOpenKeysRequest(req)
+            .build();
+    OzoneManagerProtocolProtos.ListOpenKeysResponse resp =
+            handleError(submitRequest(omRequest)).getListOpenKeysResponse();
+    keys.addAll(
+            resp.getKeyInfoList().stream()
+                    .map(OmKeyInfo::getFromProtobuf)
+                    .collect(Collectors.toList()));
+
+    return keys;
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
+++ b/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
@@ -95,6 +95,7 @@ enum Type {
 
   ListTrash = 91;
   RecoverTrash = 92;
+  ListOpenKeys = 93;
 }
 
 message OMRequest {
@@ -167,6 +168,7 @@ message OMRequest {
 
   optional ListTrashRequest                 listTrashRequest               = 91;
   optional RecoverTrashRequest              RecoverTrashRequest            = 92;
+  optional ListOpenKeysRequest              listOpenKeysRequest            = 93;
 }
 
 message OMResponse {
@@ -239,6 +241,7 @@ message OMResponse {
 
   optional ListTrashResponse                  listTrashResponse            = 91;
   optional RecoverTrashResponse               RecoverTrashResponse         = 92;
+  optional ListOpenKeysResponse               listOpenKeysResponse         = 93;
 }
 
 enum Status {
@@ -914,6 +917,15 @@ message ListKeysRequest {
 }
 
 message ListKeysResponse {
+    repeated KeyInfo keyInfo = 2;
+}
+
+message ListOpenKeysRequest {
+    required string volumeName = 1;
+    required string bucketName = 2;
+}
+
+message ListOpenKeysResponse {
     repeated KeyInfo keyInfo = 2;
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
@@ -151,6 +151,10 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
       String bucketName, String startKey, String keyPrefix, int maxKeys)
       throws IOException;
 
+  List<OmKeyInfo> listOpenKeys(String volumeName,
+                           String bucketName)
+          throws IOException;
+
   /**
    * List trash allows the user to list the keys that were marked as deleted,
    * but not actually deleted by Ozone Manager. This allows a user to recover

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -862,6 +862,15 @@ public class KeyManagerImpl implements KeyManager {
   }
 
   @Override
+  public List<OmKeyInfo> listOpenKeys(String volumeName, String bucketName)
+          throws IOException {
+    Preconditions.checkNotNull(volumeName);
+    Preconditions.checkNotNull(bucketName);
+
+    return metadataManager.listOpenKeys(volumeName,bucketName);
+  }
+
+  @Override
   public List<RepeatedOmKeyInfo> listTrash(String volumeName,
       String bucketName, String startKeyName, String keyPrefix,
       int maxKeys) throws IOException {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -184,6 +184,10 @@ public interface OMMetadataManager {
       String bucketName, String startKey, String keyPrefix, int maxKeys)
       throws IOException;
 
+  List<OmKeyInfo> listOpenKeys(String volumeName,
+                           String bucketName)
+          throws IOException;
+
   /**
    * List trash allows the user to list the keys that were marked as deleted,
    * but not actually deleted by Ozone Manager. This allows a user to recover

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2238,6 +2238,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   @Override
+  public List<OmKeyInfo> listOpenKeys(String volumeName, String bucketName) throws IOException {
+    return keyManager.listOpenKeys(volumeName,bucketName);
+  }
+
+  @Override
   public List<RepeatedOmKeyInfo> listTrash(String volumeName,
       String bucketName, String startKeyName, String keyPrefix, int maxKeys)
       throws IOException {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AllocateBlockRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AllocateBlockResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CheckVolumeAccessRequest;
@@ -159,6 +160,11 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         ListKeysResponse listKeysResponse = listKeys(
             request.getListKeysRequest());
         responseBuilder.setListKeysResponse(listKeysResponse);
+        break;
+      case ListOpenKeys:
+        OzoneManagerProtocolProtos.ListOpenKeysResponse listOpenKeysResponse = listOpenKeys(
+            request.getListOpenKeysRequest());
+        responseBuilder.setListOpenKeysResponse(listOpenKeysResponse);
         break;
       case ListTrash:
         ListTrashResponse listTrashResponse = listTrash(
@@ -414,6 +420,22 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     }
 
     return resp.build();
+  }
+
+  private OzoneManagerProtocolProtos.ListOpenKeysResponse listOpenKeys(OzoneManagerProtocolProtos.ListOpenKeysRequest request)
+    throws IOException {
+    OzoneManagerProtocolProtos.ListOpenKeysResponse.Builder resp =
+            OzoneManagerProtocolProtos.ListOpenKeysResponse.newBuilder();
+
+    List<OmKeyInfo> keys = impl.listOpenKeys(
+            request.getVolumeName(),
+            request.getBucketName()
+    );
+    for (OmKeyInfo key : keys) {
+      resp.addKeyInfo(key.getProtobuf());
+    }
+
+    return  resp.build();
   }
 
   private ListTrashResponse listTrash(ListTrashRequest request)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -287,6 +287,23 @@ public class TestOmMetadataManager {
   }
 
   @Test
+  public void testListOpenKeys() throws Exception {
+    String volumeName = "vol";
+    String bucketName = "buck";
+    TestOMRequestUtils.addVolumeToDB(volumeName,omMetadataManager);
+    addBucketsToCache(volumeName,bucketName);
+    for (int i=0;i< 10; i++) {
+      TestOMRequestUtils.addKeyToTable(true, volumeName
+              , bucketName,"key"+ i ,
+              1000L, HddsProtos.ReplicationType.RATIS,
+              HddsProtos.ReplicationFactor.ONE, omMetadataManager);
+    }
+    List<OmKeyInfo> omKeyInfoList =
+            omMetadataManager.listOpenKeys(volumeName,bucketName);
+    Assert.assertEquals(10,omKeyInfoList.size());
+
+  }
+  @Test
   public void testListKeys() throws Exception {
 
     String volumeNameA = "volumeA";

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/ListOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/ListOptions.java
@@ -39,6 +39,10 @@ public class ListOptions {
       description = "Prefix to filter the items")
   private String prefix;
 
+  @CommandLine.Option(names = {"--openKey", "-o"},
+          description = "List all open Keys")
+  private boolean openkey=false;
+
   public int getLimit() {
     if (limit < 1) {
       throw new IllegalArgumentException(
@@ -54,5 +58,9 @@ public class ListOptions {
 
   public String getPrefix() {
     return prefix;
+  }
+
+  public boolean isOpenkey() {
+    return openkey;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/ListKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/ListKeyHandler.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.shell.keys;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
 
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -43,6 +44,9 @@ public class ListKeyHandler extends BucketHandler {
 
   @CommandLine.Mixin
   private ListOptions listOptions;
+  /**
+   * Executes the Client Calls.
+   */
 
   @Override
   protected void execute(OzoneClient client, OzoneAddress address)
@@ -57,6 +61,17 @@ public class ListKeyHandler extends BucketHandler {
         listOptions.getPrefix(), listOptions.getStartItem());
 
     int maxKeyLimit = listOptions.getLimit();
+    boolean isOpenKey = listOptions.isOpenkey();
+
+    if (isOpenKey) {
+        List<OzoneKey> openKeysList = bucket.listOpenKeys();
+        Iterator<OzoneKey> ozoneKeyIterator = openKeysList.iterator();
+        while (ozoneKeyIterator.hasNext()) {
+            OzoneKey openKey = ozoneKeyIterator.next();
+            printObjectAsJson(openKey);
+        }
+        return;
+    }
 
     int counter = 0;
     while (maxKeyLimit > counter && keyIterator.hasNext()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
The tool lists keys present in the Open Key Table and can be used to debug when keys are written into ozone. There is a chance that the key might not have gotten committed into the OM (KeyTable) and will be present in the OpenKeyTable which will be displayed by the tool.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3405

## How was this patch tested?
written unit test in TestOmMetadataManager
