### PR TITLE
HDDS-3514. Fix memory leak of RaftServerImpl

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -199,7 +199,8 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
                 new RatisDropwizardExports(
                     registry.getDropWizardMetricRegistry()));
           } catch (NullPointerException e) {
-            // TODO
+            // TODO: refactor ratis to avoid use singleton of
+            //  MetricRegistries.global()
             // This should only happen in test.
             // Because 3 datanodes and om in mini-cluster share one
             // MetricRegistries.global(). When datanode1 start,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/RatisDropwizardExports.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/RatisDropwizardExports.java
@@ -25,6 +25,7 @@ import io.prometheus.client.dropwizard.samplebuilder.DefaultSampleBuilder;
  * Collect Dropwizard metrics, but rename ratis specific metrics.
  */
 public class RatisDropwizardExports extends DropwizardExports {
+  private final MetricRegistry registry;
 
   /**
    * Creates a new DropwizardExports with a {@link DefaultSampleBuilder}.
@@ -33,6 +34,19 @@ public class RatisDropwizardExports extends DropwizardExports {
    */
   public RatisDropwizardExports(MetricRegistry registry) {
     super(registry, new RatisNameRewriteSampleBuilder());
+    this.registry = registry;
   }
 
+  @Override
+  public boolean equals(Object other) {
+    return this == other
+        || (other instanceof RatisDropwizardExports
+            && ((RatisDropwizardExports) other).registry
+                .equals(this.registry));
+  }
+
+  @Override
+  public int hashCode() {
+    return registry.hashCode();
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -484,7 +484,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
                 new RatisDropwizardExports(
                     registry.getDropWizardMetricRegistry()));
           } catch (NullPointerException e) {
-            // TODO
+            // TODO: refactor ratis to avoid use singleton of
+            //  MetricRegistries.global()
             // This should only happen in test.
             // Because 3 datanodes and om in mini-cluster share one
             // MetricRegistries.global(). When datanode1 start,

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>0.6.0-cac3336-SNAPSHOT</ratis.version>
+    <ratis.version>0.6.0-b3cfec0-SNAPSHOT</ratis.version>
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>
     <distMgmtSnapshotsUrl>https://repository.apache.org/content/repositories/snapshots</distMgmtSnapshotsUrl>


### PR DESCRIPTION
## What changes were proposed in this pull request?
**This PR depends on [RATIS-845](https://github.com/apache/incubator-ratis/pull/76), we should wait RATIS-845 to merge.**

As the image shows, there are 1885 instances of  RaftServerImpl, most of them are Closed, and should be GC, but actually not. You can find from the image 
 1513 RaftServerImpl were held by ManagermentFactory->jxmMBeanServer->HashMap, 372 RaftServerImpl were held by Datanode ReportManager Thread -> prometheus -> HashMap. So 1513 RaftServerImpl leak in ratis, and 372 leak in ozone. If RaftServerImpl can not GC, there are a lot of related resource can not be GC, such as the [DirectByteBuffer](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java#L150)  in SegmentRaftLogWorker, which result 1GB memory leak out of heap.

The reason RaftServerImpl held by ManagermentFactory->jxmMBeanServer->HashMap is ratis start [JmxReporter](https://github.com/apache/incubator-ratis/blob/master/ratis-metrics/src/main/java/org/apache/ratis/metrics/MetricsReporting.java#L47), but does not stop it.

The reason RaftServerImpl held by Datanode ReportManager Thread -> prometheus -> HashMap is ozone call the ratis function to  [register](https://github.com/apache/hadoop-ozone/blob/master/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java#L189) metric in prometheus, but does not unregister it.

**1. 1885 instances of RaftServerImpl**
![image](https://user-images.githubusercontent.com/51938049/80677661-ddb81d80-8aeb-11ea-8664-8a340d19ffb6.png)

**2. 1513 RaftServerImpl were held by ManagermentFactory->jxmMBeanServer->HashMap, 372 RaftServerImpl were held by Datanode ReportManager Thread -> prometheus -> HashMap**
![image](https://user-images.githubusercontent.com/51938049/80677750-09d39e80-8aec-11ea-9da9-4f7b0d31ef9c.png)

**3. 1513 RaftServerImpl were held by ManagermentFactory->jxmMBeanServer->HashMap**
![image](https://user-images.githubusercontent.com/51938049/80677767-15bf6080-8aec-11ea-8a95-d1f23d52a286.png)

**4. 372 RaftServerImpl were held by Datanode ReportManager Thread -> prometheus -> HashMap**
![image](https://user-images.githubusercontent.com/51938049/80677785-24a61300-8aec-11ea-8ca4-5c81a44015c5.png)

5. 2038 DirectByteBuffer, and 1885 held by RaftServerImpl
![image](https://user-images.githubusercontent.com/51938049/80677796-2a9bf400-8aec-11ea-9734-29a7e62de891.png)

6. 1033 DirectByteBuffer were held by ManagermentFactory, 802 DirectByteBuffer were held by Datanode ReportManager Thread, total 1885.
![image](https://user-images.githubusercontent.com/51938049/80677834-3e475a80-8aec-11ea-933e-76a60dd082f0.png)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3514

## How was this patch tested?

ungister prometheus and stopJmxReporter when removed in ratis.
