### PR TITLE
HDDS-3665. Container info command should print uuid of datanode

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -73,7 +73,7 @@ public class InfoSubcommand implements Callable<Void> {
     }
   }
 
-  private static String buildDatanodeDisplay(DatanodeDetails details) {
+  private static String buildDatanodeDetails(DatanodeDetails details) {
     return details.getUuidString() + "/" + details.getHostName();
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -66,9 +66,14 @@ public class InfoSubcommand implements Callable<Void> {
 
       // Print pipeline of an existing container.
       String machinesStr = container.getPipeline().getNodes().stream().map(
-              DatanodeDetails::getHostName).collect(Collectors.joining(","));
+          InfoSubcommand::buildDatanodeDisplay)
+          .collect(Collectors.joining(",\n"));
       LOG.info("Datanodes: [{}]", machinesStr);
       return null;
     }
+  }
+
+  private static String buildDatanodeDisplay(DatanodeDetails details) {
+    return details.getUuidString() + "/" + details.getHostName();
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -66,7 +66,7 @@ public class InfoSubcommand implements Callable<Void> {
 
       // Print pipeline of an existing container.
       String machinesStr = container.getPipeline().getNodes().stream().map(
-          InfoSubcommand::buildDatanodeDisplay)
+          InfoSubcommand::buildDatanodeDetails)
           .collect(Collectors.joining(",\n"));
       LOG.info("Datanodes: [{}]", machinesStr);
       return null;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Display the uuid of the datanode to distinguish the datanodes in a same nodes.

With this PR, we can get the following result when info container, in fact i have 5 datanode in the same machine.

```bash
Container id: 1
Pipeline id: f47e37ff-7f7e-453b-9bcc-a58e8117b66f
Container State: CLOSED
Datanodes: [localhost, localhost, localhost]
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3665

## How was this patch tested?
```bash
bin/ozone admin container info 1
Container id: 1
Pipeline id: f47e37ff-7f7e-453b-9bcc-a58e8117b66f
Container State: CLOSED
Datanodes: [c4dcebcf-3997-4ebd-a501-8d7c3053de61/localhost,
5d7d5f77-57c6-4c90-8edf-eb0f872a0166/localhost,
aa01cb2c-6742-4938-a719-1dc75f76e88f/localhost]
```