### PR TITLE
HDDS-3510. Upgrade Ratis to 0.6.0-2816ea6-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>0.6.0-cac3336-SNAPSHOT</ratis.version>
+    <ratis.version>0.6.0-2816ea6-SNAPSHOT</ratis.version>
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>
     <distMgmtSnapshotsUrl>https://repository.apache.org/content/repositories/snapshots</distMgmtSnapshotsUrl>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade Ratis to `0.6.0-2816ea6-SNAPSHOT` to get the fix for [RATIS-840](https://issues.apache.org/jira/browse/RATIS-840).

https://issues.apache.org/jira/browse/HDDS-3510

## How was this patch tested?

Two successful CI runs:

https://github.com/adoroszlai/hadoop-ozone/runs/632673436
https://github.com/adoroszlai/hadoop-ozone/runs/635512527

Note that `TestReadRetries.testPutKeyAndGetKeyThreeNodes` failed in two other CI runs:

https://github.com/adoroszlai/hadoop-ozone/runs/629899380
https://github.com/adoroszlai/hadoop-ozone/runs/632680463

but it also failed on `master` already:

https://github.com/apache/hadoop-ozone/runs/626422906

created [HDDS-3516](https://issues.apache.org/jira/browse/HDDS-3516) for `TestReadRetries`.