### PR TITLE
HDDS-3635. Archive jacoco coverage files for unit/integration tests

### DIFF
--- a/hadoop-ozone/dev-support/checks/integration.sh
+++ b/hadoop-ozone/dev-support/checks/integration.sh
@@ -28,6 +28,9 @@ mvn -B -fae test -pl :hadoop-ozone-integration-test,:mini-chaos-tests "$@" \
   | tee "${REPORT_DIR}/output.log"
 rc=$?
 
+#Archive combined jacoco records
+mvn -B jacoco:merge -Djacoco.destFile=$REPORT_DIR/jacoco-combined.exec
+
 # shellcheck source=hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
 source "$DIR/_mvn_unit_report.sh"
 

--- a/hadoop-ozone/dev-support/checks/integration.sh
+++ b/hadoop-ozone/dev-support/checks/integration.sh
@@ -29,7 +29,7 @@ mvn -B -fae test -pl :hadoop-ozone-integration-test,:mini-chaos-tests "$@" \
 rc=$?
 
 #Archive combined jacoco records
-mvn -B jacoco:merge -Djacoco.destFile=$REPORT_DIR/jacoco-combined.exec
+mvn -B -N jacoco:merge -Djacoco.destFile=$REPORT_DIR/jacoco-combined.exec
 
 # shellcheck source=hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
 source "$DIR/_mvn_unit_report.sh"

--- a/hadoop-ozone/dev-support/checks/unit.sh
+++ b/hadoop-ozone/dev-support/checks/unit.sh
@@ -28,7 +28,7 @@ mvn -B -DskipShade -Dskip.yarn -fae test -pl \!:hadoop-ozone-integration-test,\!
 rc=$?
 
 #Archive combined jacoco records
-mvn -B jacoco:merge -Djacoco.destFile=$REPORT_DIR/jacoco-combined.exec
+mvn -B -N jacoco:merge -Djacoco.destFile=$REPORT_DIR/jacoco-combined.exec
 
 # shellcheck source=hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
 source "$DIR/_mvn_unit_report.sh"

--- a/hadoop-ozone/dev-support/checks/unit.sh
+++ b/hadoop-ozone/dev-support/checks/unit.sh
@@ -27,6 +27,9 @@ mvn -B -DskipShade -Dskip.yarn -fae test -pl \!:hadoop-ozone-integration-test,\!
   | tee "${REPORT_DIR}/output.log"
 rc=$?
 
+#Archive combined jacoco records
+mvn -B jacoco:merge -Djacoco.destFile=$REPORT_DIR/jacoco-combined.exec
+
 # shellcheck source=hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
 source "$DIR/_mvn_unit_report.sh"
 

--- a/pom.xml
+++ b/pom.xml
@@ -1793,7 +1793,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.3</version>
+          <version>0.8.5</version>
         </plugin>
         <plugin>
           <groupId>io.fabric8</groupId>
@@ -1892,6 +1892,16 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
+        <configuration>
+          <fileSets>
+            <fileSet>
+              <directory>${project.basedir}</directory>
+              <includes>
+                <include>**/jacoco.exec</include>
+              </includes>
+            </fileSet>
+          </fileSets>
+        </configuration>
         <executions>
           <execution>
             <id>default-prepare-agent</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1909,6 +1909,9 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
             <goals>
               <goal>prepare-agent</goal>
             </goals>
+            <configuration>
+              <includes>org.apache.hadoop.hdds.*,org.apache.hadoop.ozone.*</includes>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1899,6 +1899,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <includes>
                 <include>**/jacoco.exec</include>
               </includes>
+              <useDefaultExcludes>false</useDefaultExcludes>
             </fileSet>
           </fileSets>
         </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Earlier we configured jacoco maven plugin to calculate the code coverage. But the jacoco.exec files (which contain the coverage information) are not stored in the artifacts created by the github actions.

We can add it easily.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3635

## How was this patch tested?

Branch is pushed to my fork and artifacts are downloaded after the build.

Full coverage is reported based on the partial data (unit + it-*) locally...