### PR TITLE
HDDS-3373. Intermittent failure in TestOMRatisLogParser

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/parser/TestOMRatisLogParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/parser/TestOMRatisLogParser.java
@@ -95,18 +95,20 @@ public class TestOMRatisLogParser {
     Assert.assertTrue(omMetaDir.isDirectory());
 
     String[] ratisDirs = omMetaDir.list();
-    File groupDir = null;
-
+    Assert.assertNotNull(ratisDirs);
     Assert.assertEquals(2, ratisDirs.length);
 
+    File groupDir = null;
     for (int i=0; i< ratisDirs.length; i++) {
       if (ratisDirs[i].equals("snapshot")) {
         continue;
       }
-      groupDir = new File(omMetaDir, omMetaDir.list()[1]);
+      groupDir = new File(omMetaDir, ratisDirs[i]);
     }
 
     Assert.assertNotNull(groupDir);
+    Assert.assertFalse(groupDir.toString(),
+        groupDir.getName().contains("snapshot"));
     Assert.assertTrue(groupDir.isDirectory());
     File currentDir = new File(groupDir, "current");
     File logFile = new File(currentDir, "log_inprogress_0");


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent failure in `TestOMRatisLogParser`.  The problem was that regardless of which `i` index corresponded to non-`snapshot` `ratisDirs[i]`, index `1` was always used for `groupDir`.

Added an assertion to verify that we do not choose `snapshot`.  Also added a few other safety checks.

https://issues.apache.org/jira/browse/HDDS-3373

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/614616449