### PR TITLE
HDDS-3488. Remove unnecessary jackson version definition from Ozone.

### DIFF
--- a/hadoop-hdds/hadoop-dependency-server/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-server/pom.xml
@@ -47,6 +47,22 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
           <groupId>org.apache.zookeeper</groupId>
           <artifactId>zookeeper</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-mapper-asl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-core-asl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-jaxrs</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-xc</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <jersey.version>1.19</jersey.version>
 
     <!-- jackson versions -->
-    <jackson.version>1.9.13</jackson.version>
+<!--    <jackson.version>1.9.13</jackson.version>-->
     <jackson2.version>2.10.3</jackson2.version>
 
     <!-- jaegertracing veresion -->
@@ -1067,6 +1067,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <artifactId>core</artifactId>
         <version>3.1.1</version>
       </dependency>
+
+
       <dependency>
         <groupId>org.codehaus.woodstox</groupId>
         <artifactId>stax2-api</artifactId>
@@ -1077,26 +1079,26 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <artifactId>woodstox-core</artifactId>
         <version>5.0.3</version>
       </dependency>
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-mapper-asl</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-core-asl</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-jaxrs</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-xc</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
+<!--      <dependency>-->
+<!--        <groupId>org.codehaus.jackson</groupId>-->
+<!--        <artifactId>jackson-mapper-asl</artifactId>-->
+<!--        <version>${jackson.version}</version>-->
+<!--      </dependency>-->
+<!--      <dependency>-->
+<!--        <groupId>org.codehaus.jackson</groupId>-->
+<!--        <artifactId>jackson-core-asl</artifactId>-->
+<!--        <version>${jackson.version}</version>-->
+<!--      </dependency>-->
+<!--      <dependency>-->
+<!--        <groupId>org.codehaus.jackson</groupId>-->
+<!--        <artifactId>jackson-jaxrs</artifactId>-->
+<!--        <version>${jackson.version}</version>-->
+<!--      </dependency>-->
+<!--      <dependency>-->
+<!--        <groupId>org.codehaus.jackson</groupId>-->
+<!--        <artifactId>jackson-xc</artifactId>-->
+<!--        <version>${jackson.version}</version>-->
+<!--      </dependency>-->
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <jersey.version>1.19</jersey.version>
 
     <!-- jackson versions -->
-<!--    <jackson.version>1.9.13</jackson.version>-->
     <jackson2.version>2.10.3</jackson2.version>
 
     <!-- jaegertracing veresion -->
@@ -1067,8 +1066,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <artifactId>core</artifactId>
         <version>3.1.1</version>
       </dependency>
-
-
       <dependency>
         <groupId>org.codehaus.woodstox</groupId>
         <artifactId>stax2-api</artifactId>
@@ -1079,26 +1076,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <artifactId>woodstox-core</artifactId>
         <version>5.0.3</version>
       </dependency>
-<!--      <dependency>-->
-<!--        <groupId>org.codehaus.jackson</groupId>-->
-<!--        <artifactId>jackson-mapper-asl</artifactId>-->
-<!--        <version>${jackson.version}</version>-->
-<!--      </dependency>-->
-<!--      <dependency>-->
-<!--        <groupId>org.codehaus.jackson</groupId>-->
-<!--        <artifactId>jackson-core-asl</artifactId>-->
-<!--        <version>${jackson.version}</version>-->
-<!--      </dependency>-->
-<!--      <dependency>-->
-<!--        <groupId>org.codehaus.jackson</groupId>-->
-<!--        <artifactId>jackson-jaxrs</artifactId>-->
-<!--        <version>${jackson.version}</version>-->
-<!--      </dependency>-->
-<!--      <dependency>-->
-<!--        <groupId>org.codehaus.jackson</groupId>-->
-<!--        <artifactId>jackson-xc</artifactId>-->
-<!--        <version>${jackson.version}</version>-->
-<!--      </dependency>-->
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Remove unnecessary jackson dependencies from Ozone.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3488

## How was this patch tested?
Build succeeds after removing dependencies.