### PR TITLE
HDDS-3518: Add a freon generator to create directory tree and create …

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
@@ -109,7 +109,7 @@ public class TestHadoopDirTreeGenerator {
   }
 
   private void verifyDirTree(String volumeName, String bucketName, int depth,
-                             int span, int fileCount, int perFileSizeInKBs)
+                             int span, int fileCount, int perFileSizeInBytes)
           throws IOException {
 
     store.createVolume(volumeName);
@@ -120,7 +120,7 @@ public class TestHadoopDirTreeGenerator {
     new Freon().execute(
         new String[]{"-conf", confPath, "dtsg", "-d", depth + "", "-c",
             fileCount + "", "-s", span + "", "-n", "1", "-r", rootPath,
-                     "-g", perFileSizeInKBs + ""});
+                     "-g", perFileSizeInBytes + ""});
     // verify the directory structure
     FileSystem fileSystem = FileSystem.get(URI.create(rootPath),
             conf);
@@ -132,7 +132,7 @@ public class TestHadoopDirTreeGenerator {
       // as it has only one dir at root.
       verifyActualSpan(1, fileStatuses);
       int actualDepth = traverseToLeaf(fileSystem, fileStatus.getPath(),
-              1, depth, span, fileCount, perFileSizeInKBs);
+              1, depth, span, fileCount, perFileSizeInBytes);
       Assert.assertEquals("Mismatch depth in a path",
               depth, actualDepth);
     }
