### PR TITLE
WIP Patch - HDDS-2949: store dir/key entries in separate tables - first patch onl…

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
@@ -51,20 +51,13 @@ public class OmDirectoryInfo extends WithObjectID {
     this.modificationTime = builder.modificationTime;
   }
 
-  // TODO: its work around and need to remove the dependency with OMKeyInfo
-  public static OmDirectoryInfo createDirectoryInfo(OmKeyInfo omKeyInfo,
-                                             long parentObjectID) {
-    String dirName = OzoneFSUtils.getFileName(omKeyInfo.getKeyName());
-    return new Builder().setName(dirName)
-            .setParentObjectID(parentObjectID)
-            .setObjectID(omKeyInfo.getObjectID())
-            .setUpdateID(omKeyInfo.getUpdateID())
-            .setBucketName(omKeyInfo.getBucketName())
-            .setVolumeName(omKeyInfo.getVolumeName())
-            .setCreationTime(omKeyInfo.getCreationTime())
-            .setModificationTime(omKeyInfo.getModificationTime())
-            .setAcls(omKeyInfo.getAcls())
-            .setMetadata(omKeyInfo.getMetadata())
+  // TODO: its work around to represent root directory, which is the bucket.
+  public static OmDirectoryInfo createDirectoryInfo(long bucketId) {
+    // both parent and id pointing are same to
+    // represents root node.
+    return new Builder().setIndex((short) -1)
+            .setParentObjectID(bucketId)
+            .setObjectID(bucketId)
             .build();
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
@@ -1,0 +1,301 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.helpers;
+
+import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+
+import java.util.*;
+
+public class OmDirectoryInfo extends WithObjectID {
+  private final String dirSeparator = "/";
+
+  private long parentObjectID; // pointer to parent directory
+
+  private String name;
+  private String volumeName;
+  private String bucketName;
+
+  private long creationTime;
+  private long modificationTime;
+
+  private List<OzoneAcl> acls;
+
+  public OmDirectoryInfo(Builder builder) {
+    this.name = builder.name;
+    this.acls = builder.acls;
+    this.metadata = builder.metadata;
+    this.objectID = builder.objectID;
+    this.updateID = builder.updateID;
+    this.parentObjectID = builder.parentObjectID;
+    this.volumeName = builder.volumeName;
+    this.bucketName = builder.bucketName;
+    this.creationTime = builder.creationTime;
+    this.modificationTime = builder.modificationTime;
+  }
+
+  // TODO: its work around and need to remove the dependency with OMKeyInfo
+  public static OmDirectoryInfo createDirectoryInfo(OmKeyInfo omKeyInfo,
+                                             long parentObjectID) {
+    String dirName = OzoneFSUtils.getDirName(omKeyInfo.getKeyName());
+    return new Builder().setName(dirName)
+            .setParentObjectID(parentObjectID)
+            .setObjectID(omKeyInfo.getObjectID())
+            .setUpdateID(omKeyInfo.getUpdateID())
+            .setBucketName(omKeyInfo.getBucketName())
+            .setVolumeName(omKeyInfo.getVolumeName())
+            .setCreationTime(omKeyInfo.getCreationTime())
+            .setModificationTime(omKeyInfo.getModificationTime())
+            .setAcls(omKeyInfo.getAcls())
+            .setMetadata(omKeyInfo.getMetadata())
+            .build();
+  }
+
+  /**
+   * Returns new builder class that builds a OmPrefixInfo.
+   *
+   * @return Builder
+   */
+  public static OmDirectoryInfo.Builder newBuilder() {
+    return new OmDirectoryInfo.Builder();
+  }
+
+  public static class Builder {
+    private long parentObjectID; // pointer to parent directory
+
+    private long objectID;
+    private long updateID;
+
+    private String name;
+    private String volumeName;
+    private String bucketName;
+
+
+    private long creationTime;
+    private long modificationTime;
+
+    private List<OzoneAcl> acls;
+    private Map<String, String> metadata;
+
+    public Builder() {
+      //Default values
+      this.acls = new LinkedList<>();
+      this.metadata = new HashMap<>();
+    }
+
+    public Builder setParentObjectID(long parentObjectID) {
+      this.parentObjectID = parentObjectID;
+      return this;
+    }
+
+    public Builder setObjectID(long objectID) {
+      this.objectID = objectID;
+      return this;
+    }
+
+    public Builder setUpdateID(long updateID) {
+      this.updateID = updateID;
+      return this;
+    }
+
+    public Builder setName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder setVolumeName(String volumeName) {
+      this.volumeName = volumeName;
+      return this;
+    }
+
+    public Builder setBucketName(String bucketName) {
+      this.bucketName = bucketName;
+      return this;
+    }
+
+    public Builder setCreationTime(long creationTime) {
+      this.creationTime = creationTime;
+      return this;
+    }
+
+    public Builder setModificationTime(long modificationTime) {
+      this.modificationTime = modificationTime;
+      return this;
+    }
+
+    public Builder setAcls(List<OzoneAcl> acls) {
+      this.acls = acls;
+      return this;
+    }
+
+    public Builder addAcl(OzoneAcl ozoneAcl) {
+      if (ozoneAcl != null) {
+        this.acls.add(ozoneAcl);
+      }
+      return this;
+    }
+
+    public Builder setMetadata(Map<String, String> metadata) {
+      this.metadata = metadata;
+      return this;
+    }
+
+    public Builder addMetadata(String key, String value) {
+      metadata.put(key, value);
+      return this;
+    }
+
+    public Builder addAllMetadata(Map<String, String> additionalMetadata) {
+      if (additionalMetadata != null) {
+        metadata.putAll(additionalMetadata);
+      }
+      return this;
+    }
+
+    public OmDirectoryInfo build() {
+      return new OmDirectoryInfo(this);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return getObjectID() + "";
+  }
+
+  public String getVolumeName() {
+    return volumeName;
+  }
+
+  public String getBucketName() {
+    return bucketName;
+  }
+
+  public long getParentObjectID() {
+    return parentObjectID;
+  }
+
+  public String getPath() {
+    return getParentObjectID() + dirSeparator + getName();
+  }
+
+  public String getName() { return name; }
+
+  public long getCreationTime() {
+    return creationTime;
+  }
+
+  public long getModificationTime() {
+    return modificationTime;
+  }
+
+  public List<OzoneAcl> getAcls() { return acls; }
+
+  /**
+   * Creates PrefixInfo protobuf from OmDirectoryInfo.
+   */
+  public OzoneManagerProtocolProtos.DirectoryInfo getProtobuf() {
+    OzoneManagerProtocolProtos.DirectoryInfo.Builder pib =
+            OzoneManagerProtocolProtos.DirectoryInfo.newBuilder().setName(name)
+                    .addAllMetadata(KeyValueUtil.toProtobuf(metadata));
+    if (acls != null) {
+      pib.addAllAcls(OzoneAclUtil.toProtobuf(acls));
+    }
+    return pib.build();
+  }
+
+  /**
+   * Parses DirectoryInfo protobuf and creates OmPrefixInfo.
+   * @param dirInfo
+   * @return instance of OmDirectoryInfo
+   */
+  public static OmDirectoryInfo getFromProtobuf(
+          OzoneManagerProtocolProtos.DirectoryInfo dirInfo) {
+    OmDirectoryInfo.Builder opib = OmDirectoryInfo.newBuilder()
+            .setVolumeName(dirInfo.getVolumeName())
+            .setBucketName(dirInfo.getBucketName())
+            .setName(dirInfo.getName())
+            .setCreationTime(dirInfo.getCreationTime())
+            .setModificationTime(dirInfo.getModificationTime())
+            .setAcls(OzoneAclUtil.fromProtobuf(dirInfo.getAclsList()));
+    if (dirInfo.getMetadataList() != null) {
+      opib.addAllMetadata(KeyValueUtil
+              .getFromProtobuf(dirInfo.getMetadataList()));
+    }
+    if (dirInfo.hasObjectID()) {
+      opib.setObjectID(dirInfo.getObjectID());
+    }
+    if (dirInfo.hasParentID()) {
+      opib.setUpdateID(dirInfo.getParentID());
+    }
+    if (dirInfo.hasUpdateID()) {
+      opib.setUpdateID(dirInfo.getUpdateID());
+    }
+    return opib.build();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    OmDirectoryInfo omDirInfo = (OmDirectoryInfo) o;
+    return creationTime == omDirInfo.creationTime &&
+            modificationTime == omDirInfo.modificationTime &&
+            volumeName.equals(omDirInfo.volumeName) &&
+            bucketName.equals(omDirInfo.bucketName) &&
+            name.equals(omDirInfo.name) &&
+            Objects.equals(metadata, omDirInfo.metadata) &&
+            Objects.equals(acls, omDirInfo.acls) &&
+            objectID == omDirInfo.objectID &&
+            updateID == omDirInfo.updateID &&
+            parentObjectID == omDirInfo.parentObjectID;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(volumeName, bucketName, parentObjectID, name);
+  }
+
+  /**
+   * Return a new copy of the object.
+   */
+  public OmDirectoryInfo copyObject() {
+    OmDirectoryInfo.Builder builder = new Builder()
+            .setVolumeName(volumeName)
+            .setBucketName(bucketName)
+            .setName(name)
+            .setCreationTime(creationTime)
+            .setModificationTime(modificationTime)
+            .setParentObjectID(parentObjectID)
+            .setObjectID(objectID)
+            .setUpdateID(updateID);
+
+    acls.forEach(acl -> builder.addAcl(new OzoneAcl(acl.getType(),
+            acl.getName(), (BitSet) acl.getAclBitSet().clone(),
+            acl.getAclScope())));
+
+    if (metadata != null) {
+      metadata.forEach((k, v) -> builder.addMetadata(k, v));
+    }
+
+    return builder.build();
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmPrefixInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmPrefixInfo.java
@@ -35,12 +35,12 @@ import java.util.stream.Collectors;
  * can be extended for other OzFS optimizations in future.
  */
 // TODO: support Auditable interface
-public final class OmPrefixInfo extends WithObjectID {
+public class OmPrefixInfo extends WithObjectID {
 
   private String name;
   private List<OzoneAcl> acls;
 
-  public OmPrefixInfo(String name, List<OzoneAcl> acls,
+  protected OmPrefixInfo(String name, List<OzoneAcl> acls,
       Map<String, String> metadata, long objectId, long updateId) {
     this.name = name;
     this.acls = acls;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFSUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFSUtils.java
@@ -90,6 +90,13 @@ public final class OzoneFSUtils {
     return keyPath.getNameCount();
   }
 
+  public static String appendKeyName(String toKeyName, String fromFileName) {
+    StringBuilder newToKeyName = new StringBuilder(toKeyName);
+    newToKeyName.append(OZONE_URI_DELIMITER);
+    newToKeyName.append(fromFileName);
+    return newToKeyName.toString();
+  }
+
   public static String addTrailingSlashIfNeeded(String key) {
     if (!key.endsWith(OZONE_URI_DELIMITER)) {
       return key + OZONE_URI_DELIMITER;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFSUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFSUtils.java
@@ -80,17 +80,14 @@ public final class OzoneFSUtils {
    * example, the given key path '/a/b/c/d/e/file1' then it returns file name
    * 'file1'.
    */
-  public static String getDirName(String keyName) {
-    if (keyName.endsWith("/")) {
-      keyName = keyName.substring(0, keyName.lastIndexOf("/"));
-    }
-    int keyNameIndx = keyName.lastIndexOf("/");
-    if (keyNameIndx > 0) {
-      return keyName.substring(keyNameIndx + 1);
-    } else if (!keyName.contains("/")) {
-      return keyName;
-    }
-    return "";
+  public static String getFileName(String keyName) {
+    java.nio.file.Path keyPath = Paths.get(keyName);
+    return keyPath.getFileName().toString();
+  }
+
+ public static int getFileCount(String keyName) {
+    java.nio.file.Path keyPath = Paths.get(keyName);
+    return keyPath.getNameCount();
   }
 
   public static String addTrailingSlashIfNeeded(String key) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFSUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFSUtils.java
@@ -75,6 +75,24 @@ public final class OzoneFSUtils {
     return descendant;
   }
 
+  /**
+   * The function returns file name from the given absolute path. For
+   * example, the given key path '/a/b/c/d/e/file1' then it returns file name
+   * 'file1'.
+   */
+  public static String getDirName(String keyName) {
+    if (keyName.endsWith("/")) {
+      keyName = keyName.substring(0, keyName.lastIndexOf("/"));
+    }
+    int keyNameIndx = keyName.lastIndexOf("/");
+    if (keyNameIndx > 0) {
+      return keyName.substring(keyNameIndx + 1);
+    } else if (!keyName.contains("/")) {
+      return keyName;
+    }
+    return "";
+  }
+
   public static String addTrailingSlashIfNeeded(String key) {
     if (!key.endsWith(OZONE_URI_DELIMITER)) {
       return key + OZONE_URI_DELIMITER;

--- a/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
+++ b/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
@@ -750,6 +750,8 @@ message KeyInfo {
     repeated OzoneAclInfo acls = 13;
     optional uint64 objectID = 14;
     optional uint64 updateID = 15;
+    optional uint64 parentObjectID = 16;
+    optional string leafNodeName = 17;
 }
 
 message RepeatedKeyInfo {

--- a/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
+++ b/hadoop-ozone/common/src/main/proto/OzoneManagerProtocol.proto
@@ -558,6 +558,20 @@ message PrefixInfo {
     optional uint64 updateID = 5;
 }
 
+message DirectoryInfo {
+    required string volumeName = 1;
+    required string bucketName = 2;
+    required string name = 3;
+    required uint64 creationTime = 4;
+    required uint64 modificationTime = 5;
+    optional uint64 latestVersion = 6;
+    repeated hadoop.hdds.KeyValue metadata = 7;
+    repeated OzoneAclInfo acls = 8;
+    optional uint64 objectID = 9;
+    optional uint64 updateID = 10;
+    optional uint64 parentID = 11;
+}
+
 message OzoneObj {
   enum ObjectType {
     VOLUME = 1;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.fs.ozone;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Set;
 import java.util.TreeSet;
@@ -115,6 +116,36 @@ public class TestOzoneFileSystem {
     } catch (FileAlreadyExistsException fae) {
       // ignore as its expected
     }
+
+    // Directory
+    FileStatus fileStatus = fs.getFileStatus(parent);
+    assertEquals("FileStatus did not return the directory",
+            "/d1/d2/d3/d4", fileStatus.getPath().toUri().getPath());
+    assertTrue("FileStatus did not return the directory",
+            fileStatus.isDirectory());
+
+    // Directory
+    fileStatus = fs.getFileStatus(new Path("/d1/d2/d3/"));
+    assertEquals("FileStatus did not return the directory",
+            "/d1/d2/d3", fileStatus.getPath().toUri().getPath());
+    assertTrue("FileStatus did not return the directory",
+            fileStatus.isDirectory());
+
+    // File
+    FileStatus fileStatus1 = fs.getFileStatus(file2);
+    assertEquals("FileStatus did not return the file",
+            file2.toString(), fileStatus1.getPath().toUri().getPath());
+    assertFalse("FileStatus did not return the file",
+            fileStatus1.isDirectory());
+
+    // invalid
+   try{
+     fs.getFileStatus(new Path("/d1/d2/d3/d4/key3" +
+             "/invalid"));
+     fail("Should throw FileNotFoundException");
+   } catch (FileNotFoundException fnfe) {
+     // ignore as its expected
+   }
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1726,6 +1726,7 @@ public class KeyManagerImpl implements KeyManager {
             OMFileRequest.getLastKnownPrefixIfExists(volumeName, bucketName,
             keyName, metadataManager);
     int totalDirsCount = OzoneFSUtils.getFileCount(keyName);
+    // check if the key is a directory
     if(dirInfo.getIndex() == totalDirsCount - 1){
       OmKeyInfo fileKeyInfo = OMFileRequest.getKeyInfo(dirInfo, keyName);
       return new OzFileInfo(true, fileKeyInfo, scmBlockSize);
@@ -1751,7 +1752,7 @@ public class KeyManagerImpl implements KeyManager {
 
   private class OzFileInfo {
     boolean isUri = false;
-    boolean isDir = false;
+    boolean isDir = true;
     long parentId;
     @Nullable
     OmKeyInfo omKeyInfo;
@@ -1760,7 +1761,6 @@ public class KeyManagerImpl implements KeyManager {
     OzFileInfo(boolean isUri, long parentId){
       this.isUri = isUri;
       this.parentId = parentId;
-      this.isDir = true;
     }
 
     OzFileInfo(boolean isDir, OmKeyInfo omKeyInfo,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -22,13 +22,7 @@ import java.util.Set;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.common.BlockGroup;
-import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
-import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
-import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
-import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
-import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
-import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
-import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
+import org.apache.hadoop.ozone.om.helpers.*;
 import org.apache.hadoop.ozone.om.lock.OzoneManagerLock;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .UserVolumeInfo;
@@ -313,6 +307,12 @@ public interface OMMetadataManager {
    * @return Table.
    */
   Table<String, OmPrefixInfo> getPrefixTable();
+
+  /**
+   * Gets the DirectoryTable.
+   * @return Table.
+   */
+  Table<String, OmDirectoryInfo> getDirectoryTable();
 
   /**
    * Returns the DB key name of a multipart upload key in OM metadata store.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -110,6 +110,37 @@ public interface OMMetadataManager {
 
 
   /**
+   * Given a volume, bucket and a key, return the corresponding DB key.
+   *
+   * @param parentObjectId - parent object Id
+   * @param leafNodeName - leaf node name
+   * @return DB key as String.
+   */
+
+  String getOzoneLeafNodeKey(long parentObjectId, String leafNodeName);
+
+  /**
+   * Given a volume, bucket and a key, return the corresponding DB directory
+   * key.
+   *
+   * @param parentObjectId - parent object Id
+   * @param prefixName    - prefix name
+   * @return DB directory key as String.
+   */
+  String getOzonePrefixKey(long parentObjectId, String prefixName);
+
+  /**
+   * Returns the DB key name of a open key in OM metadata store. Should be
+   * #open# prefix followed by actual key name.
+   *
+   * @param parentObjectId - parent object Id
+   * @param leafNodeName - leaf node name
+   * @param id - the id for this open
+   * @return bytes of DB key.
+   */
+  String getOpenLeafNodeKey(long parentObjectId, String leafNodeName, long id);
+
+  /**
    * Returns the DB key name of a open key in OM metadata store. Should be
    * #open# prefix followed by actual key name.
    *

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -341,8 +341,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
         OmPrefixInfo.class);
     checkTableStatus(prefixTable, PREFIX_TABLE);
 
-    dirTable = this.store.getTable(DIRECTORY_TABLE, OmDirectoryInfo.class,
-        OmPrefixInfo.class);
+    dirTable = this.store.getTable(DIRECTORY_TABLE, String.class,
+            OmDirectoryInfo.class);
     checkTableStatus(dirTable, DIRECTORY_TABLE);
   }
 
@@ -424,6 +424,31 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   public String getOzoneDirKey(String volume, String bucket, String key) {
     key = OzoneFSUtils.addTrailingSlashIfNeeded(key);
     return getOzoneKey(volume, bucket, key);
+  }
+
+  @Override
+  public String getOzoneLeafNodeKey(long parentObjectId, String leafNodeName) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(parentObjectId);
+    builder.append(OM_KEY_PREFIX).append(leafNodeName);
+    return builder.toString();
+  }
+
+  @Override
+  public String getOzonePrefixKey(long parentObjectId, String prefixName) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(parentObjectId);
+    builder.append(OM_KEY_PREFIX).append(prefixName);
+    return builder.toString();
+  }
+
+  @Override
+  public String getOpenLeafNodeKey(long parentObjectId, String leafNodeName, long id) {
+    StringBuilder openKey = new StringBuilder();
+    openKey.append(parentObjectId);
+    openKey.append(OM_KEY_PREFIX).append(leafNodeName);
+    openKey.append(OM_KEY_PREFIX).append(id);
+    return openKey.toString();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OmDirectoryInfoCodec.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OmDirectoryInfoCodec.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.codec;
+
+import com.google.common.base.Preconditions;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DirectoryInfo;
+
+import java.io.IOException;
+
+/**
+ * Codec to encode OmDirectoryInfo as byte array.
+ */
+public class OmDirectoryInfoCodec implements Codec<OmDirectoryInfo> {
+
+  @Override
+  public byte[] toPersistedFormat(OmDirectoryInfo object) throws IOException {
+    Preconditions
+        .checkNotNull(object, "Null object can't be converted to byte array.");
+    return object.getProtobuf().toByteArray();
+  }
+
+  @Override
+  public OmDirectoryInfo fromPersistedFormat(byte[] rawData) throws IOException {
+    Preconditions
+        .checkNotNull(rawData,
+            "Null byte array can't converted to real object.");
+    try {
+      return OmDirectoryInfo.getFromProtobuf(DirectoryInfo.parseFrom(rawData));
+    } catch (InvalidProtocolBufferException e) {
+      throw new IllegalArgumentException(
+          "Can't encode the the raw data from the byte array", e);
+    }
+  }
+
+  @Override
+  public OmDirectoryInfo copyObject(OmDirectoryInfo object) {
+    return object.copyObject();
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -309,6 +309,7 @@ public final class OzoneManagerDoubleBuffer {
     omMetadataManager.getDelegationTokenTable().cleanupCache(
         lastRatisTransactionIndex);
     omMetadataManager.getPrefixTable().cleanupCache(lastRatisTransactionIndex);
+    omMetadataManager.getDirectoryTable().cleanupCache(lastRatisTransactionIndex);
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -288,7 +288,7 @@ public abstract class OMClientRequest implements RequestAuditor {
    * @return true if transactionID is less than or equal to updateID, false
    * otherwise.
    */
-  protected boolean isReplay(OzoneManager om, WithObjectID ozoneObj,
+  public boolean isReplay(OzoneManager om, WithObjectID ozoneObj,
       long transactionID) {
     return om.isRatisEnabled() && ozoneObj.isUpdateIDset() &&
         transactionID <= ozoneObj.getUpdateID();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -39,7 +38,6 @@ import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -63,8 +61,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .Status;
 import org.apache.hadoop.util.Time;
-import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
-import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_KEY_NAME;
@@ -191,6 +187,8 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
                 keyArgs, omPathInfo.getLeafNodeObjectId(),
                 omPathInfo.getLastKnownParentId(), trxnLogIndex,
                 OzoneAclUtil.fromProtobuf(keyArgs.getAclsList()));
+
+        // Add cache entries for the prefix directories.
         OMFileRequest.addDirectoryTableCacheEntries(omMetadataManager,
                 volumeName,
                 bucketName, Optional.of(dirInfo),
@@ -289,13 +287,6 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
       objectCount++;
 
       missingParentInfos.add(dirInfo);
-
-      // add entry to directory table
-      omMetadataManager.getDirectoryTable().addCacheEntry(
-              new CacheKey<>(omMetadataManager.getOzoneKey(volumeName,
-                      bucketName, dirInfo.getName())),
-              new CacheValue<>(Optional.of(dirInfo),
-                      trxnLogIndex));
 
       // updating id for the next sub-dir
       lastKnownParentId = nextObjId;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -252,6 +253,26 @@ public final class OMFileRequest {
           new CacheKey<>(omMetadataManager.getOzoneKey(volumeName, bucketName,
                   keyInfo.get().getKeyName())),
           new CacheValue<>(keyInfo, index));
+    }
+  }
+
+  public static void addDirectoryTableCacheEntries(
+          OMMetadataManager omMetadataManager, String volumeName,
+          String bucketName, Optional<OmDirectoryInfo> dirInfo,
+          Optional<List<OmDirectoryInfo>> parentInfoList,
+          long index) {
+    for (OmDirectoryInfo parentInfo : parentInfoList.get()) {
+      omMetadataManager.getDirectoryTable().addCacheEntry(
+              new CacheKey<>(omMetadataManager.getOzoneKey(volumeName, bucketName,
+                      parentInfo.getName())),
+              new CacheValue<>(Optional.of(parentInfo), index));
+    }
+
+    if (dirInfo.isPresent()) {
+      omMetadataManager.getDirectoryTable().addCacheEntry(
+              new CacheKey<>(omMetadataManager.getOzoneKey(volumeName, bucketName,
+                      dirInfo.get().getName())),
+              new CacheValue<>(dirInfo, index));
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -18,20 +18,25 @@
 
 package org.apache.hadoop.ozone.om.request.file;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +51,7 @@ public final class OMFileRequest {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMFileRequest.class);
   private static final long TRANSACTION_ID_SHIFT = 8;
+  private static final long DIRECTORY_ROOT_INDEX = Long.MAX_VALUE;
 
   private OMFileRequest() {
   }
@@ -71,7 +77,7 @@ public final class OMFileRequest {
     List<String> missing = new ArrayList<>();
     List<OzoneAcl> inheritAcls = new ArrayList<>();
     OMDirectoryResult result = OMDirectoryResult.NONE;
-
+    long dummyParentId = 0;
     while (keyPath != null) {
       String pathName = keyPath.toString();
 
@@ -110,7 +116,7 @@ public final class OMFileRequest {
 
         LOG.trace("verifyFiles in Path : " + "/" + volumeName
             + "/" + bucketName + "/" + keyName + ":" + result);
-        return new OMPathInfo(missing, result, inheritAcls);
+        return new OMPathInfo("", dummyParentId, missing, result, inheritAcls);
       }
       keyPath = keyPath.getParent();
     }
@@ -127,7 +133,234 @@ public final class OMFileRequest {
     LOG.trace("verifyFiles in Path : " + volumeName + "/" + bucketName + "/"
         + keyName + ":" + result);
     // Found no files/ directories in the given path.
-    return new OMPathInfo(missing, OMDirectoryResult.NONE, inheritAcls);
+    return new OMPathInfo("", dummyParentId, missing, OMDirectoryResult.NONE,
+            inheritAcls);
+  }
+
+  /**
+   * Verify any file/key exist in the given path in the specified
+   * volume/bucket by iterating through directory table and key table.
+   * @param omMetadataManager
+   * @param volumeName
+   * @param bucketName
+   * @param keyName
+   * @param keyPath
+   * @return OMPathInfo - holds.
+   * @throws IOException
+   */
+  public static OMPathInfo verifyDirectoryKeysInPath(
+          @Nonnull OMMetadataManager omMetadataManager,
+          @Nonnull String volumeName,
+          @Nonnull String bucketName, @Nonnull String keyName,
+          @Nonnull Path keyPath) throws IOException {
+
+    String leafNodeName = OzoneFSUtils.getFileName(keyName);
+    List<String> missing = new ArrayList<>();
+    List<OzoneAcl> inheritAcls = new ArrayList<>();
+    OMDirectoryResult result = OMDirectoryResult.NONE;
+
+    Iterator<Path> elements = keyPath.iterator();
+    // TODO: volume id and bucket id generation logic.
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    long bucketId =
+            omMetadataManager.getBucketTable().get(bucketKey).getObjectID();
+    long lastKnownParentId = bucketId;
+    OmDirectoryInfo parentDirectoryInfo = null;
+    String dbDirName = ""; // TODO for logging
+    while (elements.hasNext()) {
+      String fileName = elements.next().toString();
+      if (missing.size() > 0) {
+        // Add all the sub-dirs to the missing list except the leaf element.
+        // For example, /vol1/buck1/a/b/c/d/e/f/file1.txt.
+        // Assume /vol1/buck1/a/b/c exists, then add d, e, f into missing list.
+        if(elements.hasNext()){
+          // skips leaf node.
+          missing.add(fileName);
+        }
+        continue;
+      }
+
+      // For example, /vol1/buck1/a/b/c/d/e/f/file1.txt
+      // 1. Do lookup on directoryTable. If not exists goto next step.
+      // 2. Do look on keyTable. If not exists goto next step.
+      // 3. Add 'sub-dir' to missing parents list
+      String dbNodeName = omMetadataManager.getOzonePrefixKey(lastKnownParentId,
+              fileName);
+      OmDirectoryInfo omDirectoryInfo = omMetadataManager.getDirectoryTable().
+              get(dbNodeName);
+      if (omDirectoryInfo != null) {
+        if (elements.hasNext()) {
+          lastKnownParentId = omDirectoryInfo.getObjectID();
+          parentDirectoryInfo = omDirectoryInfo;
+          continue;
+        } else {
+          // Checked all the sub-dirs till the leaf node.
+          // Found a directory in the given path.
+          result = OMDirectoryResult.DIRECTORY_EXISTS;
+        }
+      } else {
+        if (parentDirectoryInfo != null) {
+          lastKnownParentId = parentDirectoryInfo.getObjectID();
+          dbNodeName = omMetadataManager.getOzoneLeafNodeKey(lastKnownParentId,
+                  fileName);
+          if (omMetadataManager.getKeyTable().isExist(dbNodeName)) {
+            if (elements.hasNext()) {
+              // Found a file in the given key name.
+              result = OMDirectoryResult.FILE_EXISTS_IN_GIVENPATH;
+            } else {
+              // Checked all the sub-dirs till the leaf file.
+              // Found a file with the given key name.
+              result = OMDirectoryResult.FILE_EXISTS;
+            }
+            break; // Skip directory traversal as it hits key.
+          }
+
+          result = OMDirectoryResult.DIRECTORY_EXISTS_IN_GIVENPATH;
+          inheritAcls = parentDirectoryInfo.getAcls();
+
+          // TODO: For this need to construct dbDirName
+            /*String dbDirKeyName = omMetadataManager.getOzoneDirKey(volumeName,
+                    bucketName, keyPath.toString());
+            LOG.trace("Acls inherited from parent " + dbDirKeyName + " are : "
+                    + inheritAcls);*/
+        }
+        // add to the missing list since this directory doesn't exist.
+        if(elements.hasNext()) {
+          // skips leaf node.
+          missing.add(fileName);
+        }
+      }
+    }
+
+    if (result != OMDirectoryResult.NONE) {
+      LOG.trace("verifyFiles in Path : " + "/" + volumeName
+              + "/" + bucketName + "/" + keyName + ":" + result);
+      return new OMPathInfo(leafNodeName, lastKnownParentId, missing, result,
+              inheritAcls);
+    }
+
+    if (inheritAcls.isEmpty()) {
+      inheritAcls = omMetadataManager.getBucketTable().get(bucketKey)
+              .getAcls();
+      LOG.trace("Acls inherited from bucket " + bucketName + " are : "
+              + inheritAcls);
+    }
+
+    LOG.trace("verifyFiles in Path : " + volumeName + "/" + bucketName + "/"
+            + keyName + ":" + result);
+    // Found no files/ directories in the given path.
+    return new OMPathInfo(leafNodeName, lastKnownParentId, missing,
+            OMDirectoryResult.NONE, inheritAcls);
+  }
+
+  /**
+   *
+   * @param volumeName
+   * @param bucketName
+   * @param keyName
+   * @param omMetadataManager
+   * @return
+   * @throws IOException
+   */
+  public static OmKeyInfo getKeyIfExists(String volumeName, String bucketName,
+                                   String keyName,
+                                   OMMetadataManager omMetadataManager)
+          throws IOException {
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    long bucketId =
+            omMetadataManager.getBucketTable().get(bucketKey).getObjectID();
+
+    Iterator<Path> elements = Paths.get(keyName).iterator();
+    long lastKnownParentId = bucketId;
+    while (elements.hasNext()) {
+      String fileName = elements.next().toString();
+      String dbNodeName = omMetadataManager.getOzonePrefixKey(lastKnownParentId,
+              fileName);
+      OmDirectoryInfo omDirectoryInfo = omMetadataManager.
+              getDirectoryTable().get(dbNodeName);
+      if (elements.hasNext()) {
+        if (omDirectoryInfo != null) {
+          lastKnownParentId = omDirectoryInfo.getObjectID();
+        } else {
+          return null;
+        }
+      } else {
+        return omMetadataManager.
+                getKeyTable().get(dbNodeName);
+      }
+    }
+    return null;
+  }
+
+  /**
+   *
+   * @param volumeName
+   * @param bucketName
+   * @param keyName
+   * @param omMetadataManager
+   * @return
+   * @throws IOException
+   */
+  public static OmDirectoryInfo getLastKnownPrefixIfExists(String volumeName,
+                                                           String bucketName,
+                                                           String keyName,
+                                                           OMMetadataManager omMetadataManager)
+          throws IOException {
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    long bucketId =
+            omMetadataManager.getBucketTable().get(bucketKey).getObjectID();
+
+    Iterator<Path> elements = Paths.get(keyName).iterator();
+    long lastKnownParentId = bucketId;
+    OmDirectoryInfo omDirectoryInfo = null;
+    short index = 0;
+    while (elements.hasNext()) {
+      String fileName = elements.next().toString();
+      String dbNodeName = omMetadataManager.getOzonePrefixKey(lastKnownParentId,
+              fileName);
+      OmDirectoryInfo tmpDirInfo = omMetadataManager.
+              getDirectoryTable().get(dbNodeName);
+      if (tmpDirInfo == null) {
+        break; // there is nor dir exists and return previous known dir.
+      }
+      lastKnownParentId = tmpDirInfo.getObjectID();
+      omDirectoryInfo = tmpDirInfo;
+      omDirectoryInfo.setIndex(index++); // TODO: improve this code.
+    }
+    return omDirectoryInfo;
+  }
+
+  public static OmKeyInfo getKeyInfo(OmDirectoryInfo directoryInfo,
+                                     String keyName){
+    OmKeyInfo.Builder builder = new OmKeyInfo.Builder();
+    builder.setParentObjectID(directoryInfo.getParentObjectID());
+    builder.setLeafNodeName(directoryInfo.getName());
+    builder.setAcls(directoryInfo.getAcls());
+    builder.addAllMetadata(directoryInfo.getMetadata());
+    builder.setVolumeName(directoryInfo.getVolumeName());
+    builder.setBucketName(directoryInfo.getBucketName());
+    builder.setCreationTime(directoryInfo.getCreationTime());
+    builder.setModificationTime(directoryInfo.getModificationTime());
+    builder.setObjectID(directoryInfo.getObjectID());
+    builder.setUpdateID(directoryInfo.getUpdateID());
+    builder.setKeyName(keyName);
+    // TODO: hardcoded below values to directory. Do we need to persist this?
+    builder.setReplicationType(HddsProtos.ReplicationType.RATIS);
+    builder.setReplicationFactor(HddsProtos.ReplicationFactor.ONE);
+    return builder.build();
+  }
+
+  /**
+   *
+   */
+  public static long getDirectoryId(
+          OMMetadataManager omMetadataManager,
+          long parentId, String dirName)
+          throws IOException {
+
+    OmDirectoryInfo dirInfo =
+            omMetadataManager.getDirectoryTable().get(dirName);
+    return dirInfo.getObjectID();
   }
 
   /**
@@ -164,15 +397,38 @@ public final class OMFileRequest {
    */
   public static class OMPathInfo {
     private OMDirectoryResult directoryResult;
+    private String leafNodeName;
+    private long lastKnownParentId;
+    private long leafNodeObjectId;
     private List<String> missingParents;
     private List<OzoneAcl> acls;
 
-    public OMPathInfo(List missingParents, OMDirectoryResult result,
-        List<OzoneAcl> aclList) {
+    public OMPathInfo(String leafNodeName, long lastKnownParentId,
+                      List missingParents,
+                      OMDirectoryResult result,
+                      List<OzoneAcl> aclList) {
+      this.leafNodeName = leafNodeName;
+      this.lastKnownParentId = lastKnownParentId;
       this.missingParents = missingParents;
       this.directoryResult = result;
       this.acls = aclList;
     }
+
+    public String getLeafNodeName() { return leafNodeName; }
+
+    public long getLeafNodeObjectId() {
+      return leafNodeObjectId;
+    }
+
+    public void setLeafNodeObjectId(long leafNodeObjectId) {
+      this.leafNodeObjectId = leafNodeObjectId;
+    }
+
+    public void setLastKnownParentId(long lastKnownParentId) {
+      this.lastKnownParentId = lastKnownParentId;
+    }
+
+    public long getLastKnownParentId() { return lastKnownParentId; }
 
     public List getMissingParents() {
       return missingParents;
@@ -263,14 +519,13 @@ public final class OMFileRequest {
           long index) {
     for (OmDirectoryInfo parentInfo : parentInfoList.get()) {
       omMetadataManager.getDirectoryTable().addCacheEntry(
-              new CacheKey<>(omMetadataManager.getOzoneKey(volumeName, bucketName,
-                      parentInfo.getName())),
+              new CacheKey<>(omMetadataManager.getOzonePrefixKey(parentInfo.getParentObjectID(), parentInfo.getName())),
               new CacheValue<>(Optional.of(parentInfo), index));
     }
 
     if (dirInfo.isPresent()) {
       omMetadataManager.getDirectoryTable().addCacheEntry(
-              new CacheKey<>(omMetadataManager.getOzoneKey(volumeName, bucketName,
+              new CacheKey<>(omMetadataManager.getOzonePrefixKey(dirInfo.get().getParentObjectID(),
                       dirInfo.get().getName())),
               new CacheValue<>(dirInfo, index));
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -37,6 +38,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -348,6 +350,8 @@ public final class OMFileRequest {
     // TODO: hardcoded below values to directory. Do we need to persist this?
     builder.setReplicationType(HddsProtos.ReplicationType.RATIS);
     builder.setReplicationFactor(HddsProtos.ReplicationFactor.ONE);
+    builder.setOmKeyLocationInfos(Collections.singletonList(
+            new OmKeyLocationInfoGroup(0, new ArrayList<>())));
     return builder.build();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.om.request.file;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -28,11 +27,13 @@ import java.util.List;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -312,7 +313,7 @@ public final class OMFileRequest {
 
     Iterator<Path> elements = Paths.get(keyName).iterator();
     long lastKnownParentId = bucketId;
-    OmDirectoryInfo omDirectoryInfo = null;
+    OmDirectoryInfo omDirectoryInfo = OmDirectoryInfo.createDirectoryInfo(bucketId);
     short index = 0;
     while (elements.hasNext()) {
       String fileName = elements.next().toString();
@@ -348,6 +349,13 @@ public final class OMFileRequest {
     builder.setReplicationType(HddsProtos.ReplicationType.RATIS);
     builder.setReplicationFactor(HddsProtos.ReplicationFactor.ONE);
     return builder.build();
+  }
+
+  public static String getAbsoluteDirName(String prefixName, String keyName) {
+    if (Strings.isNullOrEmpty(prefixName)) {
+      return keyName;
+    }
+    return prefixName.concat(OzoneConsts.OZONE_URI_DELIMITER).concat(keyName);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -144,13 +144,16 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
 
       String leafNodeName = OzoneFSUtils.getFileName(keyName);
-      OmDirectoryInfo parentInfo = getParentInfo(volumeName, bucketName, keyName, leafNodeName, omMetadataManager);
+      OmDirectoryInfo parentInfo = getParentInfo(volumeName, bucketName,
+              keyName, leafNodeName, omMetadataManager);
       if (parentInfo == null) {
         throw new OMException("Failed to commit key, as parent directory of " + keyName +
                 " entry is not found in Directory table", KEY_NOT_FOUND);
       }
-      String dbLeafNodeID = omMetadataManager.getOzoneLeafNodeKey(parentInfo.getObjectID(),leafNodeName);
-      dbOpenLeafNodeID = omMetadataManager.getOpenLeafNodeKey(parentInfo.getObjectID(),
+      String dbLeafNodeID = omMetadataManager.getOzoneLeafNodeKey(
+              parentInfo.getObjectID(),leafNodeName);
+      dbOpenLeafNodeID = omMetadataManager.getOpenLeafNodeKey(
+              parentInfo.getObjectID(),
               leafNodeName, commitKeyRequest.getClientID());
       // Revisit this logic to see how we can skip this check when ratis is
       // enabled.
@@ -282,7 +285,10 @@ public class OMKeyCommitRequest extends OMKeyRequest {
     String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
     long bucketId =
             omMetadataManager.getBucketTable().get(bucketKey).getObjectID();
-
+    int totalDirsCount = OzoneFSUtils.getFileCount(keyName);
+    if (totalDirsCount == 1) { // creating key directly under a bucket
+      return OmDirectoryInfo.createDirectoryInfo(bucketId);
+    }
     Iterator<Path> elements = Paths.get(keyName).iterator();
     long lastKnownParentId = bucketId;
     OmDirectoryInfo omDirectoryInfo = null;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponse.java
@@ -20,22 +20,38 @@ package org.apache.hadoop.ozone.om.response.file;
 
 import javax.annotation.Nonnull;
 
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.key.OMKeyCreateResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
  * Response for crate file request.
  */
-public class OMFileCreateResponse extends OMKeyCreateResponse {
+public class OMFileCreateResponse extends OMClientResponse {
+
+  public static final Logger LOG =
+          LoggerFactory.getLogger(OMKeyCreateResponse.class);
+  private OmKeyInfo omKeyInfo;
+  private long openKeySessionID;
+  private List<OmDirectoryInfo> parentDirInfos;
 
   public OMFileCreateResponse(@Nonnull OMResponse omResponse,
       @Nonnull OmKeyInfo omKeyInfo,
-      List<OmKeyInfo> parentKeyInfos, long openKeySessionID) {
-    super(omResponse, omKeyInfo, parentKeyInfos, openKeySessionID);
+      List<OmDirectoryInfo> parentDirInfos, long openKeySessionID) {
+    super(omResponse);
+    this.omKeyInfo = omKeyInfo;
+    this.openKeySessionID = openKeySessionID;
+    this.parentDirInfos = parentDirInfos;
   }
 
   /**
@@ -47,4 +63,31 @@ public class OMFileCreateResponse extends OMKeyCreateResponse {
     checkStatusNotOK();
   }
 
+  @Override
+  protected void addToDBBatch(OMMetadataManager omMetadataManager,
+                              BatchOperation batchOperation) throws IOException {
+
+    /**
+     * Create parent directory entries during Key Create - do not wait
+     * for Key Commit request.
+     * XXX handle stale directory entries.
+     */
+    if (parentDirInfos != null) {
+      for (OmDirectoryInfo parentKeyInfo : parentDirInfos) {
+        String parentKey = omMetadataManager
+                .getOzonePrefixKey(parentKeyInfo.getParentObjectID(), parentKeyInfo.getName());
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("putWithBatch adding parent : key {} info : {}", parentKey,
+                  parentKeyInfo);
+        }
+        omMetadataManager.getDirectoryTable()
+                .putWithBatch(batchOperation, parentKey, parentKeyInfo);
+      }
+    }
+
+    String openKey = omMetadataManager.getOpenLeafNodeKey(omKeyInfo.getParentObjectID(),
+            omKeyInfo.getLeafNodeName(), openKeySessionID);
+    omMetadataManager.getOpenKeyTable().putWithBatch(batchOperation,
+            openKey, omKeyInfo);
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -30,11 +30,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
-import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
-import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
-import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
-import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.*;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .MultipartUploadAbortRequest;
@@ -227,6 +223,24 @@ public final class TestOMRequestUtils {
         .setObjectID(objectID)
         .setUpdateID(objectID)
         .build();
+  }
+
+
+  /**
+   * Create OmKeyInfo.
+   */
+  public static OmDirectoryInfo createOmDirInfo(String volumeName,
+       String bucketName, String keyName, long objectID, long parentObjID) {
+    return new OmDirectoryInfo.Builder()
+            .setVolumeName(volumeName)
+            .setBucketName(bucketName)
+            .setName(keyName)
+            .setCreationTime(Time.now())
+            .setModificationTime(Time.now())
+            .setObjectID(objectID)
+            .setParentObjectID(parentObjID)
+            .setUpdateID(objectID)
+            .build();
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
@@ -51,7 +51,7 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
             .build();
 
     OMKeyDeleteResponse omKeyDeleteResponse = new OMKeyDeleteResponse(
-        omResponse, omKeyInfo, true);
+        omResponse, omKeyInfo, true, false);
 
     String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
         keyName);
@@ -113,7 +113,7 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
             .build();
 
     OMKeyDeleteResponse omKeyDeleteResponse = new OMKeyDeleteResponse(
-        omResponse, omKeyInfo, true);
+        omResponse, omKeyInfo, true, false);
 
     Assert.assertTrue(omMetadataManager.getKeyTable().isExist(ozoneKey));
     omKeyDeleteResponse.addToDBBatch(omMetadataManager, batchOperation);
@@ -142,7 +142,7 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
             .build();
 
     OMKeyDeleteResponse omKeyDeleteResponse = new OMKeyDeleteResponse(
-        omResponse, omKeyInfo, true);
+        omResponse, omKeyInfo, true, false);
 
     String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
         keyName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyRenameResponse.java
@@ -47,7 +47,7 @@ public class TestOMKeyRenameResponse extends TestOMKeyResponse {
     String toKeyName = UUID.randomUUID().toString();
 
     OMKeyRenameResponse omKeyRenameResponse = new OMKeyRenameResponse(
-        omResponse, keyName, toKeyName, omKeyInfo);
+        omResponse, keyName, toKeyName, omKeyInfo, true);
 
     String ozoneFromKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
         keyName);
@@ -86,7 +86,7 @@ public class TestOMKeyRenameResponse extends TestOMKeyResponse {
     String toKeyName = UUID.randomUUID().toString();
 
     OMKeyRenameResponse omKeyRenameResponse = new OMKeyRenameResponse(
-        omResponse, keyName, toKeyName, omKeyInfo);
+        omResponse, keyName, toKeyName, omKeyInfo, true);
 
     String ozoneFromKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
         keyName);
@@ -127,7 +127,7 @@ public class TestOMKeyRenameResponse extends TestOMKeyResponse {
 
     // Passing toKeyName also same as KeyName.
     OMKeyRenameResponse omKeyRenameResponse = new OMKeyRenameResponse(
-        omResponse, keyName, keyName, omKeyInfo);
+        omResponse, keyName, keyName, omKeyInfo, true);
 
     String ozoneFromKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
         keyName);


### PR DESCRIPTION
## What changes were proposed in this pull request?
As of HDDS-2940, all the directories from the path prefix get created as entries in the key table. as per the namespace proposal attached to HDDS-2939, directory entries need to be stored in a separate "directory" table. Files will continue to be stored in the key table, which can be thought of as the "file" table.

The advantage of a separate directory table is to make directory lookup more efficient - the entire table would fit into memory for a typical file based dataset.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2949

## How was this patch tested?

Presently used existing `TestOzoneFileSystem` unit test cases. I will add specific unit test cases in an incremental way, in my next commits.
