### PR TITLE
HDDS-3496. Make S3_ADMIN_NAME configurable

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -123,6 +123,11 @@ public final class OzoneConfigKeys {
    * */
   public static final String OZONE_ADMINISTRATORS_WILDCARD = "*";
 
+  public static final String OZONE_S3G_ADMINISTRATOR =
+      "ozone.om.s3g.administrator";
+  public static final String OZONE_S3G_ADMINISTRATOR_DEFAULT =
+      "OzoneS3Manager";
+
   public static final String OZONE_CLIENT_STREAM_BUFFER_SIZE =
       "ozone.client.stream.buffer.size";
 

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -629,6 +629,13 @@
     </description>
   </property>
   <property>
+    <name>ozone.om.s3g.administrator</name>
+    <value>OzoneS3Manager</value>
+    <tag>OZONE, OM, S3GATEWAY</tag>
+    <description>Ozone s3g administrator user. This user has all permissions of
+      bucket or volume created by s3g.</description>
+  </property>
+  <property>
     <name>ozone.metadata.dirs</name>
     <value/>
     <tag>OZONE, OM, SCM, CONTAINER, STORAGE, REQUIRED</tag>

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/S3BucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/S3BucketManagerImpl.java
@@ -29,6 +29,8 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.security.UserGroupInformation;
 
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_S3G_ADMINISTRATOR;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_S3G_ADMINISTRATOR_DEFAULT;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_ALREADY_EXISTS;
 
 import org.apache.logging.log4j.util.Strings;
@@ -50,7 +52,6 @@ public class S3BucketManagerImpl implements S3BucketManager {
   private static final Logger LOG =
       LoggerFactory.getLogger(S3BucketManagerImpl.class);
 
-  private static final String S3_ADMIN_NAME = "OzoneS3Manager";
   private final OzoneConfiguration configuration;
   private final OMMetadataManager omMetadataManager;
   private final VolumeManager volumeManager;
@@ -160,10 +161,12 @@ public class S3BucketManagerImpl implements S3BucketManager {
     // this call is invoked while holding the s3Bucket lock.
     boolean newVolumeCreate = true;
     String ozoneVolumeName = formatOzoneVolumeName(userName);
+    String s3gAdminName = configuration.get(
+        OZONE_S3G_ADMINISTRATOR, OZONE_S3G_ADMINISTRATOR_DEFAULT);
     try {
       OmVolumeArgs.Builder builder =
           OmVolumeArgs.newBuilder()
-              .setAdminName(S3_ADMIN_NAME)
+              .setAdminName(s3gAdminName)
               .setOwnerName(userName)
               .setVolume(ozoneVolumeName)
               .setQuotaInBytes(OzoneConsts.MAX_QUOTA_IN_BYTES);
@@ -194,8 +197,10 @@ public class S3BucketManagerImpl implements S3BucketManager {
    * */
   private List<OzoneAcl> getDefaultAcls(String userName) {
     UserGroupInformation ugi = ProtobufRpcEngine.Server.getRemoteUser();
+    String s3gAdminName = configuration.get(
+            OZONE_S3G_ADMINISTRATOR, OZONE_S3G_ADMINISTRATOR_DEFAULT);
     return OzoneAcl.parseAcls("user:" + (ugi == null ? userName :
-        ugi.getUserName()) + ":a,user:" + S3_ADMIN_NAME + ":a");
+        ugi.getUserName()) + ":a,user:" + s3gAdminName + ":a");
   }
 
   private void createOzoneBucket(String volumeName, String bucketName)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/bucket/TestS3BucketRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/bucket/TestS3BucketRequest.java
@@ -71,6 +71,8 @@ public class TestS3BucketRequest {
     when(ozoneManager.isRatisEnabled()).thenReturn(true);
     auditLogger = Mockito.mock(AuditLogger.class);
     when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
+    when(ozoneManager.getConfiguration()).thenReturn(
+        new OzoneConfiguration());
     Mockito.doNothing().when(auditLogger).logWrite(any(AuditMessage.class));
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

With buckets and volumes created by s3g, the admin user is now ‘OzoneS3Manager’. We need to change it to other users. This can be changed to configurable.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3496

## How was this patch tested?
1、ozone.acl.enableo ozone acl and set ozone.om.s3g.administrator=anyone in ozone-site.xml
2、create bucket use s3api：
aws s3api --endpoint-url http://s3g-host:9878 create-bucket --bucket=test
3、You can see the acl info of the bucket(by default is 'OzoneS3Manager'):
ozone sh bucket getacl s375201e1bbbdba75e600fcd0273c304ca/test


