### PR TITLE
HDDS-3389. Add response to SetVolumePropertyResponse proto

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
@@ -184,12 +184,12 @@ public class OzoneVolume extends WithMetadata {
 
   /**
    * Sets/Changes the owner of this Volume.
-   * @param owner new owner
+   * @param userName new owner
    * @throws IOException
    */
-  public boolean setOwner(String owner) throws IOException {
-    boolean result = proxy.setVolumeOwner(name, owner);
-    this.owner = owner;
+  public boolean setOwner(String userName) throws IOException {
+    boolean result = proxy.setVolumeOwner(name, userName);
+    this.owner = userName;
     return result;
   }
 
@@ -198,7 +198,7 @@ public class OzoneVolume extends WithMetadata {
    * @param quota new quota
    * @throws IOException
    */
-  public void setQuota(OzoneQuota  quota) throws IOException {
+  public void setQuota(OzoneQuota quota) throws IOException {
     proxy.setVolumeQuota(name, quota);
     this.quotaInBytes = quota.sizeInBytes();
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
@@ -187,9 +187,10 @@ public class OzoneVolume extends WithMetadata {
    * @param owner new owner
    * @throws IOException
    */
-  public void setOwner(String owner) throws IOException {
-    proxy.setVolumeOwner(name, owner);
+  public boolean setOwner(String owner) throws IOException {
+    boolean result = proxy.setVolumeOwner(name, owner);
     this.owner = owner;
+    return result;
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -88,9 +88,11 @@ public interface ClientProtocol {
    * Sets the owner of volume.
    * @param volumeName Name of the Volume
    * @param owner to be set for the Volume
+   * @return true if operation succeeded, false if specified user is
+   *         already the owner.
    * @throws IOException
    */
-  void setVolumeOwner(String volumeName, String owner) throws IOException;
+  boolean setVolumeOwner(String volumeName, String owner) throws IOException;
 
   /**
    * Set Volume Quota.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -314,11 +314,11 @@ public class RpcClient implements ClientProtocol {
   }
 
   @Override
-  public void setVolumeOwner(String volumeName, String owner)
+  public boolean setVolumeOwner(String volumeName, String owner)
       throws IOException {
     HddsClientUtils.verifyResourceName(volumeName);
     Preconditions.checkNotNull(owner);
-    ozoneManagerClient.setOwner(volumeName, owner);
+    return ozoneManagerClient.setOwner(volumeName, owner);
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -79,9 +79,11 @@ public interface OzoneManagerProtocol
    * Changes the owner of a volume.
    * @param volume  - Name of the volume.
    * @param owner - Name of the owner.
+   * @return true if operation succeeded, false if specified user is
+   *         already the owner.
    * @throws IOException
    */
-  void setOwner(String volume, String owner) throws IOException;
+  boolean setOwner(String volume, String owner) throws IOException;
 
   /**
    * Changes the Quota on a volume.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -61,6 +61,7 @@ import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AddAclRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AddAclResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AllocateBlockRequest;
@@ -463,14 +464,10 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   }
 
   /**
-   * Changes the owner of a volume.
-   *
-   * @param volume - Name of the volume.
-   * @param owner - Name of the owner.
-   * @throws IOException
+   * {@inheritDoc}
    */
   @Override
-  public void setOwner(String volume, String owner) throws IOException {
+  public boolean setOwner(String volume, String owner) throws IOException {
     SetVolumePropertyRequest.Builder req =
         SetVolumePropertyRequest.newBuilder();
     req.setVolumeName(volume).setOwnerName(owner);
@@ -480,7 +477,10 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .build();
 
     OMResponse omResponse = submitRequest(omRequest);
-    handleError(omResponse);
+    OzoneManagerProtocolProtos.SetVolumePropertyResponse response =
+        handleError(omResponse).getSetVolumePropertyResponse();
+
+    return response.getResponse();
   }
 
   /**

--- a/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
+++ b/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
@@ -423,7 +423,7 @@ message SetVolumePropertyRequest {
 }
 
 message SetVolumePropertyResponse {
-
+    optional bool response = 1;
 }
 
 /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1690,14 +1690,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   /**
-   * Changes the owner of a volume.
-   *
-   * @param volume - Name of the volume.
-   * @param owner - Name of the owner.
-   * @throws IOException
+   * {@inheritDoc}
    */
   @Override
-  public void setOwner(String volume, String owner) throws IOException {
+  public boolean setOwner(String volume, String owner) throws IOException {
     if(isAclEnabled) {
       checkAcls(ResourceType.VOLUME, StoreType.OZONE, ACLType.WRITE_ACL, volume,
           null, null);
@@ -1709,6 +1705,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       volumeManager.setOwner(volume, owner);
       AUDIT.logWriteSuccess(buildAuditMessageForSuccess(OMAction.SET_OWNER,
           auditMap));
+      return true;
     } catch (Exception ex) {
       metrics.incNumVolumeUpdateFails();
       AUDIT.logWriteFailure(buildAuditMessageForFailure(OMAction.SET_OWNER,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetOwnerRequest.java
@@ -146,7 +146,8 @@ public class OMVolumeSetOwnerRequest extends OMVolumeRequest {
             "Volume '" + volume + "' owner is already '" + newOwner + "'.")
           .setSuccess(false);
         omResponse.setSetVolumePropertyResponse(
-            SetVolumePropertyResponse.newBuilder().build());
+            SetVolumePropertyResponse.newBuilder()
+                .setResponse(false).build());
         omClientResponse = new OMVolumeSetOwnerResponse(omResponse.build());
         // Note: addResponseToDoubleBuffer would be executed in finally block.
         return omClientResponse;
@@ -182,7 +183,8 @@ public class OMVolumeSetOwnerRequest extends OMVolumeRequest {
           new CacheValue<>(Optional.of(omVolumeArgs), transactionLogIndex));
 
       omResponse.setSetVolumePropertyResponse(
-          SetVolumePropertyResponse.newBuilder().build());
+          SetVolumePropertyResponse.newBuilder()
+              .setResponse(true).build());
       omClientResponse = new OMVolumeSetOwnerResponse(omResponse.build(),
           oldOwner, oldOwnerVolumeList, newOwnerVolumeList, omVolumeArgs);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetOwnerRequest.java
@@ -146,8 +146,7 @@ public class OMVolumeSetOwnerRequest extends OMVolumeRequest {
             "Volume '" + volume + "' owner is already '" + newOwner + "'.")
           .setSuccess(false);
         omResponse.setSetVolumePropertyResponse(
-            SetVolumePropertyResponse.newBuilder()
-                .setResponse(false).build());
+            SetVolumePropertyResponse.newBuilder().setResponse(false).build());
         omClientResponse = new OMVolumeSetOwnerResponse(omResponse.build());
         // Note: addResponseToDoubleBuffer would be executed in finally block.
         return omClientResponse;
@@ -183,8 +182,7 @@ public class OMVolumeSetOwnerRequest extends OMVolumeRequest {
           new CacheValue<>(Optional.of(omVolumeArgs), transactionLogIndex));
 
       omResponse.setSetVolumePropertyResponse(
-          SetVolumePropertyResponse.newBuilder()
-              .setResponse(true).build());
+          SetVolumePropertyResponse.newBuilder().setResponse(true).build());
       omClientResponse = new OMVolumeSetOwnerResponse(omResponse.build(),
           oldOwner, oldOwnerVolumeList, newOwnerVolumeList, omVolumeArgs);
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/UpdateVolumeHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/UpdateVolumeHandler.java
@@ -58,7 +58,7 @@ public class UpdateVolumeHandler extends VolumeHandler {
     if (ownerName != null && !ownerName.isEmpty()) {
       boolean result = volume.setOwner(ownerName);
       if (LOG.isDebugEnabled() && !result) {
-        out().format("Volume '%s' owner is already '%s'. Unchanged.\n",
+        out().format("Volume '%s' owner is already '%s'. Unchanged.%n",
             volumeName, ownerName);
       }
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/UpdateVolumeHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/UpdateVolumeHandler.java
@@ -56,7 +56,11 @@ public class UpdateVolumeHandler extends VolumeHandler {
     }
 
     if (ownerName != null && !ownerName.isEmpty()) {
-      volume.setOwner(ownerName);
+      boolean result = volume.setOwner(ownerName);
+      if (LOG.isDebugEnabled() && !result) {
+        out().format("Volume '%s' owner is already '%s'. Unchanged.\n",
+            volumeName, ownerName);
+      }
     }
 
     printObjectAsJson(volume);


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://github.com/apache/hadoop-ozone/pull/806#discussion_r408279098

1. Add `optional bool response = 1;` in the message.
2. Handle the response on the client. e.g. in setOwner, if the response is false, we can print message: The specified user is already the owner of the volume.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3389

## How was this patch tested?

```bash
bash-4.2$ ozone sh volume create vol1
bash-4.2$ vi /etc/hadoop/ozone-shell-log4j.properties
# Append: log4j.logger.org.apache.hadoop.ozone.shell.Handler=DEBUG
bash-4.2$ ozone sh volume update vol1 --user=user1
{
  "metadata" : { },
  "name" : "vol1",
  "admin" : "hadoop",
  "owner" : "user1",
  "creationTime" : "2020-05-05T12:05:10.885Z",
  "acls" : [ {
    "type" : "USER",
    "name" : "hadoop",
    "aclScope" : "ACCESS",
    "aclList" : [ "ALL" ]
  }, {
    "type" : "GROUP",
    "name" : "users",
    "aclScope" : "ACCESS",
    "aclList" : [ "ALL" ]
  } ],
  "quota" : 1152921504606846976
}
bash-4.2$ ozone sh volume update vol1 --user=user1
Volume 'vol1' owner is already 'user1'. Unchanged.
{
  "metadata" : { },
  "name" : "vol1",
  "admin" : "hadoop",
  "owner" : "user1",
  "creationTime" : "2020-05-05T12:05:10.885Z",
  "acls" : [ {
    "type" : "USER",
    "name" : "hadoop",
    "aclScope" : "ACCESS",
    "aclList" : [ "ALL" ]
  }, {
    "type" : "GROUP",
    "name" : "users",
    "aclScope" : "ACCESS",
    "aclList" : [ "ALL" ]
  } ],
  "quota" : 1152921504606846976
}
```