### PR TITLE
HDDS-3624. Improve error message when GC parameters are not set.

### DIFF
--- a/hadoop-ozone/dist/src/shell/hdds/hadoop-functions.sh
+++ b/hadoop-ozone/dist/src/shell/hdds/hadoop-functions.sh
@@ -1551,7 +1551,7 @@ function hadoop_add_default_gc_opts
 {
   if [[ "${HADOOP_SUBCMD_SUPPORTDAEMONIZATION}" == true ]]; then
     if [[ ! "$HADOOP_OPTS" =~ "-XX" ]] ; then
-       hadoop_error "No '-XX:...' jvm parameters are used. Adding safer GC settings to the HADOOP_OPTS"
+       hadoop_error "No '-XX:...' jvm parameters are set. Adding safer GC settings '-XX:ParallelGCThreads=8 -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled' to the HADOOP_OPTS"
        HADOOP_OPTS="${HADOOP_OPTS} -XX:ParallelGCThreads=8 -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled"
     fi
   fi


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improve the message printed to console when starting services.
"No '-XX:...' jvm parameters are used. Adding safer GC settings to the HADOOP_OPTS"

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3624

## How was this patch tested?

Tested it with pseudo deployed cluster.

Now with this PR message looks like below.
```
$ bin/ozone --daemon start scm
No '-XX:...' jvm parameters are set. Adding safer GC settings '-XX:ParallelGCThreads=8 -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled' to the HADOOP_OPTS
```
