### PR TITLE
HDDS-3593. Set a configurable maximum limit of available pipeline

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -344,9 +344,10 @@ public final class ScmConfigKeys {
   public static final boolean
       OZONE_SCM_PIPELINE_AUTO_CREATE_FACTOR_ONE_DEFAULT = true;
 
-  public static final String OZONE_SCM_PIPELINE_AUTO_CREATE_LIMIT =
-      "ozone.scm.pipeline.creation.auto.limit";
-  public static final int OZONE_SCM_PIPELINE_AUTO_CREATE_LIMIT_DEFAULT = 3;
+  public static final String OZONE_SCM_PIPELINE_AUTO_CREATE_LIMIT_RATE =
+      "ozone.scm.pipeline.creation.auto.limit.rate";
+  public static final float OZONE_SCM_PIPELINE_AUTO_CREATE_LIMIT_RATE_DEFAULT =
+      0.0f;
 
   public static final String OZONE_SCM_BLOCK_DELETION_MAX_RETRY =
       "ozone.scm.block.deletion.max.retry";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -344,6 +344,10 @@ public final class ScmConfigKeys {
   public static final boolean
       OZONE_SCM_PIPELINE_AUTO_CREATE_FACTOR_ONE_DEFAULT = true;
 
+  public static final String OZONE_SCM_PIPELINE_AUTO_CREATE_LIMIT =
+      "ozone.scm.pipeline.creation.auto.limit";
+  public static final int OZONE_SCM_PIPELINE_AUTO_CREATE_LIMIT_DEFAULT = 3;
+
   public static final String OZONE_SCM_BLOCK_DELETION_MAX_RETRY =
       "ozone.scm.block.deletion.max.retry";
   public static final int OZONE_SCM_BLOCK_DELETION_MAX_RETRY_DEFAULT = 4096;

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1299,16 +1299,16 @@
     <value>true</value>
     <tag>OZONE, SCM, PIPELINE</tag>
     <description>
-      SCM BackgroundPipelineCreator will skip create pipeline while the count of
-      current available pipeline achieve this value.
+      If enabled, SCM will auto create RATIS factor ONE pipeline.
     </description>
   </property>
   <property>
-    <name>ozone.scm.pipeline.creation.auto.limit</name>
-    <value>3</value>
+    <name>ozone.scm.pipeline.creation.auto.limit.rate</name>
+    <value>0.0</value>
     <tag>OZONE, SCM, PIPELINE</tag>
     <description>
-      If enabled, SCM will auto create RATIS factor ONE pipeline.
+      SCM BackgroundPipelineCreator will skip create pipeline while the count of
+      current available pipeline achieve this datanodeNum * auto.limit.rate.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1299,6 +1299,15 @@
     <value>true</value>
     <tag>OZONE, SCM, PIPELINE</tag>
     <description>
+      SCM BackgroundPipelineCreator will skip create pipeline while the count of
+      current available pipeline achieve this value.
+    </description>
+  </property>
+  <property>
+    <name>ozone.scm.pipeline.creation.auto.limit</name>
+    <value>3</value>
+    <tag>OZONE, SCM, PIPELINE</tag>
+    <description>
       If enabled, SCM will auto create RATIS factor ONE pipeline.
     </description>
   </property>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreator.java
@@ -105,6 +105,9 @@ class BackgroundPipelineCreator {
     HddsProtos.ReplicationType type = HddsProtos.ReplicationType.valueOf(
         conf.get(OzoneConfigKeys.OZONE_REPLICATION_TYPE,
             OzoneConfigKeys.OZONE_REPLICATION_TYPE_DEFAULT));
+    int autoCreateLimit = conf.getInt(
+        ScmConfigKeys.OZONE_SCM_PIPELINE_AUTO_CREATE_LIMIT,
+        ScmConfigKeys.OZONE_SCM_PIPELINE_AUTO_CREATE_LIMIT_DEFAULT);
     boolean autoCreateFactorOne = conf.getBoolean(
         ScmConfigKeys.OZONE_SCM_PIPELINE_AUTO_CREATE_FACTOR_ONE,
         ScmConfigKeys.OZONE_SCM_PIPELINE_AUTO_CREATE_FACTOR_ONE_DEFAULT);
@@ -127,6 +130,12 @@ class BackgroundPipelineCreator {
       while (true) {
         try {
           if (scheduler.isClosed()) {
+            break;
+          }
+          int currentAvailablePipelineCount =
+              pipelineManager.getPipelines(type, factor,
+                  Pipeline.PipelineState.OPEN).size();
+          if (currentAvailablePipelineCount >= autoCreateLimit) {
             break;
           }
           pipelineManager.createPipeline(type, factor);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -115,7 +115,7 @@ public class SCMPipelineManager implements PipelineManager {
     // TODO: See if thread priority needs to be set for these threads
     scheduler = new Scheduler("RatisPipelineUtilsThread", false, 1);
     this.backgroundPipelineCreator =
-        new BackgroundPipelineCreator(this, scheduler, conf);
+        new BackgroundPipelineCreator(this, nodeManager, scheduler, conf);
     this.eventPublisher = eventPublisher;
     this.nodeManager = nodeManager;
     this.metrics = SCMPipelineMetrics.create();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set a configurable maximum limit of available pipeline, 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3593

## How was this patch tested?

A new cluster will not create pipeline more than confg  autoCreateLimit, 