### PR TITLE
HDDS-3676. Display datanode uuid into the printTopology command output

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/TopologySubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/TopologySubcommand.java
@@ -131,7 +131,8 @@ public class TopologySubcommand implements Callable<Void> {
   // Format "ipAddress(hostName):PortName1=PortValue1    networkLocation"
   private void printNodesWithLocation(Collection<HddsProtos.Node> nodes) {
     nodes.forEach(node -> {
-      System.out.print(" " + node.getNodeID().getIpAddress() + "(" +
+      System.out.print(" " + node.getNodeID().getUuid() + "/" +
+          node.getNodeID().getIpAddress() + "(" +
           node.getNodeID().getHostName() + ")" +
           ":" + formatPortOutput(node.getNodeID().getPortsList()));
       System.out.println("    " +

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/TopologySubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/TopologySubcommand.java
@@ -71,6 +71,10 @@ public class TopologySubcommand implements Callable<Void> {
       description = "Print Topology ordered by network location")
   private boolean order;
 
+  @CommandLine.Option(names = {"-f", "--full"},
+      description = "Print Topology with full node infos")
+  private boolean fullInfo;
+
   @Override
   public Void call() throws Exception {
     try (ScmClient scmClient = parent.createScmClient()) {
@@ -128,10 +132,14 @@ public class TopologySubcommand implements Callable<Void> {
     return sb.toString();
   }
 
+  private String getAdditionNodeOutput(HddsProtos.Node node) {
+    return fullInfo ? node.getNodeID().getUuid() + "/" : "";
+  }
+
   // Format "ipAddress(hostName):PortName1=PortValue1    networkLocation"
   private void printNodesWithLocation(Collection<HddsProtos.Node> nodes) {
     nodes.forEach(node -> {
-      System.out.print(" " + node.getNodeID().getUuid() + "/" +
+      System.out.print(" " + getAdditionNodeOutput(node) +
           node.getNodeID().getIpAddress() + "(" +
           node.getNodeID().getHostName() + ")" +
           ":" + formatPortOutput(node.getNodeID().getPortsList()));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Sorry to the previous changes HDDS-3606, it is useful, but i have to do some other efforts to distinguish the datanodes in same node, display the uuid of each datanode can make more sense.

## What is the link to the Apache JIRA

Display datanode uuid into the printTopology command output

## How was this patch tested?

```bash
➜  ozone-0.6.0-SNAPSHOT git:(factor2) ✗ bin/ozone admin printTopology
State = HEALTHY
 a33b587b-5f94-4bb5-8ace-6650cbf201ad/127.0.0.1(localhost):RATIS=51134,STANDALONE=51135    /default-rack
 e8b3bf0f-9e77-4314-87dc-85cf51f8c579/127.0.0.1(localhost):RATIS=51072,STANDALONE=51073    /default-rack
 46589563-74c1-438c-b267-c3dc4e6ad1e1/127.0.0.1(localhost):RATIS=51103,STANDALONE=51104    /default-rack
 67d4b200-85fc-4e10-a9eb-65ce2253d4d0/127.0.0.1(localhost):RATIS=51089,STANDALONE=51090    /default-rack

```

Now, i can easy to distinguish the datanodes.
