### PR TITLE
HDDS-3604. Use Ozone version of Hadoop Security/Token classes

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/RandomContainerDeletionChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/RandomContainerDeletionChoosingPolicy.java
@@ -18,9 +18,9 @@
 package org.apache.hadoop.ozone.container.common.impl;
 
 import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.hdds.scm.container.common.helpers
     .StorageContainerException;
-import org.apache.hadoop.hdfs.DFSUtil;
 import org.apache.hadoop.ozone.container.common.interfaces
     .ContainerDeletionChoosingPolicy;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
@@ -50,8 +50,9 @@ public class RandomContainerDeletionChoosingPolicy
     List<ContainerData> result = new LinkedList<>();
     ContainerData[] values = new ContainerData[candidateContainers.size()];
     // to get a shuffle list
-    for (ContainerData entry : DFSUtil.shuffle(
-        candidateContainers.values().toArray(values))) {
+    ContainerData[] shuffled = candidateContainers.values().toArray(values);
+    ArrayUtils.shuffle(shuffled);
+    for (ContainerData entry : shuffled) {
       if (currentCount < count) {
         result.add(entry);
         currentCount++;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfo.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.UnknownPipelineStateException;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyLocation;
+import org.apache.hadoop.ozone.protocolPB.OzonePBHelper;
 import org.apache.hadoop.security.token.Token;
 
 import java.util.Objects;
@@ -162,7 +163,7 @@ public final class OmKeyLocationInfo {
         .setOffset(offset)
         .setCreateVersion(createVersion);
     if (this.token != null) {
-      builder.setToken(this.token.toTokenProto());
+      builder.setToken(OzonePBHelper.protoFromToken(token));
     }
     try {
       builder.setPipeline(pipeline.getProtobufMessage());
@@ -188,7 +189,8 @@ public final class OmKeyLocationInfo {
         keyLocation.getLength(),
         keyLocation.getOffset());
     if(keyLocation.hasToken()) {
-      info.token =  new Token<>(keyLocation.getToken());
+      info.token = (Token<OzoneBlockTokenIdentifier>)
+              OzonePBHelper.tokenFromProto(keyLocation.getToken());
     }
     info.setCreateVersion(keyLocation.getCreateVersion());
     return info;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -132,9 +132,9 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.VolumeI
 import org.apache.hadoop.ozone.protocolPB.OMPBHelper;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
-import org.apache.hadoop.security.proto.SecurityProtos.CancelDelegationTokenRequestProto;
-import org.apache.hadoop.security.proto.SecurityProtos.GetDelegationTokenRequestProto;
-import org.apache.hadoop.security.proto.SecurityProtos.RenewDelegationTokenRequestProto;
+import org.apache.hadoop.ozone.security.proto.SecurityProtos.CancelDelegationTokenRequestProto;
+import org.apache.hadoop.ozone.security.proto.SecurityProtos.GetDelegationTokenRequestProto;
+import org.apache.hadoop.ozone.security.proto.SecurityProtos.RenewDelegationTokenRequestProto;
 import org.apache.hadoop.security.token.Token;
 
 import com.google.common.annotations.VisibleForTesting;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .FileEncryptionInfoProto;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
-import org.apache.hadoop.security.proto.SecurityProtos.TokenProto;
+import org.apache.hadoop.ozone.security.proto.SecurityProtos.TokenProto;
 import org.apache.hadoop.security.token.Token;
 
 /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OzonePBHelper.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OzonePBHelper.java
@@ -17,14 +17,72 @@
  */
 package org.apache.hadoop.ozone.protocolPB;
 
+import com.google.protobuf.ByteString;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.ozone.security.proto.SecurityProtos.TokenProto;
+import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.security.token.TokenIdentifier;
+
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * Helper class for converting protobuf objects.
  */
 public final class OzonePBHelper {
-
   private OzonePBHelper() {
     /** Hidden constructor */
   }
 
+  // Borrowed from ProtobuHelper.java in hadoop-common involving protobuf
+  // messages to avoid breakage due to shading of protobuf in Hadoop-3.3+.
+  /**
+   * Map used to cache fixed strings to ByteStrings. Since there is no
+   * automatic expiration policy, only use this for strings from a fixed, small
+   * set.
+   * <p/>
+   * This map should not be accessed directly. Used the getFixedByteString
+   * methods instead.
+   */
+  private final static ConcurrentHashMap<Object, ByteString>
+          FIXED_BYTESTRING_CACHE = new ConcurrentHashMap<>();
 
+  /**
+   * Get the ByteString for frequently used fixed and small set strings.
+   *
+   * @param key string
+   * @return
+   */
+  public static ByteString getFixedByteString(Text key) {
+    ByteString value = FIXED_BYTESTRING_CACHE.get(key);
+    if (value == null) {
+      value = ByteString.copyFromUtf8(key.toString());
+      ByteString oldValue = FIXED_BYTESTRING_CACHE.putIfAbsent(key, value);
+      return oldValue != null ? oldValue : value;
+    }
+    return value;
+  }
+
+  public static ByteString getByteString(byte[] bytes) {
+    // return singleton to reduce object allocation
+    return (bytes.length == 0) ? ByteString.EMPTY : ByteString.copyFrom(bytes);
+  }
+
+  public static Token<? extends TokenIdentifier> tokenFromProto(
+          TokenProto tokenProto) {
+    Token<? extends TokenIdentifier> token = new Token<>(
+            tokenProto.getIdentifier().toByteArray(),
+            tokenProto.getPassword().toByteArray(),
+            new Text(tokenProto.getKind()),
+            new Text(tokenProto.getService()));
+    return token;
+  }
+
+  public static TokenProto protoFromToken(Token<?> tok) {
+    TokenProto.Builder builder = TokenProto.newBuilder().
+            setIdentifier(getByteString(tok.getIdentifier())).
+            setPassword(getByteString(tok.getPassword())).
+            setKindBytes(getFixedByteString(tok.getKind())).
+            setServiceBytes(getFixedByteString(tok.getService()));
+    return builder.build();
+  }
 }

--- a/hadoop-ozone/interface-client/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-ozone/interface-client/dev-support/findbugsExcludeFile.xml
@@ -19,6 +19,6 @@
     <Package name="org.apache.hadoop.ozone.protocol.proto"/>
   </Match>
   <Match>
-    <Package name="org.apache.hadoop.security.proto"/>
+    <Package name="org.apache.hadoop.ozone.security.proto"/>
   </Match>
 </FindBugsFilter>

--- a/hadoop-ozone/interface-client/src/main/proto/Security.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/Security.proto
@@ -22,7 +22,8 @@
  * for what changes are allowed for a *stable* .proto interface.
  */
 
-option java_package = "org.apache.hadoop.security.proto";
+//Use ozone specific security proto until start using hadoop-thirdparty shaded protobuf everywhere.
+option java_package = "org.apache.hadoop.ozone.security.proto";
 option java_outer_classname = "SecurityProtos";
 option java_generic_services = true;
 option java_generate_equals_and_hash = true;

--- a/hadoop-ozone/interface-client/src/main/proto/proto.lock
+++ b/hadoop-ozone/interface-client/src/main/proto/proto.lock
@@ -3404,7 +3404,7 @@
         "options": [
           {
             "name": "java_package",
-            "value": "org.apache.hadoop.security.proto"
+            "value": "org.apache.hadoop.ozone.security.proto"
           },
           {
             "name": "java_outer_classname",

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMCancelDelegationTokenRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMCancelDelegationTokenRequest.java
@@ -31,8 +31,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CancelDelegationTokenResponseProto;
 import org.apache.hadoop.ozone.protocolPB.OMPBHelper;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
-import org.apache.hadoop.security.proto.SecurityProtos;
-import org.apache.hadoop.security.proto.SecurityProtos.CancelDelegationTokenRequestProto;
+import org.apache.hadoop.ozone.security.proto.SecurityProtos;
+import org.apache.hadoop.ozone.security.proto.SecurityProtos.CancelDelegationTokenRequestProto;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMGetDelegationTokenRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMGetDelegationTokenRequest.java
@@ -33,11 +33,11 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.UpdateGetDelegationTokenRequest;
 import org.apache.hadoop.ozone.protocolPB.OMPBHelper;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
-import org.apache.hadoop.security.proto.SecurityProtos;
-import org.apache.hadoop.security.proto.SecurityProtos.GetDelegationTokenRequestProto;
-import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.security.proto.SecurityProtos;
+import org.apache.hadoop.ozone.security.proto.SecurityProtos.GetDelegationTokenRequestProto;
+import org.apache.hadoop.security.token.Token;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMRenewDelegationTokenRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/security/OMRenewDelegationTokenRequest.java
@@ -37,7 +37,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RenewDe
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.UpdateRenewDelegationTokenRequest;
 import org.apache.hadoop.ozone.protocolPB.OMPBHelper;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
-import org.apache.hadoop.security.proto.SecurityProtos.RenewDelegationTokenRequestProto;
+import org.apache.hadoop.ozone.security.proto.SecurityProtos.RenewDelegationTokenRequestProto;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -67,7 +67,8 @@ public class OMRenewDelegationTokenRequest extends OMClientRequest {
     RenewDelegationTokenResponseProto.Builder renewResponse =
         RenewDelegationTokenResponseProto.newBuilder();
 
-    renewResponse.setResponse(org.apache.hadoop.security.proto.SecurityProtos
+    renewResponse.setResponse(
+            org.apache.hadoop.ozone.security.proto.SecurityProtos
         .RenewDelegationTokenResponseProto.newBuilder()
         .setNewExpiryTime(renewTime));
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/security/TestOMGetDelegationTokenRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/security/TestOMGetDelegationTokenRequest.java
@@ -30,8 +30,9 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMRequest;
 import static org.apache.hadoop.ozone.security.OzoneTokenIdentifier.KIND_NAME;
+
+import org.apache.hadoop.ozone.security.proto.SecurityProtos.GetDelegationTokenRequestProto;
 import org.apache.hadoop.security.token.Token;
-import org.apache.hadoop.security.proto.SecurityProtos.GetDelegationTokenRequestProto;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.io.Text;
 import org.mockito.Mockito;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/security/TestOMGetDelegationTokenResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/security/TestOMGetDelegationTokenResponse.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om.response.security;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.om.request.security.OMGetDelegationTokenRequest;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
-import org.apache.hadoop.security.proto.SecurityProtos.GetDelegationTokenRequestProto;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -29,6 +28,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.UpdateGetDelegationTokenRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
+import org.apache.hadoop.ozone.security.proto.SecurityProtos.GetDelegationTokenRequestProto;
 import java.io.IOException;
 import java.util.UUID;
 import org.junit.Assert;


### PR DESCRIPTION
## What changes were proposed in this pull request?

As described in Jira, this PR is to make preparations for upgrade to Hadoop-3.3, when released.
This wil remove direct depedency on Hadoop's internalyl used protobuf classes.
Hadoop 3.3 upgraded the internal protobuf usage to 3.7 and shades all protobuf classes.
Because of this change ozone compilation breaks.
1. Generating the SecurityProtos classes internal ozone, still keeping wire compatibility.
2. Borrowed the utility/helper methods which have protobuf usage in signature, which changes in Hadoop now.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3604

## How was this patch tested?
Verified manually in local and build ozone.
