### PR TITLE
HDDS-3487. Ozone start fails with NullPointerException in TLS enabled cluster

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
@@ -262,5 +262,16 @@ public class OzoneConfiguration extends Configuration
     }
     return configMap;
   }
-  
+
+  @Override
+  public char[] getPassword(String key) {
+    String value = get(key);
+    if (value == null) {
+      throw new NullPointerException(
+          "Password entry is missing for key " + key
+              + ".Note: generic ConfigurationSource interface doesn't support"
+              + " Hadoop CredentialProvider implementations");
+    }
+    return value.toCharArray();
+  }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
@@ -267,7 +267,7 @@ public class OzoneConfiguration extends Configuration
   public char[] getPassword(String key) {
     String value = get(key);
     if (value == null) {
-      throw new NullPointerException(
+      throw new UnsupportedOperationException(
           "Password entry is missing for key " + key
               + ".Note: generic ConfigurationSource interface doesn't support"
               + " Hadoop CredentialProvider implementations");

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
@@ -262,16 +262,4 @@ public class OzoneConfiguration extends Configuration
     }
     return configMap;
   }
-
-  @Override
-  public char[] getPassword(String key) {
-    String value = get(key);
-    if (value == null) {
-      throw new UnsupportedOperationException(
-          "Password entry is missing for key " + key
-              + ".Note: generic ConfigurationSource interface doesn't support"
-              + " Hadoop CredentialProvider implementations");
-    }
-    return value.toCharArray();
-  }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/LegacyHadoopConfigurationSource.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/LegacyHadoopConfigurationSource.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.utils;
 
+import java.io.IOException;
 import java.util.Collection;
 
 import org.apache.hadoop.conf.Configuration;
@@ -37,6 +38,11 @@ public class LegacyHadoopConfigurationSource implements ConfigurationSource {
   @Override
   public String get(String key) {
     return configuration.getRaw(key);
+  }
+
+  @Override
+  public char[] getPassword(String key) throws IOException {
+    return configuration.getPassword(key);
   }
 
   @Override

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationSource.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationSource.java
@@ -35,6 +35,8 @@ public interface ConfigurationSource {
 
   Collection<String> getConfigKeys();
 
+  char[] getPassword(String key) throws IOException;
+
   @Deprecated
     //TODO: user read only configs and don't use it to store actual port
     // numbers.
@@ -106,10 +108,6 @@ public interface ConfigurationSource {
     }
 
     return valueString.trim().split("\\s*[,\n]\\s*");
-  }
-
-  default char[] getPassword(String key) throws IOException {
-    return get(key).toCharArray();
   }
 
   default Map<String, String> getPropsWithPrefix(String confPrefix) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix the NPE in ozone components startup.
```
SCM start failed with exception
java.lang.NullPointerException
  at org.apache.hadoop.hdds.conf.ConfigurationSource.getPassword(ConfigurationSource.java:112)
  at org.apache.hadoop.hdds.server.http.BaseHttpServer.getPassword(BaseHttpServer.java:348)
```

**Problem** 
The LegacyHadoopConfiguration class needs to use the underlying getPassword API which reads the password from the CredentialManager, and then falls back to the config key. Instead it used the default implementation that just looked for the config key's corresponding value.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3487

## How was this patch tested?
Manually tested.