### PR TITLE
HDDS-3574. Implement ofs://: Override getTrashRoot

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -524,8 +524,7 @@ public class TestOzoneShellHA {
       try {
         fs.getFileStatus(trashPathKey2);
         Assert.fail("getFileStatus on non-existent should throw.");
-      }
-      catch (FileNotFoundException ignored) {
+      } catch (FileNotFoundException ignored) {
       }
     } finally {
       shell.close();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -469,7 +469,7 @@ public class TestOzoneShellHA {
     return clientConf;
   }
 
-  @SuppressWarnings("checkstyle:RightCurly") @Test
+  @Test
   public void testDeleteToTrashOrSkipTrash() throws Exception {
     final String hostPrefix = OZONE_OFS_URI_SCHEME + "://" + omServiceId;
     OzoneConfiguration clientConf = getClientConfForOFS(hostPrefix, conf);

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -659,6 +659,19 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   }
 
   /**
+   * Get the root directory of Trash for a path in OFS.
+   * Returns /<volumename>/<bucketname>/.Trash/<username>
+   * Caller appends either Current or checkpoint timestamp for trash destination
+   * @param path the trash root of the path to be determined.
+   * @return trash root
+   */
+  @Override
+  public Path getTrashRoot(Path path) {
+    OFSPath ofsPath = new OFSPath(path);
+    return ofsPath.getTrashRoot();
+  }
+
+  /**
    * Creates a directory. Directory is represented using a key with no value.
    *
    * @param path directory path to be created

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.http.ParseException;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
-import org.apache.http.client.utils.URIBuilder;
 
 import java.math.BigInteger;
 import java.net.URI;
@@ -256,14 +255,13 @@ class OFSPath {
   public Path getTrashRoot() {
     try {
       String username = UserGroupInformation.getCurrentUser().getUserName();
-      URI uri = new URIBuilder().setScheme(OZONE_OFS_URI_SCHEME)
-          .setHost(authority).setPath(OZONE_URI_DELIMITER + volumeName +
-              OZONE_URI_DELIMITER + bucketName +
-              OZONE_URI_DELIMITER + TRASH_PREFIX +
-              OZONE_URI_DELIMITER + username)
-          .build();
-      return new Path(uri);
-    } catch (Exception ex) {
+      final Path pathRoot = new Path(
+          OZONE_OFS_URI_SCHEME, authority, OZONE_URI_DELIMITER);
+      final Path pathToVolume = new Path(pathRoot, volumeName);
+      final Path pathToBucket = new Path(pathToVolume, bucketName);
+      final Path pathToTrash = new Path(pathToBucket, TRASH_PREFIX);
+      return new Path(pathToTrash, username);
+    } catch (IOException ex) {
       throw new RuntimeException("getTrashRoot failed.", ex);
     }
   }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
@@ -43,7 +43,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
  */
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
-class OFSPath {
+public class OFSPath {
   private String authority = "";
   /**
    * Here is a table illustrating what each name variable is given an input path
@@ -68,11 +68,11 @@ class OFSPath {
   @VisibleForTesting
   static final String OFS_MOUNT_TMP_VOLUMENAME = "tmp";
 
-  OFSPath(Path path) {
+  public OFSPath(Path path) {
     initOFSPath(path.toUri());
   }
 
-  OFSPath(String pathStr) {
+  public OFSPath(String pathStr) {
     try {
       initOFSPath(new URI(pathStr));
     } catch (URISyntaxException ex) {

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OFSPath.java
@@ -145,6 +145,39 @@ class OFSPath {
   }
 
   /**
+   * Return the reconstructed path string.
+   * Directories including volumes and buckets will have a trailing '/'.
+   */
+  @Override
+  public String toString() {
+    Preconditions.checkNotNull(authority);
+    StringBuilder sb = new StringBuilder();
+    if (!isMount()) {
+      sb.append(volumeName);
+      sb.append(OZONE_URI_DELIMITER);
+      if (!bucketName.isEmpty()) {
+        sb.append(bucketName);
+        sb.append(OZONE_URI_DELIMITER);
+      }
+    } else {
+      sb.append(mountName);
+      sb.append(OZONE_URI_DELIMITER);
+    }
+    if (!keyName.isEmpty()) {
+      sb.append(keyName);
+    }
+    if (authority.isEmpty()) {
+      sb.insert(0, OZONE_URI_DELIMITER);
+      return sb.toString();
+    } else {
+      final Path pathWithSchemeAuthority = new Path(
+          OZONE_OFS_URI_SCHEME, authority, OZONE_URI_DELIMITER);
+      sb.insert(0, pathWithSchemeAuthority.toString());
+      return sb.toString();
+    }
+  }
+
+  /**
    * Get the volume & bucket or mount name (non-key path).
    * @return String of path excluding key in bucket.
    */

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
@@ -31,6 +31,7 @@ public class TestOFSPath {
   public void testParsingVolumeBucketWithKey() {
     // Two most common cases: file key and dir key inside a bucket
     OFSPath ofsPath = new OFSPath("/volume1/bucket2/dir3/key4");
+    Assert.assertEquals("", ofsPath.getAuthority());
     Assert.assertEquals("volume1", ofsPath.getVolumeName());
     Assert.assertEquals("bucket2", ofsPath.getBucketName());
     Assert.assertEquals("dir3/key4", ofsPath.getKeyName());
@@ -39,6 +40,7 @@ public class TestOFSPath {
 
     // The ending '/' matters for key inside a bucket, indicating directory
     ofsPath = new OFSPath("/volume1/bucket2/dir3/dir5/");
+    Assert.assertEquals("", ofsPath.getAuthority());
     Assert.assertEquals("volume1", ofsPath.getVolumeName());
     Assert.assertEquals("bucket2", ofsPath.getBucketName());
     // Check the key must end with '/' (dir5 is a directory)
@@ -51,6 +53,7 @@ public class TestOFSPath {
   public void testParsingVolumeBucketOnly() {
     // Volume and bucket only
     OFSPath ofsPath = new OFSPath("/volume1/bucket2/");
+    Assert.assertEquals("", ofsPath.getAuthority());
     Assert.assertEquals("volume1", ofsPath.getVolumeName());
     Assert.assertEquals("bucket2", ofsPath.getBucketName());
     Assert.assertEquals("", ofsPath.getMountName());
@@ -60,6 +63,7 @@ public class TestOFSPath {
 
     // The ending '/' shouldn't for buckets
     ofsPath = new OFSPath("/volume1/bucket2");
+    Assert.assertEquals("", ofsPath.getAuthority());
     Assert.assertEquals("volume1", ofsPath.getVolumeName());
     Assert.assertEquals("bucket2", ofsPath.getBucketName());
     Assert.assertEquals("", ofsPath.getMountName());
@@ -72,6 +76,7 @@ public class TestOFSPath {
   public void testParsingVolumeOnly() {
     // Volume only
     OFSPath ofsPath = new OFSPath("/volume1/");
+    Assert.assertEquals("", ofsPath.getAuthority());
     Assert.assertEquals("volume1", ofsPath.getVolumeName());
     Assert.assertEquals("", ofsPath.getBucketName());
     Assert.assertEquals("", ofsPath.getMountName());
@@ -81,6 +86,7 @@ public class TestOFSPath {
 
     // Ending '/' shouldn't matter
     ofsPath = new OFSPath("/volume1");
+    Assert.assertEquals("", ofsPath.getAuthority());
     Assert.assertEquals("volume1", ofsPath.getVolumeName());
     Assert.assertEquals("", ofsPath.getBucketName());
     Assert.assertEquals("", ofsPath.getMountName());
@@ -94,13 +100,13 @@ public class TestOFSPath {
 
   @Test
   public void testParsingWithAuthority() {
-    try {
-      new OFSPath("ofs://svc1/volume1/bucket1/dir1/");
-      Assert.fail(
-          "Should have thrown exception when parsing path with authority.");
-    } catch (Exception ignored) {
-      // Test pass
-    }
+    OFSPath ofsPath = new OFSPath("ofs://svc1:9876/volume1/bucket2/dir3/");
+    Assert.assertEquals("svc1:9876", ofsPath.getAuthority());
+    Assert.assertEquals("volume1", ofsPath.getVolumeName());
+    Assert.assertEquals("bucket2", ofsPath.getBucketName());
+    Assert.assertEquals("dir3/", ofsPath.getKeyName());
+    Assert.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
+    Assert.assertFalse(ofsPath.isMount());
   }
 
   @Test
@@ -115,6 +121,7 @@ public class TestOFSPath {
     }
     // Mount only
     OFSPath ofsPath = new OFSPath("/tmp/");
+    Assert.assertEquals("", ofsPath.getAuthority());
     Assert.assertEquals(
         OFSPath.OFS_MOUNT_TMP_VOLUMENAME, ofsPath.getVolumeName());
     Assert.assertEquals(bucketName, ofsPath.getBucketName());
@@ -125,6 +132,7 @@ public class TestOFSPath {
 
     // Mount with key
     ofsPath = new OFSPath("/tmp/key1");
+    Assert.assertEquals("", ofsPath.getAuthority());
     Assert.assertEquals(
         OFSPath.OFS_MOUNT_TMP_VOLUMENAME, ofsPath.getVolumeName());
     Assert.assertEquals(bucketName, ofsPath.getBucketName());

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
@@ -113,7 +113,8 @@ public class TestOFSPath {
     Assert.assertEquals("dir3/", ofsPath.getKeyName());
     Assert.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
     Assert.assertFalse(ofsPath.isMount());
-    Assert.assertEquals("ofs://svc1:9876/volume1/bucket2/dir3/", ofsPath.toString());
+    Assert.assertEquals("ofs://svc1:9876/volume1/bucket2/dir3/",
+        ofsPath.toString());
   }
 
   @Test

--- a/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
+++ b/hadoop-ozone/ozonefs/src/test/java/org/apache/hadoop/fs/ozone/TestOFSPath.java
@@ -37,6 +37,7 @@ public class TestOFSPath {
     Assert.assertEquals("dir3/key4", ofsPath.getKeyName());
     Assert.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
     Assert.assertFalse(ofsPath.isMount());
+    Assert.assertEquals("/volume1/bucket2/dir3/key4", ofsPath.toString());
 
     // The ending '/' matters for key inside a bucket, indicating directory
     ofsPath = new OFSPath("/volume1/bucket2/dir3/dir5/");
@@ -47,6 +48,7 @@ public class TestOFSPath {
     Assert.assertEquals("dir3/dir5/", ofsPath.getKeyName());
     Assert.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
     Assert.assertFalse(ofsPath.isMount());
+    Assert.assertEquals("/volume1/bucket2/dir3/dir5/", ofsPath.toString());
   }
 
   @Test
@@ -60,8 +62,9 @@ public class TestOFSPath {
     Assert.assertEquals("", ofsPath.getKeyName());
     Assert.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
     Assert.assertFalse(ofsPath.isMount());
+    Assert.assertEquals("/volume1/bucket2/", ofsPath.toString());
 
-    // The ending '/' shouldn't for buckets
+    // The trailing '/' doesn't matter when parsing a bucket path
     ofsPath = new OFSPath("/volume1/bucket2");
     Assert.assertEquals("", ofsPath.getAuthority());
     Assert.assertEquals("volume1", ofsPath.getVolumeName());
@@ -70,6 +73,7 @@ public class TestOFSPath {
     Assert.assertEquals("", ofsPath.getKeyName());
     Assert.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
     Assert.assertFalse(ofsPath.isMount());
+    Assert.assertEquals("/volume1/bucket2/", ofsPath.toString());
   }
 
   @Test
@@ -83,8 +87,9 @@ public class TestOFSPath {
     Assert.assertEquals("", ofsPath.getKeyName());
     Assert.assertEquals("/volume1/", ofsPath.getNonKeyPath());
     Assert.assertFalse(ofsPath.isMount());
+    Assert.assertEquals("/volume1/", ofsPath.toString());
 
-    // Ending '/' shouldn't matter
+    // The trailing '/' doesn't matter when parsing a volume path
     ofsPath = new OFSPath("/volume1");
     Assert.assertEquals("", ofsPath.getAuthority());
     Assert.assertEquals("volume1", ofsPath.getVolumeName());
@@ -96,6 +101,7 @@ public class TestOFSPath {
     //  The behavior might change in the future.
     Assert.assertEquals("/volume1/", ofsPath.getNonKeyPath());
     Assert.assertFalse(ofsPath.isMount());
+    Assert.assertEquals("/volume1/", ofsPath.toString());
   }
 
   @Test
@@ -107,6 +113,7 @@ public class TestOFSPath {
     Assert.assertEquals("dir3/", ofsPath.getKeyName());
     Assert.assertEquals("/volume1/bucket2", ofsPath.getNonKeyPath());
     Assert.assertFalse(ofsPath.isMount());
+    Assert.assertEquals("ofs://svc1:9876/volume1/bucket2/dir3/", ofsPath.toString());
   }
 
   @Test
@@ -129,6 +136,7 @@ public class TestOFSPath {
     Assert.assertEquals("", ofsPath.getKeyName());
     Assert.assertEquals("/tmp", ofsPath.getNonKeyPath());
     Assert.assertTrue(ofsPath.isMount());
+    Assert.assertEquals("/tmp/", ofsPath.toString());
 
     // Mount with key
     ofsPath = new OFSPath("/tmp/key1");
@@ -140,5 +148,6 @@ public class TestOFSPath {
     Assert.assertEquals("key1", ofsPath.getKeyName());
     Assert.assertEquals("/tmp", ofsPath.getNonKeyPath());
     Assert.assertTrue(ofsPath.isMount());
+    Assert.assertEquals("/tmp/key1", ofsPath.toString());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implement `getTrashRoot()` in OFS so deleting to trash will always move files/dirs within the same bucket.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3574

## How was this patch tested?

Added new test. Manually tested in docker.

## To Check

1. Whether key path char set includes the char set for user name

## Before and After patch

Before the patch the FS client might attempt to move the file to another bucket when `-skipTrash` is not specified and `fs.trash.interval > 0`.

```bash
# Configure fs.trash.interval to a value larger than 0
bash-4.2$ vi /etc/hadoop/core-site.xml
bash-4.2$ ozone fs -mkdir -p ofs://om/vol1/bucket1/dir1/
bash-4.2$ ozone fs -touch ofs://om/vol1/bucket1/dir1/key1 
bash-4.2$ ozone fs -rm ofs://om/vol1/bucket1/dir1/key1
2020-05-18 17:57:44,953 [main] INFO Configuration.deprecation: io.bytes.per.checksum is deprecated. Instead, use dfs.bytes-per-checksum
2020-05-18 17:57:44,971 [main] INFO ozone.BasicRootedOzoneFileSystem: getTrashRoot: path = ofs://om/vol1/bucket1/dir1/key1
2020-05-18 17:57:45,069 [main] INFO rpc.RpcClient: Creating Volume: user, with hadoop as owner.
2020-05-18 17:57:45,104 [main] INFO rpc.RpcClient: Creating Bucket: user/hadoop, with Versioning false and Storage Type set to DISK and Encryption set to false 
rm: Failed to move to trash: ofs://om/vol1/bucket1/dir1/key1: Cannot rename a key to a different bucket. Consider using -skipTrash option
```

After the patch the client should move the deleted file to trash under the bucket.

```bash
bash-4.2$ vi /etc/hadoop/core-site.xml
bash-4.2$ ozone fs -mkdir -p ofs://om/vol1/bucket1/dir1/
2020-05-19 18:04:41,914 [main] INFO rpc.RpcClient: Creating Volume: vol1, with hadoop as owner.
2020-05-19 18:04:42,076 [main] INFO rpc.RpcClient: Creating Bucket: vol1/bucket1, with Versioning false and Storage Type set to DISK and Encryption set to false
bash-4.2$ ozone fs -touch ofs://om/vol1/bucket1/dir1/key1
bash-4.2$ ozone fs -rm ofs://om/vol1/bucket1/dir1/key1
2020-05-19 18:04:52,055 [main] INFO Configuration.deprecation: io.bytes.per.checksum is deprecated. Instead, use dfs.bytes-per-checksum
2020-05-19 18:04:52,274 [main] INFO fs.TrashPolicyDefault: Moved: 'ofs://om/vol1/bucket1/dir1/key1' to trash at: ofs://om/vol1/bucket1/.Trash/hadoop/Current/vol1/bucket1/dir1/key1
```