### PR TITLE
HDDS-2574. Handle InterruptedException in OzoneDelegationTokenSecretManager

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -530,6 +530,7 @@ public class OzoneDelegationTokenSecretManager
       try {
         tokenRemoverThread.join();
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new RuntimeException(
             "Unable to join on token removal thread", e);
       }
@@ -542,7 +543,7 @@ public class OzoneDelegationTokenSecretManager
    * @throws IOException
    */
   @Override
-  public void stop() throws IOException {
+  public synchronized void stop() throws IOException {
     super.stop();
     stopThreads();
     if (this.store != null) {
@@ -593,14 +594,15 @@ public class OzoneDelegationTokenSecretManager
             removeExpiredToken();
             lastTokenCacheCleanup = now;
           }
-          try {
-            Thread.sleep(Math.min(5000,
-                getTokenRemoverScanInterval())); // 5 seconds
-          } catch (InterruptedException ie) {
-            LOG.error("ExpiredTokenRemover received {}", ie);
-          }
+
+          // Sleep for 5 seconds
+          Thread.sleep(Math.min(5000, getTokenRemoverScanInterval()));
+
         }
-      } catch (Throwable t) {
+      } catch (InterruptedException ie) {
+        LOG.error("ExpiredTokenRemover received {}", ie);
+        Thread.currentThread().interrupt();
+      } catch (Exception t) {
         LOG.error("ExpiredTokenRemover thread received unexpected exception",
             t);
         Runtime.getRuntime().exit(-1);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -543,7 +543,7 @@ public class OzoneDelegationTokenSecretManager
    * @throws IOException
    */
   @Override
-  public synchronized void stop() throws IOException {
+  public void stop() throws IOException {
     super.stop();
     stopThreads();
     if (this.store != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Handle InterruptedException by interrupting currentThread, addressed other sonar violations too.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2574

## How was this patch tested?

Clean build, checkstyle, sonar in local.
