### PR TITLE
HDDS-3513. Add OzoneConfiguration to UGI when startup S3Gateway

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
@@ -211,6 +211,7 @@ public class OzoneConfiguration extends Configuration
     Configuration.addDefaultResource("hdfs-default.xml");
     Configuration.addDefaultResource("hdfs-site.xml");
     Configuration.addDefaultResource("ozone-default.xml");
+    Configuration.addDefaultResource("ozone-site.xml");
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
@@ -211,7 +211,6 @@ public class OzoneConfiguration extends Configuration
     Configuration.addDefaultResource("hdfs-default.xml");
     Configuration.addDefaultResource("hdfs-site.xml");
     Configuration.addDefaultResource("ozone-default.xml");
-    Configuration.addDefaultResource("ozone-site.xml");
   }
 
   /**

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -53,11 +53,7 @@ public class Gateway extends GenericCli {
     TracingUtil.initTracing("S3gateway", ozoneConfiguration);
     OzoneConfigurationHolder.setConfiguration(ozoneConfiguration);
     ozoneConfiguration.set("hadoop.http.authentication.type", "simple");
-    if (SecurityUtil.getAuthenticationMethod(ozoneConfiguration).equals(
-        UserGroupInformation.AuthenticationMethod.KERBEROS)) {
-      UserGroupInformation.setConfiguration(ozoneConfiguration);
-    }
-
+    UserGroupInformation.setConfiguration(ozoneConfiguration);
     httpServer = new S3GatewayHttpServer(ozoneConfiguration, "s3gateway");
     start();
     return null;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 
-import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -54,7 +54,7 @@ public class Gateway extends GenericCli {
     OzoneConfigurationHolder.setConfiguration(ozoneConfiguration);
     ozoneConfiguration.set("hadoop.http.authentication.type", "simple");
     if (SecurityUtil.getAuthenticationMethod(ozoneConfiguration).equals(
-      UserGroupInformation.AuthenticationMethod.KERBEROS)){
+        UserGroupInformation.AuthenticationMethod.KERBEROS)) {
       UserGroupInformation.setConfiguration(ozoneConfiguration);
     }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -24,6 +24,8 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 
+import org.apache.hadoop.security.SecurityUtil;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
@@ -51,6 +53,11 @@ public class Gateway extends GenericCli {
     TracingUtil.initTracing("S3gateway", ozoneConfiguration);
     OzoneConfigurationHolder.setConfiguration(ozoneConfiguration);
     ozoneConfiguration.set("hadoop.http.authentication.type", "simple");
+    if (SecurityUtil.getAuthenticationMethod(ozoneConfiguration).equals(
+      UserGroupInformation.AuthenticationMethod.KERBEROS)){
+      UserGroupInformation.setConfiguration(ozoneConfiguration);
+    }
+
     httpServer = new S3GatewayHttpServer(ozoneConfiguration, "s3gateway");
     start();
     return null;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add ozone-site.xml to OzoneConfiguration by default. In secure mode , otherwise security items configured in ozone-site.xml will not be effected when startup a secure s3 gateway. we have to configure these in core-site.xml which makes a little confused.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3513

## How was this patch tested?
setup a secure ozone cluster and configure security items in ozone-site.xml followed by document mentioned,  then start each service.