### PR TITLE
HDDS-3416. Enable TestSCMNodeManager#testScmStatsFromNodeReport

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.NodeReportFromDatanode;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
@@ -75,7 +76,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -850,24 +850,20 @@ public class TestSCMNodeManager {
     final long remaining = capacity - used;
 
     try (SCMNodeManager nodeManager = createNodeManager(conf)) {
-      NodeReportHandler nodeReportHandler = new NodeReportHandler(nodeManager);
-      EventPublisher publisher = Mockito.mock(EventPublisher.class);
+    EventQueue eventQueue = (EventQueue) scm.getEventQueue();
       for (int x = 0; x < nodeCount; x++) {
-        DatanodeDetails datanodeDetails = TestUtils
-            .createRandomDatanodeAndRegister(nodeManager);
-        UUID dnId = datanodeDetails.getUuid();
+        DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
+        UUID dnId = dn.getUuid();
         long free = capacity - used;
         String storagePath = testDir.getAbsolutePath() + "/" + dnId;
         StorageReportProto report = TestUtils
             .createStorageReport(dnId, storagePath, capacity, used, free, null);
-        NodeReportProto nodeReportProto = TestUtils.createNodeReport(report);
-        nodeReportHandler.onMessage(
-                new NodeReportFromDatanode(datanodeDetails, nodeReportProto),
-                publisher);
-        nodeManager.processHeartbeat(datanodeDetails);
+        nodeManager.register(dn, TestUtils.createNodeReport(report), null);
+        nodeManager.processHeartbeat(dn);
       }
-      //TODO: wait for heartbeat to be processed
-      Thread.sleep(4 * 1000);
+      //TODO: wait for EventQueue to be processed
+      eventQueue.processAll(8000L);
+
       assertEquals(nodeCount, nodeManager.getNodeCount(HEALTHY));
       assertEquals(capacity * nodeCount, (long) nodeManager.getStats()
           .getCapacity().get());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -850,7 +850,7 @@ public class TestSCMNodeManager {
     final long remaining = capacity - used;
 
     try (SCMNodeManager nodeManager = createNodeManager(conf)) {
-    EventQueue eventQueue = (EventQueue) scm.getEventQueue();
+      EventQueue eventQueue = (EventQueue) scm.getEventQueue();
       for (int x = 0; x < nodeCount; x++) {
         DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
         UUID dnId = dn.getUuid();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed and enabled this test method(`TestSCMNodeManager#testScmStatsFromNodeReport`).
Added the NodeReportEvent handler to get node reports from datanode.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3416

## How was this patch tested?

Ran UTs - Pass.