### PR TITLE
HDDS-3607. Lot of warnings at DN startup.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -108,9 +108,11 @@ public class BlockManagerImpl implements BlockManager {
         // transaction is reapplied in the ContainerStateMachine on restart.
         // It also implies that the given block must already exist in the db.
         // just log and return
-        LOG.warn("blockCommitSequenceId {} in the Container Db is greater than"
-            + " the supplied value {}. Ignoring it",
-            containerBCSId, bcsId);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("blockCommitSequenceId {} in the Container Db is greater"
+                  + " than the supplied value {}. Ignoring it",
+              containerBCSId, bcsId);
+        }
         return data.getSize();
       }
       // update the blockData as well as BlockCommitSequenceId here

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -108,11 +108,9 @@ public class BlockManagerImpl implements BlockManager {
         // transaction is reapplied in the ContainerStateMachine on restart.
         // It also implies that the given block must already exist in the db.
         // just log and return
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("blockCommitSequenceId {} in the Container Db is greater"
-                  + " than the supplied value {}. Ignoring it",
-              containerBCSId, bcsId);
-        }
+        LOG.debug("blockCommitSequenceId {} in the Container Db is greater"
+                + " than the supplied value {}. Ignoring it",
+            containerBCSId, bcsId);
         return data.getSize();
       }
       // update the blockData as well as BlockCommitSequenceId here


### PR DESCRIPTION
## What changes were proposed in this pull request?

The log message which is at WARN level before the PR, is printed for every edit in the raft log since the last snapshot during DataNode startup, as we replay the edits, we don't need to spam with this many warnings, especially as this is part of normal operations. The proposal is to change it to DEBUG level.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3607

## How was this patch tested?

No tests were done, seems to be too trivial to be wrong :)
