### PR TITLE
HDDS-3553. Make hadoop.http.authentication.type to be configured when startup S3Gateway

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -51,7 +51,6 @@ public class Gateway extends GenericCli {
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
     TracingUtil.initTracing("S3gateway", ozoneConfiguration);
     OzoneConfigurationHolder.setConfiguration(ozoneConfiguration);
-    ozoneConfiguration.set("hadoop.http.authentication.type", "simple");
     UserGroupInformation.setConfiguration(ozoneConfiguration);
     httpServer = new S3GatewayHttpServer(ozoneConfiguration, "s3gateway");
     start();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove a hard-code configuration which may cause this item not be effected if needed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3553

## How was this patch tested?
no need test.