### PR TITLE
HDDS-3081. Replication manager should detect and correct containers which don't meet the replication policy

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ContainerPlacementStatus.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ContainerPlacementStatus.java
@@ -52,6 +52,6 @@ public interface ContainerPlacementStatus {
    * placed correctly.
    * @return The number of additional replicas required, or zero.
    */
-  int additionalReplicaRequired();
+  int misReplicationCount();
 
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ContainerPlacementStatus.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ContainerPlacementStatus.java
@@ -24,8 +24,11 @@ package org.apache.hadoop.hdds.scm;
 public interface ContainerPlacementStatus {
 
   /**
-   * Returns a boolean indicating if the container replica meet the desired
-   * replication policy.
+   * Returns a boolean indicating if the container replicas meet the desired
+   * placement policy. That is, they are placed on a sufficient number of
+   * racks, or node groups etc. This does not check if the container is over
+   * or under replicated, as it is possible for a container to have enough
+   * replicas and still not meet the placement rules.
    * @return True if the containers meet the policy. False otherwise.
    */
   boolean isPolicySatisfied();
@@ -44,7 +47,9 @@ public interface ContainerPlacementStatus {
    * meets the placement policy. Otherwise return zero.
    * Note the count returned are the number of replicas needed to meet the
    * placement policy. The container may need additional replicas if it is
-   * under replicated.
+   * under replicated. The container could also have sufficient replicas but
+   * require more to make it meet the policy, as the existing replicas are not
+   * placed correctly.
    * @return The number of additional replicas required, or zero.
    */
   int additionalReplicaRequired();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ContainerPlacementStatus.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ContainerPlacementStatus.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.hdds.scm;
+
+/**
+ * Interface to allow container placement status to be queried to ensure a
+ * container meets its placement policy (number of racks etc).
+ */
+public interface ContainerPlacementStatus {
+
+  /**
+   * Returns a boolean indicating if the container replica meet the desired
+   * replication policy.
+   * @return True if the containers meet the policy. False otherwise.
+   */
+  boolean isPolicySatisfied();
+
+  /**
+   * If the container do not meet the placement policy, return an integer
+   * indicating how many additional replicas are required. Otherwise return
+   * zero.
+   * @return The number of additional replicas required, or zero.
+   */
+  int additionalReplicaRequired();
+
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ContainerPlacementStatus.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ContainerPlacementStatus.java
@@ -39,9 +39,12 @@ public interface ContainerPlacementStatus {
   String misReplicatedReason();
 
   /**
-   * If the container do not meet the placement policy, return an integer
-   * indicating how many additional replicas are required. Otherwise return
-   * zero.
+   * If the container does not meet the placement policy, return an integer
+   * indicating how many additional replicas are required so the container
+   * meets the placement policy. Otherwise return zero.
+   * Note the count returned are the number of replicas needed to meet the
+   * placement policy. The container may need additional replicas if it is
+   * under replicated.
    * @return The number of additional replicas required, or zero.
    */
   int additionalReplicaRequired();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ContainerPlacementStatus.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ContainerPlacementStatus.java
@@ -31,6 +31,14 @@ public interface ContainerPlacementStatus {
   boolean isPolicySatisfied();
 
   /**
+   * Returns an String describing why a container does not meet the placement
+   * policy.
+   * @return String indicating the reason the policy is not satisfied or null if
+   *         the policy is satisfied.
+   */
+  String misReplicatedReason();
+
+  /**
    * If the container do not meet the placement policy, return an integer
    * indicating how many additional replicas are required. Otherwise return
    * zero.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/PlacementPolicy.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/PlacementPolicy.java
@@ -42,4 +42,14 @@ public interface PlacementPolicy {
   List<DatanodeDetails> chooseDatanodes(List<DatanodeDetails> excludedNodes,
       List<DatanodeDetails> favoredNodes, int nodesRequired, long sizeRequired)
       throws IOException;
+
+  /**
+   * Given a list of datanode and the number of replicas required, return
+   * a PlacementPolicyStatus object indicating if the container meets the
+   * placement policy - ie is it on the correct number of racks, etc.
+   * @param dns List of datanodes holding a replica of the container
+   * @param replicas The expected number of replicas
+   */
+  ContainerPlacementStatus validateContainerPlacement(
+      List<DatanodeDetails> dns, int replicas);
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -213,16 +213,6 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
       List<DatanodeDetails> healthyNodes);
 
   /**
-   * Default implementation for basic placement policies that do not have a
-   * placement policy. If the policy has not network topology this method should
-   * return null.
-   * @return The networkTopology for the policy or null if none is configured.
-   */
-  protected NetworkTopology getNetworkTopology() {
-    return null;
-  }
-
-  /**
    * Default implementation to return the number of racks containers should span
    * to meet the placement policy. For simple policies that are not rack aware
    * we return 1, from this default implementation.
@@ -249,7 +239,7 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
   @Override
   public ContainerPlacementStatus validateContainerPlacement(
       List<DatanodeDetails> dns, int replicas) {
-    NetworkTopology topology = getNetworkTopology();
+    NetworkTopology topology = nodeManager.getClusterNetworkTopologyMap();
     int requiredRacks = getRequiredRackCount();
     if (topology == null || replicas == 1 || requiredRacks == 1) {
       if (dns.size() > 0) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -258,7 +258,6 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
     if (replicas < requiredRacks) {
       requiredRacks = replicas;
     }
-
     return new ContainerPlacementStatusDefault(
         (int)currentRackCount, requiredRacks, numRacks);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -542,11 +542,6 @@ public class ReplicationManager
             .map(ContainerReplica::getDatanodeDetails)
             .collect(Collectors.toList());
         excludeList.addAll(replicationInFlight);
-        List<InflightAction> actionList = inflightReplication.get(id);
-        if (actionList != null) {
-          actionList.stream().map(r -> r.datanode)
-              .forEach(excludeList::add);
-        }
         final List<DatanodeDetails> selectedDatanodes = containerPlacement
             .chooseDatanodes(excludeList, null, replicasNeeded,
                 container.getUsedBytes());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -534,7 +534,7 @@ public class ReplicationManager
         final ContainerPlacementStatus placementStatus =
             containerPlacement.validateContainerPlacement(
                 targetReplicas, replicationFactor);
-        final int misRepDelta = placementStatus.additionalReplicaRequired();
+        final int misRepDelta = placementStatus.misReplicationCount();
         final int replicasNeeded
             = delta < misRepDelta ? misRepDelta : delta;
 
@@ -558,7 +558,7 @@ public class ReplicationManager
           // makes the placement policy valid.
           targetReplicas.addAll(selectedDatanodes);
           newMisRepDelta = containerPlacement.validateContainerPlacement(
-              targetReplicas, replicationFactor).additionalReplicaRequired();
+              targetReplicas, replicationFactor).misReplicationCount();
         }
         if (delta > 0 || newMisRepDelta < misRepDelta) {
           // Only create new replicas if we are missing a replicas or

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -526,8 +526,7 @@ public class ReplicationManager
         // Want to check if the container is mis-replicated after considering
         // inflight add and delete.
         // Create a new list from source (healthy replicas minus pending delete)
-        List<DatanodeDetails> targetReplicas = new ArrayList<>();
-        targetReplicas.addAll(source);
+        List<DatanodeDetails> targetReplicas = new ArrayList<>(source);
         // Then add any pending additions
         targetReplicas.addAll(replicationInFlight);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -571,7 +571,8 @@ public class ReplicationManager
         } else {
           LOG.warn("Container {} is mis-replicated, requiring {} additional " +
               "replicas. After selecting new nodes, mis-replication has not " +
-              "improved. No additional will be scheduled", id, misRepDelta);
+              "improved. No additional replicas will be scheduled",
+              id, misRepDelta);
         }
       } else {
         LOG.warn("Cannot replicate container {}, no healthy replica found.",

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/ContainerPlacementStatusDefault.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/ContainerPlacementStatusDefault.java
@@ -42,6 +42,15 @@ public class ContainerPlacementStatusDefault
   }
 
   @Override
+  public String misReplicatedReason() {
+    if (isPolicySatisfied()) {
+      return null;
+    }
+    return "The container is mis-replicated as it is on " + currentRacks +
+        " racks but should be on " + requiredRacks + " racks.";
+  }
+
+  @Override
   public int additionalReplicaRequired() {
     if (isPolicySatisfied()) {
       return 0;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/ContainerPlacementStatusDefault.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/ContainerPlacementStatusDefault.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.hdds.scm.container.placement.algorithms;
+
+import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
+
+/**
+ *  Simple Status object to check if a container is replicated across enough
+ *  racks.
+ */
+public class ContainerPlacementStatusDefault
+    implements ContainerPlacementStatus {
+
+  private final int requiredRacks;
+  private final int currentRacks;
+  private final int totalRacks;
+
+  public ContainerPlacementStatusDefault(int currentRacks, int requiredRacks,
+      int totalRacks) {
+    this.requiredRacks = requiredRacks;
+    this.currentRacks = currentRacks;
+    this.totalRacks = totalRacks;
+  }
+
+  @Override
+  public boolean isPolicySatisfied() {
+    return currentRacks >= totalRacks || currentRacks >= requiredRacks;
+  }
+
+  @Override
+  public int additionalReplicaRequired() {
+    if (isPolicySatisfied()) {
+      return 0;
+    }
+    return requiredRacks - currentRacks;
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/ContainerPlacementStatusDefault.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/ContainerPlacementStatusDefault.java
@@ -51,7 +51,7 @@ public class ContainerPlacementStatusDefault
   }
 
   @Override
-  public int additionalReplicaRequired() {
+  public int misReplicationCount() {
     if (isPolicySatisfied()) {
       return 0;
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
@@ -349,11 +349,6 @@ public final class SCMContainerPlacementRackAware
   }
 
   @Override
-  protected NetworkTopology getNetworkTopology() {
-    return networkTopology;
-  }
-
-  @Override
   protected int getRequiredRackCount() {
     return REQUIRED_RACKS;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
@@ -56,6 +56,8 @@ public final class SCMContainerPlacementRackAware
   private static final int RACK_LEVEL = 1;
   private static final int MAX_RETRY= 3;
   private final SCMContainerPlacementMetrics metrics;
+  // Used to check the placement policy is validated in the parent class
+  private static final int REQUIRED_RACKS = 2;
 
   /**
    * Constructs a Container Placement with rack awareness.
@@ -344,5 +346,15 @@ public final class SCMContainerPlacementRackAware
         return Arrays.asList(chosenNodes.toArray(new DatanodeDetails[0]));
       }
     }
+  }
+
+  @Override
+  protected NetworkTopology getNetworkTopology() {
+    return networkTopology;
+  }
+
+  @Override
+  protected int getRequiredRackCount() {
+    return REQUIRED_RACKS;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -390,12 +390,6 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
     return (topology.getNumOfNodes(topology.getMaxLevel() - 1) == 1);
   }
 
-
-  @Override
-  protected NetworkTopology getNetworkTopology() {
-    return nodeManager.getClusterNetworkTopologyMap();
-  }
-
   @Override
   protected int getRequiredRackCount() {
     return REQUIRED_RACKS;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -54,6 +54,7 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
   private final PipelineStateManager stateManager;
   private final ConfigurationSource conf;
   private final int heavyNodeCriteria;
+  private static final int REQUIRED_RACKS = 2;
 
   /**
    * Constructs a pipeline placement with considering network topology,
@@ -387,6 +388,18 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
       return true;
     }
     return (topology.getNumOfNodes(topology.getMaxLevel() - 1) == 1);
+  }
+
+
+  @Override
+  protected NetworkTopology getNetworkTopology() {
+    LOG.info("Called the one");
+    return nodeManager.getClusterNetworkTopologyMap();
+  }
+
+  @Override
+  protected int getRequiredRackCount() {
+    return REQUIRED_RACKS;
   }
 
   private static class DnWithPipelines {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -393,7 +393,6 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
 
   @Override
   protected NetworkTopology getNetworkTopology() {
-    LOG.info("Called the one");
     return nodeManager.getClusterNetworkTopologyMap();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.hdds.scm.container.ReplicationManager.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.server.events.EventHandler;
@@ -39,6 +40,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -103,6 +105,13 @@ public class TestReplicationManager {
           return IntStream.range(0, count)
               .mapToObj(i -> randomDatanodeDetails())
               .collect(Collectors.toList());
+        });
+
+    Mockito.when(containerPlacementPolicy.validateContainerPlacement(
+        Mockito.anyListOf(DatanodeDetails.class),
+        Mockito.anyInt()
+        )).thenAnswer(invocation ->  {
+          return new ContainerPlacementStatusDefault(2, 2, 3);
         });
 
     replicationManager = new ReplicationManager(
@@ -635,6 +644,69 @@ public class TestReplicationManager {
 
   }
 
+  @Test
+  public void additionalReplicaScheduledWhenMisReplicated()
+      throws SCMException, ContainerNotFoundException, InterruptedException {
+    final ContainerInfo container = getContainer(LifeCycleState.CLOSED);
+    final ContainerID id = container.containerID();
+    final UUID originNodeId = UUID.randomUUID();
+    final ContainerReplica replicaOne = getReplicas(
+        id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+    final ContainerReplica replicaTwo = getReplicas(
+        id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+    final ContainerReplica replicaThree = getReplicas(
+        id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+
+    containerStateManager.loadContainer(container);
+    containerStateManager.updateContainerReplica(id, replicaOne);
+    containerStateManager.updateContainerReplica(id, replicaTwo);
+    containerStateManager.updateContainerReplica(id, replicaThree);
+
+    // Ensure a mis-replicated status is returned for any containers in this
+    // test where there are 3 replicas. When there are 2 or 4 replicas
+    // the status returned will be healthy.
+    Mockito.when(containerPlacementPolicy.validateContainerPlacement(
+        Mockito.argThat(new ListOfNElements(3)),
+        Mockito.anyInt()
+    )).thenAnswer(invocation ->  {
+      return new ContainerPlacementStatusDefault(1, 2, 3);
+    });
+
+    int currentReplicateCommandCount = datanodeCommandHandler
+        .getInvocationCount(SCMCommandProto.Type.replicateContainerCommand);
+
+    replicationManager.processContainersNow();
+    // Wait for EventQueue to call the event handler
+    Thread.sleep(100L);
+    // At this stage, due to the mocked calls to validteContainerPlacement
+    // the mis-replicated racks will not have improved, so expect to see nothing
+    // scheduled.
+    Assert.assertEquals(currentReplicateCommandCount + 1, datanodeCommandHandler
+        .getInvocationCount(SCMCommandProto.Type.replicateContainerCommand));
+
+    // Now make it so that all containers seem mis-replicated no matter how
+    // many replicas. This will test replicas are not scheduled if the new
+    // replica does not fix the mis-replication.
+    Mockito.when(containerPlacementPolicy.validateContainerPlacement(
+        Mockito.anyList(),
+        Mockito.anyInt()
+    )).thenAnswer(invocation ->  {
+      return new ContainerPlacementStatusDefault(1, 2, 3);
+    });
+
+    currentReplicateCommandCount = datanodeCommandHandler
+        .getInvocationCount(SCMCommandProto.Type.replicateContainerCommand);
+
+    replicationManager.processContainersNow();
+    // Wait for EventQueue to call the event handler
+    Thread.sleep(100L);
+    // At this stage, due to the mocked calls to validteContainerPlacement
+    // the mis-replicated racks will not have improved, so expect to see nothing
+    // scheduled.
+    Assert.assertEquals(currentReplicateCommandCount, datanodeCommandHandler
+        .getInvocationCount(SCMCommandProto.Type.replicateContainerCommand));
+  }
+
   @After
   public void teardown() throws IOException {
     containerStateManager.close();
@@ -685,6 +757,20 @@ public class TestReplicationManager {
       return commands.stream().anyMatch(dc ->
           dc.getCommand().getType().equals(type) &&
               dc.getDatanodeId().equals(datanode.getUuid()));
+    }
+  }
+
+  class ListOfNElements extends ArgumentMatcher<List> {
+
+    private int expected;
+
+    ListOfNElements(int expected) {
+      this.expected = expected;
+    }
+
+    @Override
+    public boolean matches(Object argument) {
+      return ((List)argument).size() == expected;
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
+import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeMetric;
@@ -131,6 +132,12 @@ public class TestContainerPlacementFactory {
         List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
         int nodesRequired, long sizeRequired) {
       return null;
+    }
+
+    @Override
+    public ContainerPlacementStatus
+        validateContainerPlacement(List<DatanodeDetails> dns, int replicas) {
+      return new ContainerPlacementStatusDefault(1, 1, 1);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementStatusDefault.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementStatusDefault.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.container.placement.algorithms;
+
+import org.junit.Test;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Test for the ContainerPlacementStatusDefault class.
+ */
+
+public class TestContainerPlacementStatusDefault {
+
+  @Test
+  public void testPlacementSatisfiedCorrectly() {
+    ContainerPlacementStatusDefault stat =
+        new ContainerPlacementStatusDefault(1, 1, 1);
+    assertTrue(stat.isPolicySatisfied());
+    assertEquals(0, stat.additionalReplicaRequired());
+
+    // Requires 2 racks, but cluster only has 1
+    stat = new ContainerPlacementStatusDefault(1, 2, 1);
+    assertTrue(stat.isPolicySatisfied());
+    assertEquals(0, stat.additionalReplicaRequired());
+
+    stat = new ContainerPlacementStatusDefault(2, 2, 3);
+    assertTrue(stat.isPolicySatisfied());
+    assertEquals(0, stat.additionalReplicaRequired());
+
+    stat = new ContainerPlacementStatusDefault(3, 2, 3);
+    assertTrue(stat.isPolicySatisfied());
+    assertEquals(0, stat.additionalReplicaRequired());
+  }
+
+  @Test
+  public void testPlacementNotSatisfied() {
+    ContainerPlacementStatusDefault stat =
+        new ContainerPlacementStatusDefault(1, 2, 2);
+    assertFalse(stat.isPolicySatisfied());
+    assertEquals(1, stat.additionalReplicaRequired());
+
+    // Zero rack, but need 2 - shouldn't really happen in practice
+    stat = new ContainerPlacementStatusDefault(0, 2, 1);
+    assertFalse(stat.isPolicySatisfied());
+    assertEquals(2, stat.additionalReplicaRequired());
+
+    stat = new ContainerPlacementStatusDefault(2, 3, 3);
+    assertFalse(stat.isPolicySatisfied());
+    assertEquals(1, stat.additionalReplicaRequired());
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementStatusDefault.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementStatusDefault.java
@@ -34,20 +34,20 @@ public class TestContainerPlacementStatusDefault {
     ContainerPlacementStatusDefault stat =
         new ContainerPlacementStatusDefault(1, 1, 1);
     assertTrue(stat.isPolicySatisfied());
-    assertEquals(0, stat.additionalReplicaRequired());
+    assertEquals(0, stat.misReplicationCount());
 
     // Requires 2 racks, but cluster only has 1
     stat = new ContainerPlacementStatusDefault(1, 2, 1);
     assertTrue(stat.isPolicySatisfied());
-    assertEquals(0, stat.additionalReplicaRequired());
+    assertEquals(0, stat.misReplicationCount());
 
     stat = new ContainerPlacementStatusDefault(2, 2, 3);
     assertTrue(stat.isPolicySatisfied());
-    assertEquals(0, stat.additionalReplicaRequired());
+    assertEquals(0, stat.misReplicationCount());
 
     stat = new ContainerPlacementStatusDefault(3, 2, 3);
     assertTrue(stat.isPolicySatisfied());
-    assertEquals(0, stat.additionalReplicaRequired());
+    assertEquals(0, stat.misReplicationCount());
   }
 
   @Test
@@ -55,16 +55,16 @@ public class TestContainerPlacementStatusDefault {
     ContainerPlacementStatusDefault stat =
         new ContainerPlacementStatusDefault(1, 2, 2);
     assertFalse(stat.isPolicySatisfied());
-    assertEquals(1, stat.additionalReplicaRequired());
+    assertEquals(1, stat.misReplicationCount());
 
     // Zero rack, but need 2 - shouldn't really happen in practice
     stat = new ContainerPlacementStatusDefault(0, 2, 1);
     assertFalse(stat.isPolicySatisfied());
-    assertEquals(2, stat.additionalReplicaRequired());
+    assertEquals(2, stat.misReplicationCount());
 
     stat = new ContainerPlacementStatusDefault(2, 3, 3);
     assertFalse(stat.isPolicySatisfied());
-    assertEquals(1, stat.additionalReplicaRequired());
+    assertEquals(1, stat.misReplicationCount());
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -107,6 +107,8 @@ public class TestSCMContainerPlacementRackAware {
 
     // create mock node manager
     nodeManager = Mockito.mock(NodeManager.class);
+    when(nodeManager.getClusterNetworkTopologyMap())
+        .thenReturn(cluster);
     when(nodeManager.getNodes(NodeState.HEALTHY))
         .thenReturn(new ArrayList<>(datanodes));
     when(nodeManager.getNodeStat(anyObject()))

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -393,7 +393,7 @@ public class TestSCMContainerPlacementRackAware {
     dns.add(datanodes.get(2));
     ContainerPlacementStatus stat = policy.validateContainerPlacement(dns, 3);
     assertFalse(stat.isPolicySatisfied());
-    assertEquals(1, stat.additionalReplicaRequired());
+    assertEquals(1, stat.misReplicationCount());
 
     // Pick a new list which spans 2 racks
     dns = new ArrayList<>();
@@ -402,21 +402,21 @@ public class TestSCMContainerPlacementRackAware {
     dns.add(datanodes.get(5)); // This is on second rack
     stat = policy.validateContainerPlacement(dns, 3);
     assertTrue(stat.isPolicySatisfied());
-    assertEquals(0, stat.additionalReplicaRequired());
+    assertEquals(0, stat.misReplicationCount());
 
     // Pick single DN, expecting 3 replica. Policy is not met.
     dns = new ArrayList<>();
     dns.add(datanodes.get(0));
     stat = policy.validateContainerPlacement(dns, 3);
     assertFalse(stat.isPolicySatisfied());
-    assertEquals(1, stat.additionalReplicaRequired());
+    assertEquals(1, stat.misReplicationCount());
 
     // Pick single DN, expecting 1 replica. Policy is met.
     dns = new ArrayList<>();
     dns.add(datanodes.get(0));
     stat = policy.validateContainerPlacement(dns, 1);
     assertTrue(stat.isPolicySatisfied());
-    assertEquals(0, stat.additionalReplicaRequired());
+    assertEquals(0, stat.misReplicationCount());
   }
 
   @Test
@@ -431,20 +431,20 @@ public class TestSCMContainerPlacementRackAware {
     dns.add(datanodes.get(2));
     ContainerPlacementStatus stat = policy.validateContainerPlacement(dns, 3);
     assertTrue(stat.isPolicySatisfied());
-    assertEquals(0, stat.additionalReplicaRequired());
+    assertEquals(0, stat.misReplicationCount());
 
     // Single DN - policy met as cluster only has one rack.
     dns = new ArrayList<>();
     dns.add(datanodes.get(0));
     stat = policy.validateContainerPlacement(dns, 3);
     assertTrue(stat.isPolicySatisfied());
-    assertEquals(0, stat.additionalReplicaRequired());
+    assertEquals(0, stat.misReplicationCount());
 
     // Single DN - only 1 replica expected
     dns = new ArrayList<>();
     dns.add(datanodes.get(0));
     stat = policy.validateContainerPlacement(dns, 1);
     assertTrue(stat.isPolicySatisfied());
-    assertEquals(0, stat.additionalReplicaRequired());
+    assertEquals(0, stat.misReplicationCount());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
+import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeMetric;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.net.NetConstants;
@@ -43,6 +44,7 @@ import org.hamcrest.MatcherAssert;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
@@ -376,5 +378,71 @@ public class TestSCMContainerPlacementRackAware {
         datanodeDetails.get(2)));
     Assert.assertTrue(cluster.isSameParent(datanodeDetails.get(1),
         datanodeDetails.get(2)));
+  }
+
+  @Test
+  public void testvalidateContainerPlacement() {
+    // Only run this test for the full set of DNs. 5 DNs per rack on 3 racks.
+    assumeTrue(datanodeCount == 15);
+    List<DatanodeDetails> dns = new ArrayList<>();
+    // First 5 node are on the same rack
+    dns.add(datanodes.get(0));
+    dns.add(datanodes.get(1));
+    dns.add(datanodes.get(2));
+    ContainerPlacementStatus stat = policy.validateContainerPlacement(dns, 3);
+    assertFalse(stat.isPolicySatisfied());
+    assertEquals(1, stat.additionalReplicaRequired());
+
+    // Pick a new list which spans 2 racks
+    dns = new ArrayList<>();
+    dns.add(datanodes.get(0));
+    dns.add(datanodes.get(1));
+    dns.add(datanodes.get(5)); // This is on second rack
+    stat = policy.validateContainerPlacement(dns, 3);
+    assertTrue(stat.isPolicySatisfied());
+    assertEquals(0, stat.additionalReplicaRequired());
+
+    // Pick single DN, expecting 3 replica. Policy is not met.
+    dns = new ArrayList<>();
+    dns.add(datanodes.get(0));
+    stat = policy.validateContainerPlacement(dns, 3);
+    assertFalse(stat.isPolicySatisfied());
+    assertEquals(1, stat.additionalReplicaRequired());
+
+    // Pick single DN, expecting 1 replica. Policy is met.
+    dns = new ArrayList<>();
+    dns.add(datanodes.get(0));
+    stat = policy.validateContainerPlacement(dns, 1);
+    assertTrue(stat.isPolicySatisfied());
+    assertEquals(0, stat.additionalReplicaRequired());
+  }
+
+  @Test
+  public void testvalidateContainerPlacementSingleRackCluster() {
+    assumeTrue(datanodeCount == 5);
+
+    // All nodes are on the same rack in this test, and the cluster only has
+    // one rack.
+    List<DatanodeDetails> dns = new ArrayList<>();
+    dns.add(datanodes.get(0));
+    dns.add(datanodes.get(1));
+    dns.add(datanodes.get(2));
+    ContainerPlacementStatus stat = policy.validateContainerPlacement(dns, 3);
+    assertTrue(stat.isPolicySatisfied());
+    assertEquals(0, stat.additionalReplicaRequired());
+
+    // Single DN - policy met as cluster only has one rack.
+    dns = new ArrayList<>();
+    dns.add(datanodes.get(0));
+    stat = policy.validateContainerPlacement(dns, 3);
+    assertTrue(stat.isPolicySatisfied());
+    assertEquals(0, stat.additionalReplicaRequired());
+
+    // Single DN - only 1 replica expected
+    dns = new ArrayList<>();
+    dns.add(datanodes.get(0));
+    stat = policy.validateContainerPlacement(dns, 1);
+    assertTrue(stat.isPolicySatisfied());
+    assertEquals(0, stat.additionalReplicaRequired());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
@@ -109,14 +109,14 @@ public class TestSCMContainerPlacementRandom {
     ContainerPlacementStatus status =
         scmContainerPlacementRandom.validateContainerPlacement(datanodes, 3);
     assertTrue(status.isPolicySatisfied());
-    assertEquals(0, status.additionalReplicaRequired());
+    assertEquals(0, status.misReplicationCount());
 
     status = scmContainerPlacementRandom.validateContainerPlacement(
         new ArrayList<DatanodeDetails>(), 3);
     assertFalse(status.isPolicySatisfied());
 
     // Only expect 1 more replica to give us one rack on this policy.
-    assertEquals(1, status.additionalReplicaRequired(), 3);
+    assertEquals(1, status.misReplicationCount(), 3);
 
     datanodes = new ArrayList<DatanodeDetails>();
     datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
@@ -125,6 +125,6 @@ public class TestSCMContainerPlacementRandom {
     assertTrue(status.isPolicySatisfied());
 
     // Only expect 1 more replica to give us one rack on this policy.
-    assertEquals(0, status.additionalReplicaRequired(), 3);
+    assertEquals(0, status.misReplicationCount(), 3);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
@@ -24,12 +24,16 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
+import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeMetric;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 
 import org.junit.Assert;
 import org.junit.Test;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.anyObject;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.when;
@@ -86,5 +90,41 @@ public class TestSCMContainerPlacementRandom {
           datanodes.get(2), datanode0Details);
 
     }
+  }
+
+  @Test
+  public void testPlacementPolicySatisified() {
+    //given
+    ConfigurationSource conf = new OzoneConfiguration();
+
+    List<DatanodeDetails> datanodes = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
+    }
+
+    NodeManager mockNodeManager = Mockito.mock(NodeManager.class);
+    SCMContainerPlacementRandom scmContainerPlacementRandom =
+        new SCMContainerPlacementRandom(mockNodeManager, conf, null, true,
+            null);
+    ContainerPlacementStatus status =
+        scmContainerPlacementRandom.validateContainerPlacement(datanodes, 3);
+    assertTrue(status.isPolicySatisfied());
+    assertEquals(0, status.additionalReplicaRequired());
+
+    status = scmContainerPlacementRandom.validateContainerPlacement(
+        new ArrayList<DatanodeDetails>(), 3);
+    assertFalse(status.isPolicySatisfied());
+
+    // Only expect 1 more replica to give us one rack on this policy.
+    assertEquals(1, status.additionalReplicaRequired(), 3);
+
+    datanodes = new ArrayList<DatanodeDetails>();
+    datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
+    status = scmContainerPlacementRandom.validateContainerPlacement(
+        datanodes, 3);
+    assertTrue(status.isPolicySatisfied());
+
+    // Only expect 1 more replica to give us one rack on this policy.
+    assertEquals(0, status.additionalReplicaRequired(), 3);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.MockNodeManager;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
@@ -49,10 +50,13 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Test for PipelinePlacementPolicy.
@@ -362,6 +366,77 @@ public class TestPipelinePlacementPolicy {
     // NODES should NOT be sufficient and exception should be thrown.
     Assert.assertNull(pickedNodes2);
     Assert.assertTrue(thrown);
+  }
+
+  @Test
+  public void testValidatePlacementPolicyOK() {
+    cluster = initTopology();
+    nodeManager = new MockNodeManager(cluster, getNodesWithRackAwareness(),
+        false, PIPELINE_PLACEMENT_MAX_NODES_COUNT);
+    placementPolicy = new PipelinePlacementPolicy(
+        nodeManager, stateManager, conf);
+
+    List<DatanodeDetails> dns = new ArrayList<>();
+    dns.add(MockDatanodeDetails
+        .createDatanodeDetails("host1", "/rack1"));
+    dns.add(MockDatanodeDetails
+        .createDatanodeDetails("host2", "/rack1"));
+    dns.add(MockDatanodeDetails
+        .createDatanodeDetails("host3", "/rack2"));
+    for (DatanodeDetails dn : dns) {
+      cluster.add(dn);
+    }
+    ContainerPlacementStatus status =
+        placementPolicy.validateContainerPlacement(dns, 3);
+    assertTrue(status.isPolicySatisfied());
+    assertEquals(0, status.additionalReplicaRequired());
+
+
+    List<DatanodeDetails> subSet = new ArrayList<>();
+    // Cut it down to two nodes, two racks
+    subSet.add(dns.get(0));
+    subSet.add(dns.get(2));
+    status = placementPolicy.validateContainerPlacement(subSet, 3);
+    assertTrue(status.isPolicySatisfied());
+    assertEquals(0, status.additionalReplicaRequired());
+
+    // Cut it down to two nodes, one racks
+    subSet = new ArrayList<>();
+    subSet.add(dns.get(0));
+    subSet.add(dns.get(1));
+    status = placementPolicy.validateContainerPlacement(subSet, 3);
+    assertFalse(status.isPolicySatisfied());
+    assertEquals(1, status.additionalReplicaRequired());
+
+    // One node, but only one replica
+    subSet = new ArrayList<>();
+    subSet.add(dns.get(0));
+    status = placementPolicy.validateContainerPlacement(subSet, 1);
+    assertTrue(status.isPolicySatisfied());
+  }
+
+  @Test
+  public void testValidatePlacementPolicySingleRackInCluster() {
+    cluster = initTopology();
+    nodeManager = new MockNodeManager(cluster, getNodesWithRackAwareness(),
+        false, PIPELINE_PLACEMENT_MAX_NODES_COUNT);
+    placementPolicy = new PipelinePlacementPolicy(
+        nodeManager, stateManager, conf);
+
+    List<DatanodeDetails> dns = new ArrayList<>();
+    dns.add(MockDatanodeDetails
+        .createDatanodeDetails("host1", "/rack1"));
+    dns.add(MockDatanodeDetails
+        .createDatanodeDetails("host2", "/rack1"));
+    dns.add(MockDatanodeDetails
+        .createDatanodeDetails("host3", "/rack1"));
+    for (DatanodeDetails dn : dns) {
+      cluster.add(dn);
+    }
+    ContainerPlacementStatus status =
+        placementPolicy.validateContainerPlacement(dns, 3);
+    assertTrue(status.isPolicySatisfied());
+    assertEquals(0, status.additionalReplicaRequired());
   }
 
   private boolean checkDuplicateNodesUUID(List<DatanodeDetails> nodes) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
@@ -418,7 +418,7 @@ public class TestPipelinePlacementPolicy {
   @Test
   public void testValidatePlacementPolicySingleRackInCluster() {
     cluster = initTopology();
-    nodeManager = new MockNodeManager(cluster, getNodesWithRackAwareness(),
+    nodeManager = new MockNodeManager(cluster, new ArrayList<>(),
         false, PIPELINE_PLACEMENT_MAX_NODES_COUNT);
     placementPolicy = new PipelinePlacementPolicy(
         nodeManager, stateManager, conf);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
@@ -389,7 +389,7 @@ public class TestPipelinePlacementPolicy {
     ContainerPlacementStatus status =
         placementPolicy.validateContainerPlacement(dns, 3);
     assertTrue(status.isPolicySatisfied());
-    assertEquals(0, status.additionalReplicaRequired());
+    assertEquals(0, status.misReplicationCount());
 
 
     List<DatanodeDetails> subSet = new ArrayList<>();
@@ -398,7 +398,7 @@ public class TestPipelinePlacementPolicy {
     subSet.add(dns.get(2));
     status = placementPolicy.validateContainerPlacement(subSet, 3);
     assertTrue(status.isPolicySatisfied());
-    assertEquals(0, status.additionalReplicaRequired());
+    assertEquals(0, status.misReplicationCount());
 
     // Cut it down to two nodes, one racks
     subSet = new ArrayList<>();
@@ -406,7 +406,7 @@ public class TestPipelinePlacementPolicy {
     subSet.add(dns.get(1));
     status = placementPolicy.validateContainerPlacement(subSet, 3);
     assertFalse(status.isPolicySatisfied());
-    assertEquals(1, status.additionalReplicaRequired());
+    assertEquals(1, status.misReplicationCount());
 
     // One node, but only one replica
     subSet = new ArrayList<>();
@@ -436,7 +436,7 @@ public class TestPipelinePlacementPolicy {
     ContainerPlacementStatus status =
         placementPolicy.validateContainerPlacement(dns, 3);
     assertTrue(status.isPolicySatisfied());
-    assertEquals(0, status.additionalReplicaRequired());
+    assertEquals(0, status.misReplicationCount());
   }
 
   private boolean checkDuplicateNodesUUID(List<DatanodeDetails> nodes) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now we have network topology available in Ozone, we need the ability to identify and correct containers where the replicas do not meet the replication policy. For network aware clusters, the rule is that the replicas must be on at least two racks. In the future, it is possible there will be other policies, eg node groups and so on.

Ideally, the existing ReplicationManager in SCM should be extended to detect, and correct these mis-replicated containers.

This change starts by adding a new method to the PlacementPolicy interface:

```
ContainerPlacementStatus validateContainerPlacement(
      List<DatanodeDetails> dns, int replicas);
```

This accepts the list of DNs currently hosting the replicas for a container, and the desired replication factor. It return an instance of `ContainerPlacementStatus` which has two methods indicating if the policy is met and if not, how many more replicas are needed:

```
boolean isPolicySatisfied();
int additionalReplicaRequired();
```

Currently, all placement policies extend `SCMCommonPlacementPolicy` and there is a default impelementation there, which handles both rack aware and non rack aware clusters. If we have further policies in the future (eg node groups, upgrade domain) this can be overridden in new subclasses.

Replication manager can then call:

```
placementPolicy.validateContainerPlacement(List<DatanodeDetails>, replicationFactor)
```

To get the information it needs to check the container.

For over replicated containers, when removing replicas, it is important to also ensure removing the container does not violate the policy, so some changes will be needed around the over-replicated code path too.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3081

## How was this patch tested?

New unit tests