@@ -140,7 +140,7 @@ public class TestHadoopDirTreeGenerator {
 
   private int traverseToLeaf(FileSystem fs, Path dirPath, int depth,
                              int expectedDepth, int expectedSpanCnt,
-                             int expectedFileCnt, int perFileSizeInKBs)
+                             int expectedFileCnt, int perFileSizeInBytes)
           throws IOException {
     FileStatus[] fileStatuses = fs.listStatus(dirPath);
     // check the num of peer directories except root and leaf as both
@@ -153,10 +153,10 @@ public class TestHadoopDirTreeGenerator {
       if (fileStatus.isDirectory()) {
         ++depth;
         return traverseToLeaf(fs, fileStatus.getPath(), depth, expectedDepth,
-                expectedSpanCnt, expectedFileCnt, perFileSizeInKBs);
+                expectedSpanCnt, expectedFileCnt, perFileSizeInBytes);
       } else {
         Assert.assertEquals("Mismatches file len",
-                perFileSizeInKBs * 1024, fileStatus.getLen());
+                perFileSizeInBytes, fileStatus.getLen());
         actualNumFiles++;
       }
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
@@ -98,23 +98,23 @@ public class TestHadoopDirTreeGenerator {
     out.getFD().sync();
     out.close();
 
-    verifyDataTree(conf, store, "vol1", "bucket1",
+    verifyDirTree(conf, store, "vol1", "bucket1",
             1, 1, 1);
-    verifyDataTree(conf, store, "vol2", "bucket1",
+    verifyDirTree(conf, store, "vol2", "bucket1",
             1, 5, 1);
-    verifyDataTree(conf, store, "vol3", "bucket1",
+    verifyDirTree(conf, store, "vol3", "bucket1",
             2, 5, 3);
-    verifyDataTree(conf, store, "vol4", "bucket1",
+    verifyDirTree(conf, store, "vol4", "bucket1",
             3, 2, 4);
-    verifyDataTree(conf, store, "vol5", "bucket1",
+    verifyDirTree(conf, store, "vol5", "bucket1",
             5, 4, 1);
 
     shutdown(cluster);
   }
 
-  private void verifyDataTree(OzoneConfiguration conf, ObjectStore store,
-                              String volumeName, String bucketName,
-                              int depth, int span, int fileCount)
+  private void verifyDirTree(OzoneConfiguration conf, ObjectStore store,
+                             String volumeName, String bucketName,
+                             int depth, int span, int fileCount)
           throws IOException {
 
     store.createVolume(volumeName);
@@ -124,8 +124,7 @@ public class TestHadoopDirTreeGenerator {
     String confPath = new File(path, "conf").getAbsolutePath();
     new Freon().execute(
         new String[]{"-conf", confPath, "dtsg", "-d", depth + "", "-c",
-            fileCount + "", "-s", span + "", "-n", "1", "-r",
-                rootPath});
+            fileCount + "", "-s", span + "", "-n", "1", "-r", rootPath});
     // verify the directory structure
     FileSystem fileSystem = FileSystem.get(URI.create(rootPath),
             conf);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
@@ -100,9 +100,13 @@ public class TestHadoopDirTreeGenerator {
 
     verifyDataTree(conf, store, "vol1", "bucket1",
             1, 1, 1);
-    verifyDataTree(conf, store, "vol2", "bucket2",
+    verifyDataTree(conf, store, "vol2", "bucket1",
+            1, 5, 1);
+    verifyDataTree(conf, store, "vol3", "bucket1",
+            2, 5, 3);
+    verifyDataTree(conf, store, "vol4", "bucket1",
             3, 2, 4);
-    verifyDataTree(conf, store, "vol3", "bucket3",
+    verifyDataTree(conf, store, "vol5", "bucket1",
             5, 4, 1);
 
     shutdown(cluster);
@@ -117,11 +121,11 @@ public class TestHadoopDirTreeGenerator {
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
     String rootPath = "o3fs://" + bucketName + "." + volumeName;
+    String confPath = new File(path, "conf").getAbsolutePath();
     new Freon().execute(
-            new String[]{"-conf", new File(path, "conf")
-                    .getAbsolutePath(), "dtsg", "-d", depth + "", "-c",
-                    fileCount + "", "-s", span + "", "-n", "1", "-r",
-                    rootPath});
+        new String[]{"-conf", confPath, "dtsg", "-d", depth + "", "-c",
+            fileCount + "", "-s", span + "", "-n", "1", "-r",
+                rootPath});
     // verify the directory structure
     FileSystem fileSystem = FileSystem.get(URI.create(rootPath),
             conf);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
-import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.ratis.server.impl.RaftServerImpl;
 import org.apache.ratis.server.raftlog.RaftLog;
@@ -40,7 +39,7 @@ import java.io.IOException;
 import java.net.URI;
 
 /**
- * Test for HadoopNestedDirTreeGenerator.
+ * Test for HadoopDirTreeGenerator.
  */
 public class TestHadoopDirTreeGenerator {
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.freon;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.ratis.server.impl.RaftServerImpl;
+import org.apache.ratis.server.raftlog.RaftLog;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.event.Level;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Test for HadoopNestedDirTreeGenerator.
+ */
+public class TestHadoopDirTreeGenerator {
+
+  private String path;
+
+  /**
+   * Create a MiniDFSCluster for testing.
+   *
+   * @throws IOException
+   */
+  @Before
+  public void setup() {
+    path = GenericTestUtils
+            .getTempPath(TestOzoneClientKeyGenerator.class.getSimpleName());
+    GenericTestUtils.setLogLevel(RaftLog.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(RaftServerImpl.LOG, Level.DEBUG);
+    File baseDir = new File(path);
+    baseDir.mkdirs();
+  }
+
+  /**
+   * Shutdown MiniDFSCluster.
+   */
+  private void shutdown(MiniOzoneCluster cluster) throws IOException {
+    if (cluster != null) {
+      cluster.shutdown();
+      FileUtils.deleteDirectory(new File(path));
+    }
+  }
+
+  private MiniOzoneCluster startCluster(OzoneConfiguration conf)
+          throws Exception {
+    if (conf == null) {
+      conf = new OzoneConfiguration();
+    }
+    MiniOzoneCluster cluster = MiniOzoneCluster.newBuilder(conf)
+            .setNumDatanodes(5)
+            .build();
+
+    cluster.waitForClusterToBeReady();
+    cluster.waitTobeOutOfSafeMode();
+    return cluster;
+  }
+
+  @Test
+  public void testNestedDirTreeGeneration() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    MiniOzoneCluster cluster = startCluster(conf);
+    ObjectStore store =
+            OzoneClientFactory.getRpcClient(conf).getObjectStore();
+    OzoneManager om = cluster.getOzoneManager();
+    FileOutputStream out = FileUtils.openOutputStream(new File(path,
+            "conf"));
+    cluster.getConf().writeXml(out);
+    out.getFD().sync();
+    out.close();
+
+    verifyDataTree(conf, store, "vol1", "bucket1",
+            1, 1, 1);
+    verifyDataTree(conf, store, "vol2", "bucket2",
+            3, 2, 4);
+    verifyDataTree(conf, store, "vol3", "bucket3",
+            5, 4, 1);
+
+    shutdown(cluster);
+  }
+
+  private void verifyDataTree(OzoneConfiguration conf, ObjectStore store,
+                              String volumeName, String bucketName,
+                              int depth, int span, int fileCount)
+          throws IOException {
+
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    volume.createBucket(bucketName);
+    String rootPath = "o3fs://" + bucketName + "." + volumeName;
+    new Freon().execute(
+            new String[]{"-conf", new File(path, "conf")
+                    .getAbsolutePath(), "dtsg", "-d", depth + "", "-c",
+                    fileCount + "", "-s", span + "", "-n", "1", "-r",
+                    rootPath});
+    // verify the directory structure
+    FileSystem fileSystem = FileSystem.get(URI.create(rootPath),
+            conf);
+    Path rootDir = new Path(rootPath.concat("/"));
+    // verify root path details
+    FileStatus[] fileStatuses = fileSystem.listStatus(rootDir);
+    for (FileStatus fileStatus : fileStatuses) {
+      // verify the num of peer directories, expected span count is 1
+      // as it has only one dir at root.
+      verifyActualSpan(1, fileStatuses);
+      int actualDepth = traverseToLeaf(fileSystem, fileStatus.getPath(),
+              1, depth, span, fileCount);
+      Assert.assertEquals("Mismatch depth in a path",
+              depth, actualDepth);
+    }
+  }
+
+  private int traverseToLeaf(FileSystem fileSystem, Path dirPath, int depth,
+                             int expectedDepth, int expectedSpanCnt,
+                             int expectedFileCnt)
+          throws IOException {
+    FileStatus[] fileStatuses = fileSystem.listStatus(dirPath);
+    // check the num of peer directories except root and leaf as both
+    // has less dirs.
+    if (depth < expectedDepth - 1) {
+      verifyActualSpan(expectedSpanCnt, fileStatuses);
+    }
+    int actualNumFiles = 0;
+    for (FileStatus fileStatus : fileStatuses) {
+      if (fileStatus.isDirectory()) {
+        ++depth;
+        return traverseToLeaf(fileSystem, fileStatus.getPath(),
+                depth, expectedDepth, expectedSpanCnt, expectedFileCnt);
+      } else {
+        actualNumFiles++;
+      }
+    }
+    Assert.assertEquals("Mismatches files count in a directory",
+            expectedFileCnt, actualNumFiles);
+    return depth;
+  }
+
+  private int verifyActualSpan(int expectedSpanCnt,
+                               FileStatus[] fileStatuses) {
+    int actualSpan = 0;
+    for (FileStatus fileStatus : fileStatuses) {
+      if (fileStatus.isDirectory()) {
+        ++actualSpan;
+      }
+    }
+    Assert.assertEquals("Mismatches subdirs count in a directory",
+            expectedSpanCnt, actualSpan);
+    return actualSpan;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
@@ -43,6 +43,7 @@ import picocli.CommandLine.Option;
         OmBucketGenerator.class,
         HadoopFsGenerator.class,
         HadoopNestedDirGenerator.class,
+        HadoopDirTreeGenerator.class,
         HadoopFsValidator.class,
         SameKeyReader.class,
         S3KeyGenerator.class,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
@@ -65,10 +65,10 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
   private int fileCount;
 
   @Option(names = {"-g", "--fileSize"},
-      description = "Generated data size(in KB) of each file to be written" +
-              " in each directory",
+      description = "Generated data size(in bytes) of each file to be " +
+              "written in each directory",
       defaultValue = "1")
-  private int fileSize;
+  private int fileSizeInBytes;
 
   @Option(names = {"-s", "--span"},
       description =
@@ -195,13 +195,12 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
 
       FSDataOutputStream out =
               fileSystem.create(new Path(fileName), true);
-      int fSizeInBytes = fileSize * 1024;
-      if (fSizeInBytes > 0) {
+      if (fileSizeInBytes > 0) {
         int bufferLen = 1024;
         int seed = 0;
         byte[] toWrite = new byte[bufferLen];
         Random rb = new Random(seed);
-        long bytesToWrite = fSizeInBytes;
+        long bytesToWrite = fileSizeInBytes;
         while (bytesToWrite > 0) {
           rb.nextBytes(toWrite);
           int bytesToWriteNext = (bufferLen < bytesToWrite) ? bufferLen

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
@@ -173,7 +173,8 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
     }
   }
 
-  private String makeDirWithGivenNumberOfFiles(String parent) throws IOException {
+  private String makeDirWithGivenNumberOfFiles(String parent)
+          throws IOException {
     String dir = RandomStringUtils.randomAlphanumeric(length);
     dir = parent.toString().concat("/").concat(dir);
     fileSystem.mkdirs(new Path(dir));

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
@@ -50,7 +50,7 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
       LoggerFactory.getLogger(HadoopDirTreeGenerator.class);
 
   @Option(names = {"-r", "--rpath"},
-      description = "Hadoop FS directory system path",
+      description = "Hadoop FS root path",
       defaultValue = "o3fs://bucket2.vol2")
   private String rootPath;
 
@@ -195,13 +195,13 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
 
       FSDataOutputStream out =
               fileSystem.create(new Path(fileName), true);
-      int fSizeInKBs = fileSize * 1024;
-      if (fSizeInKBs > 0) {
+      int fSizeInBytes = fileSize * 1024;
+      if (fSizeInBytes > 0) {
         int bufferLen = 1024;
         int seed = 0;
         byte[] toWrite = new byte[bufferLen];
         Random rb = new Random(seed);
-        long bytesToWrite = fileSize;
+        long bytesToWrite = fSizeInBytes;
         while (bytesToWrite > 0) {
           rb.nextBytes(toWrite);
           int bytesToWriteNext = (bufferLen < bytesToWrite) ? bufferLen

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
@@ -1,0 +1,222 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.freon;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Random;
+import java.util.concurrent.Callable;
+
+/**
+ * Directory & File Generator tool to test OM performance.
+ */
+@Command(name = "dtsg",
+    aliases = "dfs-tree-generator",
+    description =
+        "Create nested directories and create given number of files in each " +
+                "dir in any dfs compatible file system.",
+    versionProvider = HddsVersionProvider.class,
+    mixinStandardHelpOptions = true,
+    showDefaultValues = true)
+public class HadoopDirTreeGenerator extends BaseFreonGenerator
+    implements Callable<Void> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(HadoopDirTreeGenerator.class);
+
+  @Option(names = {"-r", "--rpath"},
+      description = "Hadoop FS directory system path",
+      defaultValue = "o3fs://bucket2.vol2")
+  private String rootPath;
+
+  @Option(names = {"-d", "--depth"},
+      description = "Number of directories to be generated recursively",
+      defaultValue = "5")
+  private int depth;
+
+  @Option(names = {"-c", "--fileCount"},
+      description = "Number of files to be written in each directory",
+      defaultValue = "2")
+  private int fileCount;
+
+  @Option(names = {"-g", "--fileSize"},
+      description = "Generated data size(in KB) of each file to be written" +
+              " in each directory",
+      defaultValue = "1")
+  private int fileSize;
+
+  @Option(names = {"-s", "--span"},
+      description =
+          "Number of child directories to be created in each directory.",
+      defaultValue = "10")
+  private int span;
+
+  @Option(names = {"-l", "--nameLen"},
+      description =
+          "Length of the random name of directory you want to create.",
+      defaultValue = "10")
+  private int length;
+
+  private long totalDirsCnt;
+
+  private FileSystem fileSystem;
+
+  @Override
+  public Void call() throws Exception {
+
+    init();
+    OzoneConfiguration configuration = createOzoneConfiguration();
+    fileSystem = FileSystem.get(URI.create(rootPath), configuration);
+    runTests(this::createDir);
+    return null;
+
+  }
+
+  /*
+      Nested directories will be created like this,
+      suppose you pass depth=3, span=3 and number of tests=2
+
+      Directory Structure:-
+                            |-- Dir111
+                            |
+                |-- Dir11 --|-- Dir112
+                |           |
+                |           |-- Dir113
+                |
+                |
+                |           |-- Dir121
+                |           |
+       Dir1   --|-- Dir12 --|-- Dir122
+                |           |
+                |           |-- Dir123
+                |
+                |
+                |           |-- Dir131
+                |           |
+                |-- Dir13 --|-- Dir132
+                            |
+                            |-- Dir133
+
+     In each directory 'n' number of files with file size 's' will be created.
+   */
+  private void createDir(long counter) throws Exception {
+    if (depth <= 0) {
+      LOG.info("Invalid depth value, at least one depth should be passed!");
+      return;
+    }
+    String dirString = "/";
+    String root = RandomStringUtils.
+            randomAlphanumeric(length);
+    String dir = rootPath.concat("/").concat(root);
+    makeDir(dir);
+    // create files..
+    createFiles(dir);
+    createSubDirRecursively(dir, 1, 1);
+    System.out.println("Successfully created directories & files. Total Dir " +
+            "Count=" + totalDirsCnt);
+  }
+
+  private void createSubDirRecursively(String parent, int depthIndex,
+                                       int spanIndex)
+          throws Exception {
+    if (depthIndex < depth) {
+      String depthSubDir = RandomStringUtils.
+              randomAlphanumeric(length);
+      depthSubDir =
+              parent.toString().concat("/").concat(depthSubDir);
+      makeDir(depthSubDir);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("SubDir:{}, depthIndex:{} +", depthSubDir, depthIndex);
+      }
+      ++depthIndex;
+      // create files..
+      createFiles(depthSubDir);
+      // only non-leaf nodes will be iterated recursively..
+      if (depthIndex < depth) {
+        createSubDirRecursively(depthSubDir, depthIndex, spanIndex);
+      }
+    }
+
+    while(spanIndex < span) {
+      String levelSubDir = RandomStringUtils.
+              randomAlphanumeric(length);
+      levelSubDir =
+              parent.toString().concat("/").concat(levelSubDir);
+      makeDir(levelSubDir);
+      ++spanIndex;
+
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("SpanSubDir:{}, depthIndex:{}, spanIndex:{} +", levelSubDir,
+                depthIndex, spanIndex);
+      }
+      // create files..
+      createFiles(levelSubDir);
+      // only non-leaf nodes will be iterated recursively..
+      if (depthIndex < depth) {
+        createSubDirRecursively(levelSubDir, depthIndex, 1);
+      }
+    }
+  }
+
+  private void makeDir(String levelSubDir) throws IOException {
+    fileSystem.mkdirs(new Path(levelSubDir));
+    totalDirsCnt++;
+  }
+
+  private void createFiles(String dir) throws IOException {
+    for (int i = 0; i < fileCount; i++) {
+      String fileName = dir.concat("/").concat(RandomStringUtils.
+              randomAlphanumeric(length));
+
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("FilePath:{}", fileName);
+      }
+
+      FSDataOutputStream out =
+              fileSystem.create(new Path(fileName), true);
+      int fSizeInKBs = fileSize * 1024;
+      if (fSizeInKBs > 0) {
+        int bufferLen = 1024;
+        int seed = 0;
+        byte[] toWrite = new byte[bufferLen];
+        Random rb = new Random(seed);
+        long bytesToWrite = fileSize;
+        while (bytesToWrite > 0) {
+          rb.nextBytes(toWrite);
+          int bytesToWriteNext = (bufferLen < bytesToWrite) ? bufferLen
+                  : (int) bytesToWrite;
+
+          out.write(toWrite, 0, bytesToWriteNext);
+          bytesToWrite -= bytesToWriteNext;
+        }
+      }
+      out.flush();
+      out.close();
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This Jira proposes to add a functionality to freon tool to create directories in tree structure. 

**Proposed structure:**
  /*
      Nested directories will be created like this,
      suppose you pass depth=3, span=3 and number of tests=2

      Directory Structure:-
                            |-- Dir111
                            |
                |-- Dir11 --|-- Dir112
                |           |
                |           |-- Dir113
                |
                |
                |           |-- Dir121
                |           |
       Dir1   --|-- Dir12 --|-- Dir122
                |           |
                |           |-- Dir123
                |
                |
                |           |-- Dir131
                |           |
                |-- Dir13 --|-- Dir132
                            |
                            |-- Dir133

     In each directory 'c' number of files to be written in each directory with file size 'g' will be created.
   */

This is basically useful to determine the performance evaluation of ozone, when creating defined number of nested directories and also create given number of files into each directory.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3518

## How was this patch tested?

Added unit test case..
