### PR TITLE
HDDS-3543. Remove unused joda-time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <guava.version>28.2-jre</guava.version>
     <guice.version>4.0</guice.version>
-    <joda-time.version>2.9.9</joda-time.version>
 
     <!-- Required for testing LDAP integration -->
     <apacheds.version>2.0.0-M21</apacheds.version>
@@ -1474,12 +1473,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <artifactId>bcprov-jdk16</artifactId>
         <version>${bouncycastle.version}</version>
         <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>joda-time</groupId>
-        <artifactId>joda-time</artifactId>
-        <version>${joda-time.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Joda-time is defined in the pom.xml but it's not used anywhere.
Perhaps because Ozone runs on java 8, the standard date and time features are provided by java.time (JSR-310).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3543

## How was this patch tested?

- Compiled successfully
- GitHub CI Action successfully on my fork repository [(result)](https://github.com/cku328/hadoop-ozone/actions/runs/101679345)