### PR TITLE
HDDS-3560 OMFailoverProxyProvider throws IllegalAccessError when assigning proxy with Hadoop version < 3.2 

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -198,7 +198,13 @@ public class OMFailoverProxyProvider implements
     if (proxyInfo.proxy == null) {
       InetSocketAddress address = omProxyInfos.get(nodeId).getAddress();
       try {
-        proxyInfo.proxy = createOMProxy(address);
+        OzoneManagerProtocolPB proxy = createOMProxy(address);
+        try {
+          proxyInfo.proxy = proxy;
+        } catch (IllegalAccessError iae) {
+          omProxies.put(nodeId,
+              new ProxyInfo<>(proxy, proxyInfo.proxyInfo));
+        }
       } catch (IOException ioe) {
         LOG.error("{} Failed to create RPC proxy to OM at {}",
             this.getClass().getSimpleName(), address, ioe);


### PR DESCRIPTION
## What changes were proposed in this pull request?

A small improvement of keeping compatible from hadoop 2.x and hadoop 3.x

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3560

## How was this patch tested?

No
