### PR TITLE
HDDS-3449. Enable TestSCMPipelineMetrics test cases

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineMetrics.java
@@ -45,7 +45,6 @@ import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 /**
  * Test cases to verify the metrics exposed by SCMPipelineManager.
  */
-@Ignore
 public class TestSCMPipelineMetrics {
 
   private MiniOzoneCluster cluster;
@@ -83,16 +82,15 @@ public class TestSCMPipelineMetrics {
     Optional<Pipeline> pipeline = pipelineManager
         .getPipelines().stream().findFirst();
     Assert.assertTrue(pipeline.isPresent());
-    pipeline.ifPresent(pipeline1 -> {
-      try {
-        cluster.getStorageContainerManager()
-            .getClientProtocolServer().closePipeline(
-                pipeline.get().getId().getProtobuf());
-      } catch (IOException e) {
-        e.printStackTrace();
-        Assert.fail();
-      }
-    });
+    try {
+      cluster.getStorageContainerManager()
+          .getPipelineManager()
+          .finalizeAndDestroyPipeline(
+              pipeline.get(),false);
+    } catch (IOException e) {
+      e.printStackTrace();
+      Assert.fail();
+    }
     MetricsRecordBuilder metrics = getMetrics(
         SCMPipelineMetrics.class.getSimpleName());
     assertCounter("NumPipelineDestroyed", 1L, metrics);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineMetrics.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -86,7 +85,7 @@ public class TestSCMPipelineMetrics {
       cluster.getStorageContainerManager()
           .getPipelineManager()
           .finalizeAndDestroyPipeline(
-              pipeline.get(),false);
+              pipeline.get(), false);
     } catch (IOException e) {
       e.printStackTrace();
       Assert.fail();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed and enabled this test case.

After the HDDS-2757 patch, the operation to close pipeline will run after timeout, so the results will not immediately respond to the metrics.
In the test method `TestSCMPipelineMetrics#testPipelineDestroy()` , I make the operation to close pipeline run immediately.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3449

## How was this patch tested?

Ran UTs - Pass