### PR TITLE
HDDS-3595. Add a maven proto file backward compatibility checker in Ozone.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -224,6 +224,7 @@ hadoop-hdds/framework/src/main/resources/webapps/static/d3-3.5.17.min.js
 hadoop-hdfs-project/hadoop-hdfs/src/main/webapps/static/d3-3.5.17.min.js
 hadoop-hdds/docs/themes/ozonedoc/static/fonts/glyphicons-*
 hadoop-hdds/docs/themes/ozonedoc/static/js/bootstrap.min.js
+com.salesforce.servicelibs:proto-backwards-compatibility maven plugin
 
 MIT License
 -----------

--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -327,7 +327,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
           <excludes>
-            <exclude>${basedir}/src/main/proto/proto.lock</exclude>
+            <exclude>src/main/proto/proto.lock</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -203,6 +203,20 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </extensions>
     <plugins>
       <plugin>
+        <groupId>com.salesforce.servicelibs</groupId>
+        <artifactId>proto-backwards-compatibility</artifactId>
+        <configuration>
+          <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>backwards-compatibility-check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>${protobuf-maven-plugin.version}</version>

--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -205,16 +205,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <plugin>
         <groupId>com.salesforce.servicelibs</groupId>
         <artifactId>proto-backwards-compatibility</artifactId>
-        <configuration>
-          <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>backwards-compatibility-check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>

--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -322,6 +322,15 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
           <excludeFilterFile>${basedir}/dev-support/findbugsExcludeFile.xml</excludeFilterFile>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>${basedir}/src/main/proto/proto.lock</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -322,15 +322,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
           <excludeFilterFile>${basedir}/dev-support/findbugsExcludeFile.xml</excludeFilterFile>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>src/main/proto/proto.lock</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/hadoop-hdds/common/src/main/proto/proto.lock
