### PR TITLE
HDDS-3563. Make s3GateWay s3v volume configurable.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/client/HddsClientUtils.java
@@ -219,6 +219,16 @@ public final class HddsClientUtils {
   }
 
   /**
+   * Returns the s3VolumeName configured in ConfigurationSource.
+   * @param conf Configuration object
+   * @return s3 volume name
+   */
+  public static String getS3VolumeName(ConfigurationSource conf) {
+    return conf.get(OzoneConfigKeys.OZONE_S3_VOLUME_NAME,
+            OzoneConfigKeys.OZONE_S3_VOLUME_NAME_DEFAULT);
+  }
+
+  /**
    * Returns the maximum no of outstanding async requests to be handled by
    * Standalone and Ratis client.
    */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -390,6 +390,10 @@ public final class OzoneConfigKeys {
       "ozone.acl.enabled";
   public static final boolean OZONE_ACL_ENABLED_DEFAULT =
       false;
+  public static final String OZONE_S3_VOLUME_NAME =
+          "ozone.s3g.volume.name";
+  public static final String OZONE_S3_VOLUME_NAME_DEFAULT =
+          "s3v";
   public static final String OZONE_S3_AUTHINFO_MAX_LIFETIME_KEY =
       "ozone.s3.token.max.lifetime";
   public static final String OZONE_S3_AUTHINFO_MAX_LIFETIME_KEY_DEFAULT = "3m";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -122,7 +122,6 @@ public final class OzoneConsts {
   public static final String STORAGE_DIR_CHUNKS = "chunks";
   public static final String OZONE_DB_CHECKPOINT_REQUEST_FLUSH =
       "flushBeforeCheckpoint";
-  public static final String S3_VOLUME_NAME = "s3v";
 
   /**
    * Supports Bucket Versioning.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1435,6 +1435,14 @@
   </property>
 
   <property>
+    <name>ozone.s3g.volume.name</name>
+    <value>s3v</value>
+    <tag>OZONE, S3GATEWAY</tag>
+    <description>
+      The volume name to access through the s3gateway.
+    </description>
+  </property>
+  <property>
     <name>ozone.s3g.domain.name</name>
     <value/>
     <tag>OZONE, S3GATEWAY</tag>

--- a/hadoop-hdds/docs/content/interface/S3.md
+++ b/hadoop-hdds/docs/content/interface/S3.md
@@ -24,7 +24,7 @@ summary: Ozone supports Amazon's Simple Storage Service (S3) protocol. In fact, 
 
 Ozone provides S3 compatible REST interface to use the object store data with any S3 compatible tools.
 
-S3 buckets are stored under the `/s3v` volume, which needs to be created by an administrator first.
+S3 buckets are stored under the `/s3v`(Default is s3v, which can be setted through ozone.s3g.volume.name) volume, which needs to be created by an administrator first.
 
 ## Getting started
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -41,8 +41,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import org.apache.hadoop.security.token.Token;
 
-import static org.apache.hadoop.ozone.OzoneConsts.S3_VOLUME_NAME;
-
 /**
  * ObjectStore class is responsible for the client operations that can be
  * performed on Ozone Object Store.
@@ -61,6 +59,8 @@ public class ObjectStore {
    */
   private int listCacheSize;
 
+  private String s3VolumeName;
+
   /**
    * Creates an instance of ObjectStore.
    * @param conf Configuration object.
@@ -69,6 +69,7 @@ public class ObjectStore {
   public ObjectStore(ConfigurationSource conf, ClientProtocol proxy) {
     this.proxy = TracingUtil.createProxy(proxy, ClientProtocol.class, conf);
     this.listCacheSize = HddsClientUtils.getListCacheSize(conf);
+    this.s3VolumeName = HddsClientUtils.getS3VolumeName(conf);
   }
 
   @VisibleForTesting
@@ -109,12 +110,12 @@ public class ObjectStore {
    */
   public void createS3Bucket(String bucketName) throws
       IOException {
-    OzoneVolume volume = getVolume(S3_VOLUME_NAME);
+    OzoneVolume volume = getVolume(s3VolumeName);
     volume.createBucket(bucketName);
   }
 
   public OzoneBucket getS3Bucket(String bucketName) throws IOException {
-    return getVolume(S3_VOLUME_NAME).getBucket(bucketName);
+    return getVolume(s3VolumeName).getBucket(bucketName);
   }
 
   /**
@@ -124,7 +125,7 @@ public class ObjectStore {
    */
   public void deleteS3Bucket(String bucketName) throws IOException {
     try {
-      OzoneVolume volume = getVolume(S3_VOLUME_NAME);
+      OzoneVolume volume = getVolume(s3VolumeName);
       volume.deleteBucket(bucketName);
     } catch (OMException ex) {
       if (ex.getResult() == OMException.ResultCodes.VOLUME_NOT_FOUND) {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -26,6 +26,7 @@ import java.util.NoSuchElementException;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.crypto.key.KeyProvider;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.io.Text;
@@ -74,6 +75,9 @@ public class ObjectStore {
 
   @VisibleForTesting
   protected ObjectStore() {
+    // For the unit test
+    OzoneConfiguration conf = new OzoneConfiguration();
+    this.s3VolumeName = HddsClientUtils.getS3VolumeName(conf);
     proxy = null;
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClient.java
@@ -74,6 +74,7 @@ public class OzoneClient implements Closeable {
 
   private final ClientProtocol proxy;
   private final ObjectStore objectStore;
+  private  ConfigurationSource conf;
 
   /**
    * Creates a new OzoneClient object, generally constructed
@@ -84,6 +85,7 @@ public class OzoneClient implements Closeable {
   public OzoneClient(ConfigurationSource conf, ClientProtocol proxy) {
     this.proxy = proxy;
     this.objectStore = new ObjectStore(conf, this.proxy);
+    this.conf = conf;
   }
 
   @VisibleForTesting
@@ -97,6 +99,14 @@ public class OzoneClient implements Closeable {
    */
   public ObjectStore getObjectStore() {
     return objectStore;
+  }
+
+  /**
+   * Returns the configuration of client.
+   * @return ConfigurationSource
+   */
+  public ConfigurationSource getConfiguration() {
+    return conf;
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClient.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.client;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 
 import java.io.Closeable;
@@ -92,6 +93,8 @@ public class OzoneClient implements Closeable {
   protected OzoneClient(ObjectStore objectStore) {
     this.objectStore = objectStore;
     this.proxy = null;
+    // For the unit test
+    this.conf = new OzoneConfiguration();
   }
   /**
    * Returns the object store associated with the Ozone Cluster.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -160,7 +161,8 @@ public abstract class TestOzoneRpcClientAbstract {
     cluster.waitForClusterToBeReady();
     ozClient = OzoneClientFactory.getRpcClient(conf);
     store = ozClient.getObjectStore();
-    store.createVolume(OzoneConsts.S3_VOLUME_NAME);
+    String volumeName = HddsClientUtils.getS3VolumeName(conf);
+    store.createVolume(volumeName);
     storageContainerLocationClient =
         cluster.getStorageContainerLocationClient();
     ozoneManager = cluster.getOzoneManager();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.BlockTokenSecretProto.AccessModeProto;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.security.token.BlockTokenVerifier;
@@ -118,7 +119,8 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
     cluster.waitForClusterToBeReady();
     ozClient = OzoneClientFactory.getRpcClient(conf);
     store = ozClient.getObjectStore();
-    store.createVolume(OzoneConsts.S3_VOLUME_NAME);
+    String volumeName = HddsClientUtils.getS3VolumeName(conf);
+    store.createVolume(volumeName);
     storageContainerLocationClient =
         cluster.getStorageContainerLocationClient();
     ozoneManager = cluster.getOzoneManager();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.hdds.security.token.BlockTokenVerifier;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.CertificateClientTestImpl;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.function.Function;
 
+import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
@@ -33,8 +34,6 @@ import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 
 import com.google.common.annotations.VisibleForTesting;
-
-import static org.apache.hadoop.ozone.OzoneConsts.S3_VOLUME_NAME;
 
 /**
  * Basic helpers for all the REST endpoints.
@@ -79,7 +78,9 @@ public class EndpointBase {
   }
 
   protected OzoneVolume getVolume() throws IOException {
-    return client.getObjectStore().getVolume(S3_VOLUME_NAME);
+    String s3VolumeName = HddsClientUtils.getS3VolumeName(
+        client.getConfiguration());
+    return client.getObjectStore().getVolume(s3VolumeName);
   }
 
   /**

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ObjectStoreStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ObjectStoreStub.java
@@ -26,7 +26,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_ALREADY_EXISTS;
@@ -45,6 +46,7 @@ public class ObjectStoreStub extends ObjectStore {
 
   private Map<String, OzoneVolumeStub> volumes = new HashMap<>();
   private Map<String, Boolean> bucketEmptyStatus = new HashMap<>();
+  private static OzoneConfiguration conf = new OzoneConfiguration();
 
   @Override
   public void createVolume(String volumeName) throws IOException {
@@ -121,11 +123,12 @@ public class ObjectStoreStub extends ObjectStore {
   public void createS3Bucket(String s3BucketName) throws
       IOException {
     if (!bucketEmptyStatus.containsKey(s3BucketName)) {
+      String volumeName = HddsClientUtils.getS3VolumeName(conf);
       bucketEmptyStatus.put(s3BucketName, true);
-      if (!volumes.containsKey(OzoneConsts.S3_VOLUME_NAME)) {
-        createVolume(OzoneConsts.S3_VOLUME_NAME);
+      if (!volumes.containsKey(volumeName)) {
+        createVolume(volumeName);
       }
-      volumes.get(OzoneConsts.S3_VOLUME_NAME).createBucket(s3BucketName);
+      volumes.get(volumeName).createBucket(s3BucketName);
     } else {
       throw new OMException("", BUCKET_ALREADY_EXISTS);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-3385 has a big change to s3g for creating buckets. At present, the volume is fixed as s3v. This should be user-configurable to better accommodate the older cluster (0.5).

After rebase master, our production cluster will encounter the problem that the old s3g volume could not find. So we are very eager to solve this problem.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3563

## How was this patch tested?

https://github.com/captainzmc/hadoop-ozone/runs/665703241
