### PR TITLE
HDDS-3613. Fix JVMPause monitor start in OzoneManager.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1148,6 +1148,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       LOG.error("OM HttpServer failed to start.", ex);
     }
     registerMXBean();
+
+    startJVMPauseMonitor();
     setStartTime();
     omState = State.RUNNING;
   }
@@ -1201,10 +1203,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     }
     registerMXBean();
 
-    // Start jvm monitor
-    jvmPauseMonitor = new JvmPauseMonitor();
-    jvmPauseMonitor.init(configuration);
-    jvmPauseMonitor.start();
+    startJVMPauseMonitor();
     setStartTime();
     omState = State.RUNNING;
   }
@@ -3315,5 +3314,12 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   @VisibleForTesting
   public boolean isRunning() {
     return omState == State.RUNNING;
+  }
+
+  private void startJVMPauseMonitor() {
+    // Start jvm monitor
+    jvmPauseMonitor = new JvmPauseMonitor();
+    jvmPauseMonitor.init(configuration);
+    jvmPauseMonitor.start();
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Start JVM pause monitor during OM start up.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3613


## How was this patch tested?

Tested it on a cluster, now able to see JVM pauses detected.

2020-05-18 16:17:15,693 [org.apache.hadoop.util.JvmPauseMonitor$Monitor@1fde0371] WARN org.apache.hadoop.util.JvmPauseMonitor: Detected pause in JVM or host machine (eg GC): pause of approximately 25546ms
GC pool 'ParNew' had collection(s): count=1 time=0ms