+++ b/hadoop-hdds/common/src/main/proto/proto.lock
@@ -1,0 +1,3640 @@
+{
+  "definitions": [
+    {
+      "protopath": "DatanodeContainerProtocol.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "Type",
+            "enum_fields": [
+              {
+                "name": "CreateContainer",
+                "integer": 1
+              },
+              {
+                "name": "ReadContainer",
+                "integer": 2
+              },
+              {
+                "name": "UpdateContainer",
+                "integer": 3
+              },
+              {
+                "name": "DeleteContainer",
+                "integer": 4
+              },
+              {
+                "name": "ListContainer",
+                "integer": 5
+              },
+              {
+                "name": "PutBlock",
+                "integer": 6
+              },
+              {
+                "name": "GetBlock",
+                "integer": 7
+              },
+              {
+                "name": "DeleteBlock",
+                "integer": 8
+              },
+              {
+                "name": "ListBlock",
+                "integer": 9
+              },
+              {
+                "name": "ReadChunk",
+                "integer": 10
+              },
+              {
+                "name": "DeleteChunk",
+                "integer": 11
+              },
+              {
+                "name": "WriteChunk",
+                "integer": 12
+              },
+              {
+                "name": "ListChunk",
+                "integer": 13
+              },
+              {
+                "name": "CompactChunk",
+                "integer": 14
+              },
+              {
+                "name": "PutSmallFile",
+                "integer": 15
+              },
+              {
+                "name": "GetSmallFile",
+                "integer": 16
+              },
+              {
+                "name": "CloseContainer",
+                "integer": 17
+              },
+              {
+                "name": "GetCommittedBlockLength",
+                "integer": 18
+              }
+            ]
+          },
+          {
+            "name": "Result",
+            "enum_fields": [
+              {
+                "name": "SUCCESS",
+                "integer": 1
+              },
+              {
+                "name": "UNSUPPORTED_REQUEST",
+                "integer": 2
+              },
+              {
+                "name": "MALFORMED_REQUEST",
+                "integer": 3
+              },
+              {
+                "name": "CONTAINER_INTERNAL_ERROR",
+                "integer": 4
+              },
+              {
+                "name": "INVALID_CONFIG",
+                "integer": 5
+              },
+              {
+                "name": "INVALID_FILE_HASH_FOUND",
+                "integer": 6
+              },
+              {
+                "name": "CONTAINER_EXISTS",
+                "integer": 7
+              },
+              {
+                "name": "NO_SUCH_ALGORITHM",
+                "integer": 8
+              },
+              {
+                "name": "CONTAINER_NOT_FOUND",
+                "integer": 9
+              },
+              {
+                "name": "IO_EXCEPTION",
+                "integer": 10
+              },
+              {
+                "name": "UNABLE_TO_READ_METADATA_DB",
+                "integer": 11
+              },
+              {
+                "name": "NO_SUCH_BLOCK",
+                "integer": 12
+              },
+              {
+                "name": "OVERWRITE_FLAG_REQUIRED",
+                "integer": 13
+              },
+              {
+                "name": "UNABLE_TO_FIND_DATA_DIR",
+                "integer": 14
+              },
+              {
+                "name": "INVALID_WRITE_SIZE",
+                "integer": 15
+              },
+              {
+                "name": "CHECKSUM_MISMATCH",
+                "integer": 16
+              },
+              {
+                "name": "UNABLE_TO_FIND_CHUNK",
+                "integer": 17
+              },
+              {
+                "name": "PROTOC_DECODING_ERROR",
+                "integer": 18
+              },
+              {
+                "name": "INVALID_ARGUMENT",
+                "integer": 19
+              },
+              {
+                "name": "PUT_SMALL_FILE_ERROR",
+                "integer": 20
+              },
+              {
+                "name": "GET_SMALL_FILE_ERROR",
+                "integer": 21
+              },
+              {
+                "name": "CLOSED_CONTAINER_IO",
+                "integer": 22
+              },
+              {
+                "name": "ERROR_IN_COMPACT_DB",
+                "integer": 24
+              },
+              {
+                "name": "UNCLOSED_CONTAINER_IO",
+                "integer": 25
+              },
+              {
+                "name": "DELETE_ON_OPEN_CONTAINER",
+                "integer": 26
+              },
+              {
+                "name": "CLOSED_CONTAINER_RETRY",
+                "integer": 27
+              },
+              {
+                "name": "INVALID_CONTAINER_STATE",
+                "integer": 28
+              },
+              {
+                "name": "DISK_OUT_OF_SPACE",
+                "integer": 29
+              },
+              {
+                "name": "CONTAINER_ALREADY_EXISTS",
+                "integer": 30
+              },
+              {
+                "name": "CONTAINER_METADATA_ERROR",
+                "integer": 31
+              },
+              {
+                "name": "CONTAINER_FILES_CREATE_ERROR",
+                "integer": 32
+              },
+              {
+                "name": "CONTAINER_CHECKSUM_ERROR",
+                "integer": 33
+              },
+              {
+                "name": "UNKNOWN_CONTAINER_TYPE",
+                "integer": 34
+              },
+              {
+                "name": "BLOCK_NOT_COMMITTED",
+                "integer": 35
+              },
+              {
+                "name": "CONTAINER_UNHEALTHY",
+                "integer": 36
+              },
+              {
+                "name": "UNKNOWN_BCSID",
+                "integer": 37
+              },
+              {
+                "name": "BCSID_MISMATCH",
+                "integer": 38
+              },
+              {
+                "name": "CONTAINER_NOT_OPEN",
+                "integer": 39
+              },
+              {
+                "name": "CONTAINER_MISSING",
+                "integer": 40
+              },
+              {
+                "name": "BLOCK_TOKEN_VERIFICATION_FAILED",
+                "integer": 41
+              },
+              {
+                "name": "ERROR_IN_DB_SYNC",
+                "integer": 42
+              }
+            ]
+          },
+          {
+            "name": "ContainerDataProto.State",
+            "enum_fields": [
+              {
+                "name": "OPEN",
+                "integer": 1
+              },
+              {
+                "name": "CLOSING",
+                "integer": 2
+              },
+              {
+                "name": "QUASI_CLOSED",
+                "integer": 3
+              },
+              {
+                "name": "CLOSED",
+                "integer": 4
+              },
+              {
+                "name": "UNHEALTHY",
+                "integer": 5
+              },
+              {
+                "name": "INVALID",
+                "integer": 6
+              }
+            ]
+          },
+          {
+            "name": "ContainerType",
+            "enum_fields": [
+              {
+                "name": "KeyValueContainer",
+                "integer": 1
+              }
+            ]
+          },
+          {
+            "name": "ChecksumType",
+            "enum_fields": [
+              {
+                "name": "NONE",
+                "integer": 1
+              },
+              {
+                "name": "CRC32",
+                "integer": 2
+              },
+              {
+                "name": "CRC32C",
+                "integer": 3
+              },
+              {
+                "name": "SHA256",
+                "integer": 4
+              },
+              {
+                "name": "MD5",
+                "integer": 5
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "DatanodeBlockID",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "localID",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "blockCommitSequenceId",
+                "type": "uint64",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "0"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "KeyValue",
+            "fields": [
+              {
+                "id": 1,
+                "name": "key",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "value",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ContainerCommandRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cmdType",
+                "type": "Type"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "containerID",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "datanodeUuid",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "pipelineID",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "createContainer",
+                "type": "CreateContainerRequestProto"
+              },
+              {
+                "id": 7,
+                "name": "readContainer",
+                "type": "ReadContainerRequestProto"
+              },
+              {
+                "id": 8,
+                "name": "updateContainer",
+                "type": "UpdateContainerRequestProto"
+              },
+              {
+                "id": 9,
+                "name": "deleteContainer",
+                "type": "DeleteContainerRequestProto"
+              },
+              {
+                "id": 10,
+                "name": "listContainer",
+                "type": "ListContainerRequestProto"
+              },
+              {
+                "id": 11,
+                "name": "closeContainer",
+                "type": "CloseContainerRequestProto"
+              },
+              {
+                "id": 12,
+                "name": "putBlock",
+                "type": "PutBlockRequestProto"
+              },
+              {
+                "id": 13,
+                "name": "getBlock",
+                "type": "GetBlockRequestProto"
+              },
+              {
+                "id": 14,
+                "name": "deleteBlock",
+                "type": "DeleteBlockRequestProto"
+              },
+              {
+                "id": 15,
+                "name": "listBlock",
+                "type": "ListBlockRequestProto"
+              },
+              {
+                "id": 16,
+                "name": "readChunk",
+                "type": "ReadChunkRequestProto"
+              },
+              {
+                "id": 17,
+                "name": "writeChunk",
+                "type": "WriteChunkRequestProto"
+              },
+              {
+                "id": 18,
+                "name": "deleteChunk",
+                "type": "DeleteChunkRequestProto"
+              },
+              {
+                "id": 19,
+                "name": "listChunk",
+                "type": "ListChunkRequestProto"
+              },
+              {
+                "id": 20,
+                "name": "putSmallFile",
+                "type": "PutSmallFileRequestProto"
+              },
+              {
+                "id": 21,
+                "name": "getSmallFile",
+                "type": "GetSmallFileRequestProto"
+              },
+              {
+                "id": 22,
+                "name": "getCommittedBlockLength",
+                "type": "GetCommittedBlockLengthRequestProto"
+              },
+              {
+                "id": 23,
+                "name": "encodedToken",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ContainerCommandResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cmdType",
+                "type": "Type"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "result",
+                "type": "Result"
+              },
+              {
+                "id": 4,
+                "name": "message",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "createContainer",
+                "type": "CreateContainerResponseProto"
+              },
+              {
+                "id": 6,
+                "name": "readContainer",
+                "type": "ReadContainerResponseProto"
+              },
+              {
+                "id": 7,
+                "name": "updateContainer",
+                "type": "UpdateContainerResponseProto"
+              },
+              {
+                "id": 8,
+                "name": "deleteContainer",
+                "type": "DeleteContainerResponseProto"
+              },
+              {
+                "id": 9,
+                "name": "listContainer",
+                "type": "ListContainerResponseProto"
+              },
+              {
+                "id": 10,
+                "name": "closeContainer",
+                "type": "CloseContainerResponseProto"
+              },
+              {
+                "id": 11,
+                "name": "putBlock",
+                "type": "PutBlockResponseProto"
+              },
+              {
+                "id": 12,
+                "name": "getBlock",
+                "type": "GetBlockResponseProto"
+              },
+              {
+                "id": 13,
+                "name": "deleteBlock",
+                "type": "DeleteBlockResponseProto"
+              },
+              {
+                "id": 14,
+                "name": "listBlock",
+                "type": "ListBlockResponseProto"
+              },
+              {
+                "id": 15,
+                "name": "writeChunk",
+                "type": "WriteChunkResponseProto"
+              },
+              {
+                "id": 16,
+                "name": "readChunk",
+                "type": "ReadChunkResponseProto"
+              },
+              {
+                "id": 17,
+                "name": "deleteChunk",
+                "type": "DeleteChunkResponseProto"
+              },
+              {
+                "id": 18,
+                "name": "listChunk",
+                "type": "ListChunkResponseProto"
+              },
+              {
+                "id": 19,
+                "name": "putSmallFile",
+                "type": "PutSmallFileResponseProto"
+              },
+              {
+                "id": 20,
+                "name": "getSmallFile",
+                "type": "GetSmallFileResponseProto"
+              },
+              {
+                "id": 21,
+                "name": "getCommittedBlockLength",
+                "type": "GetCommittedBlockLengthResponseProto"
+              }
+            ]
+          },
+          {
+            "name": "ContainerDataProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "metadata",
+                "type": "KeyValue",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "containerPath",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "bytesUsed",
+                "type": "int64"
+              },
+              {
+                "id": 7,
+                "name": "size",
+                "type": "int64"
+              },
+              {
+                "id": 8,
+                "name": "blockCount",
+                "type": "int64"
+              },
+              {
+                "id": 9,
+                "name": "state",
+                "type": "State",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "OPEN"
+                  }
+                ]
+              },
+              {
+                "id": 10,
+                "name": "containerType",
+                "type": "ContainerType",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "KeyValueContainer"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Container2BCSIDMapProto",
+            "maps": [
+              {
+                "key_type": "int64",
+                "field": {
+                  "id": 1,
+                  "name": "container2BCSID",
+                  "type": "int64"
+                }
+              }
+            ]
+          },
+          {
+            "name": "CreateContainerRequestProto",
+            "fields": [
+              {
+                "id": 2,
+                "name": "metadata",
+                "type": "KeyValue",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "containerType",
+                "type": "ContainerType",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "KeyValueContainer"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "CreateContainerResponseProto"
+          },
+          {
+            "name": "ReadContainerRequestProto"
+          },
+          {
+            "name": "ReadContainerResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerData",
+                "type": "ContainerDataProto"
+              }
+            ]
+          },
+          {
+            "name": "UpdateContainerRequestProto",
+            "fields": [
+              {
+                "id": 2,
+                "name": "metadata",
+                "type": "KeyValue",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "forceUpdate",
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "false"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "UpdateContainerResponseProto"
+          },
+          {
+            "name": "DeleteContainerRequestProto",
+            "fields": [
+              {
+                "id": 2,
+                "name": "forceDelete",
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "false"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "DeleteContainerResponseProto"
+          },
+          {
+            "name": "ListContainerRequestProto",
+            "fields": [
+              {
+                "id": 2,
+                "name": "count",
+                "type": "uint32"
+              }
+            ]
+          },
+          {
+            "name": "ListContainerResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerData",
+                "type": "ContainerDataProto",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "CloseContainerRequestProto"
+          },
+          {
+            "name": "CloseContainerResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "hash",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "containerID",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "BlockData",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockID",
+                "type": "DatanodeBlockID"
+              },
+              {
+                "id": 2,
+                "name": "flags",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "metadata",
+                "type": "KeyValue",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "chunks",
+                "type": "ChunkInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "size",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "PutBlockRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockData",
+                "type": "BlockData"
+              },
+              {
+                "id": 2,
+                "name": "eof",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "PutBlockResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "committedBlockLength",
+                "type": "GetCommittedBlockLengthResponseProto"
+              }
+            ]
+          },
+          {
+            "name": "GetBlockRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockID",
+                "type": "DatanodeBlockID"
+              }
+            ]
+          },
+          {
+            "name": "GetBlockResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockData",
+                "type": "BlockData"
+              }
+            ]
+          },
+          {
+            "name": "DeleteBlockRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockID",
+                "type": "DatanodeBlockID"
+              }
+            ]
+          },
+          {
+            "name": "GetCommittedBlockLengthRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockID",
+                "type": "DatanodeBlockID"
+              }
+            ]
+          },
+          {
+            "name": "GetCommittedBlockLengthResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockID",
+                "type": "DatanodeBlockID"
+              },
+              {
+                "id": 2,
+                "name": "blockLength",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "DeleteBlockResponseProto"
+          },
+          {
+            "name": "ListBlockRequestProto",
+            "fields": [
+              {
+                "id": 2,
+                "name": "startLocalID",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "count",
+                "type": "uint32"
+              }
+            ]
+          },
+          {
+            "name": "ListBlockResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockData",
+                "type": "BlockData",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ChunkInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "chunkName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "offset",
+                "type": "uint64"
+              },
+              {
+                "id": 3,
+                "name": "len",
+                "type": "uint64"
+              },
+              {
+                "id": 4,
+                "name": "metadata",
+                "type": "KeyValue",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "checksumData",
+                "type": "ChecksumData"
+              }
+            ]
+          },
+          {
+            "name": "ChecksumData",
+            "fields": [
+              {
+                "id": 1,
+                "name": "type",
+                "type": "ChecksumType"
+              },
+              {
+                "id": 2,
+                "name": "bytesPerChecksum",
+                "type": "uint32"
+              },
+              {
+                "id": 3,
+                "name": "checksums",
+                "type": "bytes",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "WriteChunkRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockID",
+                "type": "DatanodeBlockID"
+              },
+              {
+                "id": 2,
+                "name": "chunkData",
+                "type": "ChunkInfo"
+              },
+              {
+                "id": 3,
+                "name": "data",
+                "type": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "WriteChunkResponseProto"
+          },
+          {
+            "name": "ReadChunkRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockID",
+                "type": "DatanodeBlockID"
+              },
+              {
+                "id": 2,
+                "name": "chunkData",
+                "type": "ChunkInfo"
+              }
+            ]
+          },
+          {
+            "name": "ReadChunkResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockID",
+                "type": "DatanodeBlockID"
+              },
+              {
+                "id": 2,
+                "name": "chunkData",
+                "type": "ChunkInfo"
+              },
+              {
+                "id": 3,
+                "name": "data",
+                "type": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "DeleteChunkRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockID",
+                "type": "DatanodeBlockID"
+              },
+              {
+                "id": 2,
+                "name": "chunkData",
+                "type": "ChunkInfo"
+              }
+            ]
+          },
+          {
+            "name": "DeleteChunkResponseProto"
+          },
+          {
+            "name": "ListChunkRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockID",
+                "type": "DatanodeBlockID"
+              },
+              {
+                "id": 2,
+                "name": "prevChunkName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "count",
+                "type": "uint32"
+              }
+            ]
+          },
+          {
+            "name": "ListChunkResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "chunkData",
+                "type": "ChunkInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "PutSmallFileRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "block",
+                "type": "PutBlockRequestProto"
+              },
+              {
+                "id": 2,
+                "name": "chunkInfo",
+                "type": "ChunkInfo"
+              },
+              {
+                "id": 3,
+                "name": "data",
+                "type": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "PutSmallFileResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "committedBlockLength",
+                "type": "GetCommittedBlockLengthResponseProto"
+              }
+            ]
+          },
+          {
+            "name": "GetSmallFileRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "block",
+                "type": "GetBlockRequestProto"
+              }
+            ]
+          },
+          {
+            "name": "GetSmallFileResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "data",
+                "type": "ReadChunkResponseProto"
+              }
+            ]
+          },
+          {
+            "name": "CopyContainerRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "readOffset",
+                "type": "uint64"
+              },
+              {
+                "id": 3,
+                "name": "len",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "CopyContainerResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "readOffset",
+                "type": "uint64"
+              },
+              {
+                "id": 3,
+                "name": "len",
+                "type": "uint64"
+              },
+              {
+                "id": 4,
+                "name": "eof",
+                "type": "bool"
+              },
+              {
+                "id": 5,
+                "name": "data",
+                "type": "bytes"
+              },
+              {
+                "id": 6,
+                "name": "checksum",
+                "type": "int64"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "XceiverClientProtocolService",
+            "rpcs": [
+              {
+                "name": "send",
+                "in_type": "ContainerCommandRequestProto",
+                "out_type": "ContainerCommandResponseProto",
+                "in_streamed": true,
+                "out_streamed": true
+              }
+            ]
+          },
+          {
+            "name": "IntraDatanodeProtocolService",
+            "rpcs": [
+              {
+                "name": "download",
+                "in_type": "CopyContainerRequestProto",
+                "out_type": "CopyContainerResponseProto",
+                "out_streamed": true
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "hadoop.hdds.datanode"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "org.apache.hadoop.hdds.protocol.datanode.proto"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "ContainerProtos"
+          },
+          {
+            "name": "java_generate_equals_and_hash",
+            "value": "true"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "SCMSecurityProtocol.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "Type",
+            "enum_fields": [
+              {
+                "name": "GetDataNodeCertificate",
+                "integer": 1
+              },
+              {
+                "name": "GetOMCertificate",
+                "integer": 2
+              },
+              {
+                "name": "GetCertificate",
+                "integer": 3
+              },
+              {
+                "name": "GetCACertificate",
+                "integer": 4
+              }
+            ]
+          },
+          {
+            "name": "Status",
+            "enum_fields": [
+              {
+                "name": "OK",
+                "integer": 1
+              }
+            ]
+          },
+          {
+            "name": "SCMGetCertResponseProto.ResponseCode",
+            "enum_fields": [
+              {
+                "name": "success",
+                "integer": 1
+              },
+              {
+                "name": "authenticationFailed",
+                "integer": 2
+              },
+              {
+                "name": "invalidCSR",
+                "integer": 3
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "SCMSecurityRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cmdType",
+                "type": "Type"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "getDataNodeCertRequest",
+                "type": "SCMGetDataNodeCertRequestProto"
+              },
+              {
+                "id": 4,
+                "name": "getOMCertRequest",
+                "type": "SCMGetOMCertRequestProto"
+              },
+              {
+                "id": 5,
+                "name": "getCertificateRequest",
+                "type": "SCMGetCertificateRequestProto"
+              },
+              {
+                "id": 6,
+                "name": "getCACertificateRequest",
+                "type": "SCMGetCACertificateRequestProto"
+              }
+            ]
+          },
+          {
+            "name": "SCMSecurityResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cmdType",
+                "type": "Type"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "success",
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "true"
+                  }
+                ]
+              },
+              {
+                "id": 4,
+                "name": "message",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "status",
+                "type": "Status"
+              },
+              {
+                "id": 6,
+                "name": "getCertResponseProto",
+                "type": "SCMGetCertResponseProto"
+              }
+            ]
+          },
+          {
+            "name": "SCMGetDataNodeCertRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "datanodeDetails",
+                "type": "DatanodeDetailsProto"
+              },
+              {
+                "id": 2,
+                "name": "CSR",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "SCMGetOMCertRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "omDetails",
+                "type": "OzoneManagerDetailsProto"
+              },
+              {
+                "id": 2,
+                "name": "CSR",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "SCMGetCertificateRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "certSerialId",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "SCMGetCACertificateRequestProto"
+          },
+          {
+            "name": "SCMGetCertResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "responseCode",
+                "type": "ResponseCode"
+              },
+              {
+                "id": 2,
+                "name": "x509Certificate",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "x509CACertificate",
+                "type": "string"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "SCMSecurityProtocolService",
+            "rpcs": [
+              {
+                "name": "submitRequest",
+                "in_type": "SCMSecurityRequest",
+                "out_type": "SCMSecurityResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "hdds.proto"
+          }
+        ],
+        "package": {
+          "name": "hadoop.hdds.security"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "org.apache.hadoop.hdds.protocol.proto"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "SCMSecurityProtocolProtos"
+          },
+          {
+            "name": "java_generic_services",
+            "value": "true"
+          },
+          {
+            "name": "java_generate_equals_and_hash",
+            "value": "true"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "ScmBlockLocationProtocol.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "Type",
+            "enum_fields": [
+              {
+                "name": "AllocateScmBlock",
+                "integer": 11
+              },
+              {
+                "name": "DeleteScmKeyBlocks",
+                "integer": 12
+              },
+              {
+                "name": "GetScmInfo",
+                "integer": 13
+              },
+              {
+                "name": "SortDatanodes",
+                "integer": 14
+              }
+            ]
+          },
+          {
+            "name": "Status",
+            "enum_fields": [
+              {
+                "name": "OK",
+                "integer": 1
+              },
+              {
+                "name": "FAILED_TO_LOAD_NODEPOOL",
+                "integer": 2
+              },
+              {
+                "name": "FAILED_TO_FIND_NODE_IN_POOL",
+                "integer": 3
+              },
+              {
+                "name": "FAILED_TO_FIND_HEALTHY_NODES",
+                "integer": 4
+              },
+              {
+                "name": "FAILED_TO_FIND_NODES_WITH_SPACE",
+                "integer": 5
+              },
+              {
+                "name": "FAILED_TO_FIND_SUITABLE_NODE",
+                "integer": 6
+              },
+              {
+                "name": "INVALID_CAPACITY",
+                "integer": 7
+              },
+              {
+                "name": "INVALID_BLOCK_SIZE",
+                "integer": 8
+              },
+              {
+                "name": "SAFE_MODE_EXCEPTION",
+                "integer": 9
+              },
+              {
+                "name": "FAILED_TO_LOAD_OPEN_CONTAINER",
+                "integer": 10
+              },
+              {
+                "name": "FAILED_TO_ALLOCATE_CONTAINER",
+                "integer": 11
+              },
+              {
+                "name": "FAILED_TO_CHANGE_CONTAINER_STATE",
+                "integer": 12
+              },
+              {
+                "name": "FAILED_TO_CHANGE_PIPELINE_STATE",
+                "integer": 13
+              },
+              {
+                "name": "CONTAINER_EXISTS",
+                "integer": 14
+              },
+              {
+                "name": "FAILED_TO_FIND_CONTAINER",
+                "integer": 15
+              },
+              {
+                "name": "FAILED_TO_FIND_CONTAINER_WITH_SPACE",
+                "integer": 16
+              },
+              {
+                "name": "BLOCK_EXISTS",
+                "integer": 17
+              },
+              {
+                "name": "FAILED_TO_FIND_BLOCK",
+                "integer": 18
+              },
+              {
+                "name": "IO_EXCEPTION",
+                "integer": 19
+              },
+              {
+                "name": "UNEXPECTED_CONTAINER_STATE",
+                "integer": 20
+              },
+              {
+                "name": "SCM_NOT_INITIALIZED",
+                "integer": 21
+              },
+              {
+                "name": "DUPLICATE_DATANODE",
+                "integer": 22
+              },
+              {
+                "name": "NO_SUCH_DATANODE",
+                "integer": 23
+              },
+              {
+                "name": "NO_REPLICA_FOUND",
+                "integer": 24
+              },
+              {
+                "name": "FAILED_TO_FIND_ACTIVE_PIPELINE",
+                "integer": 25
+              },
+              {
+                "name": "FAILED_TO_INIT_CONTAINER_PLACEMENT_POLICY",
+                "integer": 26
+              },
+              {
+                "name": "FAILED_TO_ALLOCATE_ENOUGH_BLOCKS",
+                "integer": 27
+              },
+              {
+                "name": "INTERNAL_ERROR",
+                "integer": 29
+              }
+            ]
+          },
+          {
+            "name": "DeleteScmBlockResult.Result",
+            "enum_fields": [
+              {
+                "name": "success",
+                "integer": 1
+              },
+              {
+                "name": "safeMode",
+                "integer": 2
+              },
+              {
+                "name": "errorNotFound",
+                "integer": 3
+              },
+              {
+                "name": "unknownFailure",
+                "integer": 4
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "SCMBlockLocationRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cmdType",
+                "type": "Type"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "userInfo",
+                "type": "UserInfo"
+              },
+              {
+                "id": 11,
+                "name": "allocateScmBlockRequest",
+                "type": "AllocateScmBlockRequestProto"
+              },
+              {
+                "id": 12,
+                "name": "deleteScmKeyBlocksRequest",
+                "type": "DeleteScmKeyBlocksRequestProto"
+              },
+              {
+                "id": 13,
+                "name": "getScmInfoRequest",
+                "type": "hadoop.hdds.GetScmInfoRequestProto"
+              },
+              {
+                "id": 14,
+                "name": "sortDatanodesRequest",
+                "type": "SortDatanodesRequestProto"
+              }
+            ]
+          },
+          {
+            "name": "SCMBlockLocationResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cmdType",
+                "type": "Type"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "success",
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "true"
+                  }
+                ]
+              },
+              {
+                "id": 4,
+                "name": "message",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "status",
+                "type": "Status"
+              },
+              {
+                "id": 6,
+                "name": "leaderOMNodeId",
+                "type": "string"
+              },
+              {
+                "id": 11,
+                "name": "allocateScmBlockResponse",
+                "type": "AllocateScmBlockResponseProto"
+              },
+              {
+                "id": 12,
+                "name": "deleteScmKeyBlocksResponse",
+                "type": "DeleteScmKeyBlocksResponseProto"
+              },
+              {
+                "id": 13,
+                "name": "getScmInfoResponse",
+                "type": "hadoop.hdds.GetScmInfoResponseProto"
+              },
+              {
+                "id": 14,
+                "name": "sortDatanodesResponse",
+                "type": "SortDatanodesResponseProto"
+              }
+            ]
+          },
+          {
+            "name": "UserInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "userName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "remoteAddress",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "AllocateScmBlockRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "size",
+                "type": "uint64"
+              },
+              {
+                "id": 2,
+                "name": "numBlocks",
+                "type": "uint32"
+              },
+              {
+                "id": 3,
+                "name": "type",
+                "type": "ReplicationType"
+              },
+              {
+                "id": 4,
+                "name": "factor",
+                "type": "hadoop.hdds.ReplicationFactor"
+              },
+              {
+                "id": 5,
+                "name": "owner",
+                "type": "string"
+              },
+              {
+                "id": 7,
+                "name": "excludeList",
+                "type": "ExcludeListProto"
+              }
+            ]
+          },
+          {
+            "name": "DeleteScmKeyBlocksRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyBlocks",
+                "type": "KeyBlocks",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "KeyBlocks",
+            "fields": [
+              {
+                "id": 1,
+                "name": "key",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "blocks",
+                "type": "BlockID",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "DeleteScmKeyBlocksResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "results",
+                "type": "DeleteKeyBlocksResultProto",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "DeleteKeyBlocksResultProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "objectKey",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "blockResults",
+                "type": "DeleteScmBlockResult",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "DeleteScmBlockResult",
+            "fields": [
+              {
+                "id": 1,
+                "name": "result",
+                "type": "Result"
+              },
+              {
+                "id": 2,
+                "name": "blockID",
+                "type": "BlockID"
+              }
+            ]
+          },
+          {
+            "name": "AllocateBlockResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerBlockID",
+                "type": "ContainerBlockID"
+              },
+              {
+                "id": 2,
+                "name": "pipeline",
+                "type": "hadoop.hdds.Pipeline"
+              }
+            ]
+          },
+          {
+            "name": "AllocateScmBlockResponseProto",
+            "fields": [
+              {
+                "id": 3,
+                "name": "blocks",
+                "type": "AllocateBlockResponse",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "SortDatanodesRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "client",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "nodeNetworkName",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "SortDatanodesResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "node",
+                "type": "DatanodeDetailsProto",
+                "is_repeated": true
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "ScmBlockLocationProtocolService",
+            "rpcs": [
+              {
+                "name": "send",
+                "in_type": "SCMBlockLocationRequest",
+                "out_type": "SCMBlockLocationResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "hdds.proto"
+          }
+        ],
+        "package": {
+          "name": "hadoop.hdds.block"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "org.apache.hadoop.hdds.protocol.proto"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "ScmBlockLocationProtocolProtos"
+          },
+          {
+            "name": "java_generic_services",
+            "value": "true"
+          },
+          {
+            "name": "java_generate_equals_and_hash",
+            "value": "true"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "Security.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "TokenProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "identifier",
+                "type": "bytes"
+              },
+              {
+                "id": 2,
+                "name": "password",
+                "type": "bytes"
+              },
+              {
+                "id": 3,
+                "name": "kind",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "service",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "CredentialsKVProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "alias",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "token",
+                "type": "hadoop.common.TokenProto"
+              },
+              {
+                "id": 3,
+                "name": "secret",
+                "type": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "CredentialsProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "tokens",
+                "type": "hadoop.common.CredentialsKVProto",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "secrets",
+                "type": "hadoop.common.CredentialsKVProto",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "GetDelegationTokenRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "renewer",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetDelegationTokenResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "token",
+                "type": "hadoop.common.TokenProto"
+              }
+            ]
+          },
+          {
+            "name": "RenewDelegationTokenRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "token",
+                "type": "hadoop.common.TokenProto"
+              }
+            ]
+          },
+          {
+            "name": "RenewDelegationTokenResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "newExpiryTime",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "CancelDelegationTokenRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "token",
+                "type": "hadoop.common.TokenProto"
+              }
+            ]
+          },
+          {
+            "name": "CancelDelegationTokenResponseProto"
+          }
+        ],
+        "package": {
+          "name": "hadoop.common"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "org.apache.hadoop.security.proto"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "SecurityProtos"
+          },
+          {
+            "name": "java_generic_services",
+            "value": "true"
+          },
+          {
+            "name": "java_generate_equals_and_hash",
+            "value": "true"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "StorageContainerLocationProtocol.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "ScmContainerLocationResponse.Status",
+            "enum_fields": [
+              {
+                "name": "OK",
+                "integer": 1
+              },
+              {
+                "name": "CONTAINER_ALREADY_EXISTS",
+                "integer": 2
+              },
+              {
+                "name": "CONTAINER_IS_MISSING",
+                "integer": 3
+              }
+            ]
+          },
+          {
+            "name": "Type",
+            "enum_fields": [
+              {
+                "name": "AllocateContainer",
+                "integer": 1
+              },
+              {
+                "name": "GetContainer",
+                "integer": 2
+              },
+              {
+                "name": "GetContainerWithPipeline",
+                "integer": 3
+              },
+              {
+                "name": "ListContainer",
+                "integer": 4
+              },
+              {
+                "name": "DeleteContainer",
+                "integer": 5
+              },
+              {
+                "name": "QueryNode",
+                "integer": 6
+              },
+              {
+                "name": "CloseContainer",
+                "integer": 7
+              },
+              {
+                "name": "AllocatePipeline",
+                "integer": 8
+              },
+              {
+                "name": "ListPipelines",
+                "integer": 9
+              },
+              {
+                "name": "ActivatePipeline",
+                "integer": 10
+              },
+              {
+                "name": "DeactivatePipeline",
+                "integer": 11
+              },
+              {
+                "name": "ClosePipeline",
+                "integer": 12
+              },
+              {
+                "name": "GetScmInfo",
+                "integer": 13
+              },
+              {
+                "name": "InSafeMode",
+                "integer": 14
+              },
+              {
+                "name": "ForceExitSafeMode",
+                "integer": 15
+              },
+              {
+                "name": "StartReplicationManager",
+                "integer": 16
+              },
+              {
+                "name": "StopReplicationManager",
+                "integer": 17
+              },
+              {
+                "name": "GetReplicationManagerStatus",
+                "integer": 18
+              },
+              {
+                "name": "GetPipeline",
+                "integer": 19
+              },
+              {
+                "name": "GetContainerWithPipelineBatch",
+                "integer": 20
+              }
+            ]
+          },
+          {
+            "name": "ContainerResponseProto.Error",
+            "enum_fields": [
+              {
+                "name": "success",
+                "integer": 1
+              },
+              {
+                "name": "errorContainerAlreadyExists",
+                "integer": 2
+              },
+              {
+                "name": "errorContainerMissing",
+                "integer": 3
+              }
+            ]
+          },
+          {
+            "name": "PipelineResponseProto.Error",
+            "enum_fields": [
+              {
+                "name": "success",
+                "integer": 1
+              },
+              {
+                "name": "errorPipelineAlreadyExists",
+                "integer": 2
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "ScmContainerLocationRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cmdType",
+                "type": "Type"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "containerRequest",
+                "type": "ContainerRequestProto"
+              },
+              {
+                "id": 7,
+                "name": "getContainerRequest",
+                "type": "GetContainerRequestProto"
+              },
+              {
+                "id": 8,
+                "name": "getContainerWithPipelineRequest",
+                "type": "GetContainerWithPipelineRequestProto"
+              },
+              {
+                "id": 9,
+                "name": "scmListContainerRequest",
+                "type": "SCMListContainerRequestProto"
+              },
+              {
+                "id": 10,
+                "name": "scmDeleteContainerRequest",
+                "type": "SCMDeleteContainerRequestProto"
+              },
+              {
+                "id": 11,
+                "name": "nodeQueryRequest",
+                "type": "NodeQueryRequestProto"
+              },
+              {
+                "id": 12,
+                "name": "scmCloseContainerRequest",
+                "type": "SCMCloseContainerRequestProto"
+              },
+              {
+                "id": 13,
+                "name": "pipelineRequest",
+                "type": "PipelineRequestProto"
+              },
+              {
+                "id": 14,
+                "name": "listPipelineRequest",
+                "type": "ListPipelineRequestProto"
+              },
+              {
+                "id": 15,
+                "name": "activatePipelineRequest",
+                "type": "ActivatePipelineRequestProto"
+              },
+              {
+                "id": 16,
+                "name": "deactivatePipelineRequest",
+                "type": "DeactivatePipelineRequestProto"
+              },
+              {
+                "id": 17,
+                "name": "closePipelineRequest",
+                "type": "ClosePipelineRequestProto"
+              },
+              {
+                "id": 18,
+                "name": "getScmInfoRequest",
+                "type": "GetScmInfoRequestProto"
+              },
+              {
+                "id": 19,
+                "name": "inSafeModeRequest",
+                "type": "InSafeModeRequestProto"
+              },
+              {
+                "id": 20,
+                "name": "forceExitSafeModeRequest",
+                "type": "ForceExitSafeModeRequestProto"
+              },
+              {
+                "id": 21,
+                "name": "startReplicationManagerRequest",
+                "type": "StartReplicationManagerRequestProto"
+              },
+              {
+                "id": 22,
+                "name": "stopReplicationManagerRequest",
+                "type": "StopReplicationManagerRequestProto"
+              },
+              {
+                "id": 23,
+                "name": "seplicationManagerStatusRequest",
+                "type": "ReplicationManagerStatusRequestProto"
+              },
+              {
+                "id": 24,
+                "name": "getPipelineRequest",
+                "type": "GetPipelineRequestProto"
+              },
+              {
+                "id": 25,
+                "name": "getContainerWithPipelineBatchRequest",
+                "type": "GetContainerWithPipelineBatchRequestProto"
+              }
+            ]
+          },
+          {
+            "name": "ScmContainerLocationResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cmdType",
+                "type": "Type"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "success",
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "true"
+                  }
+                ]
+              },
+              {
+                "id": 4,
+                "name": "message",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "status",
+                "type": "Status"
+              },
+              {
+                "id": 6,
+                "name": "containerResponse",
+                "type": "ContainerResponseProto"
+              },
+              {
+                "id": 7,
+                "name": "getContainerResponse",
+                "type": "GetContainerResponseProto"
+              },
+              {
+                "id": 8,
+                "name": "getContainerWithPipelineResponse",
+                "type": "GetContainerWithPipelineResponseProto"
+              },
+              {
+                "id": 9,
+                "name": "scmListContainerResponse",
+                "type": "SCMListContainerResponseProto"
+              },
+              {
+                "id": 10,
+                "name": "scmDeleteContainerResponse",
+                "type": "SCMDeleteContainerResponseProto"
+              },
+              {
+                "id": 11,
+                "name": "nodeQueryResponse",
+                "type": "NodeQueryResponseProto"
+              },
+              {
+                "id": 12,
+                "name": "scmCloseContainerResponse",
+                "type": "SCMCloseContainerResponseProto"
+              },
+              {
+                "id": 13,
+                "name": "pipelineResponse",
+                "type": "PipelineResponseProto"
+              },
+              {
+                "id": 14,
+                "name": "listPipelineResponse",
+                "type": "ListPipelineResponseProto"
+              },
+              {
+                "id": 15,
+                "name": "activatePipelineResponse",
+                "type": "ActivatePipelineResponseProto"
+              },
+              {
+                "id": 16,
+                "name": "deactivatePipelineResponse",
+                "type": "DeactivatePipelineResponseProto"
+              },
+              {
+                "id": 17,
+                "name": "closePipelineResponse",
+                "type": "ClosePipelineResponseProto"
+              },
+              {
+                "id": 18,
+                "name": "getScmInfoResponse",
+                "type": "GetScmInfoResponseProto"
+              },
+              {
+                "id": 19,
+                "name": "inSafeModeResponse",
+                "type": "InSafeModeResponseProto"
+              },
+              {
+                "id": 20,
+                "name": "forceExitSafeModeResponse",
+                "type": "ForceExitSafeModeResponseProto"
+              },
+              {
+                "id": 21,
+                "name": "startReplicationManagerResponse",
+                "type": "StartReplicationManagerResponseProto"
+              },
+              {
+                "id": 22,
+                "name": "stopReplicationManagerResponse",
+                "type": "StopReplicationManagerResponseProto"
+              },
+              {
+                "id": 23,
+                "name": "replicationManagerStatusResponse",
+                "type": "ReplicationManagerStatusResponseProto"
+              },
+              {
+                "id": 24,
+                "name": "getPipelineResponse",
+                "type": "GetPipelineResponseProto"
+              },
+              {
+                "id": 25,
+                "name": "getContainerWithPipelineBatchResponse",
+                "type": "GetContainerWithPipelineBatchResponseProto"
+              }
+            ]
+          },
+          {
+            "name": "ContainerRequestProto",
+            "fields": [
+              {
+                "id": 2,
+                "name": "replicationFactor",
+                "type": "ReplicationFactor"
+              },
+              {
+                "id": 3,
+                "name": "replicationType",
+                "type": "ReplicationType"
+              },
+              {
+                "id": 4,
+                "name": "owner",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ContainerResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "errorCode",
+                "type": "Error"
+              },
+              {
+                "id": 2,
+                "name": "containerWithPipeline",
+                "type": "ContainerWithPipeline"
+              },
+              {
+                "id": 3,
+                "name": "errorMessage",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetContainerRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetContainerResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerInfo",
+                "type": "ContainerInfoProto"
+              }
+            ]
+          },
+          {
+            "name": "GetContainerWithPipelineRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetContainerWithPipelineResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerWithPipeline",
+                "type": "ContainerWithPipeline"
+              }
+            ]
+          },
+          {
+            "name": "GetContainerWithPipelineBatchRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerIDs",
+                "type": "int64",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetContainerWithPipelineBatchResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerWithPipelines",
+                "type": "ContainerWithPipeline",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "SCMListContainerRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "count",
+                "type": "uint32"
+              },
+              {
+                "id": 2,
+                "name": "startContainerID",
+                "type": "uint64"
+              },
+              {
+                "id": 3,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "SCMListContainerResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containers",
+                "type": "ContainerInfoProto",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "SCMDeleteContainerRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "SCMDeleteContainerResponseProto"
+          },
+          {
+            "name": "SCMCloseContainerRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "SCMCloseContainerResponseProto"
+          },
+          {
+            "name": "NodeQueryRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "state",
+                "type": "NodeState"
+              },
+              {
+                "id": 2,
+                "name": "scope",
+                "type": "QueryScope"
+              },
+              {
+                "id": 3,
+                "name": "poolName",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "NodeQueryResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "datanodes",
+                "type": "Node",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "PipelineRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "replicationType",
+                "type": "ReplicationType"
+              },
+              {
+                "id": 2,
+                "name": "replicationFactor",
+                "type": "ReplicationFactor"
+              },
+              {
+                "id": 3,
+                "name": "nodePool",
+                "type": "NodePool"
+              },
+              {
+                "id": 4,
+                "name": "pipelineID",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "PipelineResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "errorCode",
+                "type": "Error"
+              },
+              {
+                "id": 2,
+                "name": "pipeline",
+                "type": "Pipeline"
+              },
+              {
+                "id": 3,
+                "name": "errorMessage",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ListPipelineRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ListPipelineResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "pipelines",
+                "type": "Pipeline",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "GetPipelineRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "pipelineID",
+                "type": "PipelineID"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetPipelineResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "pipeline",
+                "type": "Pipeline"
+              }
+            ]
+          },
+          {
+            "name": "ActivatePipelineRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "pipelineID",
+                "type": "PipelineID"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ActivatePipelineResponseProto"
+          },
+          {
+            "name": "DeactivatePipelineRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "pipelineID",
+                "type": "PipelineID"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "DeactivatePipelineResponseProto"
+          },
+          {
+            "name": "ClosePipelineRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "pipelineID",
+                "type": "PipelineID"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ClosePipelineResponseProto"
+          },
+          {
+            "name": "InSafeModeRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "InSafeModeResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "inSafeMode",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "ForceExitSafeModeRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ForceExitSafeModeResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "exitedSafeMode",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "StartReplicationManagerRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "StartReplicationManagerResponseProto"
+          },
+          {
+            "name": "StopReplicationManagerRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "StopReplicationManagerResponseProto"
+          },
+          {
+            "name": "ReplicationManagerStatusRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ReplicationManagerStatusResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "isRunning",
+                "type": "bool"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "StorageContainerLocationProtocolService",
+            "rpcs": [
+              {
+                "name": "submitRequest",
+                "in_type": "ScmContainerLocationRequest",
+                "out_type": "ScmContainerLocationResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "hdds.proto"
+          }
+        ],
+        "package": {
+          "name": "hadoop.hdds.container"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "org.apache.hadoop.hdds.protocol.proto"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "StorageContainerLocationProtocolProtos"
+          },
+          {
+            "name": "java_generic_services",
+            "value": "true"
+          },
+          {
+            "name": "java_generate_equals_and_hash",
+            "value": "true"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "hdds.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "PipelineState",
+            "enum_fields": [
+              {
+                "name": "PIPELINE_ALLOCATED",
+                "integer": 1
+              },
+              {
+                "name": "PIPELINE_OPEN",
+                "integer": 2
+              },
+              {
+                "name": "PIPELINE_DORMANT",
+                "integer": 3
+              },
+              {
+                "name": "PIPELINE_CLOSED",
+                "integer": 4
+              }
+            ]
+          },
+          {
+            "name": "NodeType",
+            "enum_fields": [
+              {
+                "name": "OM",
+                "integer": 1
+              },
+              {
+                "name": "SCM",
+                "integer": 2
+              },
+              {
+                "name": "DATANODE",
+                "integer": 3
+              },
+              {
+                "name": "RECON",
+                "integer": 4
+              }
+            ]
+          },
+          {
+            "name": "NodeState",
+            "enum_fields": [
+              {
+                "name": "HEALTHY",
+                "integer": 1
+              },
+              {
+                "name": "STALE",
+                "integer": 2
+              },
+              {
+                "name": "DEAD",
+                "integer": 3
+              },
+              {
+                "name": "DECOMMISSIONING",
+                "integer": 4
+              },
+              {
+                "name": "DECOMMISSIONED",
+                "integer": 5
+              }
+            ]
+          },
+          {
+            "name": "QueryScope",
+            "enum_fields": [
+              {
+                "name": "CLUSTER",
+                "integer": 1
+              },
+              {
+                "name": "POOL",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "LifeCycleState",
+            "enum_fields": [
+              {
+                "name": "OPEN",
+                "integer": 1
+              },
+              {
+                "name": "CLOSING",
+                "integer": 2
+              },
+              {
+                "name": "QUASI_CLOSED",
+                "integer": 3
+              },
+              {
+                "name": "CLOSED",
+                "integer": 4
+              },
+              {
+                "name": "DELETING",
+                "integer": 5
+              },
+              {
+                "name": "DELETED",
+                "integer": 6
+              }
+            ]
+          },
+          {
+            "name": "LifeCycleEvent",
+            "enum_fields": [
+              {
+                "name": "FINALIZE",
+                "integer": 1
+              },
+              {
+                "name": "QUASI_CLOSE",
+                "integer": 2
+              },
+              {
+                "name": "CLOSE",
+                "integer": 3
+              },
+              {
+                "name": "FORCE_CLOSE",
+                "integer": 4
+              },
+              {
+                "name": "DELETE",
+                "integer": 5
+              },
+              {
+                "name": "CLEANUP",
+                "integer": 6
+              }
+            ]
+          },
+          {
+            "name": "ReplicationType",
+            "enum_fields": [
+              {
+                "name": "RATIS",
+                "integer": 1
+              },
+              {
+                "name": "STAND_ALONE",
+                "integer": 2
+              },
+              {
+                "name": "CHAINED",
+                "integer": 3
+              }
+            ]
+          },
+          {
+            "name": "ReplicationFactor",
+            "enum_fields": [
+              {
+                "name": "ONE",
+                "integer": 1
+              },
+              {
+                "name": "THREE",
+                "integer": 3
+              }
+            ]
+          },
+          {
+            "name": "ScmOps",
+            "enum_fields": [
+              {
+                "name": "allocateBlock",
+                "integer": 1
+              },
+              {
+                "name": "keyBlocksInfoList",
+                "integer": 2
+              },
+              {
+                "name": "getScmInfo",
+                "integer": 3
+              },
+              {
+                "name": "deleteBlock",
+                "integer": 4
+              },
+              {
+                "name": "createReplicationPipeline",
+                "integer": 5
+              },
+              {
+                "name": "allocateContainer",
+                "integer": 6
+              },
+              {
+                "name": "getContainer",
+                "integer": 7
+              },
+              {
+                "name": "getContainerWithPipeline",
+                "integer": 8
+              },
+              {
+                "name": "listContainer",
+                "integer": 9
+              },
+              {
+                "name": "deleteContainer",
+                "integer": 10
+              },
+              {
+                "name": "queryNode",
+                "integer": 11
+              }
+            ]
+          },
+          {
+            "name": "BlockTokenSecretProto.AccessModeProto",
+            "enum_fields": [
+              {
+                "name": "READ",
+                "integer": 1
+              },
+              {
+                "name": "WRITE",
+                "integer": 2
+              },
+              {
+                "name": "COPY",
+                "integer": 3
+              },
+              {
+                "name": "DELETE",
+                "integer": 4
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "DatanodeDetailsProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "uuid",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "ipAddress",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "hostName",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "ports",
+                "type": "Port",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "certSerialId",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "networkName",
+                "type": "string"
+              },
+              {
+                "id": 7,
+                "name": "networkLocation",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "OzoneManagerDetailsProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "uuid",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "ipAddress",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "hostName",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "ports",
+                "type": "Port",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "Port",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "value",
+                "type": "uint32"
+              }
+            ]
+          },
+          {
+            "name": "PipelineID",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Pipeline",
+            "fields": [
+              {
+                "id": 1,
+                "name": "members",
+                "type": "DatanodeDetailsProto",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "state",
+                "type": "PipelineState",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "PIPELINE_ALLOCATED"
+                  }
+                ]
+              },
+              {
+                "id": 3,
+                "name": "type",
+                "type": "ReplicationType",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "STAND_ALONE"
+                  }
+                ]
+              },
+              {
+                "id": 4,
+                "name": "factor",
+                "type": "ReplicationFactor",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "ONE"
+                  }
+                ]
+              },
+              {
+                "id": 5,
+                "name": "id",
+                "type": "PipelineID"
+              },
+              {
+                "id": 6,
+                "name": "leaderID",
+                "type": "string"
+              },
+              {
+                "id": 7,
+                "name": "memberOrders",
+                "type": "uint32",
+                "is_repeated": true
+              },
+              {
+                "id": 8,
+                "name": "creationTimeStamp",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "KeyValue",
+            "fields": [
+              {
+                "id": 1,
+                "name": "key",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "value",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Node",
+            "fields": [
+              {
+                "id": 1,
+                "name": "nodeID",
+                "type": "DatanodeDetailsProto"
+              },
+              {
+                "id": 2,
+                "name": "nodeStates",
+                "type": "NodeState",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "NodePool",
+            "fields": [
+              {
+                "id": 1,
+                "name": "nodes",
+                "type": "Node",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ContainerInfoProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "state",
+                "type": "LifeCycleState"
+              },
+              {
+                "id": 3,
+                "name": "pipelineID",
+                "type": "PipelineID"
+              },
+              {
+                "id": 4,
+                "name": "usedBytes",
+                "type": "uint64"
+              },
+              {
+                "id": 5,
+                "name": "numberOfKeys",
+                "type": "uint64"
+              },
+              {
+                "id": 6,
+                "name": "stateEnterTime",
+                "type": "int64"
+              },
+              {
+                "id": 7,
+                "name": "owner",
+                "type": "string"
+              },
+              {
+                "id": 8,
+                "name": "deleteTransactionId",
+                "type": "int64"
+              },
+              {
+                "id": 9,
+                "name": "sequenceId",
+                "type": "int64"
+              },
+              {
+                "id": 10,
+                "name": "replicationFactor",
+                "type": "ReplicationFactor"
+              },
+              {
+                "id": 11,
+                "name": "replicationType",
+                "type": "ReplicationType"
+              }
+            ]
+          },
+          {
+            "name": "ContainerWithPipeline",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerInfo",
+                "type": "ContainerInfoProto"
+              },
+              {
+                "id": 2,
+                "name": "pipeline",
+                "type": "Pipeline"
+              }
+            ]
+          },
+          {
+            "name": "GetScmInfoRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetScmInfoResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "clusterId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "scmId",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ExcludeListProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "datanodes",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "containerIds",
+                "type": "int64",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "pipelineIds",
+                "type": "PipelineID",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ContainerBlockID",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "localID",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "BlockTokenSecretProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "ownerId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "blockId",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "expiryDate",
+                "type": "uint64"
+              },
+              {
+                "id": 4,
+                "name": "omCertSerialId",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "modes",
+                "type": "AccessModeProto",
+                "is_repeated": true
+              },
+              {
+                "id": 6,
+                "name": "maxLength",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "BlockID",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerBlockID",
+                "type": "ContainerBlockID"
+              },
+              {
+                "id": 2,
+                "name": "blockCommitSequenceId",
+                "type": "uint64",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "0"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "hadoop.hdds"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "org.apache.hadoop.hdds.protocol.proto"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "HddsProtos"
+          },
+          {
+            "name": "java_generic_services",
+            "value": "true"
+          },
+          {
+            "name": "java_generate_equals_and_hash",
+            "value": "true"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -115,6 +115,15 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>${basedir}/src/main/proto/proto.lock</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-maven-plugins</artifactId>
         <executions>

--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -101,6 +101,20 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <build>
     <plugins>
       <plugin>
+        <groupId>com.salesforce.servicelibs</groupId>
+        <artifactId>proto-backwards-compatibility</artifactId>
+        <configuration>
+          <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>backwards-compatibility-check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-maven-plugins</artifactId>
         <executions>

--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -115,15 +115,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>src/main/proto/proto.lock</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-maven-plugins</artifactId>
         <executions>

--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -119,7 +119,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
           <excludes>
-            <exclude>${basedir}/src/main/proto/proto.lock</exclude>
+            <exclude>src/main/proto/proto.lock</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -103,16 +103,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <plugin>
         <groupId>com.salesforce.servicelibs</groupId>
         <artifactId>proto-backwards-compatibility</artifactId>
-        <configuration>
-          <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>backwards-compatibility-check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.hadoop</groupId>

--- a/hadoop-hdds/container-service/src/main/proto/proto.lock
+++ b/hadoop-hdds/container-service/src/main/proto/proto.lock
@@ -1,0 +1,1070 @@
+{
+  "definitions": [
+    {
+      "protopath": "StorageContainerDatanodeProtocol.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "Type",
+            "enum_fields": [
+              {
+                "name": "GetVersion",
+                "integer": 1
+              },
+              {
+                "name": "Register",
+                "integer": 2
+              },
+              {
+                "name": "SendHeartbeat",
+                "integer": 3
+              }
+            ]
+          },
+          {
+            "name": "Status",
+            "enum_fields": [
+              {
+                "name": "OK",
+                "integer": 1
+              },
+              {
+                "name": "ERROR",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "SCMRegisteredResponseProto.ErrorCode",
+            "enum_fields": [
+              {
+                "name": "success",
+                "integer": 1
+              },
+              {
+                "name": "errorNodeNotPermitted",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "StorageTypeProto",
+            "enum_fields": [
+              {
+                "name": "DISK",
+                "integer": 1
+              },
+              {
+                "name": "SSD",
+                "integer": 2
+              },
+              {
+                "name": "ARCHIVE",
+                "integer": 3
+              },
+              {
+                "name": "RAM_DISK",
+                "integer": 4
+              },
+              {
+                "name": "PROVIDED",
+                "integer": 5
+              }
+            ]
+          },
+          {
+            "name": "ContainerReplicaProto.State",
+            "enum_fields": [
+              {
+                "name": "OPEN",
+                "integer": 1
+              },
+              {
+                "name": "CLOSING",
+                "integer": 2
+              },
+              {
+                "name": "QUASI_CLOSED",
+                "integer": 3
+              },
+              {
+                "name": "CLOSED",
+                "integer": 4
+              },
+              {
+                "name": "UNHEALTHY",
+                "integer": 5
+              },
+              {
+                "name": "INVALID",
+                "integer": 6
+              }
+            ]
+          },
+          {
+            "name": "CommandStatus.Status",
+            "enum_fields": [
+              {
+                "name": "PENDING",
+                "integer": 1
+              },
+              {
+                "name": "EXECUTED",
+                "integer": 2
+              },
+              {
+                "name": "FAILED",
+                "integer": 3
+              }
+            ]
+          },
+          {
+            "name": "ContainerAction.Action",
+            "enum_fields": [
+              {
+                "name": "CLOSE",
+                "integer": 1
+              }
+            ]
+          },
+          {
+            "name": "ContainerAction.Reason",
+            "enum_fields": [
+              {
+                "name": "CONTAINER_FULL",
+                "integer": 1
+              },
+              {
+                "name": "CONTAINER_UNHEALTHY",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "ClosePipelineInfo.Reason",
+            "enum_fields": [
+              {
+                "name": "PIPELINE_FAILED",
+                "integer": 1
+              },
+              {
+                "name": "PIPELINE_LOG_FAILED",
+                "integer": 2
+              },
+              {
+                "name": "STATEMACHINE_TRANSACTION_FAILED",
+                "integer": 3
+              }
+            ]
+          },
+          {
+            "name": "PipelineAction.Action",
+            "enum_fields": [
+              {
+                "name": "CLOSE",
+                "integer": 1
+              }
+            ]
+          },
+          {
+            "name": "SCMCommandProto.Type",
+            "enum_fields": [
+              {
+                "name": "reregisterCommand",
+                "integer": 1
+              },
+              {
+                "name": "deleteBlocksCommand",
+                "integer": 2
+              },
+              {
+                "name": "closeContainerCommand",
+                "integer": 3
+              },
+              {
+                "name": "deleteContainerCommand",
+                "integer": 4
+              },
+              {
+                "name": "replicateContainerCommand",
+                "integer": 5
+              },
+              {
+                "name": "createPipelineCommand",
+                "integer": 6
+              },
+              {
+                "name": "closePipelineCommand",
+                "integer": 7
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "SCMDatanodeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cmdType",
+                "type": "Type"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "getVersionRequest",
+                "type": "SCMVersionRequestProto"
+              },
+              {
+                "id": 4,
+                "name": "registerRequest",
+                "type": "SCMRegisterRequestProto"
+              },
+              {
+                "id": 5,
+                "name": "sendHeartbeatRequest",
+                "type": "SCMHeartbeatRequestProto"
+              }
+            ]
+          },
+          {
+            "name": "SCMDatanodeResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cmdType",
+                "type": "Type"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "success",
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "true"
+                  }
+                ]
+              },
+              {
+                "id": 4,
+                "name": "message",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "status",
+                "type": "Status"
+              },
+              {
+                "id": 6,
+                "name": "getVersionResponse",
+                "type": "SCMVersionResponseProto"
+              },
+              {
+                "id": 7,
+                "name": "registerResponse",
+                "type": "SCMRegisteredResponseProto"
+              },
+              {
+                "id": 8,
+                "name": "sendHeartbeatResponse",
+                "type": "SCMHeartbeatResponseProto"
+              }
+            ]
+          },
+          {
+            "name": "SCMVersionRequestProto"
+          },
+          {
+            "name": "SCMVersionResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "softwareVersion",
+                "type": "uint32"
+              },
+              {
+                "id": 2,
+                "name": "keys",
+                "type": "hadoop.hdds.KeyValue",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "SCMRegisterRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "datanodeDetails",
+                "type": "DatanodeDetailsProto"
+              },
+              {
+                "id": 2,
+                "name": "nodeReport",
+                "type": "NodeReportProto"
+              },
+              {
+                "id": 3,
+                "name": "containerReport",
+                "type": "ContainerReportsProto"
+              },
+              {
+                "id": 4,
+                "name": "pipelineReports",
+                "type": "PipelineReportsProto"
+              }
+            ]
+          },
+          {
+            "name": "SCMRegisteredResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "errorCode",
+                "type": "ErrorCode"
+              },
+              {
+                "id": 2,
+                "name": "datanodeUUID",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "clusterID",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "addressList",
+                "type": "SCMNodeAddressList"
+              },
+              {
+                "id": 5,
+                "name": "hostname",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "ipAddress",
+                "type": "string"
+              },
+              {
+                "id": 7,
+                "name": "networkName",
+                "type": "string"
+              },
+              {
+                "id": 8,
+                "name": "networkLocation",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "SCMHeartbeatRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "datanodeDetails",
+                "type": "DatanodeDetailsProto"
+              },
+              {
+                "id": 2,
+                "name": "nodeReport",
+                "type": "NodeReportProto"
+              },
+              {
+                "id": 3,
+                "name": "containerReport",
+                "type": "ContainerReportsProto"
+              },
+              {
+                "id": 4,
+                "name": "incrementalContainerReport",
+                "type": "IncrementalContainerReportProto",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "commandStatusReports",
+                "type": "CommandStatusReportsProto",
+                "is_repeated": true
+              },
+              {
+                "id": 6,
+                "name": "containerActions",
+                "type": "ContainerActionsProto"
+              },
+              {
+                "id": 7,
+                "name": "pipelineActions",
+                "type": "PipelineActionsProto"
+              },
+              {
+                "id": 8,
+                "name": "pipelineReports",
+                "type": "PipelineReportsProto"
+              }
+            ]
+          },
+          {
+            "name": "SCMHeartbeatResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "datanodeUUID",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "commands",
+                "type": "SCMCommandProto",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "SCMNodeAddressList",
+            "fields": [
+              {
+                "id": 1,
+                "name": "addressList",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "NodeReportProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "storageReport",
+                "type": "StorageReportProto",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "StorageReportProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "storageUuid",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "storageLocation",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "capacity",
+                "type": "uint64",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "0"
+                  }
+                ]
+              },
+              {
+                "id": 4,
+                "name": "scmUsed",
+                "type": "uint64",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "0"
+                  }
+                ]
+              },
+              {
+                "id": 5,
+                "name": "remaining",
+                "type": "uint64",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "0"
+                  }
+                ]
+              },
+              {
+                "id": 6,
+                "name": "storageType",
+                "type": "StorageTypeProto",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "DISK"
+                  }
+                ]
+              },
+              {
+                "id": 7,
+                "name": "failed",
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "false"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "ContainerReportsProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "reports",
+                "type": "ContainerReplicaProto",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "IncrementalContainerReportProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "report",
+                "type": "ContainerReplicaProto",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ContainerReplicaProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "state",
+                "type": "State"
+              },
+              {
+                "id": 3,
+                "name": "size",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "used",
+                "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "keyCount",
+                "type": "int64"
+              },
+              {
+                "id": 6,
+                "name": "readCount",
+                "type": "int64"
+              },
+              {
+                "id": 7,
+                "name": "writeCount",
+                "type": "int64"
+              },
+              {
+                "id": 8,
+                "name": "readBytes",
+                "type": "int64"
+              },
+              {
+                "id": 9,
+                "name": "writeBytes",
+                "type": "int64"
+              },
+              {
+                "id": 10,
+                "name": "finalhash",
+                "type": "string"
+              },
+              {
+                "id": 11,
+                "name": "deleteTransactionId",
+                "type": "int64"
+              },
+              {
+                "id": 12,
+                "name": "blockCommitSequenceId",
+                "type": "uint64"
+              },
+              {
+                "id": 13,
+                "name": "originNodeId",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "CommandStatusReportsProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cmdStatus",
+                "type": "CommandStatus",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "CommandStatus",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cmdId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "status",
+                "type": "Status",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "PENDING"
+                  }
+                ]
+              },
+              {
+                "id": 3,
+                "name": "type",
+                "type": "SCMCommandProto.Type"
+              },
+              {
+                "id": 4,
+                "name": "msg",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "blockDeletionAck",
+                "type": "ContainerBlocksDeletionACKProto"
+              }
+            ]
+          },
+          {
+            "name": "ContainerActionsProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerActions",
+                "type": "ContainerAction",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ContainerAction",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "action",
+                "type": "Action"
+              },
+              {
+                "id": 3,
+                "name": "reason",
+                "type": "Reason"
+              }
+            ]
+          },
+          {
+            "name": "PipelineReport",
+            "fields": [
+              {
+                "id": 1,
+                "name": "pipelineID",
+                "type": "PipelineID"
+              },
+              {
+                "id": 2,
+                "name": "isLeader",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "bytesWritten",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "PipelineReportsProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "pipelineReport",
+                "type": "PipelineReport",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "PipelineActionsProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "pipelineActions",
+                "type": "PipelineAction",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ClosePipelineInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "pipelineID",
+                "type": "PipelineID"
+              },
+              {
+                "id": 3,
+                "name": "reason",
+                "type": "Reason"
+              },
+              {
+                "id": 4,
+                "name": "detailedReason",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "PipelineAction",
+            "fields": [
+              {
+                "id": 1,
+                "name": "action",
+                "type": "Action"
+              },
+              {
+                "id": 2,
+                "name": "closePipeline",
+                "type": "ClosePipelineInfo"
+              }
+            ]
+          },
+          {
+            "name": "SCMCommandProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "commandType",
+                "type": "Type"
+              },
+              {
+                "id": 2,
+                "name": "reregisterCommandProto",
+                "type": "ReregisterCommandProto"
+              },
+              {
+                "id": 3,
+                "name": "deleteBlocksCommandProto",
+                "type": "DeleteBlocksCommandProto"
+              },
+              {
+                "id": 4,
+                "name": "closeContainerCommandProto",
+                "type": "CloseContainerCommandProto"
+              },
+              {
+                "id": 5,
+                "name": "deleteContainerCommandProto",
+                "type": "DeleteContainerCommandProto"
+              },
+              {
+                "id": 6,
+                "name": "replicateContainerCommandProto",
+                "type": "ReplicateContainerCommandProto"
+              },
+              {
+                "id": 7,
+                "name": "createPipelineCommandProto",
+                "type": "CreatePipelineCommandProto"
+              },
+              {
+                "id": 8,
+                "name": "closePipelineCommandProto",
+                "type": "ClosePipelineCommandProto"
+              }
+            ]
+          },
+          {
+            "name": "ReregisterCommandProto"
+          },
+          {
+            "name": "DeleteBlocksCommandProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "deletedBlocksTransactions",
+                "type": "DeletedBlocksTransaction",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "cmdId",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "DeletedBlocksTransaction",
+            "fields": [
+              {
+                "id": 1,
+                "name": "txID",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "containerID",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "localID",
+                "type": "int64",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "count",
+                "type": "int32"
+              }
+            ]
+          },
+          {
+            "name": "ContainerBlocksDeletionACKProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "results",
+                "type": "DeleteBlockTransactionResult",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "dnId",
+                "type": "string"
+              }
+            ],
+            "messages": [
+              {
+                "name": "DeleteBlockTransactionResult",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "txID",
+                    "type": "int64"
+                  },
+                  {
+                    "id": 2,
+                    "name": "containerID",
+                    "type": "int64"
+                  },
+                  {
+                    "id": 3,
+                    "name": "success",
+                    "type": "bool"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "CloseContainerCommandProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "pipelineID",
+                "type": "PipelineID"
+              },
+              {
+                "id": 3,
+                "name": "cmdId",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "force",
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "false"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "DeleteContainerCommandProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "cmdId",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "force",
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "false"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "ReplicateContainerCommandProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "sources",
+                "type": "DatanodeDetailsProto",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "cmdId",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "CreatePipelineCommandProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "pipelineID",
+                "type": "PipelineID"
+              },
+              {
+                "id": 2,
+                "name": "type",
+                "type": "ReplicationType"
+              },
+              {
+                "id": 3,
+                "name": "factor",
+                "type": "ReplicationFactor"
+              },
+              {
+                "id": 4,
+                "name": "datanode",
+                "type": "DatanodeDetailsProto",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "cmdId",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "ClosePipelineCommandProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "pipelineID",
+                "type": "PipelineID"
+              },
+              {
+                "id": 2,
+                "name": "cmdId",
+                "type": "int64"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "StorageContainerDatanodeProtocolService",
+            "rpcs": [
+              {
+                "name": "submitRequest",
+                "in_type": "SCMDatanodeRequest",
+                "out_type": "SCMDatanodeResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "hdds.proto"
+          }
+        ],
+        "package": {
+          "name": "hadoop.hdds"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "org.apache.hadoop.hdds.protocol.proto"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "StorageContainerDatanodeProtocolProtos"
+          },
+          {
+            "name": "java_generic_services",
+            "value": "true"
+          },
+          {
+            "name": "java_generate_equals_and_hash",
+            "value": "true"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -248,6 +248,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
             <exclude>src/test/resources/incorrect.checksum.container</exclude>
             <exclude>src/test/resources/incorrect.container</exclude>
             <exclude>src/test/resources/test.db.ini</exclude>
+            <exclude>src/main/proto/proto.lock</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -86,16 +86,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <plugin>
         <groupId>com.salesforce.servicelibs</groupId>
         <artifactId>proto-backwards-compatibility</artifactId>
-        <configuration>
-          <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>backwards-compatibility-check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.hadoop</groupId>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -98,6 +98,15 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>${basedir}/src/main/proto/proto.lock</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-maven-plugins</artifactId>
         <executions>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -84,6 +84,20 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </resources>
     <plugins>
       <plugin>
+        <groupId>com.salesforce.servicelibs</groupId>
+        <artifactId>proto-backwards-compatibility</artifactId>
+        <configuration>
+          <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>backwards-compatibility-check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-maven-plugins</artifactId>
         <executions>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -98,15 +98,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>src/main/proto/proto.lock</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-maven-plugins</artifactId>
         <executions>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -102,7 +102,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
           <excludes>
-            <exclude>${basedir}/src/main/proto/proto.lock</exclude>
+            <exclude>src/main/proto/proto.lock</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/hadoop-ozone/common/src/main/proto/proto.lock
+++ b/hadoop-ozone/common/src/main/proto/proto.lock
@@ -1,0 +1,3240 @@
+{
+  "definitions": [
+    {
+      "protopath": "OzoneManagerProtocol.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "Type",
+            "enum_fields": [
+              {
+                "name": "CreateVolume",
+                "integer": 11
+              },
+              {
+                "name": "SetVolumeProperty",
+                "integer": 12
+              },
+              {
+                "name": "CheckVolumeAccess",
+                "integer": 13
+              },
+              {
+                "name": "InfoVolume",
+                "integer": 14
+              },
+              {
+                "name": "DeleteVolume",
+                "integer": 15
+              },
+              {
+                "name": "ListVolume",
+                "integer": 16
+              },
+              {
+                "name": "CreateBucket",
+                "integer": 21
+              },
+              {
+                "name": "InfoBucket",
+                "integer": 22
+              },
+              {
+                "name": "SetBucketProperty",
+                "integer": 23
+              },
+              {
+                "name": "DeleteBucket",
+                "integer": 24
+              },
+              {
+                "name": "ListBuckets",
+                "integer": 25
+              },
+              {
+                "name": "CreateKey",
+                "integer": 31
+              },
+              {
+                "name": "LookupKey",
+                "integer": 32
+              },
+              {
+                "name": "RenameKey",
+                "integer": 33
+              },
+              {
+                "name": "DeleteKey",
+                "integer": 34
+              },
+              {
+                "name": "ListKeys",
+                "integer": 35
+              },
+              {
+                "name": "CommitKey",
+                "integer": 36
+              },
+              {
+                "name": "AllocateBlock",
+                "integer": 37
+              },
+              {
+                "name": "InitiateMultiPartUpload",
+                "integer": 45
+              },
+              {
+                "name": "CommitMultiPartUpload",
+                "integer": 46
+              },
+              {
+                "name": "CompleteMultiPartUpload",
+                "integer": 47
+              },
+              {
+                "name": "AbortMultiPartUpload",
+                "integer": 48
+              },
+              {
+                "name": "GetS3Secret",
+                "integer": 49
+              },
+              {
+                "name": "ListMultiPartUploadParts",
+                "integer": 50
+              },
+              {
+                "name": "ServiceList",
+                "integer": 51
+              },
+              {
+                "name": "DBUpdates",
+                "integer": 53
+              },
+              {
+                "name": "GetDelegationToken",
+                "integer": 61
+              },
+              {
+                "name": "RenewDelegationToken",
+                "integer": 62
+              },
+              {
+                "name": "CancelDelegationToken",
+                "integer": 63
+              },
+              {
+                "name": "GetFileStatus",
+                "integer": 70
+              },
+              {
+                "name": "CreateDirectory",
+                "integer": 71
+              },
+              {
+                "name": "CreateFile",
+                "integer": 72
+              },
+              {
+                "name": "LookupFile",
+                "integer": 73
+              },
+              {
+                "name": "ListStatus",
+                "integer": 74
+              },
+              {
+                "name": "AddAcl",
+                "integer": 75
+              },
+              {
+                "name": "RemoveAcl",
+                "integer": 76
+              },
+              {
+                "name": "SetAcl",
+                "integer": 77
+              },
+              {
+                "name": "GetAcl",
+                "integer": 78
+              },
+              {
+                "name": "PurgeKeys",
+                "integer": 81
+              },
+              {
+                "name": "ListMultipartUploads",
+                "integer": 82
+              },
+              {
+                "name": "ListTrash",
+                "integer": 91
+              },
+              {
+                "name": "RecoverTrash",
+                "integer": 92
+              }
+            ]
+          },
+          {
+            "name": "Status",
+            "enum_fields": [
+              {
+                "name": "OK",
+                "integer": 1
+              },
+              {
+                "name": "VOLUME_NOT_UNIQUE",
+                "integer": 2
+              },
+              {
+                "name": "VOLUME_NOT_FOUND",
+                "integer": 3
+              },
+              {
+                "name": "VOLUME_NOT_EMPTY",
+                "integer": 4
+              },
+              {
+                "name": "VOLUME_ALREADY_EXISTS",
+                "integer": 5
+              },
+              {
+                "name": "USER_NOT_FOUND",
+                "integer": 6
+              },
+              {
+                "name": "USER_TOO_MANY_VOLUMES",
+                "integer": 7
+              },
+              {
+                "name": "BUCKET_NOT_FOUND",
+                "integer": 8
+              },
+              {
+                "name": "BUCKET_NOT_EMPTY",
+                "integer": 9
+              },
+              {
+                "name": "BUCKET_ALREADY_EXISTS",
+                "integer": 10
+              },
+              {
+                "name": "KEY_ALREADY_EXISTS",
+                "integer": 11
+              },
+              {
+                "name": "KEY_NOT_FOUND",
+                "integer": 12
+              },
+              {
+                "name": "INVALID_KEY_NAME",
+                "integer": 13
+              },
+              {
+                "name": "ACCESS_DENIED",
+                "integer": 14
+              },
+              {
+                "name": "INTERNAL_ERROR",
+                "integer": 15
+              },
+              {
+                "name": "KEY_ALLOCATION_ERROR",
+                "integer": 16
+              },
+              {
+                "name": "KEY_DELETION_ERROR",
+                "integer": 17
+              },
+              {
+                "name": "KEY_RENAME_ERROR",
+                "integer": 18
+              },
+              {
+                "name": "METADATA_ERROR",
+                "integer": 19
+              },
+              {
+                "name": "OM_NOT_INITIALIZED",
+                "integer": 20
+              },
+              {
+                "name": "SCM_VERSION_MISMATCH_ERROR",
+                "integer": 21
+              },
+              {
+                "name": "INITIATE_MULTIPART_UPLOAD_ERROR",
+                "integer": 24
+              },
+              {
+                "name": "MULTIPART_UPLOAD_PARTFILE_ERROR",
+                "integer": 25
+              },
+              {
+                "name": "NO_SUCH_MULTIPART_UPLOAD_ERROR",
+                "integer": 26
+              },
+              {
+                "name": "MISMATCH_MULTIPART_LIST",
+                "integer": 27
+              },
+              {
+                "name": "MISSING_UPLOAD_PARTS",
+                "integer": 28
+              },
+              {
+                "name": "COMPLETE_MULTIPART_UPLOAD_ERROR",
+                "integer": 29
+              },
+              {
+                "name": "ENTITY_TOO_SMALL",
+                "integer": 30
+              },
+              {
+                "name": "ABORT_MULTIPART_UPLOAD_FAILED",
+                "integer": 31
+              },
+              {
+                "name": "S3_SECRET_NOT_FOUND",
+                "integer": 32
+              },
+              {
+                "name": "INVALID_AUTH_METHOD",
+                "integer": 33
+              },
+              {
+                "name": "INVALID_TOKEN",
+                "integer": 34
+              },
+              {
+                "name": "TOKEN_EXPIRED",
+                "integer": 35
+              },
+              {
+                "name": "TOKEN_ERROR_OTHER",
+                "integer": 36
+              },
+              {
+                "name": "LIST_MULTIPART_UPLOAD_PARTS_FAILED",
+                "integer": 37
+              },
+              {
+                "name": "SCM_IN_SAFE_MODE",
+                "integer": 38
+              },
+              {
+                "name": "INVALID_REQUEST",
+                "integer": 39
+              },
+              {
+                "name": "BUCKET_ENCRYPTION_KEY_NOT_FOUND",
+                "integer": 40
+              },
+              {
+                "name": "UNKNOWN_CIPHER_SUITE",
+                "integer": 41
+              },
+              {
+                "name": "INVALID_KMS_PROVIDER",
+                "integer": 42
+              },
+              {
+                "name": "TOKEN_CREATION_ERROR",
+                "integer": 43
+              },
+              {
+                "name": "FILE_NOT_FOUND",
+                "integer": 44
+              },
+              {
+                "name": "DIRECTORY_NOT_FOUND",
+                "integer": 45
+              },
+              {
+                "name": "FILE_ALREADY_EXISTS",
+                "integer": 46
+              },
+              {
+                "name": "NOT_A_FILE",
+                "integer": 47
+              },
+              {
+                "name": "PERMISSION_DENIED",
+                "integer": 48
+              },
+              {
+                "name": "TIMEOUT",
+                "integer": 49
+              },
+              {
+                "name": "PREFIX_NOT_FOUND",
+                "integer": 50
+              },
+              {
+                "name": "RATIS_ERROR",
+                "integer": 52
+              },
+              {
+                "name": "INVALID_PATH_IN_ACL_REQUEST",
+                "integer": 53
+              },
+              {
+                "name": "USER_MISMATCH",
+                "integer": 54
+              },
+              {
+                "name": "INVALID_PART",
+                "integer": 55
+              },
+              {
+                "name": "INVALID_PART_ORDER",
+                "integer": 56
+              },
+              {
+                "name": "SCM_GET_PIPELINE_EXCEPTION",
+                "integer": 57
+              },
+              {
+                "name": "INVALID_BUCKET_NAME",
+                "integer": 58
+              },
+              {
+                "name": "CANNOT_CREATE_DIRECTORY_AT_ROOT",
+                "integer": 59
+              },
+              {
+                "name": "DIRECTORY_ALREADY_EXISTS",
+                "integer": 60
+              },
+              {
+                "name": "INVALID_VOLUME_NAME",
+                "integer": 61
+              },
+              {
+                "name": "REPLAY",
+                "integer": 100
+              }
+            ]
+          },
+          {
+            "name": "ListVolumeRequest.Scope",
+            "enum_fields": [
+              {
+                "name": "USER_VOLUMES",
+                "integer": 1
+              },
+              {
+                "name": "VOLUMES_BY_USER",
+                "integer": 2
+              },
+              {
+                "name": "VOLUMES_BY_CLUSTER",
+                "integer": 3
+              }
+            ]
+          },
+          {
+            "name": "StorageTypeProto",
+            "enum_fields": [
+              {
+                "name": "DISK",
+                "integer": 1
+              },
+              {
+                "name": "SSD",
+                "integer": 2
+              },
+              {
+                "name": "ARCHIVE",
+                "integer": 3
+              },
+              {
+                "name": "RAM_DISK",
+                "integer": 4
+              }
+            ]
+          },
+          {
+            "name": "CipherSuiteProto",
+            "enum_fields": [
+              {
+                "name": "UNKNOWN",
+                "integer": 1
+              },
+              {
+                "name": "AES_CTR_NOPADDING",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "CryptoProtocolVersionProto",
+            "enum_fields": [
+              {
+                "name": "UNKNOWN_PROTOCOL_VERSION",
+                "integer": 1
+              },
+              {
+                "name": "ENCRYPTION_ZONES",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "OzoneObj.ObjectType",
+            "enum_fields": [
+              {
+                "name": "VOLUME",
+                "integer": 1
+              },
+              {
+                "name": "BUCKET",
+                "integer": 2
+              },
+              {
+                "name": "KEY",
+                "integer": 3
+              },
+              {
+                "name": "PREFIX",
+                "integer": 4
+              }
+            ]
+          },
+          {
+            "name": "OzoneObj.StoreType",
+            "enum_fields": [
+              {
+                "name": "OZONE",
+                "integer": 1
+              },
+              {
+                "name": "S3",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "OzoneAclInfo.OzoneAclType",
+            "enum_fields": [
+              {
+                "name": "USER",
+                "integer": 1
+              },
+              {
+                "name": "GROUP",
+                "integer": 2
+              },
+              {
+                "name": "WORLD",
+                "integer": 3
+              },
+              {
+                "name": "ANONYMOUS",
+                "integer": 4
+              },
+              {
+                "name": "CLIENT_IP",
+                "integer": 5
+              }
+            ]
+          },
+          {
+            "name": "OzoneAclInfo.OzoneAclScope",
+            "enum_fields": [
+              {
+                "name": "ACCESS"
+              },
+              {
+                "name": "DEFAULT",
+                "integer": 1
+              }
+            ]
+          },
+          {
+            "name": "OMTokenProto.Type",
+            "enum_fields": [
+              {
+                "name": "DELEGATION_TOKEN",
+                "integer": 1
+              },
+              {
+                "name": "S3AUTHINFO",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "ServicePort.Type",
+            "enum_fields": [
+              {
+                "name": "RPC",
+                "integer": 1
+              },
+              {
+                "name": "HTTP",
+                "integer": 2
+              },
+              {
+                "name": "HTTPS",
+                "integer": 3
+              },
+              {
+                "name": "RATIS",
+                "integer": 4
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "OMRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cmdType",
+                "type": "Type"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "clientId",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "userInfo",
+                "type": "UserInfo"
+              },
+              {
+                "id": 11,
+                "name": "createVolumeRequest",
+                "type": "CreateVolumeRequest"
+              },
+              {
+                "id": 12,
+                "name": "setVolumePropertyRequest",
+                "type": "SetVolumePropertyRequest"
+              },
+              {
+                "id": 13,
+                "name": "checkVolumeAccessRequest",
+                "type": "CheckVolumeAccessRequest"
+              },
+              {
+                "id": 14,
+                "name": "infoVolumeRequest",
+                "type": "InfoVolumeRequest"
+              },
+              {
+                "id": 15,
+                "name": "deleteVolumeRequest",
+                "type": "DeleteVolumeRequest"
+              },
+              {
+                "id": 16,
+                "name": "listVolumeRequest",
+                "type": "ListVolumeRequest"
+              },
+              {
+                "id": 21,
+                "name": "createBucketRequest",
+                "type": "CreateBucketRequest"
+              },
+              {
+                "id": 22,
+                "name": "infoBucketRequest",
+                "type": "InfoBucketRequest"
+              },
+              {
+                "id": 23,
+                "name": "setBucketPropertyRequest",
+                "type": "SetBucketPropertyRequest"
+              },
+              {
+                "id": 24,
+                "name": "deleteBucketRequest",
+                "type": "DeleteBucketRequest"
+              },
+              {
+                "id": 25,
+                "name": "listBucketsRequest",
+                "type": "ListBucketsRequest"
+              },
+              {
+                "id": 31,
+                "name": "createKeyRequest",
+                "type": "CreateKeyRequest"
+              },
+              {
+                "id": 32,
+                "name": "lookupKeyRequest",
+                "type": "LookupKeyRequest"
+              },
+              {
+                "id": 33,
+                "name": "renameKeyRequest",
+                "type": "RenameKeyRequest"
+              },
+              {
+                "id": 34,
+                "name": "deleteKeyRequest",
+                "type": "DeleteKeyRequest"
+              },
+              {
+                "id": 35,
+                "name": "listKeysRequest",
+                "type": "ListKeysRequest"
+              },
+              {
+                "id": 36,
+                "name": "commitKeyRequest",
+                "type": "CommitKeyRequest"
+              },
+              {
+                "id": 37,
+                "name": "allocateBlockRequest",
+                "type": "AllocateBlockRequest"
+              },
+              {
+                "id": 45,
+                "name": "initiateMultiPartUploadRequest",
+                "type": "MultipartInfoInitiateRequest"
+              },
+              {
+                "id": 46,
+                "name": "commitMultiPartUploadRequest",
+                "type": "MultipartCommitUploadPartRequest"
+              },
+              {
+                "id": 47,
+                "name": "completeMultiPartUploadRequest",
+                "type": "MultipartUploadCompleteRequest"
+              },
+              {
+                "id": 48,
+                "name": "abortMultiPartUploadRequest",
+                "type": "MultipartUploadAbortRequest"
+              },
+              {
+                "id": 49,
+                "name": "getS3SecretRequest",
+                "type": "GetS3SecretRequest"
+              },
+              {
+                "id": 50,
+                "name": "listMultipartUploadPartsRequest",
+                "type": "MultipartUploadListPartsRequest"
+              },
+              {
+                "id": 51,
+                "name": "serviceListRequest",
+                "type": "ServiceListRequest"
+              },
+              {
+                "id": 53,
+                "name": "dbUpdatesRequest",
+                "type": "DBUpdatesRequest"
+              },
+              {
+                "id": 61,
+                "name": "getDelegationTokenRequest",
+                "type": "hadoop.common.GetDelegationTokenRequestProto"
+              },
+              {
+                "id": 62,
+                "name": "renewDelegationTokenRequest",
+                "type": "hadoop.common.RenewDelegationTokenRequestProto"
+              },
+              {
+                "id": 63,
+                "name": "cancelDelegationTokenRequest",
+                "type": "hadoop.common.CancelDelegationTokenRequestProto"
+              },
+              {
+                "id": 64,
+                "name": "updateGetDelegationTokenRequest",
+                "type": "UpdateGetDelegationTokenRequest"
+              },
+              {
+                "id": 65,
+                "name": "updatedRenewDelegationTokenRequest",
+                "type": "UpdateRenewDelegationTokenRequest"
+              },
+              {
+                "id": 70,
+                "name": "getFileStatusRequest",
+                "type": "GetFileStatusRequest"
+              },
+              {
+                "id": 71,
+                "name": "createDirectoryRequest",
+                "type": "CreateDirectoryRequest"
+              },
+              {
+                "id": 72,
+                "name": "createFileRequest",
+                "type": "CreateFileRequest"
+              },
+              {
+                "id": 73,
+                "name": "lookupFileRequest",
+                "type": "LookupFileRequest"
+              },
+              {
+                "id": 74,
+                "name": "listStatusRequest",
+                "type": "ListStatusRequest"
+              },
+              {
+                "id": 75,
+                "name": "addAclRequest",
+                "type": "AddAclRequest"
+              },
+              {
+                "id": 76,
+                "name": "removeAclRequest",
+                "type": "RemoveAclRequest"
+              },
+              {
+                "id": 77,
+                "name": "setAclRequest",
+                "type": "SetAclRequest"
+              },
+              {
+                "id": 78,
+                "name": "getAclRequest",
+                "type": "GetAclRequest"
+              },
+              {
+                "id": 81,
+                "name": "purgeKeysRequest",
+                "type": "PurgeKeysRequest"
+              },
+              {
+                "id": 82,
+                "name": "updateGetS3SecretRequest",
+                "type": "UpdateGetS3SecretRequest"
+              },
+              {
+                "id": 83,
+                "name": "listMultipartUploadsRequest",
+                "type": "ListMultipartUploadsRequest"
+              },
+              {
+                "id": 91,
+                "name": "listTrashRequest",
+                "type": "ListTrashRequest"
+              },
+              {
+                "id": 92,
+                "name": "RecoverTrashRequest",
+                "type": "RecoverTrashRequest"
+              }
+            ]
+          },
+          {
+            "name": "OMResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cmdType",
+                "type": "Type"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "success",
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "true"
+                  }
+                ]
+              },
+              {
+                "id": 4,
+                "name": "message",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "status",
+                "type": "Status"
+              },
+              {
+                "id": 6,
+                "name": "leaderOMNodeId",
+                "type": "string"
+              },
+              {
+                "id": 11,
+                "name": "createVolumeResponse",
+                "type": "CreateVolumeResponse"
+              },
+              {
+                "id": 12,
+                "name": "setVolumePropertyResponse",
+                "type": "SetVolumePropertyResponse"
+              },
+              {
+                "id": 13,
+                "name": "checkVolumeAccessResponse",
+                "type": "CheckVolumeAccessResponse"
+              },
+              {
+                "id": 14,
+                "name": "infoVolumeResponse",
+                "type": "InfoVolumeResponse"
+              },
+              {
+                "id": 15,
+                "name": "deleteVolumeResponse",
+                "type": "DeleteVolumeResponse"
+              },
+              {
+                "id": 16,
+                "name": "listVolumeResponse",
+                "type": "ListVolumeResponse"
+              },
+              {
+                "id": 21,
+                "name": "createBucketResponse",
+                "type": "CreateBucketResponse"
+              },
+              {
+                "id": 22,
+                "name": "infoBucketResponse",
+                "type": "InfoBucketResponse"
+              },
+              {
+                "id": 23,
+                "name": "setBucketPropertyResponse",
+                "type": "SetBucketPropertyResponse"
+              },
+              {
+                "id": 24,
+                "name": "deleteBucketResponse",
+                "type": "DeleteBucketResponse"
+              },
+              {
+                "id": 25,
+                "name": "listBucketsResponse",
+                "type": "ListBucketsResponse"
+              },
+              {
+                "id": 31,
+                "name": "createKeyResponse",
+                "type": "CreateKeyResponse"
+              },
+              {
+                "id": 32,
+                "name": "lookupKeyResponse",
+                "type": "LookupKeyResponse"
+              },
+              {
+                "id": 33,
+                "name": "renameKeyResponse",
+                "type": "RenameKeyResponse"
+              },
+              {
+                "id": 34,
+                "name": "deleteKeyResponse",
+                "type": "DeleteKeyResponse"
+              },
+              {
+                "id": 35,
+                "name": "listKeysResponse",
+                "type": "ListKeysResponse"
+              },
+              {
+                "id": 36,
+                "name": "commitKeyResponse",
+                "type": "CommitKeyResponse"
+              },
+              {
+                "id": 37,
+                "name": "allocateBlockResponse",
+                "type": "AllocateBlockResponse"
+              },
+              {
+                "id": 45,
+                "name": "initiateMultiPartUploadResponse",
+                "type": "MultipartInfoInitiateResponse"
+              },
+              {
+                "id": 46,
+                "name": "commitMultiPartUploadResponse",
+                "type": "MultipartCommitUploadPartResponse"
+              },
+              {
+                "id": 47,
+                "name": "completeMultiPartUploadResponse",
+                "type": "MultipartUploadCompleteResponse"
+              },
+              {
+                "id": 48,
+                "name": "abortMultiPartUploadResponse",
+                "type": "MultipartUploadAbortResponse"
+              },
+              {
+                "id": 49,
+                "name": "getS3SecretResponse",
+                "type": "GetS3SecretResponse"
+              },
+              {
+                "id": 50,
+                "name": "listMultipartUploadPartsResponse",
+                "type": "MultipartUploadListPartsResponse"
+              },
+              {
+                "id": 51,
+                "name": "ServiceListResponse",
+                "type": "ServiceListResponse"
+              },
+              {
+                "id": 52,
+                "name": "dbUpdatesResponse",
+                "type": "DBUpdatesResponse"
+              },
+              {
+                "id": 61,
+                "name": "getDelegationTokenResponse",
+                "type": "GetDelegationTokenResponseProto"
+              },
+              {
+                "id": 62,
+                "name": "renewDelegationTokenResponse",
+                "type": "RenewDelegationTokenResponseProto"
+              },
+              {
+                "id": 63,
+                "name": "cancelDelegationTokenResponse",
+                "type": "CancelDelegationTokenResponseProto"
+              },
+              {
+                "id": 70,
+                "name": "getFileStatusResponse",
+                "type": "GetFileStatusResponse"
+              },
+              {
+                "id": 71,
+                "name": "createDirectoryResponse",
+                "type": "CreateDirectoryResponse"
+              },
+              {
+                "id": 72,
+                "name": "createFileResponse",
+                "type": "CreateFileResponse"
+              },
+              {
+                "id": 73,
+                "name": "lookupFileResponse",
+                "type": "LookupFileResponse"
+              },
+              {
+                "id": 74,
+                "name": "listStatusResponse",
+                "type": "ListStatusResponse"
+              },
+              {
+                "id": 75,
+                "name": "addAclResponse",
+                "type": "AddAclResponse"
+              },
+              {
+                "id": 76,
+                "name": "removeAclResponse",
+                "type": "RemoveAclResponse"
+              },
+              {
+                "id": 77,
+                "name": "setAclResponse",
+                "type": "SetAclResponse"
+              },
+              {
+                "id": 78,
+                "name": "getAclResponse",
+                "type": "GetAclResponse"
+              },
+              {
+                "id": 81,
+                "name": "purgeKeysResponse",
+                "type": "PurgeKeysResponse"
+              },
+              {
+                "id": 82,
+                "name": "listMultipartUploadsResponse",
+                "type": "ListMultipartUploadsResponse"
+              },
+              {
+                "id": 91,
+                "name": "listTrashResponse",
+                "type": "ListTrashResponse"
+              },
+              {
+                "id": 92,
+                "name": "RecoverTrashResponse",
+                "type": "RecoverTrashResponse"
+              }
+            ]
+          },
+          {
+            "name": "ListTrashRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "bucketName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "startKeyName",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "keyPrefix",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "maxKeys",
+                "type": "int32"
+              }
+            ]
+          },
+          {
+            "name": "ListTrashResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "deletedKeys",
+                "type": "RepeatedKeyInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "RecoverTrashRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "bucketName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "keyName",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "destinationBucket",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "RecoverTrashResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "response",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "VolumeInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "adminName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "ownerName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "volume",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "quotaInBytes",
+                "type": "uint64"
+              },
+              {
+                "id": 5,
+                "name": "metadata",
+                "type": "hadoop.hdds.KeyValue",
+                "is_repeated": true
+              },
+              {
+                "id": 6,
+                "name": "volumeAcls",
+                "type": "OzoneAclInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 7,
+                "name": "creationTime",
+                "type": "uint64"
+              },
+              {
+                "id": 8,
+                "name": "objectID",
+                "type": "uint64"
+              },
+              {
+                "id": 9,
+                "name": "updateID",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "UserInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "userName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "remoteAddress",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "hostName",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "UpdateGetDelegationTokenRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "getDelegationTokenResponse",
+                "type": "GetDelegationTokenResponseProto"
+              },
+              {
+                "id": 2,
+                "name": "tokenRenewInterval",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "UpdateRenewDelegationTokenRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "renewDelegationTokenRequest",
+                "type": "hadoop.common.RenewDelegationTokenRequestProto"
+              },
+              {
+                "id": 2,
+                "name": "renewDelegationTokenResponse",
+                "type": "RenewDelegationTokenResponseProto"
+              }
+            ]
+          },
+          {
+            "name": "CreateVolumeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeInfo",
+                "type": "VolumeInfo"
+              }
+            ]
+          },
+          {
+            "name": "CreateVolumeResponse"
+          },
+          {
+            "name": "UserVolumeInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeNames",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "objectID",
+                "type": "uint64"
+              },
+              {
+                "id": 3,
+                "name": "updateID",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "SetVolumePropertyRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "ownerName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "quotaInBytes",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "SetVolumePropertyResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "response",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "CheckVolumeAccessRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "userAcl",
+                "type": "OzoneAclInfo"
+              }
+            ]
+          },
+          {
+            "name": "CheckVolumeAccessResponse"
+          },
+          {
+            "name": "InfoVolumeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "InfoVolumeResponse",
+            "fields": [
+              {
+                "id": 2,
+                "name": "volumeInfo",
+                "type": "VolumeInfo"
+              }
+            ]
+          },
+          {
+            "name": "DeleteVolumeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "DeleteVolumeResponse"
+          },
+          {
+            "name": "ListVolumeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "scope",
+                "type": "Scope"
+              },
+              {
+                "id": 2,
+                "name": "userName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "prefix",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "prevKey",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "maxKeys",
+                "type": "uint32"
+              }
+            ]
+          },
+          {
+            "name": "ListVolumeResponse",
+            "fields": [
+              {
+                "id": 2,
+                "name": "volumeInfo",
+                "type": "VolumeInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "BucketInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "bucketName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "acls",
+                "type": "OzoneAclInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "isVersionEnabled",
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "false"
+                  }
+                ]
+              },
+              {
+                "id": 5,
+                "name": "storageType",
+                "type": "StorageTypeProto",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "DISK"
+                  }
+                ]
+              },
+              {
+                "id": 6,
+                "name": "creationTime",
+                "type": "uint64"
+              },
+              {
+                "id": 7,
+                "name": "metadata",
+                "type": "hadoop.hdds.KeyValue",
+                "is_repeated": true
+              },
+              {
+                "id": 8,
+                "name": "beinfo",
+                "type": "BucketEncryptionInfoProto"
+              },
+              {
+                "id": 9,
+                "name": "objectID",
+                "type": "uint64"
+              },
+              {
+                "id": 10,
+                "name": "updateID",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "BucketEncryptionInfoProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "suite",
+                "type": "CipherSuiteProto"
+              },
+              {
+                "id": 3,
+                "name": "cryptoProtocolVersion",
+                "type": "CryptoProtocolVersionProto"
+              }
+            ]
+          },
+          {
+            "name": "FileEncryptionInfoProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "suite",
+                "type": "CipherSuiteProto"
+              },
+              {
+                "id": 2,
+                "name": "cryptoProtocolVersion",
+                "type": "CryptoProtocolVersionProto"
+              },
+              {
+                "id": 3,
+                "name": "key",
+                "type": "bytes"
+              },
+              {
+                "id": 4,
+                "name": "iv",
+                "type": "bytes"
+              },
+              {
+                "id": 5,
+                "name": "keyName",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "ezKeyVersionName",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "PerFileEncryptionInfoProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "key",
+                "type": "bytes"
+              },
+              {
+                "id": 2,
+                "name": "iv",
+                "type": "bytes"
+              },
+              {
+                "id": 3,
+                "name": "ezKeyVersionName",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "DataEncryptionKeyProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyId",
+                "type": "uint32"
+              },
+              {
+                "id": 3,
+                "name": "nonce",
+                "type": "bytes"
+              },
+              {
+                "id": 4,
+                "name": "encryptionKey",
+                "type": "bytes"
+              },
+              {
+                "id": 5,
+                "name": "expiryDate",
+                "type": "uint64"
+              },
+              {
+                "id": 6,
+                "name": "encryptionAlgorithm",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "BucketArgs",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "bucketName",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "isVersionEnabled",
+                "type": "bool"
+              },
+              {
+                "id": 6,
+                "name": "storageType",
+                "type": "StorageTypeProto"
+              },
+              {
+                "id": 7,
+                "name": "metadata",
+                "type": "hadoop.hdds.KeyValue",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "PrefixInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "acls",
+                "type": "OzoneAclInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "metadata",
+                "type": "hadoop.hdds.KeyValue",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "objectID",
+                "type": "uint64"
+              },
+              {
+                "id": 5,
+                "name": "updateID",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "OzoneObj",
+            "fields": [
+              {
+                "id": 1,
+                "name": "resType",
+                "type": "ObjectType"
+              },
+              {
+                "id": 2,
+                "name": "storeType",
+                "type": "StoreType",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "S3"
+                  }
+                ]
+              },
+              {
+                "id": 3,
+                "name": "path",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "OzoneAclInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "type",
+                "type": "OzoneAclType"
+              },
+              {
+                "id": 2,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "rights",
+                "type": "bytes"
+              },
+              {
+                "id": 4,
+                "name": "aclScope",
+                "type": "OzoneAclScope",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "ACCESS"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "GetAclRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "obj",
+                "type": "OzoneObj"
+              }
+            ]
+          },
+          {
+            "name": "GetAclResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "acls",
+                "type": "OzoneAclInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "AddAclRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "obj",
+                "type": "OzoneObj"
+              },
+              {
+                "id": 2,
+                "name": "acl",
+                "type": "OzoneAclInfo"
+              }
+            ]
+          },
+          {
+            "name": "AddAclResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "response",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "RemoveAclRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "obj",
+                "type": "OzoneObj"
+              },
+              {
+                "id": 2,
+                "name": "acl",
+                "type": "OzoneAclInfo"
+              }
+            ]
+          },
+          {
+            "name": "RemoveAclResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "response",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "SetAclRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "obj",
+                "type": "OzoneObj"
+              },
+              {
+                "id": 2,
+                "name": "acl",
+                "type": "OzoneAclInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "SetAclResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "response",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "CreateBucketRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "bucketInfo",
+                "type": "BucketInfo"
+              }
+            ]
+          },
+          {
+            "name": "CreateBucketResponse"
+          },
+          {
+            "name": "InfoBucketRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "bucketName",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "InfoBucketResponse",
+            "fields": [
+              {
+                "id": 2,
+                "name": "bucketInfo",
+                "type": "BucketInfo"
+              }
+            ]
+          },
+          {
+            "name": "SetBucketPropertyRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "bucketArgs",
+                "type": "BucketArgs"
+              }
+            ]
+          },
+          {
+            "name": "SetBucketPropertyResponse"
+          },
+          {
+            "name": "DeleteBucketRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "bucketName",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "DeleteBucketResponse"
+          },
+          {
+            "name": "ListBucketsRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "startKey",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "prefix",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "count",
+                "type": "int32"
+              }
+            ]
+          },
+          {
+            "name": "ListBucketsResponse",
+            "fields": [
+              {
+                "id": 2,
+                "name": "bucketInfo",
+                "type": "BucketInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "KeyArgs",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "bucketName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "keyName",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "dataSize",
+                "type": "uint64"
+              },
+              {
+                "id": 5,
+                "name": "type",
+                "type": "hadoop.hdds.ReplicationType"
+              },
+              {
+                "id": 6,
+                "name": "factor",
+                "type": "hadoop.hdds.ReplicationFactor"
+              },
+              {
+                "id": 7,
+                "name": "keyLocations",
+                "type": "KeyLocation",
+                "is_repeated": true
+              },
+              {
+                "id": 8,
+                "name": "isMultipartKey",
+                "type": "bool"
+              },
+              {
+                "id": 9,
+                "name": "multipartUploadID",
+                "type": "string"
+              },
+              {
+                "id": 10,
+                "name": "multipartNumber",
+                "type": "uint32"
+              },
+              {
+                "id": 11,
+                "name": "metadata",
+                "type": "hadoop.hdds.KeyValue",
+                "is_repeated": true
+              },
+              {
+                "id": 12,
+                "name": "acls",
+                "type": "OzoneAclInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 13,
+                "name": "modificationTime",
+                "type": "uint64"
+              },
+              {
+                "id": 14,
+                "name": "sortDatanodes",
+                "type": "bool"
+              },
+              {
+                "id": 15,
+                "name": "fileEncryptionInfo",
+                "type": "FileEncryptionInfoProto"
+              }
+            ]
+          },
+          {
+            "name": "KeyLocation",
+            "fields": [
+              {
+                "id": 1,
+                "name": "blockID",
+                "type": "hadoop.hdds.BlockID"
+              },
+              {
+                "id": 3,
+                "name": "offset",
+                "type": "uint64"
+              },
+              {
+                "id": 4,
+                "name": "length",
+                "type": "uint64"
+              },
+              {
+                "id": 5,
+                "name": "createVersion",
+                "type": "uint64"
+              },
+              {
+                "id": 6,
+                "name": "token",
+                "type": "hadoop.common.TokenProto"
+              },
+              {
+                "id": 7,
+                "name": "pipeline",
+                "type": "hadoop.hdds.Pipeline"
+              }
+            ]
+          },
+          {
+            "name": "KeyLocationList",
+            "fields": [
+              {
+                "id": 1,
+                "name": "version",
+                "type": "uint64"
+              },
+              {
+                "id": 2,
+                "name": "keyLocations",
+                "type": "KeyLocation",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "fileEncryptionInfo",
+                "type": "FileEncryptionInfoProto"
+              }
+            ]
+          },
+          {
+            "name": "KeyInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "bucketName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "keyName",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "dataSize",
+                "type": "uint64"
+              },
+              {
+                "id": 5,
+                "name": "type",
+                "type": "hadoop.hdds.ReplicationType"
+              },
+              {
+                "id": 6,
+                "name": "factor",
+                "type": "hadoop.hdds.ReplicationFactor"
+              },
+              {
+                "id": 7,
+                "name": "keyLocationList",
+                "type": "KeyLocationList",
+                "is_repeated": true
+              },
+              {
+                "id": 8,
+                "name": "creationTime",
+                "type": "uint64"
+              },
+              {
+                "id": 9,
+                "name": "modificationTime",
+                "type": "uint64"
+              },
+              {
+                "id": 10,
+                "name": "latestVersion",
+                "type": "uint64"
+              },
+              {
+                "id": 11,
+                "name": "metadata",
+                "type": "hadoop.hdds.KeyValue",
+                "is_repeated": true
+              },
+              {
+                "id": 12,
+                "name": "fileEncryptionInfo",
+                "type": "FileEncryptionInfoProto"
+              },
+              {
+                "id": 13,
+                "name": "acls",
+                "type": "OzoneAclInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 14,
+                "name": "objectID",
+                "type": "uint64"
+              },
+              {
+                "id": 15,
+                "name": "updateID",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "RepeatedKeyInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyInfo",
+                "type": "KeyInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "OzoneFileStatusProto",
+            "fields": [
+              {
+                "id": 2,
+                "name": "keyInfo",
+                "type": "KeyInfo"
+              },
+              {
+                "id": 3,
+                "name": "blockSize",
+                "type": "uint64"
+              },
+              {
+                "id": 4,
+                "name": "isDirectory",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "GetFileStatusRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyArgs",
+                "type": "KeyArgs"
+              }
+            ]
+          },
+          {
+            "name": "GetFileStatusResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "OzoneFileStatusProto"
+              }
+            ]
+          },
+          {
+            "name": "CreateDirectoryRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyArgs",
+                "type": "KeyArgs"
+              }
+            ]
+          },
+          {
+            "name": "CreateDirectoryResponse"
+          },
+          {
+            "name": "CreateFileRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyArgs",
+                "type": "KeyArgs"
+              },
+              {
+                "id": 2,
+                "name": "isRecursive",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "isOverwrite",
+                "type": "bool"
+              },
+              {
+                "id": 4,
+                "name": "clientID",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "CreateFileResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyInfo",
+                "type": "KeyInfo"
+              },
+              {
+                "id": 2,
+                "name": "ID",
+                "type": "uint64"
+              },
+              {
+                "id": 3,
+                "name": "openVersion",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "LookupFileRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyArgs",
+                "type": "KeyArgs"
+              }
+            ]
+          },
+          {
+            "name": "LookupFileResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyInfo",
+                "type": "KeyInfo"
+              }
+            ]
+          },
+          {
+            "name": "ListStatusRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyArgs",
+                "type": "KeyArgs"
+              },
+              {
+                "id": 2,
+                "name": "recursive",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "startKey",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "numEntries",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "ListStatusResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "statuses",
+                "type": "OzoneFileStatusProto",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "CreateKeyRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyArgs",
+                "type": "KeyArgs"
+              },
+              {
+                "id": 2,
+                "name": "clientID",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "CreateKeyResponse",
+            "fields": [
+              {
+                "id": 2,
+                "name": "keyInfo",
+                "type": "KeyInfo"
+              },
+              {
+                "id": 3,
+                "name": "ID",
+                "type": "uint64"
+              },
+              {
+                "id": 4,
+                "name": "openVersion",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "LookupKeyRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyArgs",
+                "type": "KeyArgs"
+              }
+            ]
+          },
+          {
+            "name": "LookupKeyResponse",
+            "fields": [
+              {
+                "id": 2,
+                "name": "keyInfo",
+                "type": "KeyInfo"
+              },
+              {
+                "id": 3,
+                "name": "ID",
+                "type": "uint64"
+              },
+              {
+                "id": 4,
+                "name": "openVersion",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "RenameKeyRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyArgs",
+                "type": "KeyArgs"
+              },
+              {
+                "id": 2,
+                "name": "toKeyName",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "RenameKeyResponse"
+          },
+          {
+            "name": "DeleteKeyRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyArgs",
+                "type": "KeyArgs"
+              }
+            ]
+          },
+          {
+            "name": "DeleteKeyResponse",
+            "fields": [
+              {
+                "id": 2,
+                "name": "keyInfo",
+                "type": "KeyInfo"
+              },
+              {
+                "id": 3,
+                "name": "ID",
+                "type": "uint64"
+              },
+              {
+                "id": 4,
+                "name": "openVersion",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "DeletedKeys",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "bucketName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "keys",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "PurgeKeysRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "deletedKeys",
+                "type": "DeletedKeys",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "PurgeKeysResponse"
+          },
+          {
+            "name": "OMTokenProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "type",
+                "type": "Type"
+              },
+              {
+                "id": 2,
+                "name": "version",
+                "type": "uint32"
+              },
+              {
+                "id": 3,
+                "name": "owner",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "renewer",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "realUser",
+                "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "issueDate",
+                "type": "uint64"
+              },
+              {
+                "id": 7,
+                "name": "maxDate",
+                "type": "uint64"
+              },
+              {
+                "id": 8,
+                "name": "sequenceNumber",
+                "type": "uint32"
+              },
+              {
+                "id": 9,
+                "name": "masterKeyId",
+                "type": "uint32"
+              },
+              {
+                "id": 10,
+                "name": "expiryDate",
+                "type": "uint64"
+              },
+              {
+                "id": 11,
+                "name": "omCertSerialId",
+                "type": "string"
+              },
+              {
+                "id": 12,
+                "name": "accessKeyId",
+                "type": "string"
+              },
+              {
+                "id": 13,
+                "name": "signature",
+                "type": "string"
+              },
+              {
+                "id": 14,
+                "name": "strToSign",
+                "type": "string"
+              },
+              {
+                "id": 15,
+                "name": "omServiceId",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "SecretKeyProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyId",
+                "type": "uint32"
+              },
+              {
+                "id": 2,
+                "name": "expiryDate",
+                "type": "uint64"
+              },
+              {
+                "id": 3,
+                "name": "privateKeyBytes",
+                "type": "bytes"
+              },
+              {
+                "id": 4,
+                "name": "publicKeyBytes",
+                "type": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "ListKeysRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "bucketName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "startKey",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "prefix",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "count",
+                "type": "int32"
+              }
+            ]
+          },
+          {
+            "name": "ListKeysResponse",
+            "fields": [
+              {
+                "id": 2,
+                "name": "keyInfo",
+                "type": "KeyInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "CommitKeyRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyArgs",
+                "type": "KeyArgs"
+              },
+              {
+                "id": 2,
+                "name": "clientID",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "CommitKeyResponse"
+          },
+          {
+            "name": "AllocateBlockRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyArgs",
+                "type": "KeyArgs"
+              },
+              {
+                "id": 2,
+                "name": "clientID",
+                "type": "uint64"
+              },
+              {
+                "id": 3,
+                "name": "excludeList",
+                "type": "hadoop.hdds.ExcludeListProto"
+              },
+              {
+                "id": 4,
+                "name": "keyLocation",
+                "type": "KeyLocation"
+              }
+            ]
+          },
+          {
+            "name": "AllocateBlockResponse",
+            "fields": [
+              {
+                "id": 2,
+                "name": "keyLocation",
+                "type": "KeyLocation"
+              }
+            ]
+          },
+          {
+            "name": "ServiceListRequest"
+          },
+          {
+            "name": "DBUpdatesRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "sequenceNumber",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "ServiceListResponse",
+            "fields": [
+              {
+                "id": 2,
+                "name": "serviceInfo",
+                "type": "ServiceInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "caCertificate",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "DBUpdatesResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "sequenceNumber",
+                "type": "uint64"
+              },
+              {
+                "id": 2,
+                "name": "data",
+                "type": "bytes",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ServicePort",
+            "fields": [
+              {
+                "id": 1,
+                "name": "type",
+                "type": "Type"
+              },
+              {
+                "id": 2,
+                "name": "value",
+                "type": "uint32"
+              }
+            ]
+          },
+          {
+            "name": "OMRoleInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "nodeId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "serverRole",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ServiceInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "nodeType",
+                "type": "hadoop.hdds.NodeType"
+              },
+              {
+                "id": 2,
+                "name": "hostname",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "servicePorts",
+                "type": "ServicePort",
+                "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "omRole",
+                "type": "OMRoleInfo"
+              }
+            ]
+          },
+          {
+            "name": "MultipartInfoInitiateRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyArgs",
+                "type": "KeyArgs"
+              }
+            ]
+          },
+          {
+            "name": "MultipartInfoInitiateResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "bucketName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "keyName",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "multipartUploadID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "MultipartKeyInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "uploadID",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "creationTime",
+                "type": "uint64"
+              },
+              {
+                "id": 3,
+                "name": "type",
+                "type": "hadoop.hdds.ReplicationType"
+              },
+              {
+                "id": 4,
+                "name": "factor",
+                "type": "hadoop.hdds.ReplicationFactor"
+              },
+              {
+                "id": 5,
+                "name": "partKeyInfoList",
+                "type": "PartKeyInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 6,
+                "name": "objectID",
+                "type": "uint64"
+              },
+              {
+                "id": 7,
+                "name": "updateID",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "PartKeyInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "partName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "partNumber",
+                "type": "uint32"
+              },
+              {
+                "id": 3,
+                "name": "partKeyInfo",
+                "type": "KeyInfo"
+              }
+            ]
+          },
+          {
+            "name": "MultipartCommitUploadPartRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyArgs",
+                "type": "KeyArgs"
+              },
+              {
+                "id": 2,
+                "name": "clientID",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "MultipartCommitUploadPartResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "partName",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "MultipartUploadCompleteRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyArgs",
+                "type": "KeyArgs"
+              },
+              {
+                "id": 2,
+                "name": "partsList",
+                "type": "Part",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "MultipartUploadCompleteResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volume",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "bucket",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "key",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "hash",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "Part",
+            "fields": [
+              {
+                "id": 1,
+                "name": "partNumber",
+                "type": "uint32"
+              },
+              {
+                "id": 2,
+                "name": "partName",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "MultipartUploadAbortRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyArgs",
+                "type": "KeyArgs"
+              }
+            ]
+          },
+          {
+            "name": "MultipartUploadAbortResponse"
+          },
+          {
+            "name": "MultipartUploadListPartsRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volume",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "bucket",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "key",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "uploadID",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "partNumbermarker",
+                "type": "uint32"
+              },
+              {
+                "id": 6,
+                "name": "maxParts",
+                "type": "uint32"
+              }
+            ]
+          },
+          {
+            "name": "MultipartUploadListPartsResponse",
+            "fields": [
+              {
+                "id": 2,
+                "name": "type",
+                "type": "hadoop.hdds.ReplicationType"
+              },
+              {
+                "id": 3,
+                "name": "factor",
+                "type": "hadoop.hdds.ReplicationFactor"
+              },
+              {
+                "id": 4,
+                "name": "nextPartNumberMarker",
+                "type": "uint32"
+              },
+              {
+                "id": 5,
+                "name": "isTruncated",
+                "type": "bool"
+              },
+              {
+                "id": 6,
+                "name": "partsList",
+                "type": "PartInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ListMultipartUploadsRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volume",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "bucket",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "prefix",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ListMultipartUploadsResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "isTruncated",
+                "type": "bool"
+              },
+              {
+                "id": 2,
+                "name": "uploadsList",
+                "type": "MultipartUploadInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "MultipartUploadInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "bucketName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "keyName",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "uploadId",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "creationTime",
+                "type": "uint64"
+              },
+              {
+                "id": 6,
+                "name": "type",
+                "type": "hadoop.hdds.ReplicationType"
+              },
+              {
+                "id": 7,
+                "name": "factor",
+                "type": "hadoop.hdds.ReplicationFactor"
+              }
+            ]
+          },
+          {
+            "name": "PartInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "partNumber",
+                "type": "uint32"
+              },
+              {
+                "id": 2,
+                "name": "partName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "modificationTime",
+                "type": "uint64"
+              },
+              {
+                "id": 4,
+                "name": "size",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "GetDelegationTokenResponseProto",
+            "fields": [
+              {
+                "id": 2,
+                "name": "response",
+                "type": "hadoop.common.GetDelegationTokenResponseProto"
+              }
+            ]
+          },
+          {
+            "name": "RenewDelegationTokenResponseProto",
+            "fields": [
+              {
+                "id": 2,
+                "name": "response",
+                "type": "hadoop.common.RenewDelegationTokenResponseProto"
+              }
+            ]
+          },
+          {
+            "name": "CancelDelegationTokenResponseProto",
+            "fields": [
+              {
+                "id": 2,
+                "name": "response",
+                "type": "hadoop.common.CancelDelegationTokenResponseProto"
+              }
+            ]
+          },
+          {
+            "name": "S3Secret",
+            "fields": [
+              {
+                "id": 1,
+                "name": "kerberosID",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "awsSecret",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetS3SecretRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "kerberosID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetS3SecretResponse",
+            "fields": [
+              {
+                "id": 2,
+                "name": "s3Secret",
+                "type": "S3Secret"
+              }
+            ]
+          },
+          {
+            "name": "UpdateGetS3SecretRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "kerberosID",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "awsSecret",
+                "type": "string"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "OzoneManagerService",
+            "rpcs": [
+              {
+                "name": "submitRequest",
+                "in_type": "OMRequest",
+                "out_type": "OMResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "hdds.proto"
+          },
+          {
+            "path": "Security.proto"
+          }
+        ],
+        "package": {
+          "name": "hadoop.ozone"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "org.apache.hadoop.ozone.protocol.proto"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "OzoneManagerProtocolProtos"
+          },
+          {
+            "name": "java_generic_services",
+            "value": "true"
+          },
+          {
+            "name": "java_generate_equals_and_hash",
+            "value": "true"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -144,6 +144,15 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>${basedir}/src/main/proto/proto.lock</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>${protobuf-maven-plugin.version}</version>

--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -148,7 +148,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
           <excludes>
-            <exclude>${basedir}/src/main/proto/proto.lock</exclude>
+            <exclude>src/main/proto/proto.lock</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -132,16 +132,6 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
       <plugin>
         <groupId>com.salesforce.servicelibs</groupId>
         <artifactId>proto-backwards-compatibility</artifactId>
-        <configuration>
-          <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>backwards-compatibility-check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>

--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -130,6 +130,20 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     </extensions>
     <plugins>
       <plugin>
+        <groupId>com.salesforce.servicelibs</groupId>
+        <artifactId>proto-backwards-compatibility</artifactId>
+        <configuration>
+          <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>backwards-compatibility-check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>${protobuf-maven-plugin.version}</version>

--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -144,15 +144,6 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>src/main/proto/proto.lock</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>${protobuf-maven-plugin.version}</version>

--- a/hadoop-ozone/csi/src/main/proto/proto.lock
+++ b/hadoop-ozone/csi/src/main/proto/proto.lock
@@ -1,0 +1,1471 @@
+{
+  "definitions": [
+    {
+      "protopath": "csi.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "Service.Type",
+            "enum_fields": [
+              {
+                "name": "UNKNOWN"
+              },
+              {
+                "name": "CONTROLLER_SERVICE",
+                "integer": 1
+              },
+              {
+                "name": "VOLUME_ACCESSIBILITY_CONSTRAINTS",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "VolumeExpansion.Type",
+            "enum_fields": [
+              {
+                "name": "UNKNOWN"
+              },
+              {
+                "name": "ONLINE",
+                "integer": 1
+              },
+              {
+                "name": "OFFLINE",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "AccessMode.Mode",
+            "enum_fields": [
+              {
+                "name": "UNKNOWN"
+              },
+              {
+                "name": "SINGLE_NODE_WRITER",
+                "integer": 1
+              },
+              {
+                "name": "SINGLE_NODE_READER_ONLY",
+                "integer": 2
+              },
+              {
+                "name": "MULTI_NODE_READER_ONLY",
+                "integer": 3
+              },
+              {
+                "name": "MULTI_NODE_SINGLE_WRITER",
+                "integer": 4
+              },
+              {
+                "name": "MULTI_NODE_MULTI_WRITER",
+                "integer": 5
+              }
+            ]
+          },
+          {
+            "name": "RPC.Type",
+            "enum_fields": [
+              {
+                "name": "UNKNOWN"
+              },
+              {
+                "name": "CREATE_DELETE_VOLUME",
+                "integer": 1
+              },
+              {
+                "name": "PUBLISH_UNPUBLISH_VOLUME",
+                "integer": 2
+              },
+              {
+                "name": "LIST_VOLUMES",
+                "integer": 3
+              },
+              {
+                "name": "GET_CAPACITY",
+                "integer": 4
+              },
+              {
+                "name": "CREATE_DELETE_SNAPSHOT",
+                "integer": 5
+              },
+              {
+                "name": "LIST_SNAPSHOTS",
+                "integer": 6
+              },
+              {
+                "name": "CLONE_VOLUME",
+                "integer": 7
+              },
+              {
+                "name": "PUBLISH_READONLY",
+                "integer": 8
+              },
+              {
+                "name": "EXPAND_VOLUME",
+                "integer": 9
+              }
+            ]
+          },
+          {
+            "name": "VolumeUsage.Unit",
+            "enum_fields": [
+              {
+                "name": "UNKNOWN"
+              },
+              {
+                "name": "BYTES",
+                "integer": 1
+              },
+              {
+                "name": "INODES",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "RPC.Type",
+            "enum_fields": [
+              {
+                "name": "UNKNOWN"
+              },
+              {
+                "name": "STAGE_UNSTAGE_VOLUME",
+                "integer": 1
+              },
+              {
+                "name": "GET_VOLUME_STATS",
+                "integer": 2
+              },
+              {
+                "name": "EXPAND_VOLUME",
+                "integer": 3
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "google.protobuf.FieldOptions",
+            "fields": [
+              {
+                "id": 1059,
+                "name": "csi_secret",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "GetPluginInfoRequest"
+          },
+          {
+            "name": "GetPluginInfoResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "vendor_version",
+                "type": "string"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 3,
+                  "name": "manifest",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "GetPluginCapabilitiesRequest"
+          },
+          {
+            "name": "GetPluginCapabilitiesResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "capabilities",
+                "type": "PluginCapability",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "PluginCapability",
+            "fields": [
+              {
+                "id": 1,
+                "name": "service",
+                "type": "Service"
+              },
+              {
+                "id": 2,
+                "name": "volume_expansion",
+                "type": "VolumeExpansion"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Service",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "type",
+                    "type": "Type"
+                  }
+                ]
+              },
+              {
+                "name": "VolumeExpansion"
+              }
+            ]
+          },
+          {
+            "name": "ProbeRequest"
+          },
+          {
+            "name": "ProbeResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "ready",
+                "type": ".google.protobuf.BoolValue"
+              }
+            ]
+          },
+          {
+            "name": "CreateVolumeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "capacity_range",
+                "type": "CapacityRange"
+              },
+              {
+                "id": 3,
+                "name": "volume_capabilities",
+                "type": "VolumeCapability",
+                "is_repeated": true
+              },
+              {
+                "id": 6,
+                "name": "volume_content_source",
+                "type": "VolumeContentSource"
+              },
+              {
+                "id": 7,
+                "name": "accessibility_requirements",
+                "type": "TopologyRequirement"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 4,
+                  "name": "parameters",
+                  "type": "string"
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 5,
+                  "name": "secrets",
+                  "type": "string",
+                  "options": [
+                    {
+                      "name": "(csi_secret)",
+                      "value": "true"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "name": "VolumeContentSource",
+            "fields": [
+              {
+                "id": 1,
+                "name": "snapshot",
+                "type": "SnapshotSource"
+              },
+              {
+                "id": 2,
+                "name": "volume",
+                "type": "VolumeSource"
+              }
+            ],
+            "messages": [
+              {
+                "name": "SnapshotSource",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "snapshot_id",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "name": "VolumeSource",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "volume_id",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "CreateVolumeResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volume",
+                "type": "Volume"
+              }
+            ]
+          },
+          {
+            "name": "VolumeCapability",
+            "fields": [
+              {
+                "id": 1,
+                "name": "block",
+                "type": "BlockVolume"
+              },
+              {
+                "id": 2,
+                "name": "mount",
+                "type": "MountVolume"
+              },
+              {
+                "id": 3,
+                "name": "access_mode",
+                "type": "AccessMode"
+              }
+            ],
+            "messages": [
+              {
+                "name": "BlockVolume"
+              },
+              {
+                "name": "MountVolume",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "fs_type",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "mount_flags",
+                    "type": "string",
+                    "is_repeated": true
+                  }
+                ]
+              },
+              {
+                "name": "AccessMode",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "mode",
+                    "type": "Mode"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "CapacityRange",
+            "fields": [
+              {
+                "id": 1,
+                "name": "required_bytes",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "limit_bytes",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "Volume",
+            "fields": [
+              {
+                "id": 1,
+                "name": "capacity_bytes",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "volume_id",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "content_source",
+                "type": "VolumeContentSource"
+              },
+              {
+                "id": 5,
+                "name": "accessible_topology",
+                "type": "Topology",
+                "is_repeated": true
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 3,
+                  "name": "volume_context",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "TopologyRequirement",
+            "fields": [
+              {
+                "id": 1,
+                "name": "requisite",
+                "type": "Topology",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "preferred",
+                "type": "Topology",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "Topology",
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 1,
+                  "name": "segments",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "DeleteVolumeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volume_id",
+                "type": "string"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "secrets",
+                  "type": "string",
+                  "options": [
+                    {
+                      "name": "(csi_secret)",
+                      "value": "true"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "name": "DeleteVolumeResponse"
+          },
+          {
+            "name": "ControllerPublishVolumeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volume_id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "node_id",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "volume_capability",
+                "type": "VolumeCapability"
+              },
+              {
+                "id": 4,
+                "name": "readonly",
+                "type": "bool"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 5,
+                  "name": "secrets",
+                  "type": "string",
+                  "options": [
+                    {
+                      "name": "(csi_secret)",
+                      "value": "true"
+                    }
+                  ]
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 6,
+                  "name": "volume_context",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "ControllerPublishVolumeResponse",
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 1,
+                  "name": "publish_context",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "ControllerUnpublishVolumeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volume_id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "node_id",
+                "type": "string"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 3,
+                  "name": "secrets",
+                  "type": "string",
+                  "options": [
+                    {
+                      "name": "(csi_secret)",
+                      "value": "true"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "name": "ControllerUnpublishVolumeResponse"
+          },
+          {
+            "name": "ValidateVolumeCapabilitiesRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volume_id",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "volume_capabilities",
+                "type": "VolumeCapability",
+                "is_repeated": true
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "volume_context",
+                  "type": "string"
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 4,
+                  "name": "parameters",
+                  "type": "string"
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 5,
+                  "name": "secrets",
+                  "type": "string",
+                  "options": [
+                    {
+                      "name": "(csi_secret)",
+                      "value": "true"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "name": "ValidateVolumeCapabilitiesResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "confirmed",
+                "type": "Confirmed"
+              },
+              {
+                "id": 2,
+                "name": "message",
+                "type": "string"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Confirmed",
+                "fields": [
+                  {
+                    "id": 2,
+                    "name": "volume_capabilities",
+                    "type": "VolumeCapability",
+                    "is_repeated": true
+                  }
+                ],
+                "maps": [
+                  {
+                    "key_type": "string",
+                    "field": {
+                      "id": 1,
+                      "name": "volume_context",
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "key_type": "string",
+                    "field": {
+                      "id": 3,
+                      "name": "parameters",
+                      "type": "string"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "ListVolumesRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "max_entries",
+                "type": "int32"
+              },
+              {
+                "id": 2,
+                "name": "starting_token",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ListVolumesResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "entries",
+                "type": "Entry",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "next_token",
+                "type": "string"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Entry",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "volume",
+                    "type": "Volume"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "GetCapacityRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volume_capabilities",
+                "type": "VolumeCapability",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "accessible_topology",
+                "type": "Topology"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "parameters",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "GetCapacityResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "available_capacity",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "ControllerGetCapabilitiesRequest"
+          },
+          {
+            "name": "ControllerGetCapabilitiesResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "capabilities",
+                "type": "ControllerServiceCapability",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ControllerServiceCapability",
+            "fields": [
+              {
+                "id": 1,
+                "name": "rpc",
+                "type": "RPC"
+              }
+            ],
+            "messages": [
+              {
+                "name": "RPC",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "type",
+                    "type": "Type"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "CreateSnapshotRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "source_volume_id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "name",
+                "type": "string"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 3,
+                  "name": "secrets",
+                  "type": "string",
+                  "options": [
+                    {
+                      "name": "(csi_secret)",
+                      "value": "true"
+                    }
+                  ]
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 4,
+                  "name": "parameters",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "CreateSnapshotResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "snapshot",
+                "type": "Snapshot"
+              }
+            ]
+          },
+          {
+            "name": "Snapshot",
+            "fields": [
+              {
+                "id": 1,
+                "name": "size_bytes",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "snapshot_id",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "source_volume_id",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "creation_time",
+                "type": ".google.protobuf.Timestamp"
+              },
+              {
+                "id": 5,
+                "name": "ready_to_use",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "DeleteSnapshotRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "snapshot_id",
+                "type": "string"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "secrets",
+                  "type": "string",
+                  "options": [
+                    {
+                      "name": "(csi_secret)",
+                      "value": "true"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "name": "DeleteSnapshotResponse"
+          },
+          {
+            "name": "ListSnapshotsRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "max_entries",
+                "type": "int32"
+              },
+              {
+                "id": 2,
+                "name": "starting_token",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "source_volume_id",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "snapshot_id",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ListSnapshotsResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "entries",
+                "type": "Entry",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "next_token",
+                "type": "string"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Entry",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "snapshot",
+                    "type": "Snapshot"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "ControllerExpandVolumeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volume_id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "capacity_range",
+                "type": "CapacityRange"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 3,
+                  "name": "secrets",
+                  "type": "string",
+                  "options": [
+                    {
+                      "name": "(csi_secret)",
+                      "value": "true"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "name": "ControllerExpandVolumeResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "capacity_bytes",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "node_expansion_required",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "NodeStageVolumeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volume_id",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "staging_target_path",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "volume_capability",
+                "type": "VolumeCapability"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "publish_context",
+                  "type": "string"
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 5,
+                  "name": "secrets",
+                  "type": "string",
+                  "options": [
+                    {
+                      "name": "(csi_secret)",
+                      "value": "true"
+                    }
+                  ]
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 6,
+                  "name": "volume_context",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "NodeStageVolumeResponse"
+          },
+          {
+            "name": "NodeUnstageVolumeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volume_id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "staging_target_path",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "NodeUnstageVolumeResponse"
+          },
+          {
+            "name": "NodePublishVolumeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volume_id",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "staging_target_path",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "target_path",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "volume_capability",
+                "type": "VolumeCapability"
+              },
+              {
+                "id": 6,
+                "name": "readonly",
+                "type": "bool"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "publish_context",
+                  "type": "string"
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 7,
+                  "name": "secrets",
+                  "type": "string",
+                  "options": [
+                    {
+                      "name": "(csi_secret)",
+                      "value": "true"
+                    }
+                  ]
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 8,
+                  "name": "volume_context",
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          {
+            "name": "NodePublishVolumeResponse"
+          },
+          {
+            "name": "NodeUnpublishVolumeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volume_id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "target_path",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "NodeUnpublishVolumeResponse"
+          },
+          {
+            "name": "NodeGetVolumeStatsRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volume_id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "volume_path",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "NodeGetVolumeStatsResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "usage",
+                "type": "VolumeUsage",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "VolumeUsage",
+            "fields": [
+              {
+                "id": 1,
+                "name": "available",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "total",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "used",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "unit",
+                "type": "Unit"
+              }
+            ]
+          },
+          {
+            "name": "NodeGetCapabilitiesRequest"
+          },
+          {
+            "name": "NodeGetCapabilitiesResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "capabilities",
+                "type": "NodeServiceCapability",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "NodeServiceCapability",
+            "fields": [
+              {
+                "id": 1,
+                "name": "rpc",
+                "type": "RPC"
+              }
+            ],
+            "messages": [
+              {
+                "name": "RPC",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "type",
+                    "type": "Type"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "NodeGetInfoRequest"
+          },
+          {
+            "name": "NodeGetInfoResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "node_id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "max_volumes_per_node",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "accessible_topology",
+                "type": "Topology"
+              }
+            ]
+          },
+          {
+            "name": "NodeExpandVolumeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volume_id",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "volume_path",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "capacity_range",
+                "type": "CapacityRange"
+              }
+            ]
+          },
+          {
+            "name": "NodeExpandVolumeResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "capacity_bytes",
+                "type": "int64"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "Identity",
+            "rpcs": [
+              {
+                "name": "GetPluginInfo",
+                "in_type": "GetPluginInfoRequest",
+                "out_type": "GetPluginInfoResponse"
+              },
+              {
+                "name": "GetPluginCapabilities",
+                "in_type": "GetPluginCapabilitiesRequest",
+                "out_type": "GetPluginCapabilitiesResponse"
+              },
+              {
+                "name": "Probe",
+                "in_type": "ProbeRequest",
+                "out_type": "ProbeResponse"
+              }
+            ]
+          },
+          {
+            "name": "Controller",
+            "rpcs": [
+              {
+                "name": "CreateVolume",
+                "in_type": "CreateVolumeRequest",
+                "out_type": "CreateVolumeResponse"
+              },
+              {
+                "name": "DeleteVolume",
+                "in_type": "DeleteVolumeRequest",
+                "out_type": "DeleteVolumeResponse"
+              },
+              {
+                "name": "ControllerPublishVolume",
+                "in_type": "ControllerPublishVolumeRequest",
+                "out_type": "ControllerPublishVolumeResponse"
+              },
+              {
+                "name": "ControllerUnpublishVolume",
+                "in_type": "ControllerUnpublishVolumeRequest",
+                "out_type": "ControllerUnpublishVolumeResponse"
+              },
+              {
+                "name": "ValidateVolumeCapabilities",
+                "in_type": "ValidateVolumeCapabilitiesRequest",
+                "out_type": "ValidateVolumeCapabilitiesResponse"
+              },
+              {
+                "name": "ListVolumes",
+                "in_type": "ListVolumesRequest",
+                "out_type": "ListVolumesResponse"
+              },
+              {
+                "name": "GetCapacity",
+                "in_type": "GetCapacityRequest",
+                "out_type": "GetCapacityResponse"
+              },
+              {
+                "name": "ControllerGetCapabilities",
+                "in_type": "ControllerGetCapabilitiesRequest",
+                "out_type": "ControllerGetCapabilitiesResponse"
+              },
+              {
+                "name": "CreateSnapshot",
+                "in_type": "CreateSnapshotRequest",
+                "out_type": "CreateSnapshotResponse"
+              },
+              {
+                "name": "DeleteSnapshot",
+                "in_type": "DeleteSnapshotRequest",
+                "out_type": "DeleteSnapshotResponse"
+              },
+              {
+                "name": "ListSnapshots",
+                "in_type": "ListSnapshotsRequest",
+                "out_type": "ListSnapshotsResponse"
+              },
+              {
+                "name": "ControllerExpandVolume",
+                "in_type": "ControllerExpandVolumeRequest",
+                "out_type": "ControllerExpandVolumeResponse"
+              }
+            ]
+          },
+          {
+            "name": "Node",
+            "rpcs": [
+              {
+                "name": "NodeStageVolume",
+                "in_type": "NodeStageVolumeRequest",
+                "out_type": "NodeStageVolumeResponse"
+              },
+              {
+                "name": "NodeUnstageVolume",
+                "in_type": "NodeUnstageVolumeRequest",
+                "out_type": "NodeUnstageVolumeResponse"
+              },
+              {
+                "name": "NodePublishVolume",
+                "in_type": "NodePublishVolumeRequest",
+                "out_type": "NodePublishVolumeResponse"
+              },
+              {
+                "name": "NodeUnpublishVolume",
+                "in_type": "NodeUnpublishVolumeRequest",
+                "out_type": "NodeUnpublishVolumeResponse"
+              },
+              {
+                "name": "NodeGetVolumeStats",
+                "in_type": "NodeGetVolumeStatsRequest",
+                "out_type": "NodeGetVolumeStatsResponse"
+              },
+              {
+                "name": "NodeExpandVolume",
+                "in_type": "NodeExpandVolumeRequest",
+                "out_type": "NodeExpandVolumeResponse"
+              },
+              {
+                "name": "NodeGetCapabilities",
+                "in_type": "NodeGetCapabilitiesRequest",
+                "out_type": "NodeGetCapabilitiesResponse"
+              },
+              {
+                "name": "NodeGetInfo",
+                "in_type": "NodeGetInfoRequest",
+                "out_type": "NodeGetInfoResponse"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "google/protobuf/descriptor.proto"
+          },
+          {
+            "path": "google/protobuf/timestamp.proto"
+          },
+          {
+            "path": "google/protobuf/wrappers.proto"
+          }
+        ],
+        "package": {
+          "name": "csi.v1"
+        },
+        "options": [
+          {
+            "name": "go_package",
+            "value": "csi"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -280,6 +280,7 @@
             <exclude>**/yarn.lock</exclude>
             <exclude>**/ozone-recon-web/build/**</exclude>
             <exclude>src/main/license/**</exclude>
+            <exclude>src/main/proto/proto.lock</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -243,11 +243,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.salesforce.servicelibs</groupId>
-        <artifactId>proto-backwards-compatibility</artifactId>
-        <version>${proto-backwards-compatibility.version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.squareup.okhttp</groupId>
         <artifactId>okhttp</artifactId>
         <version>${okhttp.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1602,8 +1602,29 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   </dependencyManagement>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>${os-maven-plugin.version}</version>
+      </extension>
+    </extensions>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>com.salesforce.servicelibs</groupId>
+          <artifactId>proto-backwards-compatibility</artifactId>
+          <configuration>
+            <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>backwards-compatibility-check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
         <plugin>
           <groupId>com.github.eirslett</groupId>
           <artifactId>frontend-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1609,6 +1609,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <plugin>
           <groupId>com.salesforce.servicelibs</groupId>
           <artifactId>proto-backwards-compatibility</artifactId>
+          <version>${proto-backwards-compatibility.version}</version>
           <configuration>
             <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- the version of Hadoop declared in the version resources; can be overridden
     so that Hadoop 3.x can declare itself a 2.x artifact. -->
     <declared.hadoop.version>${hadoop.version}</declared.hadoop.version>
+    <proto-backwards-compatibility.version>1.0.5</proto-backwards-compatibility.version>
 
     <swagger-annotations-version>1.5.4</swagger-annotations-version>
     <snakeyaml.version>1.16</snakeyaml.version>
@@ -241,6 +242,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>com.salesforce.servicelibs</groupId>
+        <artifactId>proto-backwards-compatibility</artifactId>
+        <version>${proto-backwards-compatibility.version}</version>
+      </dependency>
       <dependency>
         <groupId>com.squareup.okhttp</groupId>
         <artifactId>okhttp</artifactId>


### PR DESCRIPTION
## What changes were proposed in this pull request?
This patch adds a protobuf backward compatibility checker into Ozone.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3595

## How was this patch tested?
Build works, and able to detect failure because of this.


diff --git a/hadoop-ozone/csi/src/main/proto/csi.proto b/hadoop-ozone/csi/src/main/proto/csi.proto
index 3bd53a075..b8a984de2 100644
--- a/hadoop-ozone/csi/src/main/proto/csi.proto
+++ b/hadoop-ozone/csi/src/main/proto/csi.proto
@@ -119,7 +119,7 @@ message GetPluginInfoResponse {
   // characters or less, beginning and ending with an alphanumeric
   // character ([a-z0-9A-Z]) with dashes (-), dots (.), and
   // alphanumerics between. This field is REQUIRED.
-  string name = 1;
+  string newName = 1;



[ERROR] CONFLICT: "GetPluginInfoResponse" field: "name" has been removed, but is not reserved [csi.proto]
[ERROR] CONFLICT: "GetPluginInfoResponse" field: "newName" ID: 1 has an updated name, previously "name" [csi.proto]