### PR TITLE
HDDS-3672. Ozone fs failed to list intermediate directory.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -2037,11 +2037,11 @@ public class KeyManagerImpl implements KeyManager {
                 // if entry is a directory
                 if (!deletedKeySet.contains(entryInDb)) {
                   if (!entryKeyName.equals(immediateChild)) {
-                    OmKeyInfo fakeDirEntry = new OmKeyInfo.Builder()
-                        .setVolumeName(omKeyInfo.getVolumeName())
-                        .setBucketName(omKeyInfo.getBucketName())
-                        .setKeyName(immediateChild)
-                        .build();
+                    OmKeyInfo fakeDirEntry = createDirectoryKey(
+                        omKeyInfo.getVolumeName(),
+                        omKeyInfo.getBucketName(),
+                        immediateChild,
+                        omKeyInfo.getAcls());
                     cacheKeyMap.put(entryInDb,
                         new OzoneFileStatus(fakeDirEntry, scmBlockSize, true));
                   } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The root cause is replication factor and replication type are required fieldsin KeyInfo proto. 

While the way to create the OMKeyInfo object for intermediate directory doesn't provide all required fields.  

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3672

## How was this patch tested?

Unit test is updated + manual confirmation:

```
bin/ozone sh volume create /hadoop
bin/ozone sh bucket create /hadoop/ozone
bin/ozone sh key put /hadoop/ozone/benchmarks/TestDFSIO/dir1/test README.md
bin/ozone fs -ls o3fs://ozone.hadoop/
```