### PR TITLE
HDDS-3646. Add a copy command to copy key to a new one.

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
@@ -114,6 +114,10 @@ Test key handling
                     Execute             rm -f /tmp/NOTICE.txt.1
                     Execute             ozone sh key get ${protocol}${server}/${volume}/bb1/key1 /tmp/NOTICE.txt.1
                     Execute             diff -q /opt/hadoop/NOTICE.txt /tmp/NOTICE.txt.1
+                    Execute             ozone sh key cp ${protocol}${server}/${volume}/bb1/key1 ${protocol}${server}/${volume}/bb1/key1-copy
+                    Execute             rm -f /tmp/key1-copy
+                    Execute             ozone sh key get ${protocol}${server}/${volume}/bb1/key1-copy /tmp/key1-copy
+                    Execute             diff -q /opt/hadoop/NOTICE.txt /tmp/key1-copy
     ${result} =     Execute And Ignore Error    ozone sh key get ${protocol}${server}/${volume}/bb1/key1 /tmp/NOTICE.txt.1
                     Should Contain      ${result}       NOTICE.txt.1 exists
     ${result} =     Execute             ozone sh key get --force ${protocol}${server}/${volume}/bb1/key1 /tmp/NOTICE.txt.1

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
@@ -114,7 +114,7 @@ Test key handling
                     Execute             rm -f /tmp/NOTICE.txt.1
                     Execute             ozone sh key get ${protocol}${server}/${volume}/bb1/key1 /tmp/NOTICE.txt.1
                     Execute             diff -q /opt/hadoop/NOTICE.txt /tmp/NOTICE.txt.1
-                    Execute             ozone sh key cp ${protocol}${server}/${volume}/bb1/key1 ${protocol}${server}/${volume}/bb1/key1-copy
+                    Execute             ozone sh key cp ${protocol}${server}/${volume}/bb1 key1 key1-copy
                     Execute             rm -f /tmp/key1-copy
                     Execute             ozone sh key get ${protocol}${server}/${volume}/bb1/key1-copy /tmp/key1-copy
                     Execute             diff -q /opt/hadoop/NOTICE.txt /tmp/key1-copy

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
@@ -118,6 +118,7 @@ Test key handling
                     Execute             rm -f /tmp/key1-copy
                     Execute             ozone sh key get ${protocol}${server}/${volume}/bb1/key1-copy /tmp/key1-copy
                     Execute             diff -q /opt/hadoop/NOTICE.txt /tmp/key1-copy
+                    Execute             ozone sh key delete ${protocol}${server}/${volume}/bb1/key1-copy
     ${result} =     Execute And Ignore Error    ozone sh key get ${protocol}${server}/${volume}/bb1/key1 /tmp/NOTICE.txt.1
                     Should Contain      ${result}       NOTICE.txt.1 exists
     ${result} =     Execute             ozone sh key get --force ${protocol}${server}/${volume}/bb1/key1 /tmp/NOTICE.txt.1

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/CopyKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/CopyKeyHandler.java
@@ -22,10 +22,7 @@ import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.hadoop.ozone.client.OzoneBucket;
-import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneClientException;
-import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.*;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.shell.bucket.BucketHandler;
 import picocli.CommandLine.Command;
@@ -92,7 +89,11 @@ public class CopyKeyHandler extends BucketHandler {
               OZONE_REPLICATION_TYPE_DEFAULT));
     }
 
