### PR TITLE
HDDS-3638. Add a cat command to show the text of a file in the Ozone server

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/CatKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/CatKeyHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.shell.keys;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_DEFAULT;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_KEY;
+
+import org.apache.hadoop.conf.StorageUnit;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientException;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.shell.OzoneAddress;
+import picocli.CommandLine.Command;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Cat an existing key.
+ */
+@Command(name = "cat",
+    description = "Cat a specific key from ozone server")
+public class CatKeyHandler extends KeyHandler {
+
+  @Override
+  protected void execute(OzoneClient client, OzoneAddress address)
+      throws IOException, OzoneClientException {
+
+    String volumeName = address.getVolumeName();
+    String bucketName = address.getBucketName();
+    String keyName = address.getKeyName();
+
+    int chunkSize = (int) getConf().getStorageSize(OZONE_SCM_CHUNK_SIZE_KEY,
+        OZONE_SCM_CHUNK_SIZE_DEFAULT, StorageUnit.BYTES);
+
+    OzoneVolume vol = client.getObjectStore().getVolume(volumeName);
+    OzoneBucket bucket = vol.getBucket(bucketName);
+    try (InputStream input = bucket.readKey(keyName)) {
+      IOUtils.copyBytes(input, System.out, chunkSize);
+    }
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/CatKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/CatKeyHandler.java
@@ -18,10 +18,6 @@
 
 package org.apache.hadoop.ozone.shell.keys;
 
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_DEFAULT;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_KEY;
-
-import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -48,13 +44,10 @@ public class CatKeyHandler extends KeyHandler {
     String bucketName = address.getBucketName();
     String keyName = address.getKeyName();
 
-    int chunkSize = (int) getConf().getStorageSize(OZONE_SCM_CHUNK_SIZE_KEY,
-        OZONE_SCM_CHUNK_SIZE_DEFAULT, StorageUnit.BYTES);
-
     OzoneVolume vol = client.getObjectStore().getVolume(volumeName);
     OzoneBucket bucket = vol.getBucket(bucketName);
     try (InputStream input = bucket.readKey(keyName)) {
-      IOUtils.copyBytes(input, System.out, chunkSize);
+      IOUtils.copyBytes(input, System.out, 4096);
     }
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/KeyCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/KeyCommands.java
@@ -38,6 +38,7 @@ import picocli.CommandLine.ParentCommand;
         InfoKeyHandler.class,
         ListKeyHandler.class,
         GetKeyHandler.class,
+        CatKeyHandler.class,
         PutKeyHandler.class,
         RenameKeyHandler.class,
         DeleteKeyHandler.class,


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we deploy a hdfs cluster, our devops usually want to put a file into the cluster and cat the result to ensure anything is ok, so they want this command of ozone too.

Some time, we only want to print the content of the file in Ozone, we don't need to download it now.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3638

## How was this patch tested?

```bash
bin/ozone sh key cat /myvol/mybucket/NOTIC.txt
```
