### PR TITLE
HDDS-3517. Add a directory based Ozone Manager LoadGenerator.

### DIFF
--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
@@ -27,6 +27,9 @@ import org.apache.hadoop.ozone.loadgenerators.RandomLoadGenerator;
 import org.apache.hadoop.ozone.loadgenerators.ReadOnlyLoadGenerator;
 import org.apache.hadoop.ozone.loadgenerators.FilesystemLoadGenerator;
 import org.apache.hadoop.ozone.loadgenerators.AgedLoadGenerator;
+import org.apache.hadoop.ozone.loadgenerators.AgedDirLoadGenerator;
+import org.apache.hadoop.ozone.loadgenerators.RandomDirLoadGenerator;
+import org.apache.hadoop.ozone.loadgenerators.NestedDirLoadGenerator;
 import org.junit.BeforeClass;
 import org.junit.AfterClass;
 import org.junit.Ignore;
@@ -117,6 +120,9 @@ public class TestMiniChaosOzoneCluster extends GenericCli {
         .addLoadGenerator(AgedLoadGenerator.class)
         .addLoadGenerator(FilesystemLoadGenerator.class)
         .addLoadGenerator(ReadOnlyLoadGenerator.class)
+        .addLoadGenerator(RandomDirLoadGenerator.class)
+        .addLoadGenerator(AgedDirLoadGenerator.class)
+        .addLoadGenerator(NestedDirLoadGenerator.class)
         .build();
   }
 

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/AgedDirLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/AgedDirLoadGenerator.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.loadgenerators;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.hadoop.ozone.utils.LoadBucket;
+
+/**
+ * A load generator where directories are read multiple times.
+ */
+public class AgedDirLoadGenerator extends LoadGenerator {
+  private final LoadBucket fsBucket;
+  private final int maxDirIndex;
+
+  public AgedDirLoadGenerator(DataBuffer dataBuffer, LoadBucket fsBucket) {
+    this.fsBucket = fsBucket;
+    this.maxDirIndex = 100;
+  }
+
+  @Override
+  public void generateLoad() throws Exception {
+    int index = RandomUtils.nextInt(0, maxDirIndex);
+    String keyName = getKeyName(index);
+    fsBucket.readDirectory(keyName);
+  }
+
+  @Override
+  public void initialize() throws Exception {
+    for (int i = 0; i < maxDirIndex; i++) {
+      String keyName = getKeyName(i);
+      fsBucket.createDirectory(keyName);
+    }
+  }
+}

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/AgedLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/AgedLoadGenerator.java
@@ -34,7 +34,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  * The default writes to read ratio is 10:90.
  */
 public class AgedLoadGenerator extends LoadGenerator {
-  private static String agedSuffix = "aged";
 
   private final AtomicInteger agedFileWrittenIndex;
   private final AtomicInteger agedFileAllocationIndex;

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/NestedDirLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/NestedDirLoadGenerator.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.loadgenerators;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.hadoop.ozone.utils.LoadBucket;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A Load generator where nested directories are created and read them.
+ */
+public class NestedDirLoadGenerator extends LoadGenerator {
+  private final LoadBucket fsBucket;
+  private final int maxDirWidth;
+  private final Map<Integer, String> pathMap;
+
+  public NestedDirLoadGenerator(DataBuffer dataBuffer, LoadBucket fsBucket) {
+    this.fsBucket = fsBucket;
+    this.maxDirWidth = 20;
+    this.pathMap = new ConcurrentHashMap<>();
+  }
+
+  private String createNewPath(int i, String s) {
+    String base = s != null ? s : "";
+    return base + "/" + getKeyName(i);
+  }
+
+  @Override
+  public void generateLoad() throws Exception {
+    int index = RandomUtils.nextInt(0, maxDirWidth);
+    String str = this.pathMap.compute(index, this::createNewPath);
+    fsBucket.createDirectory(str);
+    fsBucket.readDirectory(str);
+  }
+
+  @Override
+  public void initialize() throws Exception {
+    // Nothing to do here
+  }
+}

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/NestedDirLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/NestedDirLoadGenerator.java
@@ -29,12 +29,12 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class NestedDirLoadGenerator extends LoadGenerator {
   private final LoadBucket fsBucket;
-  private final int maxDirWidth;
+  private final int maxDirDepth;
   private final Map<Integer, String> pathMap;
 
   public NestedDirLoadGenerator(DataBuffer dataBuffer, LoadBucket fsBucket) {
     this.fsBucket = fsBucket;
-    this.maxDirWidth = 20;
+    this.maxDirDepth = 20;
     this.pathMap = new ConcurrentHashMap<>();
   }
 
@@ -45,7 +45,7 @@ public class NestedDirLoadGenerator extends LoadGenerator {
 
   @Override
   public void generateLoad() throws Exception {
-    int index = RandomUtils.nextInt(0, maxDirWidth);
+    int index = RandomUtils.nextInt(0, maxDirDepth);
     String str = this.pathMap.compute(index, this::createNewPath);
     fsBucket.createDirectory(str);
     fsBucket.readDirectory(str);

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/RandomDirLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/RandomDirLoadGenerator.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.loadgenerators;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.hadoop.ozone.utils.LoadBucket;
+
+/**
+ * A simple directory based load generator
+ */
+public class RandomDirLoadGenerator extends LoadGenerator {
+  private final LoadBucket fsBucket;
+
+  public RandomDirLoadGenerator(DataBuffer dataBuffer, LoadBucket fsBucket) {
+    this.fsBucket = fsBucket;
+  }
+
+  @Override
+  public void generateLoad() throws Exception {
+    int index = RandomUtils.nextInt();
+    String keyName = getKeyName(index);
+    fsBucket.createDirectory(keyName);
+    fsBucket.readDirectory(keyName);
+  }
+
+  @Override
+  public void initialize() {
+    // Nothing to do here
+  }
+}

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/RandomDirLoadGenerator.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/loadgenerators/RandomDirLoadGenerator.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.ozone.utils.LoadBucket;
 
 /**
- * A simple directory based load generator
+ * A simple directory based load generator.
  */
 public class RandomDirLoadGenerator extends LoadGenerator {
   private final LoadBucket fsBucket;

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/utils/LoadBucket.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/utils/LoadBucket.java
@@ -159,8 +159,12 @@ public class LoadBucket {
     }
   }
 
+  /**
+   * Create and Read Directories.
+   */
   public class DirectoryOp extends Op {
-    boolean readDir;
+    private final boolean readDir;
+
     DirectoryOp(String keyName, boolean readDir) {
       super(true, keyName);
       this.readDir = readDir;

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/utils/LoadBucket.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/utils/LoadBucket.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.utils;
 
 import org.apache.commons.lang3.RandomUtils;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.ozone.OzoneFileSystem;
@@ -29,6 +30,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import java.io.InputStream;
 import java.io.OutputStream;
+import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,6 +76,16 @@ public class LoadBucket {
                        String keyName) throws Exception {
     Op writeOp = new WriteOp(fsOp, keyName, buffer);
     writeOp.execute();
+  }
+
+  public void createDirectory(String keyName) throws Exception {
+    Op dirOp = new DirectoryOp(keyName, false);
+    dirOp.execute();
+  }
+
+  public void readDirectory(String keyName) throws Exception {
+    Op dirOp = new DirectoryOp(keyName, true);
+    dirOp.execute();
   }
 
   // Read ops.
@@ -144,6 +156,42 @@ public class LoadBucket {
     @Override
     public String toString() {
       return "opType=" + opName + " keyName=" + keyName;
+    }
+  }
+
+  public class DirectoryOp extends Op {
+    boolean readDir;
+    DirectoryOp(String keyName, boolean readDir) {
+      super(true, keyName);
+      this.readDir = readDir;
+    }
+
+    @Override
+    void doFsOp(Path p) throws IOException {
+      if (readDir) {
+        FileStatus status = fs.getFileStatus(p);
+        Assert.assertTrue(status.isDirectory());
+        Assert.assertEquals(p,
+            Path.getPathWithoutSchemeAndAuthority(status.getPath()));
+      } else {
+        Assert.assertTrue(fs.mkdirs(p));
+      }
+    }
+
+    @Override
+    void doBucketOp(String key) throws IOException {
+      // nothing to do here
+    }
+
+    @Override
+    void doPostOp() throws IOException {
+      // Nothing to do here
+    }
+
+    @Override
+    public String toString() {
+      return super.toString() + " "
+          + (readDir ? "readDirectory": "writeDirectory");
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Most of the LoadGenerators in MiniOzoneLoadGenerator are all based on the read/write path. The purpose of this LoadGenerator is to add a directory-based load generator which stresses the IN.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3517

## How was this patch tested?
Ran MiniOzoneChaosTests, also already found https://issues.apache.org/jira/browse/HDDS-3382, https://issues.apache.org/jira/browse/HDDS-3381 because of this load generator
