### PR TITLE
HDDS-3625. BadRequestException interception doesn't take effect in s3g.

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequestUnmarshaller.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CompleteMultipartUploadRequestUnmarshaller.java
@@ -32,13 +32,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import javax.ws.rs.ext.Provider;
 
 import static org.apache.hadoop.ozone.s3.util.S3Consts.S3_XML_NAMESPACE;
 
 /**
  * Custom unmarshaller to read CompleteMultipartUploadRequest wo namespace.
  */
-
+@Provider
 public class CompleteMultipartUploadRequestUnmarshaller
     implements MessageBodyReader<CompleteMultipartUploadRequest> {
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/BadRequestExceptionMapper.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/BadRequestExceptionMapper.java
@@ -24,10 +24,12 @@ import org.slf4j.LoggerFactory;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
 
 /**
  * Class that represents BadRequestException.
  */
+@Provider
 public class BadRequestExceptionMapper implements
     ExceptionMapper<BadRequestException> {
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-3625  

@Provider is missed in the previous fix， which causes the function is not recognized by the jax-ws infra。
