### PR TITLE
HDDS-3417. Enable TestSCMNodeManager#testScmNodeReportUpdate

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -34,6 +34,8 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.NodeReportFromDatanode;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
@@ -42,6 +44,7 @@ import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
@@ -69,12 +72,14 @@ import org.junit.After;
 import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
 
 /**
  * Test the SCM Node Manager class.
@@ -877,8 +882,6 @@ public class TestSCMNodeManager {
    * @throws TimeoutException
    */
   @Test
-  @Ignore
-  // TODO: Enable this after we implement NodeReportEvent handler.
   public void testScmNodeReportUpdate()
       throws IOException, InterruptedException, TimeoutException,
       AuthenticationException {
@@ -896,6 +899,8 @@ public class TestSCMNodeManager {
     try (SCMNodeManager nodeManager = createNodeManager(conf)) {
       DatanodeDetails datanodeDetails =
           TestUtils.createRandomDatanodeAndRegister(nodeManager);
+      NodeReportHandler nodeReportHandler = new NodeReportHandler(nodeManager);
+      EventPublisher publisher = Mockito.mock(EventPublisher.class);
       final long capacity = 2000;
       final long usedPerHeartbeat = 100;
       UUID dnId = datanodeDetails.getUuid();
@@ -906,7 +911,10 @@ public class TestSCMNodeManager {
         StorageReportProto report = TestUtils
             .createStorageReport(dnId, storagePath, capacity, scmUsed,
                 remaining, null);
-
+        NodeReportProto nodeReportProto = TestUtils.createNodeReport(report);
+        nodeReportHandler.onMessage(
+                new NodeReportFromDatanode(datanodeDetails, nodeReportProto),
+                publisher);
         nodeManager.processHeartbeat(datanodeDetails);
         Thread.sleep(100);
       }
@@ -944,7 +952,7 @@ public class TestSCMNodeManager {
       // Compare the result from
       // NodeManager#getNodeStats and NodeManager#getNodeStat
       SCMNodeStat stat1 = nodeManager.getNodeStats().
-          get(datanodeDetails.getUuid());
+          get(datanodeDetails);
       SCMNodeStat stat2 = nodeManager.getNodeStat(datanodeDetails).get();
       assertEquals(stat1, stat2);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed and enabled this test method(`TestSCMNodeManager#testScmNodeReportUpdate`).
Added the NodeReportEvent handler to get node reports from datanode.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3417

## How was this patch tested?

Ran UTs - Pass.