### PR TITLE
HDDS-3494. Implement ofs://: Support volume and bucket deletion

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -65,6 +66,7 @@ import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
 
 /**
  * Ozone file system tests that are not covered by contract tests.
@@ -764,6 +766,105 @@ public class TestRootedOzoneFileSystem {
     Assert.assertEquals(1, fileStatusesInDir1.length);
     Assert.assertEquals("/tmp/dir1/file1",
         fileStatusesInDir1[0].getPath().toUri().getPath());
+  }
+
+  /**
+   * Helper function. Check Ozone volume existence.
+   * @param volumeStr Name of the volume
+   * @return true if volume exists, false if not
+   */
+  private boolean volumeExist(String volumeStr) throws IOException {
+    try {
+      objectStore.getVolume(volumeStr);
+    } catch (OMException ex) {
+      if (ex.getResult() == VOLUME_NOT_FOUND) {
+        return false;
+      } else {
+        throw ex;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Helper function. Delete a path non-recursively and expect failure.
+   * @param f Path to delete.
+   * @throws IOException
+   */
+  private void deleteNonRecursivelyAndFail(Path f) throws IOException {
+    try {
+      fs.delete(f, false);
+      Assert.fail("Should have thrown PathIsNotEmptyDirectoryException!");
+    } catch (PathIsNotEmptyDirectoryException ignored) {
+    }
+  }
+
+  @Test
+  public void testDeleteVolumeAndBucket() throws IOException {
+    // Case 1: Delete empty volume
+
+    // Create volume
+    String volumeStr1 = getRandomNonExistVolumeName();
+    Path volumePath1 = new Path(OZONE_URI_DELIMITER + volumeStr1);
+    fs.mkdirs(volumePath1);
+    // Check volume creation
+    OzoneVolume volume1 = objectStore.getVolume(volumeStr1);
+    Assert.assertEquals(volumeStr1, volume1.getName());
+    // Delete empty volume non-recursively
+    Assert.assertTrue(fs.delete(volumePath1, false));
+    // Verify the volume is deleted
+    Assert.assertFalse(volumeStr1 + " should have been deleted!",
+        volumeExist(volumeStr1));
+
+    // Case 2: Delete volume and bucket
+
+    // Create volume and bucket
+    String volumeStr2 = getRandomNonExistVolumeName();
+    Path volumePath2 = new Path(OZONE_URI_DELIMITER + volumeStr2);
+    String bucketStr2 = "bucket2";
+    Path bucketPath2 = new Path(volumePath2, bucketStr2);
+    fs.mkdirs(bucketPath2);
+    // Check volume and bucket creation
+    OzoneVolume volume2 = objectStore.getVolume(volumeStr2);
+    Assert.assertEquals(volumeStr2, volume2.getName());
+    OzoneBucket bucket2 = volume2.getBucket(bucketStr2);
+    Assert.assertEquals(bucketStr2, bucket2.getName());
+    // Delete volume non-recursively should fail since it is not empty
+    deleteNonRecursivelyAndFail(volumePath2);
+    // Delete bucket first, then volume
+    Assert.assertTrue(fs.delete(bucketPath2, false));
+    Assert.assertTrue(fs.delete(volumePath2, false));
+    // Verify the volume is deleted
+    Assert.assertFalse(volumeExist(volumeStr2));
+
+    // Case 3: Delete volume, bucket and key
+
+    // Create test volume, bucket and key
+    String volumeStr3 = getRandomNonExistVolumeName();
+    Path volumePath3 = new Path(OZONE_URI_DELIMITER + volumeStr3);
+    String bucketStr3 = "bucket3";
+    Path bucketPath3 = new Path(volumePath3, bucketStr3);
+    String dirStr3 = "dir3";
+    Path dirPath3 = new Path(bucketPath3, dirStr3);
+    fs.mkdirs(dirPath3);
+    // Delete volume or bucket non-recursively, should fail
+    deleteNonRecursivelyAndFail(volumePath3);
+    deleteNonRecursivelyAndFail(bucketPath3);
+    // Delete key first, then bucket, then volume
+    Assert.assertTrue(fs.delete(dirPath3, false));
+    Assert.assertTrue(fs.delete(bucketPath3, false));
+    Assert.assertTrue(fs.delete(volumePath3, false));
+    // Verify the volume is deleted
+    Assert.assertFalse(volumeExist(volumeStr3));
+
+    // Case 4: Recursively delete volume
+
+    // Create test volume, bucket and key
+    fs.mkdirs(dirPath3);
+    // Delete volume recursively
+    Assert.assertTrue(fs.delete(volumePath3, true));
+    // Verify the volume is deleted
+    Assert.assertFalse(volumeExist(volumeStr3));
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -800,9 +800,7 @@ public class TestRootedOzoneFileSystem {
   }
 
   @Test
-  public void testDeleteVolumeAndBucket() throws IOException {
-    // Case 1: Delete empty volume
-
+  public void testDeleteEmptyVolume() throws IOException {
     // Create volume
     String volumeStr1 = getRandomNonExistVolumeName();
     Path volumePath1 = new Path(OZONE_URI_DELIMITER + volumeStr1);
@@ -815,9 +813,10 @@ public class TestRootedOzoneFileSystem {
     // Verify the volume is deleted
     Assert.assertFalse(volumeStr1 + " should have been deleted!",
         volumeExist(volumeStr1));
+  }
 
-    // Case 2: Delete volume and bucket
-
+  @Test
+  public void testDeleteVolumeAndBucket() throws IOException {
     // Create volume and bucket
     String volumeStr2 = getRandomNonExistVolumeName();
     Path volumePath2 = new Path(OZONE_URI_DELIMITER + volumeStr2);
@@ -836,9 +835,10 @@ public class TestRootedOzoneFileSystem {
     Assert.assertTrue(fs.delete(volumePath2, false));
     // Verify the volume is deleted
     Assert.assertFalse(volumeExist(volumeStr2));
+  }
 
-    // Case 3: Delete volume, bucket and key
-
+  @Test
+  public void testDeleteVolumeBucketAndKey() throws IOException {
     // Create test volume, bucket and key
     String volumeStr3 = getRandomNonExistVolumeName();
     Path volumePath3 = new Path(OZONE_URI_DELIMITER + volumeStr3);
@@ -857,14 +857,20 @@ public class TestRootedOzoneFileSystem {
     // Verify the volume is deleted
     Assert.assertFalse(volumeExist(volumeStr3));
 
-    // Case 4: Recursively delete volume
-
+    // Test recursively delete volume
     // Create test volume, bucket and key
     fs.mkdirs(dirPath3);
     // Delete volume recursively
     Assert.assertTrue(fs.delete(volumePath3, true));
     // Verify the volume is deleted
     Assert.assertFalse(volumeExist(volumeStr3));
+  }
+
+  @Test
+  public void testFailToDeleteRoot() throws IOException {
+    // rm root should always fail for OFS
+    Assert.assertFalse(fs.delete(new Path("/"), false));
+    Assert.assertFalse(fs.delete(new Path("/"), true));
   }
 
 }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -467,6 +467,13 @@ public class BasicOzoneFileSystem extends FileSystem {
     }
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * OFS supports volume and bucket deletion, recursive or non-recursive.
+   * e.g. delete(new Path("/volume1"), true)
+   * But root deletion is explicitly disallowed for safety concerns.
+   */
   @Override
   public boolean delete(Path f, boolean recursive) throws IOException {
     incrementCounter(Statistic.INVOCATION_DELETE);

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -307,6 +307,9 @@ public class BasicRootedOzoneClientAdapterImpl
       boolean overWrite, boolean recursive) throws IOException {
     incrementCounter(Statistic.OBJECTS_CREATED);
     OFSPath ofsPath = new OFSPath(pathStr);
+    if (ofsPath.isRoot() || ofsPath.isVolume() || ofsPath.isBucket()) {
+      throw new IOException("Cannot create file under root or volume.");
+    }
     String key = ofsPath.getKeyName();
     try {
       // Hadoop CopyCommands class always sets recursive to true
@@ -658,6 +661,10 @@ public class BasicRootedOzoneClientAdapterImpl
     token.setKind(OzoneTokenIdentifier.KIND_NAME);
     return token;
 
+  }
+
+  public ObjectStore getObjectStore() {
+    return objectStore;
   }
 
   @Override

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -490,10 +490,10 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
           OzoneVolume volume =
               adapterImpl.getObjectStore().getVolume(volumeName);
           Iterator<? extends OzoneBucket> it = volume.listBuckets("");
+          String prefixVolumePathStr = addTrailingSlashIfNeeded(f.toString());
           while (it.hasNext()) {
             OzoneBucket bucket = it.next();
-            String nextBucket = addTrailingSlashIfNeeded(
-                f.toString()) + bucket.getName();
+            String nextBucket = prefixVolumePathStr + bucket.getName();
             delete(new Path(nextBucket), true);
           }
         }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -482,15 +482,11 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
       // Handle rm root
       if (ofsPath.isRoot()) {
-        Iterator<? extends OzoneVolume> it =
-            adapterImpl.getObjectStore().listVolumes("");
-        while (it.hasNext()) {
-          OzoneVolume volume = it.next();
-          String nextVolume = addTrailingSlashIfNeeded(
-              f.toString()) + volume.getName();
-          delete(new Path(nextVolume), true);
-        }
-        return true;
+        // Intentionally drop support for rm root
+        // because it is too dangerous and doesn't provide much value
+        LOG.warn("delete: OFS does not support rm root. "
+            + "To wipe the cluster, please re-init OM instead.");
+        return false;
       }
 
       // Handle delete volume

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -471,13 +471,6 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
     if (status.isDirectory()) {
       LOG.debug("delete: Path is a directory: {}", f);
-      key = addTrailingSlashIfNeeded(key);
-
-      if (key.equals("/")) {
-        LOG.warn("Cannot delete root directory.");
-        return false;
-      }
-
       OFSPath ofsPath = new OFSPath(key);
 
       // Handle rm root

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -462,6 +462,10 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       return false;
     }
 
+    if (status == null) {
+      return false;
+    }
+
     String key = pathToKey(f);
     boolean result;
 

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
@@ -190,6 +190,17 @@ class OFSPath {
     return this.getBucketName().isEmpty() && !this.getVolumeName().isEmpty();
   }
 
+  /**
+   * If key name is empty but volume and bucket names are not, the given path
+   * it bucket.
+   * e.g. /volume1/bucket2
+   */
+  public boolean isBucket() {
+    return this.getKeyName().isEmpty() &&
+        !this.getBucketName().isEmpty() &&
+        !this.getVolumeName().isEmpty();
+  }
+
   private static String md5Hex(String input) {
     try {
       MessageDigest md = MessageDigest.getInstance("MD5");


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support volume and bucket deletion directly via ofs://

- Support empty volume and bucket deletion.
- Support recursive volume and bucket deletion. (see examples below)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3494

## How was this patch tested?

Tested via contract tests.
Added new integration test case.

## Examples

```bash

```