### PR TITLE
HDDS-3398. Update Ratis/gRPC/Netty dependencies.

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -223,7 +223,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <extensions>true</extensions>
         <configuration>
           <protocArtifact>
-            com.google.protobuf:protoc:${datanode.protobuf-compile.version}:exe:${os.detected.classifier}
+            com.google.protobuf:protoc:${protobuf-compile.version}:exe:${os.detected.classifier}
           </protocArtifact>
           <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
           <includes>
@@ -244,7 +244,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               <configuration>
                 <pluginId>grpc-java</pluginId>
                 <pluginArtifact>
-                  io.grpc:protoc-gen-grpc-java:${datanode.grpc-compile.version}:exe:${os.detected.classifier}
+                  io.grpc:protoc-gen-grpc-java:${grpc-compile.version}:exe:${os.detected.classifier}
                 </pluginArtifact>
               </configuration>
           </execution>

--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -28,15 +28,11 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Hadoop Ozone CSI service</name>
   <packaging>jar</packaging>
 
-  <properties>
-    <grpc-compile.version>1.17.1</grpc-compile.version>
-    <protobuf-compile.version>3.5.0</protobuf-compile.version>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
-      <version>3.5.1</version>
+      <version>${protobuf-compile.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.protobuf</groupId>
@@ -66,7 +62,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.5.1</version>
+      <version>${protobuf-compile.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
@@ -76,12 +72,12 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
-      <version>4.1.30.Final</version>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-unix-common</artifactId>
-      <version>4.1.30.Final</version>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -164,7 +164,7 @@
                 <artifactItem>
                   <groupId>com.google.protobuf</groupId>
                   <artifactId>protobuf-java</artifactId>
-                  <version>3.5.1</version>
+                  <version>${protobuf-compile.version}</version>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -123,7 +123,7 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
   @Override
   public void initialize(RaftServer server, RaftGroupId id,
       RaftStorage raftStorage) throws IOException {
-    lifeCycle.startAndTransition(() -> {
+    getLifeCycle().startAndTransition(() -> {
       super.initialize(server, id, raftStorage);
       this.raftGroupId = id;
       storage.init(raftStorage);
@@ -304,8 +304,8 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
 
   @Override
   public void pause() {
-    lifeCycle.transition(LifeCycle.State.PAUSING);
-    lifeCycle.transition(LifeCycle.State.PAUSED);
+    getLifeCycle().transition(LifeCycle.State.PAUSING);
+    getLifeCycle().transition(LifeCycle.State.PAUSED);
     ozoneManagerDoubleBuffer.stop();
   }
 
@@ -316,7 +316,7 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
    */
   public void unpause(long newLastAppliedSnaphsotIndex,
       long newLastAppliedSnapShotTermIndex) {
-    lifeCycle.startAndTransition(() -> {
+    getLifeCycle().startAndTransition(() -> {
       this.ozoneManagerDoubleBuffer =
           new OzoneManagerDoubleBuffer(ozoneManager.getMetadataManager(),
               this::updateLastAppliedIndex);

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>0.6.0-490b689-SNAPSHOT</ratis.version>
+    <ratis.version>0.6.0-cac3336-SNAPSHOT</ratis.version>
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>
     <distMgmtSnapshotsUrl>https://repository.apache.org/content/repositories/snapshots</distMgmtSnapshotsUrl>
@@ -166,9 +166,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <!-- Maven protoc compiler -->
     <protobuf-maven-plugin.version>0.5.1</protobuf-maven-plugin.version>
-    <datanode.protobuf-compile.version>3.10.0</datanode.protobuf-compile.version>
-    <datanode.grpc-compile.version>1.24.0</datanode.grpc-compile.version>
+    <protobuf-compile.version>3.11.0</protobuf-compile.version>
+    <grpc-compile.version>1.28.1</grpc-compile.version>
     <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
+
+    <netty.version>4.1.48.Final</netty.version>
 
     <!-- define the Java language version used by the compiler -->
     <javac.version>1.8</javac.version>
@@ -906,7 +908,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.47.Final</version>
+        <version>${netty.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This jira updates the Ratis, Netty and gRPC dependencies on Ozone.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3398

## How was this patch tested?
Tried to bring up Ozone CSI server which worked fine. Also ran unit tests.