-    Map<String, String> keyMetadata = new HashMap<>();
+    OzoneKeyDetails keyDetail = bucket.getKey(fromKey);
+    Map<String, String> keyMetadata = new HashMap<>(keyDetail.getMetadata());
+    keyMetadata.remove(OzoneConsts.GDPR_SECRET);
+    keyMetadata.remove(OzoneConsts.GDPR_ALGORITHM);
+
     String gdprEnabled = bucket.getMetadata().get(OzoneConsts.GDPR_FLAG);
     if (Boolean.parseBoolean(gdprEnabled)) {
       keyMetadata.put(OzoneConsts.GDPR_FLAG, Boolean.TRUE.toString());

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/CpKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/CpKeyHandler.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.shell.keys;
+
+import org.apache.hadoop.conf.StorageUnit;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientException;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.shell.OzoneAddress;
+import org.apache.hadoop.ozone.shell.bucket.BucketHandler;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_DEFAULT;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_KEY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.*;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_TYPE_DEFAULT;
+
+/**
+ * Copy an existing key to another one.
+ */
+@Command(name = "cp",
+    description = "copies an existing key to another one")
+public class CpKeyHandler extends BucketHandler {
+
+  @Parameters(index = "1", arity = "1..1",
+      description = "The existing key to be renamed")
+  private String fromKey;
+
+  @Parameters(index = "2", arity = "1..1",
+      description = "The new desired name of the key")
+  private String toKey;
+
+  @Option(names = {"-r", "--replication"},
+      description = "Replication factor of the new key. (use ONE or THREE) "
+          + "Default is specified in the cluster-wide config.")
+  private ReplicationFactor replicationFactor;
+
+  @Option(names = {"-t", "--type"},
+      description = "Replication type of the new key. (use RATIS or " +
+          "STAND_ALONE) Default is specified in the cluster-wide config.")
+  private ReplicationType replicationType;
+
+  @Override
+  protected void execute(OzoneClient client, OzoneAddress address)
+      throws IOException, OzoneClientException {
+
+    String volumeName = address.getVolumeName();
+    String bucketName = address.getBucketName();
+
+    OzoneVolume vol = client.getObjectStore().getVolume(volumeName);
+    OzoneBucket bucket = vol.getBucket(bucketName);
+
+    if (replicationFactor == null) {
+      replicationFactor = ReplicationFactor.valueOf(
+          getConf().getInt(OZONE_REPLICATION, OZONE_REPLICATION_DEFAULT));
+    }
+
+    if (replicationType == null) {
+      replicationType = ReplicationType.valueOf(
+          getConf().get(OZONE_REPLICATION_TYPE,
+              OZONE_REPLICATION_TYPE_DEFAULT));
+    }
+
+    Map<String, String> keyMetadata = new HashMap<>();
+    String gdprEnabled = bucket.getMetadata().get(OzoneConsts.GDPR_FLAG);
+    if (Boolean.parseBoolean(gdprEnabled)) {
+      keyMetadata.put(OzoneConsts.GDPR_FLAG, Boolean.TRUE.toString());
+    }
+
+    int chunkSize = (int) getConf().getStorageSize(OZONE_SCM_CHUNK_SIZE_KEY,
+        OZONE_SCM_CHUNK_SIZE_DEFAULT, StorageUnit.BYTES);
+    try (InputStream input = bucket.readKey(fromKey);
+         OutputStream output = bucket.createKey(toKey, 0,
+             replicationType, replicationFactor, keyMetadata)) {
+      IOUtils.copyBytes(input, output, chunkSize);
+    }
+
+    if (isVerbose()) {
+      out().printf("Copy Key : %s to %s%n", fromKey, toKey);
+    }
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/KeyCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/KeyCommands.java
@@ -41,6 +41,7 @@ import picocli.CommandLine.ParentCommand;
         CatKeyHandler.class,
         PutKeyHandler.class,
         RenameKeyHandler.class,
+        CopyKeyHandler.class,
         DeleteKeyHandler.class,
         AddAclKeyHandler.class,
         RemoveAclKeyHandler.class,


### PR DESCRIPTION
## What changes were proposed in this pull request?

A copy command can copy an exist key into a new one, It should support specify the replication factor and type. Cross-bucket copy is not supported.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3646

## How was this patch tested?

```bash
ozone sh key cp <bucket URI> <fromKey> <toKey>
```


