### PR TITLE
HDDS-3327. Fix s3api  create bucket BUCKET_NOT_FOUND and acl initialization problem when enable acl.

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -34,6 +34,8 @@ import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMTokenProto.Type.S3AUTHINFO;
 import static org.apache.hadoop.ozone.s3.SignatureProcessor.UTF_8;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.S3_AUTHINFO_CREATION_ERROR;
@@ -76,6 +78,8 @@ public class OzoneClientProducer {
 
   private OzoneClient getClient(OzoneConfiguration config) throws IOException {
     try {
+      Boolean isAclEnable = config.getBoolean(
+          OZONE_ACL_ENABLED, OZONE_ACL_ENABLED_DEFAULT);
       if (OzoneSecurityUtil.isSecurityEnabled(config)) {
         LOG.debug("Creating s3 auth info for client.");
         try {
@@ -103,6 +107,13 @@ public class OzoneClientProducer {
           throw S3_AUTHINFO_CREATION_ERROR;
         }
 
+      } else if (isAclEnable) {
+        String awsAccessId = v4RequestParser.getAwsAccessId();
+        if (awsAccessId != null) {
+          UserGroupInformation remoteUser =
+              UserGroupInformation.createRemoteUser(awsAccessId);
+          UserGroupInformation.setLoginUser(remoteUser);
+        }
       }
     } catch (Exception e) {
       LOG.error("Error: ", e);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -107,7 +107,7 @@ public class OzoneClientProducer {
           throw S3_AUTHINFO_CREATION_ERROR;
         }
 
-      } else if (isAclEnable) {
+      } else {
         String awsAccessId = v4RequestParser.getAwsAccessId();
         if (awsAccessId != null) {
           UserGroupInformation remoteUser =


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the acl is enabled(not enable security), It report an error of BUCKET_NOT_FOUND, when execute the following command to create the bucket. This is successful when the acl is not enabled. 
aws s3api --endpoint-url http://localhost:9878 create-bucket --bucket=bucket1

When creating a bucket through s3g, the volume name is determined by the md5Hex value of awsAccessId.
After the bucket is created, the location of that bucket is retrieved and returned to the client. When acls enabled, checkaccess is executed when we get the location. IF we are not set UserGroupInformation.setLoginUser(remoteUser), ozone will get s3g start the user as a username(this username will be used to determine the volume name). When this user is  different with awsAccessId, checkaccess will get BUCKET_NOT_FOUND exception.

For example:
When we create a bucket, the bucket is (test_user is the value of awsAccessId):
Md5Hex (test_user)/bucket1 
When get location and checkaccess , the bucket is (root is the start user of s3g):
Md5Hex (root)/bucket1 

Because the user is different, the volume is different, so the om can't find the bucket.
This PR will get awsAccessId as the current user.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3327

## How was this patch tested?

1、enable ozone acl without security.
2、create bucket use s3api(Make sure the s3g startup user is different with awsAccessId)：
aws s3api --endpoint-url http://s3g-host:9878 create-bucket --bucket=test