### PR TITLE
HDDS-3647. NPE while open datanode page since a pipeline no leader

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/NodeEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/NodeEndpoint.java
@@ -96,7 +96,7 @@ public class NodeEndpoint {
               leaderNode
           );
           pipelines.add(datanodePipeline);
-          if (pipeline.getLeaderId().equals(datanode.getUuid())) {
+          if (datanode.getUuid().equals(pipeline.getLeaderId())) {
             leaderCount.getAndIncrement();
           }
         } catch (PipelineNotFoundException ex) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

If there is a pipeline have no leader on a datanode, it will through NPE. STAND_ALONE pipeline have no leader, and ratis pipeline have no leader some time.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3647

## How was this patch tested?

Create STAND_ALONE pipeline, and start recon server, open the datanode page, no 500 return.