### PR TITLE
HDDS-2562. Handle InterruptedException in DatanodeStateMachine

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -188,7 +188,7 @@ public class DatanodeStateMachine implements Closeable {
   /**
    * Runs the state machine at a fixed frequency.
    */
-  private void start() {
+  private void start() throws IOException {
     long now = 0;
 
     reportManager.init();
@@ -216,6 +216,7 @@ public class DatanodeStateMachine implements Closeable {
         // 1. Trigger heartbeat immediately
         // 2. Shutdown has been initiated.
         Thread.currentThread().interrupt();
+        throw new IOException("Unable to finish the execution.", e);
       } catch (Exception e) {
         LOG.error("Unable to finish the execution.", e);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Addressed sonar violations - handle InterruptedException, removed unused variables etc.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2562

## How was this patch tested?

Clean build, sonar & checkstyle in local.
