### PR TITLE
HDDS-3673. Version information not printed correctly in SCM WebUI.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <hdds.version>${ozone.version}</hdds.version>
     <ozone.version>0.6.0-SNAPSHOT</ozone.version>
     <ozone.release>Denali</ozone.release>
-    <declared.hdds.version>${ozone.version}</declared.hdds.version>
+    <declared.hdds.version>${hdds.version}</declared.hdds.version>
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <hdds.version>${ozone.version}</hdds.version>
     <ozone.version>0.6.0-SNAPSHOT</ozone.version>
     <ozone.release>Denali</ozone.release>
+    <declared.hdds.version>${ozone.version}</declared.hdds.version>
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add property in pom so that can get correct version information.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3673

## How was this patch tested?

Run on local docker-compose.
![Screenshot from 2020-05-28 15-42-48](https://user-images.githubusercontent.com/2565172/83113388-2f0ef900-a0fa-11ea-9ebb-b190503e0c7f.png)

