### PR TITLE
HDDS-3657. Unregister the metrics source when replicationmanager stop.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -209,6 +209,7 @@ public class ReplicationManager
       inflightReplication.clear();
       inflightDeletion.clear();
       running = false;
+      DefaultMetricsSystem.instance().unregisterSource(METRICS_SOURCE_NAME);
       notifyAll();
     } else {
       LOG.info("Replication Monitor Thread is not running.");


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix a bug which cannot restart the replicationManager service after stopped.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3657

## How was this patch tested?
expect the following result.

```bash
bin/ozone admin replicationmanager stop  
Stopping ReplicationManager...
Requested SCM to stop ReplicationManager, it might take sometime for the ReplicationManager to stop
bin/ozone admin replicationmanager status                                      
ReplicationManager is Not Running.
bin/ozone admin replicationmanager start 
Starting ReplicationManager...
bin/ozone admin replicationmanager status
ReplicationManager is Running.
```
