### PR TITLE
HDDS-3588. Fix NPE while getPipelines if absent in query2OpenPipelines

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
@@ -210,13 +210,9 @@ class PipelineStateMap {
     Preconditions.checkNotNull(state, "Pipeline state cannot be null");
 
     if (state == PipelineState.OPEN) {
-      List<Pipeline> pipeline =
-          query2OpenPipelines.get(new PipelineQuery(type, factor));
-      if (pipeline == null) {
-        return Collections.EMPTY_LIST;
-      }
       return Collections.unmodifiableList(
-          query2OpenPipelines.get(new PipelineQuery(type, factor)));
+          query2OpenPipelines.getOrDefault(new PipelineQuery(type, factor)),
+          Collections.EMPTY_LIST);
     }
     return pipelineMap.values().stream().filter(
         pipeline -> pipeline.getType() == type

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
@@ -211,7 +211,7 @@ class PipelineStateMap {
 
     if (state == PipelineState.OPEN) {
       List<Pipeline> pipeline =
-        query2OpenPipelines.get(new PipelineQuery(type, factor));
+          query2OpenPipelines.get(new PipelineQuery(type, factor));
       if (pipeline == null) {
         return Collections.EMPTY_LIST;
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
@@ -211,8 +211,8 @@ class PipelineStateMap {
 
     if (state == PipelineState.OPEN) {
       return Collections.unmodifiableList(
-          query2OpenPipelines.getOrDefault(new PipelineQuery(type, factor)),
-          Collections.EMPTY_LIST);
+          query2OpenPipelines.getOrDefault(
+              new PipelineQuery(type, factor), Collections.EMPTY_LIST));
     }
     return pipelineMap.values().stream().filter(
         pipeline -> pipeline.getType() == type

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
@@ -210,6 +210,10 @@ class PipelineStateMap {
     Preconditions.checkNotNull(state, "Pipeline state cannot be null");
 
     if (state == PipelineState.OPEN) {
+      List<Pipeline> pipeline = query2OpenPipelines.get(new PipelineQuery(type, factor));
+      if (pipeline == null) {
+        return Collections.EMPTY_LIST;
+      }
       return Collections.unmodifiableList(
           query2OpenPipelines.get(new PipelineQuery(type, factor)));
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
@@ -210,7 +210,8 @@ class PipelineStateMap {
     Preconditions.checkNotNull(state, "Pipeline state cannot be null");
 
     if (state == PipelineState.OPEN) {
-      List<Pipeline> pipeline = query2OpenPipelines.get(new PipelineQuery(type, factor));
+      List<Pipeline> pipeline =
+        query2OpenPipelines.get(new PipelineQuery(type, factor));
       if (pipeline == null) {
         return Collections.EMPTY_LIST;
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

As title described, there maybe a NPE if get pipeline from query2OpenPipelines return null. It is possible if we can specify a replication number other than 1 and 3.

## What is the link to the Apache JIRA 

https://issues.apache.org/jira/browse/HDDS-3588

## How was this patch tested?

Now, this issue cannot be trigger until HDDS-3581 merged.
