### PR TITLE
HDDS-3550. Fix TestReadRetries.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestReadRetries.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestReadRetries.java
@@ -88,10 +88,12 @@ public class TestReadRetries {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT, 1);
     cluster = MiniOzoneCluster.newBuilder(conf)
-        .setNumDatanodes(10)
+        .setNumDatanodes(3)
         .setScmId(SCM_ID)
         .build();
     cluster.waitForClusterToBeReady();
+    cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.THREE,
+            180000);
     ozClient = OzoneClientFactory.getRpcClient(conf);
     store = ozClient.getObjectStore();
     storageContainerLocationClient =
@@ -177,22 +179,13 @@ public class TestReadRetries {
     ratisClient.watchForCommit(keyInfo.getBlockCommitSequenceId());
     // shutdown the datanode
     cluster.shutdownHddsDatanode(datanodeDetails);
-
-    Assert.assertTrue(container.getState()
-        == HddsProtos.LifeCycleState.OPEN);
-    // try to read, this shouls be successful
+    // try to read, this should be successful
     readKey(bucket, keyName, value);
-
-    Assert.assertTrue(container.getState()
-        == HddsProtos.LifeCycleState.OPEN);
     // shutdown the second datanode
     datanodeDetails = datanodes.get(1);
     cluster.shutdownHddsDatanode(datanodeDetails);
-    Assert.assertTrue(container.getState()
-        == HddsProtos.LifeCycleState.OPEN);
 
-    // the container is open and with loss of 2 nodes we still should be able
-    // to read via Standalone protocol
+    // we still should be able to read via Standalone protocol
     // try to read
     readKey(bucket, keyName, value);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added a wait condition for the pipeline to elect a leader before starting the test execution. 
Removed the container state checks as the test involves shutting down of datanodes and container state will mutate during the whole sequence of events and assuming the container state will be open throughout the test won't be true. 

Moreover, the idea of the test is to read with multiple dn failures not testing the container state transitions.
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3550

## How was this patch tested?
Verified by manual run.