### PR TITLE
HDDS-2556. Handle InterruptedException in BlockOutputStream

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -317,8 +317,14 @@ public class BlockOutputStream extends OutputStream {
       if (!commitWatcher.getFutureMap().isEmpty()) {
         waitOnFlushFutures();
       }
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (ExecutionException e) {
       setIoException(e);
+      adjustBuffersOnException();
+      throw getIoException();
+    } catch (InterruptedException ex) {
+      LOG.error("Command execution was interrupted.");
+      Thread.currentThread().interrupt();
+      setIoException(ex);
       adjustBuffersOnException();
       throw getIoException();
     }
@@ -427,9 +433,14 @@ public class BlockOutputStream extends OutputStream {
         setIoException(ce);
         throw ce;
       });
-    } catch (IOException | InterruptedException | ExecutionException e) {
+    } catch (IOException | ExecutionException e) {
       throw new IOException(
           "Unexpected Storage Container Exception: " + e.toString(), e);
+    } catch (InterruptedException ex) {
+      LOG.error("Command execution was interrupted.");
+      Thread.currentThread().interrupt();
+      throw new IOException(
+          "Unexpected Storage Container Exception: " + ex.toString(), ex);
     }
     commitWatcher.getFutureMap().put(flushPos, flushFuture);
     return flushFuture;
@@ -443,10 +454,16 @@ public class BlockOutputStream extends OutputStream {
             writtenDataLength - totalDataFlushedLength >= streamBufferSize)) {
       try {
         handleFlush(false);
-      } catch (InterruptedException | ExecutionException e) {
+      } catch (ExecutionException e) {
         // just set the exception here as well in order to maintain sanctity of
         // ioException field
         setIoException(e);
+        adjustBuffersOnException();
+        throw getIoException();
+      } catch (InterruptedException ex) {
+        LOG.error("Command execution was interrupted.");
+        Thread.currentThread().interrupt();
+        setIoException(ex);
         adjustBuffersOnException();
         throw getIoException();
       }
@@ -506,8 +523,14 @@ public class BlockOutputStream extends OutputStream {
         && bufferPool != null && bufferPool.getSize() > 0) {
       try {
         handleFlush(true);
-      } catch (InterruptedException | ExecutionException e) {
+      } catch (ExecutionException e) {
         setIoException(e);
+        adjustBuffersOnException();
+        throw getIoException();
+      } catch (InterruptedException ex) {
+        LOG.error("Command execution was interrupted.");
+        Thread.currentThread().interrupt();
+        setIoException(ex);
         adjustBuffersOnException();
         throw getIoException();
       } finally {
@@ -643,9 +666,14 @@ public class BlockOutputStream extends OutputStream {
         setIoException(ce);
         throw ce;
       });
-    } catch (IOException | InterruptedException | ExecutionException e) {
+    } catch (IOException | ExecutionException e) {
       throw new IOException(
           "Unexpected Storage Container Exception: " + e.toString(), e);
+    } catch (InterruptedException ex) {
+      LOG.error("Command execution was interrupted.");
+      Thread.currentThread().interrupt();
+      throw new IOException(
+          "Unexpected Storage Container Exception: " + ex.toString(), ex);
     }
     containerBlockData.addChunks(chunkInfo);
   }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -44,7 +44,6 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -323,7 +323,7 @@ public class BlockOutputStream extends OutputStream {
       handleExecutionException(e);
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
-      handleInterruptedException(ex, Boolean.TRUE);
+      handleInterruptedException(ex, true);
     }
     watchForCommit(true);
   }
@@ -434,7 +434,7 @@ public class BlockOutputStream extends OutputStream {
       throw new IOException(EXCEPTION_MSG + e.toString(), e);
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
-      handleInterruptedException(ex, Boolean.FALSE);
+      handleInterruptedException(ex, false);
     }
     commitWatcher.getFutureMap().put(flushPos, flushFuture);
     return flushFuture;
@@ -454,7 +454,7 @@ public class BlockOutputStream extends OutputStream {
         handleExecutionException(e);
       } catch (InterruptedException ex) {
         Thread.currentThread().interrupt();
-        handleInterruptedException(ex, Boolean.TRUE);
+        handleInterruptedException(ex, true);
       }
     }
   }
