### PR TITLE
HDDS-3606. Add datanode port into the printTopology command output

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/TopologySubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/TopologySubcommand.java
@@ -116,12 +116,24 @@ public class TopologySubcommand implements Callable<Void> {
     });
   }
 
+  private String formatPortOutput(List<HddsProtos.Port> ports) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < ports.size(); i++) {
+      HddsProtos.Port port = ports.get(i);
+      sb.append(port.getName() + "=" + port.getValue());
+      if (i < ports.size() -1) {
+        sb.append(",");
+      }
+    }
+    return sb.toString();
+  }
 
-  // Format "ipAddress(hostName)    networkLocation"
+  // Format "ipAddress(hostName):PortName1=PortValue1    networkLocation"
   private void printNodesWithLocation(Collection<HddsProtos.Node> nodes) {
     nodes.forEach(node -> {
       System.out.print(" " + node.getNodeID().getIpAddress() + "(" +
-          node.getNodeID().getHostName() + ")");
+          node.getNodeID().getHostName() + ")" +
+          ":" + formatPortOutput(node.getNodeID().getPortsList()));
       System.out.println("    " +
           (node.getNodeID().getNetworkLocation() != null ?
               node.getNodeID().getNetworkLocation() : "NA"));

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/TopologySubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/TopologySubcommand.java
@@ -121,7 +121,7 @@ public class TopologySubcommand implements Callable<Void> {
     for (int i = 0; i < ports.size(); i++) {
       HddsProtos.Port port = ports.get(i);
       sb.append(port.getName() + "=" + port.getValue());
-      if (i < ports.size() -1) {
+      if (i < ports.size() - 1) {
         sb.append(",");
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now, i start 3 datanode in a node, the 3 datanode use differents port, but i cannot distinguish which one is HEALTHY, which one is not. A port print is necessary.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3606

## How was this patch tested?

```bash
 bin/ozone  admin printTopology
State = HEALTHY
 127.0.0.1(localhost):RATIS=52789,STANDALONE=52790    /default-rack
 127.0.0.1(localhost):RATIS=52777,STANDALONE=52778    /default-rack
 127.0.0.1(localhost):RATIS=52752,STANDALONE=52753    /default-rack

```