### PR TITLE
HDDS-3492. With hdfs-fuse file implementation 'cp' command is not working - fixed.

### DIFF
--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/PosixOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/PosixOzoneFileSystem.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.util.Progressable;
+import java.io.IOException;
+
+/**
+ * The PosixOzoneFileSystem implementation.
+ * The create function in this class overrides
+ * the create function of OzoneFileSystem class.
+ * This create function first creates a file, then
+ * closes it and again calls the create function
+ * of super class.
+ */
+
+public class PosixOzoneFileSystem extends OzoneFileSystem {
+  @Override
+  public FSDataOutputStream create(Path f, FsPermission permission,
+                                   boolean overwrite, int bufferSize,
+                                   short replication, long blockSize,
+                                   Progressable progress) throws IOException {
+    FSDataOutputStream cstream = super.create(f, permission, overwrite,
+        bufferSize, replication, blockSize, progress);
+    cstream.close();
+    return super.create(f, permission, overwrite, bufferSize,
+        replication, blockSize, progress);
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

'cp' (copy) command doesn’t work with hdfs-fuse file system. It works by passing 'cp' command two times for the same file. It mainly happens when destination file doesn’t exists. It happens because when 'cp' command is performed for the first time it creates the file at the destination path, but as per ozone file system protocols any file has no access till its committed. So, 'getattr' function is not able to locate the file(though it’s present at the destination path). Hence, 'cp' command fails in the first go. Second time when 'cp' command is executed, file is already present in the destination path so 'cp' command simply override the data in the file.
This change introduces a new class 'PosixOzoneFileSystem' which creates the file, closes it and again opens it to make the 'cp' command work perfectly.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3492

## How was this patch tested?

Tested manually 
