### PR TITLE
HDDS-3622. Implement rocksdb tool to parse scm db

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ListTables.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ListTables.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug;
+
+import org.rocksdb.*;
+import picocli.CommandLine;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * List all column Families/Tables in db.
+ */
+@CommandLine.Command(
+        name = "list",
+        description = "list all tables in db."
+)
+public class ListTables implements Callable<Void> {
+
+  @CommandLine.ParentCommand
+  private RDBParser parent;
+
+  @Override
+  public Void call() throws Exception {
+    List<byte[]> cfList = getColumnFamilyList(parent.getDbPath());
+    for (byte[] b : cfList) {
+      System.out.println(new String(b, StandardCharsets.UTF_8));
+    }
+    return null;
+  }
+
+  private static List<byte[]> getColumnFamilyList(String dbPath) {
+    List<byte[]> cfList = null;
+    try {
+      cfList = RocksDB.listColumnFamilies(new Options(), dbPath);
+    } catch (RocksDBException e) {
+      e.printStackTrace();
+    }
+    return cfList;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ListTables.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ListTables.java
@@ -18,7 +18,9 @@
 
 package org.apache.hadoop.ozone.debug;
 
-import org.rocksdb.*;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
 import picocli.CommandLine;
 
 import java.nio.charset.StandardCharsets;
@@ -46,13 +48,10 @@ public class ListTables implements Callable<Void> {
     return null;
   }
 
-  private static List<byte[]> getColumnFamilyList(String dbPath) {
+  private static List<byte[]> getColumnFamilyList(String dbPath)
+      throws RocksDBException {
     List<byte[]> cfList = null;
-    try {
-      cfList = RocksDB.listColumnFamilies(new Options(), dbPath);
-    } catch (RocksDBException e) {
-      e.printStackTrace();
-    }
+    cfList = RocksDB.listColumnFamilies(new Options(), dbPath);
     return cfList;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ListTables.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ListTables.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.debug;
 
 import org.rocksdb.Options;
 import org.rocksdb.RocksDB;
-import org.rocksdb.RocksDBException;
 import picocli.CommandLine;
 
 import java.nio.charset.StandardCharsets;
@@ -31,8 +30,9 @@ import java.util.concurrent.Callable;
  * List all column Families/Tables in db.
  */
 @CommandLine.Command(
-        name = "list",
-        description = "list all tables in db."
+        name = "list_column_families",
+        aliases = "ls",
+        description = "list all column families in db."
 )
 public class ListTables implements Callable<Void> {
 
@@ -41,17 +41,11 @@ public class ListTables implements Callable<Void> {
 
   @Override
   public Void call() throws Exception {
-    List<byte[]> cfList = getColumnFamilyList(parent.getDbPath());
-    for (byte[] b : cfList) {
+    List<byte[]> columnFamilies = RocksDB.listColumnFamilies(new Options(),
+            parent.getDbPath());
+    for (byte[] b : columnFamilies) {
       System.out.println(new String(b, StandardCharsets.UTF_8));
     }
     return null;
-  }
-
-  private static List<byte[]> getColumnFamilyList(String dbPath)
-      throws RocksDBException {
-    List<byte[]> cfList = null;
-    cfList = RocksDB.listColumnFamilies(new Options(), dbPath);
-    return cfList;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/OzoneDebug.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/OzoneDebug.java
@@ -31,7 +31,8 @@ import picocli.CommandLine;
         versionProvider = HddsVersionProvider.class,
         subcommands = {
                 ChunkKeyHandler.class,
-                RatisLogParser.class
+                RatisLogParser.class,
+                RDBParser.class
         },
         mixinStandardHelpOptions = true)
 public class OzoneDebug extends GenericCli {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/RDBParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/RDBParser.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug;
+
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
+import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
+import picocli.CommandLine;
+
+import java.util.HashMap;
+
+/**
+ * Tool that parses rocksdb file.
+ */
+@CommandLine.Command(
+        name = "rdbparser",
+        description = "Parse rocksdb file content",
+        subcommands = {
+                SCMDBParser.class,
+                ListTables.class
+        })
+public class RDBParser extends GenericCli {
+
+  @CommandLine.Option(names = {"-path"},
+            description = "Database File Path")
+    private String dbPath;
+
+  public static HashMap<String, DBColumnFamilyDefinition>
+      getColumnFamilyMap() {
+    return columnFamilyMap;
+  }
+
+  private static HashMap<String, DBColumnFamilyDefinition>  columnFamilyMap;
+
+  public String getDbPath() {
+    return dbPath;
+  }
+
+  static {
+    columnFamilyMap = constructColumnFamilyMap();
+  }
+
+  private static HashMap<String, DBColumnFamilyDefinition>
+      constructColumnFamilyMap() {
+    columnFamilyMap = new HashMap<String, DBColumnFamilyDefinition>();
+    columnFamilyMap.put("validCerts", SCMDBDefinition.VALID_CERTS);
+    columnFamilyMap.put("deletedBlocks", SCMDBDefinition.DELETED_BLOCKS);
+    columnFamilyMap.put("pipelines", SCMDBDefinition.PIPELINES);
+    columnFamilyMap.put("revokedCerts", SCMDBDefinition.REVOKED_CERTS);
+    columnFamilyMap.put("containers", SCMDBDefinition.CONTAINERS);
+    return columnFamilyMap;
+  }
+
+  @Override
+  public void execute(String[] argv) {
+    new RDBParser().run(argv);
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/RDBParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/RDBParser.java
@@ -19,52 +19,26 @@
 package org.apache.hadoop.ozone.debug;
 
 import org.apache.hadoop.hdds.cli.GenericCli;
-import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
-import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import picocli.CommandLine;
-
-import java.util.HashMap;
 
 /**
  * Tool that parses rocksdb file.
  */
 @CommandLine.Command(
-        name = "rdbparser",
+        name = "ldb",
         description = "Parse rocksdb file content",
         subcommands = {
-                SCMDBParser.class,
+                DBScanner.class,
                 ListTables.class
         })
 public class RDBParser extends GenericCli {
 
-  @CommandLine.Option(names = {"-path"},
+  @CommandLine.Option(names = {"--db"},
             description = "Database File Path")
-    private String dbPath;
-
-  public static HashMap<String, DBColumnFamilyDefinition>
-      getColumnFamilyMap() {
-    return columnFamilyMap;
-  }
-
-  private static HashMap<String, DBColumnFamilyDefinition>  columnFamilyMap;
+    private  String dbPath;
 
   public String getDbPath() {
     return dbPath;
-  }
-
-  static {
-    columnFamilyMap = constructColumnFamilyMap();
-  }
-
-  private static HashMap<String, DBColumnFamilyDefinition>
-      constructColumnFamilyMap() {
-    columnFamilyMap = new HashMap<String, DBColumnFamilyDefinition>();
-    DBColumnFamilyDefinition[] columnFamilyDefinitions = new SCMDBDefinition()
-            .getColumnFamilies();
-    for(DBColumnFamilyDefinition definition:columnFamilyDefinitions){
-      columnFamilyMap.put(definition.getTableName(), definition);
-    }
-    return columnFamilyMap;
   }
 
   @Override

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/RDBParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/RDBParser.java
@@ -59,11 +59,11 @@ public class RDBParser extends GenericCli {
   private static HashMap<String, DBColumnFamilyDefinition>
       constructColumnFamilyMap() {
     columnFamilyMap = new HashMap<String, DBColumnFamilyDefinition>();
-    columnFamilyMap.put("validCerts", SCMDBDefinition.VALID_CERTS);
-    columnFamilyMap.put("deletedBlocks", SCMDBDefinition.DELETED_BLOCKS);
-    columnFamilyMap.put("pipelines", SCMDBDefinition.PIPELINES);
-    columnFamilyMap.put("revokedCerts", SCMDBDefinition.REVOKED_CERTS);
-    columnFamilyMap.put("containers", SCMDBDefinition.CONTAINERS);
+    DBColumnFamilyDefinition[] columnFamilyDefinitions = new SCMDBDefinition()
+            .getColumnFamilies();
+    for(DBColumnFamilyDefinition definition:columnFamilyDefinitions){
+      columnFamilyMap.put(definition.getTableName(), definition);
+    }
     return columnFamilyMap;
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/SCMDBParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/SCMDBParser.java
@@ -52,6 +52,9 @@ public class SCMDBParser implements Callable<Void> {
     ColumnFamilyHandle columnFamilyHandle = getColumnFamilyHandle(
             dbColumnFamilyDefinition.getTableName()
                     .getBytes(StandardCharsets.UTF_8), list);
+    if (columnFamilyHandle==null){
+      throw new IllegalArgumentException("columnFamilyHandle is null");
+    }
     RocksIterator iterator = rocksDB.newIterator(columnFamilyHandle);
     iterator.seekToFirst();
     while (iterator.isValid()){

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/SCMDBParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/SCMDBParser.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug;
+
+import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
+import org.rocksdb.*;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * Parser for scm.db file.
+ */
+@CommandLine.Command(
+        name = "scmdbparser",
+        description = "Parse specified metadataTable"
+)
+public class SCMDBParser implements Callable<Void> {
+
+  @CommandLine.Option(names = {"-table"},
+            description = "Table name")
+  private String tableName;
+
+  @CommandLine.ParentCommand
+  private RDBParser parent;
+
+
+  private static void displayTable(RocksDB rocksDB,
+        DBColumnFamilyDefinition dbColumnFamilyDefinition,
+        List<ColumnFamilyHandle> list) throws IOException {
+    ColumnFamilyHandle columnFamilyHandle = getColumnFamilyHandle(
+            dbColumnFamilyDefinition.getTableName()
+                    .getBytes(StandardCharsets.UTF_8), list);
+    RocksIterator iterator = rocksDB.newIterator(columnFamilyHandle);
+    iterator.seekToFirst();
+    while (iterator.isValid()){
+      Object o = dbColumnFamilyDefinition.getValueCodec()
+              .fromPersistedFormat(iterator.value());
+      System.out.println(o);
+      iterator.next();
+    }
+  }
+
+  private static ColumnFamilyHandle getColumnFamilyHandle(
+            byte[] name, List<ColumnFamilyHandle> columnFamilyHandles) {
+    return columnFamilyHandles
+            .stream()
+            .filter(
+              handle -> {
+                try {
+                  return Arrays.equals(handle.getName(), name);
+                    } catch (Exception ex) {
+                  throw new RuntimeException(ex);
+                    }
+              })
+            .findAny()
+            .orElse(null);
+  }
+
+  @Override
+  public Void call() throws Exception {
+    List<ColumnFamilyDescriptor> cfs = new ArrayList<>();
+    final List<ColumnFamilyHandle> columnFamilyHandleList =
+            new ArrayList<>();
+    List<byte[]> cfList = null;
+    try {
+      cfList = RocksDB.listColumnFamilies(new Options(),
+                    parent.getDbPath());
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    if (cfList != null) {
+      for (byte[] b : cfList) {
+        cfs.add(new ColumnFamilyDescriptor(b));
+      }
+    }
+    RocksDB rocksDB = null;
+    try {
+      rocksDB = RocksDB.openReadOnly(parent.getDbPath(),
+              cfs, columnFamilyHandleList);
+    } catch (RocksDBException e) {
+      e.printStackTrace();
+    }
+    printAppropriateTable(columnFamilyHandleList, rocksDB);
+    return null;
+  }
+
+  private void printAppropriateTable(
+      List<ColumnFamilyHandle> columnFamilyHandleList,
+      RocksDB rocksDB) throws IOException {
+    if (!RDBParser.getColumnFamilyMap().containsKey(tableName)){
+      System.out.print("Table with specified name does not exist");
+    } else {
+      DBColumnFamilyDefinition columnFamilyDefinition =
+              RDBParser.getColumnFamilyMap().get(tableName);
+      displayTable(rocksDB, columnFamilyDefinition, columnFamilyHandleList);
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
This tool parses rocksdb file for SCM and dumps specified table data. Also there is a list command which parses any db file and lists the columnFamilies(tables).

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3622

## How was this patch tested?
Manually Tested.

Here are the commands:
1.bin/ozone debug ldb --db=/tmp/ozone/data/metadata/scm.db/ list_column_families
default
validCerts
deletedBlocks
pipelines
revokedCerts
containers

2.bin/ozone debug ldb --db=/tmp/ozone/data/metadata/scm.db/ scan --column_family=containers

