### PR TITLE
WIP HDDS-3572. Make sure ozone. administrators have access to all keys when acl enabled.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -23,6 +23,7 @@ import java.security.GeneralSecurityException;
 import java.security.PrivilegedExceptionAction;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -122,6 +123,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BL
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BLOCKS_MAX_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.DIRECTORY_NOT_FOUND;
@@ -163,6 +165,7 @@ public class KeyManagerImpl implements KeyManager {
 
   private final KeyProviderCryptoExtension kmsProvider;
   private final PrefixManager prefixManager;
+  private OzoneConfiguration conf;
 
 
   @VisibleForTesting
@@ -206,6 +209,7 @@ public class KeyManagerImpl implements KeyManager {
     this.prefixManager = prefixManager;
     this.secretManager = secretManager;
     this.kmsProvider = kmsProvider;
+    this.conf = conf;
 
   }
 
@@ -1589,6 +1593,11 @@ public class KeyManagerImpl implements KeyManager {
     Objects.requireNonNull(ozObject);
     Objects.requireNonNull(context);
     Objects.requireNonNull(context.getClientUgi());
+    Collection<String> ozAdmins =
+        conf.getTrimmedStringCollection(OZONE_ADMINISTRATORS);
+    if(ozAdmins.contains(context.getClientUgi().getUserName())) {
+      return true;
+    }
 
     String volume = ozObject.getVolumeName();
     String bucket = ozObject.getBucketName();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -486,7 +486,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     metadataManager = new OmMetadataManagerImpl(configuration);
     volumeManager = new VolumeManagerImpl(metadataManager, configuration);
     bucketManager = new BucketManagerImpl(metadataManager, getKmsProvider(),
-        isRatisEnabled);
+        isRatisEnabled, configuration);
     if (secConfig.isSecurityEnabled()) {
       s3SecretManager = new S3SecretManagerImpl(configuration, metadataManager);
       delegationTokenMgr = createDelegationTokenSecretManager(configuration);
@@ -1631,8 +1631,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       ACLType aclType, String vol, String bucket, String key,
       UserGroupInformation ugi, InetAddress remoteAddress, String hostName)
       throws OMException {
-    checkAcls(resType, storeType, aclType, vol, bucket, key,
-        ugi, remoteAddress, hostName, true);
+    if(!ozAdmins.contains(ugi.getUserName())) {
+      checkAcls(resType, storeType, aclType, vol, bucket, key,
+              ugi, remoteAddress, hostName, true);
+    }
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
@@ -86,7 +86,7 @@ public class TestBucketManagerImpl {
     OmMetadataManagerImpl metaMgr =
         new OmMetadataManagerImpl(conf);
     try {
-      BucketManager bucketManager = new BucketManagerImpl(metaMgr);
+      BucketManager bucketManager = new BucketManagerImpl(metaMgr, conf);
       OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
           .setVolumeName("sampleVol")
           .setBucketName("bucketOne")
@@ -104,6 +104,7 @@ public class TestBucketManagerImpl {
   @Test
   public void testCreateBucket() throws Exception {
     OmMetadataManagerImpl metaMgr = createSampleVol();
+    OzoneConfiguration conf = new OzoneConfiguration();
 
     KeyProviderCryptoExtension kmsProvider = Mockito.mock(
         KeyProviderCryptoExtension.class);
@@ -116,7 +117,7 @@ public class TestBucketManagerImpl {
     Mockito.when(mockMetadata.getCipher()).thenReturn(testCipherName);
 
     BucketManager bucketManager = new BucketManagerImpl(metaMgr,
-        kmsProvider);
+        kmsProvider, conf);
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
         .setVolumeName("sampleVol")
         .setBucketName("bucketOne")
@@ -138,8 +139,9 @@ public class TestBucketManagerImpl {
   @Test
   public void testCreateEncryptedBucket() throws Exception {
     OmMetadataManagerImpl metaMgr = createSampleVol();
+    OzoneConfiguration conf = new OzoneConfiguration();
 
-    BucketManager bucketManager = new BucketManagerImpl(metaMgr);
+    BucketManager bucketManager = new BucketManagerImpl(metaMgr, conf);
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
         .setVolumeName("sampleVol")
         .setBucketName("bucketOne")
@@ -154,9 +156,10 @@ public class TestBucketManagerImpl {
   public void testCreateAlreadyExistingBucket() throws Exception {
     thrown.expectMessage("Bucket already exist");
     OmMetadataManagerImpl metaMgr = createSampleVol();
+    OzoneConfiguration conf = new OzoneConfiguration();
 
     try {
-      BucketManager bucketManager = new BucketManagerImpl(metaMgr);
+      BucketManager bucketManager = new BucketManagerImpl(metaMgr, conf);
       OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
           .setVolumeName("sampleVol")
           .setBucketName("bucketOne")
@@ -176,10 +179,10 @@ public class TestBucketManagerImpl {
   public void testGetBucketInfoForInvalidBucket() throws Exception {
     thrown.expectMessage("Bucket not found");
     OmMetadataManagerImpl metaMgr = createSampleVol();
+    OzoneConfiguration conf = new OzoneConfiguration();
+
     try {
-
-
-      BucketManager bucketManager = new BucketManagerImpl(metaMgr);
+      BucketManager bucketManager = new BucketManagerImpl(metaMgr, conf);
       bucketManager.getBucketInfo("sampleVol", "bucketOne");
     } catch (OMException omEx) {
       Assert.assertEquals(ResultCodes.BUCKET_NOT_FOUND,
@@ -193,8 +196,9 @@ public class TestBucketManagerImpl {
   @Test
   public void testGetBucketInfo() throws Exception {
     OmMetadataManagerImpl metaMgr = createSampleVol();
+    OzoneConfiguration conf = new OzoneConfiguration();
 
-    BucketManager bucketManager = new BucketManagerImpl(metaMgr);
+    BucketManager bucketManager = new BucketManagerImpl(metaMgr, conf);
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
         .setVolumeName("sampleVol")
         .setBucketName("bucketOne")
@@ -220,8 +224,9 @@ public class TestBucketManagerImpl {
   @Test
   public void testSetBucketPropertyChangeStorageType() throws Exception {
     OmMetadataManagerImpl metaMgr = createSampleVol();
+    OzoneConfiguration conf = new OzoneConfiguration();
 
-    BucketManager bucketManager = new BucketManagerImpl(metaMgr);
+    BucketManager bucketManager = new BucketManagerImpl(metaMgr, conf);
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
         .setVolumeName("sampleVol")
         .setBucketName("bucketOne")
@@ -248,8 +253,9 @@ public class TestBucketManagerImpl {
   @Test
   public void testSetBucketPropertyChangeVersioning() throws Exception {
     OmMetadataManagerImpl metaMgr = createSampleVol();
+    OzoneConfiguration conf = new OzoneConfiguration();
 
-    BucketManager bucketManager = new BucketManagerImpl(metaMgr);
+    BucketManager bucketManager = new BucketManagerImpl(metaMgr, conf);
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
         .setVolumeName("sampleVol")
         .setBucketName("bucketOne")
@@ -275,7 +281,9 @@ public class TestBucketManagerImpl {
   public void testDeleteBucket() throws Exception {
     thrown.expectMessage("Bucket not found");
     OmMetadataManagerImpl metaMgr = createSampleVol();
-    BucketManager bucketManager = new BucketManagerImpl(metaMgr);
+    OzoneConfiguration conf = new OzoneConfiguration();
+
+    BucketManager bucketManager = new BucketManagerImpl(metaMgr, conf);
     for (int i = 0; i < 5; i++) {
       OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
           .setVolumeName("sampleVol")
@@ -309,7 +317,9 @@ public class TestBucketManagerImpl {
   public void testDeleteNonEmptyBucket() throws Exception {
     thrown.expectMessage("Bucket is not empty");
     OmMetadataManagerImpl metaMgr = createSampleVol();
-    BucketManager bucketManager = new BucketManagerImpl(metaMgr);
+    OzoneConfiguration conf = new OzoneConfiguration();
+
+    BucketManager bucketManager = new BucketManagerImpl(metaMgr, conf);
     OmBucketInfo bucketInfo = OmBucketInfo.newBuilder()
         .setVolumeName("sampleVol")
         .setBucketName("bucketOne")

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
@@ -153,7 +153,7 @@ public class TestOzoneNativeAuthorizer {
 
     metadataManager = new OmMetadataManagerImpl(ozConfig);
     volumeManager = new VolumeManagerImpl(metadataManager, ozConfig);
-    bucketManager = new BucketManagerImpl(metadataManager);
+    bucketManager = new BucketManagerImpl(metadataManager, ozConfig);
     prefixManager = new PrefixManagerImpl(metadataManager, false);
 
     keyManager = new KeyManagerImpl(mock(ScmBlockLocationProtocol.class),

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkOMKeyAllocation.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkOMKeyAllocation.java
@@ -76,7 +76,7 @@ public class BenchMarkOMKeyAllocation {
     OmMetadataManagerImpl omMetadataManager =
         new OmMetadataManagerImpl(configuration);
     volumeManager = new VolumeManagerImpl(omMetadataManager, configuration);
-    bucketManager = new BucketManagerImpl(omMetadataManager);
+    bucketManager = new BucketManagerImpl(omMetadataManager, configuration);
 
     volumeManager.createVolume(new OmVolumeArgs.Builder().setVolume(volumeName)
         .setAdminName(UserGroupInformation.getLoginUser().getUserName())


### PR DESCRIPTION
## What changes were proposed in this pull request?

In some cases, a particular user need to access all the keys.
When acl enabled, if  there is a user needed access all the keys. We need to increase the user's access to all the keys. Usually there are a lot of keys in a cluster, so it's very difficult to add permissions to all keys. 
I found that the current ozone Administrators cannot access all keys. Administrators of ozone are also checked for permissions. In HDFS, dfs.cluster.administrators can able to access all files. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3572


## How was this patch tested?

https://github.com/captainzmc/hadoop-ozone/runs/667241978
