### PR TITLE
HDDS-3608. NPE while process a pipeline report when PipelineQuery absent in query2OpenPipelines

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
@@ -374,7 +374,12 @@ class PipelineStateMap {
     PipelineQuery query = new PipelineQuery(pipeline);
     if (updatedPipeline.getPipelineState() == PipelineState.OPEN) {
       // for transition to OPEN state add pipeline to query2OpenPipelines
-      query2OpenPipelines.get(query).add(updatedPipeline);
+      List<Pipeline> pipelineList = query2OpenPipelines.get(query);
+      if (pipelineList == null) {
+        pipelineList = new CopyOnWriteArrayList<>();
+        query2OpenPipelines.put(query, pipelineList);
+      }
+      pipelineList.add(updatedPipeline);
     } else {
       // for transition from OPEN to CLOSED state remove pipeline from
       // query2OpenPipelines

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
@@ -372,9 +372,9 @@ class PipelineStateMap {
     Pipeline updatedPipeline = pipelineMap.compute(pipelineID,
         (id, p) -> Pipeline.newBuilder(pipeline).setState(state).build());
     PipelineQuery query = new PipelineQuery(pipeline);
+    List<Pipeline> pipelineList = query2OpenPipelines.get(query);
     if (updatedPipeline.getPipelineState() == PipelineState.OPEN) {
       // for transition to OPEN state add pipeline to query2OpenPipelines
-      List<Pipeline> pipelineList = query2OpenPipelines.get(query);
       if (pipelineList == null) {
         pipelineList = new CopyOnWriteArrayList<>();
         query2OpenPipelines.put(query, pipelineList);
@@ -383,7 +383,9 @@ class PipelineStateMap {
     } else {
       // for transition from OPEN to CLOSED state remove pipeline from
       // query2OpenPipelines
-      query2OpenPipelines.get(query).remove(pipeline);
+      if (pipelineList != null) {
+        pipelineList.remove(pipeline);
+      }
     }
     return updatedPipeline;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix a NPE while SCM receive and handle a datanode pipeline report, PipelineStateMap will get the pipelineList from `query2OpenPipelines`, and put the `updatedPipeline` to the list, but if the list is NULL, NPE will occur. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3608

## How was this patch tested?

No need