@@ -516,7 +516,7 @@ public class BlockOutputStream extends OutputStream {
         handleExecutionException(e);
       } catch (InterruptedException ex) {
         Thread.currentThread().interrupt();
-        handleInterruptedException(ex, Boolean.TRUE);
+        handleInterruptedException(ex, true);
       } finally {
         cleanup(false);
       }
@@ -653,7 +653,7 @@ public class BlockOutputStream extends OutputStream {
       throw new IOException(EXCEPTION_MSG + e.toString(), e);
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
-      handleInterruptedException(ex, Boolean.FALSE);
+      handleInterruptedException(ex, false);
     }
     containerBlockData.addChunks(chunkInfo);
   }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -324,7 +324,7 @@ public class BlockOutputStream extends OutputStream {
       handleExecutionException(e);
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
-      handleInterruptedException(ex, Optional.of(Boolean.TRUE));
+      handleInterruptedException(ex, Boolean.TRUE);
     }
     watchForCommit(true);
   }
@@ -435,7 +435,7 @@ public class BlockOutputStream extends OutputStream {
       throw new IOException(EXCEPTION_MSG + e.toString(), e);
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
-      handleInterruptedException(ex, Optional.empty());
+      handleInterruptedException(ex, Boolean.FALSE);
     }
     commitWatcher.getFutureMap().put(flushPos, flushFuture);
     return flushFuture;
@@ -455,7 +455,7 @@ public class BlockOutputStream extends OutputStream {
         handleExecutionException(e);
       } catch (InterruptedException ex) {
         Thread.currentThread().interrupt();
-        handleInterruptedException(ex, Optional.of(Boolean.TRUE));
+        handleInterruptedException(ex, Boolean.TRUE);
       }
     }
   }
@@ -517,7 +517,7 @@ public class BlockOutputStream extends OutputStream {
         handleExecutionException(e);
       } catch (InterruptedException ex) {
         Thread.currentThread().interrupt();
-        handleInterruptedException(ex, Optional.of(Boolean.TRUE));
+        handleInterruptedException(ex, Boolean.TRUE);
       } finally {
         cleanup(false);
       }
@@ -654,7 +654,7 @@ public class BlockOutputStream extends OutputStream {
       throw new IOException(EXCEPTION_MSG + e.toString(), e);
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
-      handleInterruptedException(ex, Optional.empty());
+      handleInterruptedException(ex, Boolean.FALSE);
     }
     containerBlockData.addChunks(chunkInfo);
   }
@@ -673,11 +673,10 @@ public class BlockOutputStream extends OutputStream {
    * @throws IOException
    */
   private void handleInterruptedException(Exception ex,
-      Optional<Boolean> skipExecutionException)
+      boolean skipExecutionException)
       throws IOException {
     LOG.error("Command execution was interrupted.");
-    if(skipExecutionException.isPresent() &&
-        skipExecutionException.get().equals(Boolean.TRUE)) {
+    if(skipExecutionException) {
       handleExecutionException(ex);
     } else {
       throw new IOException(EXCEPTION_MSG + ex.toString(), ex);

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -667,15 +667,15 @@ public class BlockOutputStream extends OutputStream {
    * Handles InterruptedExecution.
    *
    * @param ex
-   * @param skipExecutionException is optional, if passed as TRUE, then
+   * @param processExecutionException is optional, if passed as TRUE, then
    * handle ExecutionException else skip it.
    * @throws IOException
    */
   private void handleInterruptedException(Exception ex,
-      boolean skipExecutionException)
+      boolean processExecutionException)
       throws IOException {
     LOG.error("Command execution was interrupted.");
-    if(skipExecutionException) {
+    if(processExecutionException) {
       handleExecutionException(ex);
     } else {
       throw new IOException(EXCEPTION_MSG + ex.toString(), ex);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Address sonar violations to handle InterruptedException appropriately.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2556

## How was this patch tested?
Sonar plugin in IntelliJ, Clean build, unit tests