### PR TITLE
HDDS-3457. Fix ozonefs put and mkdir KEY_NOT_FOUND issue when ACL enable 

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1614,8 +1614,15 @@ public class KeyManagerImpl implements KeyManager {
           OzoneFileStatus fileStatus = getFileStatus(args);
           keyInfo = fileStatus.getKeyInfo();
         } catch (IOException e) {
-          throw new OMException("Key not found, checkAccess failed. Key:" +
-              objectKey, KEY_NOT_FOUND);
+          // OzoneFS will check whether the key exists when write a new key.
+          // For Acl Type "READ", when the key is not exist return true.
+          // To Avoid KEY_NOT_FOUND Exception.
+          if (context.getAclRights() == IAccessAuthorizer.ACLType.READ) {
+            return true;
+          } else {
+            throw new OMException("Key not found, checkAccess failed. Key:" +
+                objectKey, KEY_NOT_FOUND);
+          }
         }
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When ACL enabled(not enable security), while we put file of  mkdir using O3FS, FileSystem will check if it exists first. If the key not exist, checkAccess will report KEY_NOT_FOUND Exception when get keyInfo. 

Because the previous bucket permission check has passed, it’s currently reading a key that does not exist, so this should be allowed.

So when KEY_NOT_FOUND appears, we confirm whether it is a read ACLType, and if it’s a read ACLType we return true. To avoid KEY_NOT_FOUND exception.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3457

## How was this patch tested?

Enable acl and put file or mkdir using o3fs.
