### PR TITLE
HDDS-3391. Delegate admin ACL checks to Ozone authorizer plugin.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -89,6 +89,8 @@ public final class OzoneConsts {
   public static final String OZONE_RPC_SCHEME = "o3";
   public static final String OZONE_HTTP_SCHEME = "http";
   public static final String OZONE_URI_DELIMITER = "/";
+  public static final String OZONE_ROOT = OZONE_URI_DELIMITER;
+
 
   public static final String CONTAINER_EXTENSION = ".container";
   public static final String CONTAINER_META = ".meta";

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -45,7 +45,7 @@ HDFS-SITE.XML_dfs.datanode.address=0.0.0.0:1019
 HDFS-SITE.XML_dfs.datanode.http.address=0.0.0.0:1012
 CORE-SITE.XML_dfs.data.transfer.protection=authentication
 CORE-SITE.XML_hadoop.security.authentication=kerberos
-CORE-SITE.XML_hadoop.security.auth_to_local=RULE:[2:$1@$0](.*)s/.*/root/
+CORE-SITE.XML_hadoop.security.auth_to_local="RULE:[2:$1](testuser2.*) RULE:[2:$1@$0](.*)s/.*/root/"
 CORE-SITE.XML_hadoop.security.key.provider.path=kms://http@kms:9600/kms
 
 

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
@@ -40,7 +40,7 @@ Create volume bucket with wrong credentials
 Create volume with non-admin user
     Run Keyword         Kinit test user     testuser2     testuser2.keytab
     ${rc}               ${output} =          Run And Return Rc And Output       ozone sh volume create o3://om/fstest
-    Should contain      ${output}       Only admin users are authorized to create
+    Should contain      ${output}       doesn't have CREATE permission to access volume
 
 Create volume bucket with credentials
                         # Authenticate testuser

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -605,7 +605,7 @@ public final class TestSecureOzoneCluster {
 
     // Setup secure OM for start.
     OzoneConfiguration newConf = new OzoneConfiguration(conf);
-    int tokenMaxLifetime = 500;
+    int tokenMaxLifetime = 1000;
     newConf.setLong(DELEGATION_TOKEN_MAX_LIFETIME_KEY, tokenMaxLifetime);
     setupOm(newConf);
     long omVersion =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
@@ -58,17 +58,20 @@ import org.junit.rules.Timeout;
 public class TestOzoneManagerListVolumes {
 
   @Rule
-  public Timeout timeout = new Timeout(120_000);
+  public Timeout timeout = new Timeout(120_000_0000);
 
-  private UserGroupInformation loginUser;
+  private UserGroupInformation adminUser =
+      UserGroupInformation.createUserForTesting("om", new String[]{"ozone"});
   private UserGroupInformation user1 =
-      UserGroupInformation.createRemoteUser("user1");  // Admin user
+      UserGroupInformation.createUserForTesting("user1", new String[]{"test"});
   private UserGroupInformation user2 =
-      UserGroupInformation.createRemoteUser("user2");  // Non-admin user
+      UserGroupInformation.createUserForTesting("user2", new String[]{"test"});
 
   @Before
   public void init() throws Exception {
-    loginUser = UserGroupInformation.getLoginUser();
+    // loginUser is the user running this test.
+    // Implication: loginUser is automatically added to the OM admin list.
+    UserGroupInformation.setLoginUser(adminUser);
   }
 
   /**
@@ -82,7 +85,6 @@ public class TestOzoneManagerListVolumes {
     String scmId = UUID.randomUUID().toString();
     String omId = UUID.randomUUID().toString();
     conf.setInt(OZONE_OPEN_KEY_EXPIRE_THRESHOLD_SECONDS, 2);
-    conf.set(OZONE_ADMINISTRATORS, "user1");
     conf.setInt(OZONE_SCM_RATIS_PIPELINE_LIMIT, 10);
 
     // Use native impl here, default impl doesn't do actual checks
@@ -95,9 +97,6 @@ public class TestOzoneManagerListVolumes {
         .setClusterId(clusterId).setScmId(scmId).setOmId(omId).build();
     cluster.waitForClusterToBeReady();
 
-    // loginUser is the user running this test.
-    // Implication: loginUser is automatically added to the OM admin list.
-    UserGroupInformation.setLoginUser(loginUser);
     // Create volumes with non-default owners and ACLs
     OzoneClient client = cluster.getClient();
     ObjectStore objectStore = client.getObjectStore();
@@ -154,7 +153,7 @@ public class TestOzoneManagerListVolumes {
 
     // `ozone sh volume list` shall return volumes with LIST permission of user.
     Iterator<? extends OzoneVolume> it = objectStore.listVolumesByUser(
-        null, "", "");
+        user.getUserName(), "", "");
     Set<String> accessibleVolumes = new HashSet<>();
     while (it.hasNext()) {
       OzoneVolume vol = it.next();
@@ -200,6 +199,8 @@ public class TestOzoneManagerListVolumes {
         true);
     checkUser(cluster, user2, Arrays.asList("volume2", "volume3", "volume5"),
         true);
+    checkUser(cluster, adminUser, Arrays.asList("volume1", "volume2", "volume3",
+        "volume4", "volume5"), true);
     stopCluster(cluster);
   }
 
@@ -208,9 +209,11 @@ public class TestOzoneManagerListVolumes {
     // ozone.acl.enabled = true, ozone.om.volume.listall.allowed = false
     MiniOzoneCluster cluster = startCluster(true, false);
     checkUser(cluster, user1, Arrays.asList("volume1", "volume4", "volume5"),
-        true);
+        false);
     checkUser(cluster, user2, Arrays.asList("volume2", "volume3", "volume5"),
         false);
+    checkUser(cluster, adminUser, Arrays.asList("volume1", "volume2", "volume3",
+        "volume4", "volume5"), true);
     stopCluster(cluster);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
@@ -42,7 +42,6 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_RATIS_PIPELINE_
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS_NATIVE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OPEN_KEY_EXPIRE_THRESHOLD_SECONDS;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_ALLOWED;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.StoreType.OZONE;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
@@ -57,7 +57,7 @@ import org.junit.rules.Timeout;
 public class TestOzoneManagerListVolumes {
 
   @Rule
-  public Timeout timeout = new Timeout(120_000_0000);
+  public Timeout timeout = new Timeout(120_000);
 
   private UserGroupInformation adminUser =
       UserGroupInformation.createUserForTesting("om", new String[]{"ozone"});

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3289,7 +3289,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       throws IOException {
     Collection<String> ozAdmins =
         conf.getTrimmedStringCollection(OZONE_ADMINISTRATORS);
-    String omSPN = UserGroupInformation.getCurrentUser().getUserName();
+    String omSPN = UserGroupInformation.getCurrentUser().getShortUserName();
     if (!ozAdmins.contains(omSPN)) {
       ozAdmins.add(omSPN);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -186,7 +186,6 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BLOCKS_MAX;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BLOCKS_MAX_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
@@ -287,7 +286,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private List<OMNodeDetails> peerNodes;
   private File omRatisSnapshotDir;
   private final OMRatisSnapshotInfo omRatisSnapshotInfo;
-  private final Collection<String> ozAdmins;
 
   private KeyProviderCryptoExtension kmsProvider = null;
   private static String keyProviderUriKeyName =
@@ -352,12 +350,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
           omStorage.getState().name() + ". Please ensure 'ozone om --init' "
           + "command is executed once before starting the OM service.",
           ResultCodes.OM_NOT_INITIALIZED);
-    }
-
-    ozAdmins = conf.getTrimmedStringCollection(OZONE_ADMINISTRATORS);
-    String omSPN = UserGroupInformation.getCurrentUser().getUserName();
-    if (!ozAdmins.contains(omSPN)) {
-      ozAdmins.add(omSPN);
     }
     omMetaDir = OMStorage.getOmDbDir(configuration);
     this.isAclEnabled = conf.getBoolean(OZONE_ACL_ENABLED,
@@ -506,6 +498,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         authorizer.setBucketManager(bucketManager);
         authorizer.setKeyManager(keyManager);
         authorizer.setPrefixManager(prefixManager);
+        authorizer.setOzoneAdmins(getOzoneAdmins(configuration));
       }
     } else {
       accessAuthorizer = null;
@@ -1570,7 +1563,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public void createVolume(OmVolumeArgs args) throws IOException {
     try {
       metrics.incNumVolumeCreates();
-      checkAdmin();
+      if(isAclEnabled) {
+        checkAcls(ResourceType.VOLUME, StoreType.OZONE, ACLType.CREATE,
+            args.getVolume(), null, null);
+      }
       volumeManager.createVolume(args);
       AUDIT.logWriteSuccess(buildAuditMessageForSuccess(OMAction.CREATE_VOLUME,
           (args == null) ? null : args.toAuditMap()));
@@ -1922,7 +1918,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       metrics.incNumVolumeLists();
       if (!allowListAllVolumes) {
         // Only admin can list all volumes when disallowed in config
-        checkAdmin();
+        if(isAclEnabled) {
+          checkAcls(ResourceType.VOLUME, StoreType.OZONE, ACLType.LIST,
+              OzoneConsts.OZONE_ROOT, null, null);
+        }
       }
       return volumeManager.listVolumes(null, prefix, prevKey, maxKeys);
     } catch (Exception ex) {
@@ -1935,20 +1934,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       if(auditSuccess){
         AUDIT.logReadSuccess(buildAuditMessageForSuccess(OMAction.LIST_VOLUMES,
             auditMap));
-      }
-    }
-  }
-
-  private void checkAdmin() throws OMException {
-    if(isAclEnabled) {
-      if (!ozAdmins.contains(OZONE_ADMINISTRATORS_WILDCARD) &&
-          !ozAdmins.contains(ProtobufRpcEngine.Server.getRemoteUser()
-              .getUserName())) {
-        LOG.error("Only admin users are authorized to create or list " +
-                "Ozone volumes. User :{} is not an admin.",
-            ProtobufRpcEngine.Server.getRemoteUser().getUserName());
-        throw new OMException("Only admin users are authorized to create " +
-            "or list Ozone volumes.", ResultCodes.PERMISSION_DENIED);
       }
     }
   }
@@ -3300,7 +3285,14 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   /**
    * Return list of OzoneAdministrators.
    */
-  public Collection<String> getOzoneAdmins() {
+  private Collection<String> getOzoneAdmins(OzoneConfiguration conf)
+      throws IOException {
+    Collection<String> ozAdmins =
+        conf.getTrimmedStringCollection(OZONE_ADMINISTRATORS);
+    String omSPN = UserGroupInformation.getCurrentUser().getUserName();
+    if (!ozAdmins.contains(omSPN)) {
+      ozAdmins.add(omSPN);
+    }
     return ozAdmins;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.ozone.om.request.volume;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,6 +28,8 @@ import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
+import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +54,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.UserVolumeInfo;
 import org.apache.hadoop.util.Time;
 
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_LOCK;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.USER_LOCK;
 
@@ -114,7 +114,6 @@ public class OMVolumeCreateRequest extends OMVolumeRequest {
     OMClientResponse omClientResponse = null;
     OmVolumeArgs omVolumeArgs = null;
     Map<String, String> auditMap = new HashMap<>();
-    Collection<String> ozAdmins = ozoneManager.getOzoneAdmins();
     try {
       omVolumeArgs = OmVolumeArgs.getFromProtobuf(volumeInfo);
       // when you create a volume, we set both Object ID and update ID.
@@ -128,14 +127,11 @@ public class OMVolumeCreateRequest extends OMVolumeRequest {
 
       auditMap = omVolumeArgs.toAuditMap();
 
-      // check Acl
-      if (ozoneManager.getAclsEnabled() &&
-          !ozAdmins.contains(OZONE_ADMINISTRATORS_WILDCARD) &&
-            !ozAdmins.contains(getOmRequest().getUserInfo().getUserName())) {
-        throw new OMException("Only admin users are authorized to create " +
-            "Ozone volumes. User: " +
-            getOmRequest().getUserInfo().getUserName(),
-            OMException.ResultCodes.PERMISSION_DENIED);
+      // check acl
+      if (ozoneManager.getAclsEnabled()) {
+        checkAcls(ozoneManager, OzoneObj.ResourceType.VOLUME,
+            OzoneObj.StoreType.OZONE, IAccessAuthorizer.ACLType.CREATE, volume,
+            null, null);
       }
 
       // acquire lock.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAuthorizer.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Objects;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
@@ -172,7 +173,7 @@ public class OzoneNativeAuthorizer implements IAccessAuthorizer {
   }
 
   public Collection<String> getOzoneAdmins() {
-    return this.ozAdmins;
+    return Collections.unmodifiableCollection(this.ozAdmins);
   }
 
   private boolean isAdmin(UserGroupInformation callerUgi) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.security.acl;
+
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
+
+/**
+ * Test Ozone Administrators from OzoneNativeAuthorizer.
+ */
+public class TestOzoneAdministrators {
+
+  private static OzoneNativeAuthorizer nativeAuthorizer;
+
+  @BeforeClass
+  public static void setup() {
+    nativeAuthorizer = new OzoneNativeAuthorizer();
+  }
+
+  @Test
+  public void testCreateVolume() throws Exception {
+    OzoneObj obj = getTestVolumeobj("testvolume");
+    RequestContext context = getUserRequestContext("testuser",
+        IAccessAuthorizer.ACLType.CREATE);
+    testAdminOperations(obj, context);
+  }
+
+  @Test
+  public void testListAllVolume() throws Exception {
+    OzoneObj obj = getTestVolumeobj("/");
+    RequestContext context = getUserRequestContext("testuser",
+        IAccessAuthorizer.ACLType.LIST);
+    testAdminOperations(obj, context);
+  }
+
+  private void testAdminOperations(OzoneObj obj, RequestContext context)
+      throws OMException {
+    nativeAuthorizer.setOzoneAdmins(Collections.emptyList());
+    Assert.assertFalse("empty admin list disallow anyone to perform " +
+            "admin operations", nativeAuthorizer.checkAccess(obj, context));
+
+    nativeAuthorizer.setOzoneAdmins(
+        Collections.singletonList(OZONE_ADMINISTRATORS_WILDCARD));
+    Assert.assertTrue("wildcard admin allows everyone to perform admin" +
+        " operations", nativeAuthorizer.checkAccess(obj, context));
+
+    nativeAuthorizer.setOzoneAdmins(
+        Collections.singletonList("testuser"));
+    Assert.assertTrue("matching admins are allowed to perform admin " +
+            "operations", nativeAuthorizer.checkAccess(obj, context));
+
+    nativeAuthorizer.setOzoneAdmins(
+        Arrays.asList(new String[]{"testuser2", "testuser"}));
+    Assert.assertTrue("matching admins are allowed to perform admin " +
+            "operations", nativeAuthorizer.checkAccess(obj, context));
+
+    nativeAuthorizer.setOzoneAdmins(
+        Arrays.asList(new String[]{"testuser2", "testuser3"}));
+    Assert.assertTrue("mismatching admins are not allowed perform " +
+        "admin operations", nativeAuthorizer.checkAccess(obj, context));
+  }
+
+  private RequestContext getUserRequestContext(String username,
+                                               IAccessAuthorizer.ACLType type) {
+    return RequestContext.newBuilder()
+        .setClientUgi(UserGroupInformation.createRemoteUser(username))
+        .setAclType(IAccessAuthorizer.ACLIdentityType.USER)
+        .setAclRights(type)
+        .build();
+  }
+
+  private OzoneObj getTestVolumeobj(String volumename) {
+    return OzoneObjInfo.Builder.newBuilder()
+        .setResType(OzoneObj.ResourceType.VOLUME)
+        .setStoreType(OzoneObj.StoreType.OZONE)
+        .setVolumeName(volumename).build();
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
@@ -80,7 +80,7 @@ public class TestOzoneAdministrators {
 
     nativeAuthorizer.setOzoneAdmins(
         Arrays.asList(new String[]{"testuser2", "testuser3"}));
-    Assert.assertTrue("mismatching admins are not allowed perform " +
+    Assert.assertFalse("mismatching admins are not allowed perform " +
         "admin operations", nativeAuthorizer.checkAccess(obj, context));
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
@@ -348,15 +348,10 @@ public class TestOzoneNativeAuthorizer {
   private void resetAclsAndValidateAccess(OzoneObj obj,
       ACLIdentityType accessType, IOzoneAcl aclImplementor)
       throws IOException {
-
     List<OzoneAcl> acls;
-    String user = "";
-    String group = "";
-
-    user = testUgi.getUserName();
-    if (testUgi.getGroups().size() > 0) {
-      group = testUgi.getGroups().get(0);
-    }
+    String user = testUgi.getUserName();
+    String group = (testUgi.getGroups().size() > 0) ?
+        testUgi.getGroups().get(0): "";
 
     RequestContext.Builder builder = new RequestContext.Builder()
         .setClientUgi(testUgi)
@@ -405,12 +400,12 @@ public class TestOzoneNativeAuthorizer {
       String msg = "Acl to check:" + a1 + " accessType:" +
           accessType + " path:" + obj.getPath();
       if (a1.equals(CREATE) && obj.getResourceType().equals(VOLUME)) {
-          assertEquals(msg, nativeAuthorizer.getOzoneAdmins().contains(user),
-              nativeAuthorizer.checkAccess(obj,
-                  builder.setAclRights(a1).build()));
-        } else {
-          assertEquals(msg, expectedAclResult, nativeAuthorizer.checkAccess(obj,
-              builder.setAclRights(a1).build()));
+        assertEquals(msg, nativeAuthorizer.getOzoneAdmins().contains(user),
+            nativeAuthorizer.checkAccess(obj,
+                builder.setAclRights(a1).build()));
+      } else {
+        assertEquals(msg, expectedAclResult, nativeAuthorizer.checkAccess(obj,
+            builder.setAclRights(a1).build()));
       }
       List<ACLType> aclsToBeValidated =
           Arrays.stream(ACLType.values()).collect(Collectors.toList());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
@@ -160,7 +160,8 @@ public class TestOzoneNativeAuthorizer {
         metadataManager, ozConfig, "om1", null);
 
     nativeAuthorizer = new OzoneNativeAuthorizer(volumeManager, bucketManager,
-        keyManager, prefixManager);
+        keyManager, prefixManager,
+        Collections.singletonList(OZONE_ADMINISTRATORS_WILDCARD));
     //keySession.
     ugi = UserGroupInformation.getCurrentUser();
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
@@ -62,7 +62,6 @@ import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS_NATIVE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.ANONYMOUS;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.GROUP;
@@ -102,14 +101,13 @@ public class TestOzoneNativeAuthorizer {
   private static PrefixManager prefixManager;
   private static OMMetadataManager metadataManager;
   private static OzoneNativeAuthorizer nativeAuthorizer;
-
-  private static UserGroupInformation ugi;
+  private static UserGroupInformation adminUgi;
+  private static UserGroupInformation testUgi;
 
   private static OzoneObj volObj;
   private static OzoneObj buckObj;
   private static OzoneObj keyObj;
   private static OzoneObj prefixObj;
-  private static long keySessionId;
 
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
@@ -149,7 +147,7 @@ public class TestOzoneNativeAuthorizer {
         OZONE_ACL_AUTHORIZER_CLASS_NATIVE);
     File dir = GenericTestUtils.getRandomizedTestDir();
     ozConfig.set(OZONE_METADATA_DIRS, dir.toString());
-    ozConfig.set(OZONE_ADMINISTRATORS, OZONE_ADMINISTRATORS_WILDCARD);
+    ozConfig.set(OZONE_ADMINISTRATORS, "om");
 
     metadataManager = new OmMetadataManagerImpl(ozConfig);
     volumeManager = new VolumeManagerImpl(metadataManager, ozConfig);
@@ -161,9 +159,11 @@ public class TestOzoneNativeAuthorizer {
 
     nativeAuthorizer = new OzoneNativeAuthorizer(volumeManager, bucketManager,
         keyManager, prefixManager,
-        Collections.singletonList(OZONE_ADMINISTRATORS_WILDCARD));
-    //keySession.
-    ugi = UserGroupInformation.getCurrentUser();
+        Collections.singletonList("om"));
+    adminUgi = UserGroupInformation.createUserForTesting("om",
+        new String[]{"ozone"});
+    testUgi = UserGroupInformation.createUserForTesting("testuser",
+        new String[]{"test"});
   }
 
   private void createKey(String volume,
@@ -175,8 +175,8 @@ public class TestOzoneNativeAuthorizer {
         .setFactor(HddsProtos.ReplicationFactor.ONE)
         .setDataSize(0)
         .setType(HddsProtos.ReplicationType.STAND_ALONE)
-        .setAcls(OzoneAclUtil.getAclList(ugi.getUserName(), ugi.getGroups(),
-            ALL, ALL))
+        .setAcls(OzoneAclUtil.getAclList(testUgi.getUserName(),
+            testUgi.getGroups(), ALL, ALL))
         .build();
 
     if (keyName.split(OZONE_URI_DELIMITER).length > 1) {
@@ -188,7 +188,6 @@ public class TestOzoneNativeAuthorizer {
           keySession.getKeyInfo().getLatestVersionLocations()
               .getLocationList());
       keyManager.commitKey(keyArgs, keySession.getId());
-      keySessionId = keySession.getId();
     }
 
     keyObj = new OzoneObjInfo.Builder()
@@ -218,8 +217,8 @@ public class TestOzoneNativeAuthorizer {
   private void createVolume(String volumeName) throws IOException {
     OmVolumeArgs volumeArgs = OmVolumeArgs.newBuilder()
         .setVolume(volumeName)
-        .setAdminName("bilbo")
-        .setOwnerName("bilbo")
+        .setAdminName(adminUgi.getUserName())
+        .setOwnerName(testUgi.getUserName())
         .build();
     TestOMRequestUtils.addVolumeToOM(metadataManager, volumeArgs);
     volObj = new OzoneObjInfo.Builder()
@@ -241,10 +240,10 @@ public class TestOzoneNativeAuthorizer {
   @Test
   public void testCheckAccessForBucket() throws Exception {
 
-    OzoneAcl userAcl = new OzoneAcl(USER, ugi.getUserName(), parentDirUserAcl,
-        ACCESS);
-    OzoneAcl groupAcl = new OzoneAcl(GROUP, ugi.getGroups().size() > 0 ?
-        ugi.getGroups().get(0) : "", parentDirGroupAcl, ACCESS);
+    OzoneAcl userAcl = new OzoneAcl(USER, testUgi.getUserName(),
+        parentDirUserAcl, ACCESS);
+    OzoneAcl groupAcl = new OzoneAcl(GROUP, testUgi.getGroups().size() > 0 ?
+        testUgi.getGroups().get(0) : "", parentDirGroupAcl, ACCESS);
     // Set access for volume.
     // We should directly add to table because old API's update to DB.
 
@@ -259,10 +258,10 @@ public class TestOzoneNativeAuthorizer {
 
   @Test
   public void testCheckAccessForKey() throws Exception {
-    OzoneAcl userAcl = new OzoneAcl(USER, ugi.getUserName(), parentDirUserAcl,
-        ACCESS);
-    OzoneAcl groupAcl = new OzoneAcl(GROUP, ugi.getGroups().size() > 0 ?
-        ugi.getGroups().get(0) : "", parentDirGroupAcl, ACCESS);
+    OzoneAcl userAcl = new OzoneAcl(USER, testUgi.getUserName(),
+        parentDirUserAcl, ACCESS);
+    OzoneAcl groupAcl = new OzoneAcl(GROUP, testUgi.getGroups().size() > 0 ?
+        testUgi.getGroups().get(0) : "", parentDirGroupAcl, ACCESS);
     // Set access for volume & bucket. We should directly add to table
     // because old API's update to DB.
 
@@ -285,10 +284,10 @@ public class TestOzoneNativeAuthorizer {
         .setStoreType(OZONE)
         .build();
 
-    OzoneAcl userAcl = new OzoneAcl(USER, ugi.getUserName(), parentDirUserAcl,
-        ACCESS);
-    OzoneAcl groupAcl = new OzoneAcl(GROUP, ugi.getGroups().size() > 0 ?
-        ugi.getGroups().get(0) : "", parentDirGroupAcl, ACCESS);
+    OzoneAcl userAcl = new OzoneAcl(USER, testUgi.getUserName(),
+        parentDirUserAcl, ACCESS);
+    OzoneAcl groupAcl = new OzoneAcl(GROUP, testUgi.getGroups().size() > 0 ?
+        testUgi.getGroups().get(0) : "", parentDirGroupAcl, ACCESS);
     // Set access for volume & bucket. We should directly add to table
     // because old API's update to DB.
 
@@ -354,13 +353,13 @@ public class TestOzoneNativeAuthorizer {
     String user = "";
     String group = "";
 
-    user = ugi.getUserName();
-    if (ugi.getGroups().size() > 0) {
-      group = ugi.getGroups().get(0);
+    user = testUgi.getUserName();
+    if (testUgi.getGroups().size() > 0) {
+      group = testUgi.getGroups().get(0);
     }
 
     RequestContext.Builder builder = new RequestContext.Builder()
-        .setClientUgi(ugi)
+        .setClientUgi(testUgi)
         .setAclType(accessType);
 
     // Get all acls.
@@ -403,11 +402,16 @@ public class TestOzoneNativeAuthorizer {
         validateNone(obj, builder);
         continue;
       }
-      assertEquals("Acl to check:" + a1 + " accessType:" +
-              accessType + " path:" + obj.getPath(),
-          expectedAclResult, nativeAuthorizer.checkAccess(obj,
+      String msg = "Acl to check:" + a1 + " accessType:" +
+          accessType + " path:" + obj.getPath();
+      if (a1.equals(CREATE) && obj.getResourceType().equals(VOLUME)) {
+          assertEquals(msg, nativeAuthorizer.getOzoneAdmins().contains(user),
+              nativeAuthorizer.checkAccess(obj,
+                  builder.setAclRights(a1).build()));
+        } else {
+          assertEquals(msg, expectedAclResult, nativeAuthorizer.checkAccess(obj,
               builder.setAclRights(a1).build()));
-
+      }
       List<ACLType> aclsToBeValidated =
           Arrays.stream(ACLType.values()).collect(Collectors.toList());
       List<ACLType> aclsToBeAdded =
@@ -500,10 +504,10 @@ public class TestOzoneNativeAuthorizer {
   private String getAclName(ACLIdentityType identityType) {
     switch (identityType) {
     case USER:
-      return ugi.getUserName();
+      return testUgi.getUserName();
     case GROUP:
-      if (ugi.getGroups().size() > 0) {
-        return ugi.getGroups().get(0);
+      if (testUgi.getGroups().size() > 0) {
+        return testUgi.getGroups().get(0);
       }
     default:
       return "";
@@ -520,10 +524,15 @@ public class TestOzoneNativeAuthorizer {
     List<ACLType> allAcls = new ArrayList<>(Arrays.asList(ACLType.values()));
     allAcls.remove(ALL);
     allAcls.remove(NONE);
+    RequestContext ctx = builder.build();
+    boolean expectedResult = expectedAclResult;
+    if (nativeAuthorizer.getOzoneAdmins().contains(
+        ctx.getClientUgi().getUserName())) {
+      expectedResult = true;
+    }
     for (ACLType a : allAcls) {
-      assertEquals("User should have right " + a + ".", 
-          nativeAuthorizer.checkAccess(obj,
-          builder.setAclRights(a).build()), expectedAclResult);
+      assertEquals("User should have right " + a + ".",
+          expectedResult, nativeAuthorizer.checkAccess(obj, ctx));
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Delegate admin check (volume create and list) to authorizer plugin.
Bypass admin acl check for ozone native authorizer.  

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3391

## How was this patch tested?
Added UT
Existing acceptance tests.