### PR TITLE
HDDS-3584. Support write 2 replication

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationFactor.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationFactor.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
  */
 public enum ReplicationFactor {
   ONE(1),
+  TWO(2),
   THREE(3);
 
   /**
@@ -49,6 +50,9 @@ public enum ReplicationFactor {
     if(value == 1) {
       return ONE;
     }
+    if(value == 2) {
+      return TWO;
+    }
     if (value == 3) {
       return THREE;
     }
@@ -63,6 +67,8 @@ public enum ReplicationFactor {
     switch (replicationFactor) {
     case ONE:
       return ReplicationFactor.ONE;
+    case TWO:
+      return ReplicationFactor.TWO;
     case THREE:
       return ReplicationFactor.THREE;
     default:

--- a/hadoop-hdds/common/src/main/proto/hdds.proto
+++ b/hadoop-hdds/common/src/main/proto/hdds.proto
@@ -190,6 +190,7 @@ enum ReplicationType {
 
 enum ReplicationFactor {
     ONE = 1;
+    TWO = 2;
     THREE = 3;
 }
 

--- a/hadoop-hdds/common/src/main/proto/proto.lock
+++ b/hadoop-hdds/common/src/main/proto/proto.lock
@@ -3141,6 +3141,10 @@
                 "integer": 1
               },
               {
+                "name": "TWO",
+                "integer": 2
+              },
+              {
                 "name": "THREE",
                 "integer": 3
               }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -254,10 +254,12 @@ public class ContainerStateManager {
 
     boolean bgCreateOne = (type == ReplicationType.RATIS) && replicationFactor
         == ReplicationFactor.ONE && autoCreateRatisOne;
+    boolean bgCreateTwo = (type == ReplicationType.RATIS) && replicationFactor
+        == ReplicationFactor.TWO;
     boolean bgCreateThree = (type == ReplicationType.RATIS) && replicationFactor
         == ReplicationFactor.THREE;
 
-    if (!pipelines.isEmpty() && (bgCreateOne || bgCreateThree)) {
+    if (!pipelines.isEmpty() && (bgCreateOne || bgCreateTwo || bgCreateThree)) {
       // let background create Ratis pipelines.
       pipeline = pipelines.get((int) containerCount.get() % pipelines.size());
     } else {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -232,7 +232,8 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
   public List<DatanodeDetails> getResultSet(
       int nodesRequired, List<DatanodeDetails> healthyNodes)
       throws SCMException {
-    if (nodesRequired != HddsProtos.ReplicationFactor.THREE.getNumber()) {
+    if (nodesRequired != HddsProtos.ReplicationFactor.THREE.getNumber() &&
+        nodesRequired != HddsProtos.ReplicationFactor.TWO.getNumber()) {
       throw new SCMException("Nodes required number is not supported: " +
           nodesRequired, SCMException.ResultCodes.INVALID_CAPACITY);
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -113,6 +113,7 @@ public class RatisPipelineProvider extends PipelineProvider {
     case ONE:
       dns = pickNodesNeverUsed(ReplicationType.RATIS, ReplicationFactor.ONE);
       break;
+    case TWO:
     case THREE:
       dns = placementPolicy.chooseDatanodes(null,
           null, factor.getNumber(), 0);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineUtils.java
@@ -111,7 +111,7 @@ public final class RatisPipelineUtils {
       PipelineStateManager stateManager, Pipeline pipeline) {
     return stateManager.getPipelines(
         HddsProtos.ReplicationType.RATIS,
-        HddsProtos.ReplicationFactor.THREE)
+        pipeline.getFactor())
         .stream().filter(p -> !p.getId().equals(pipeline.getId()) &&
             (p.getPipelineState() != Pipeline.PipelineState.CLOSED &&
                 p.sameDatanodes(pipeline)))

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -412,7 +412,9 @@ public class SCMPipelineManager implements PipelineManager {
   @Override
   public void scrubPipeline(ReplicationType type, ReplicationFactor factor)
       throws IOException{
-    if (type != ReplicationType.RATIS || factor != ReplicationFactor.THREE) {
+    if (type != ReplicationType.RATIS ||
+        (factor != ReplicationFactor.THREE &&
+            factor != ReplicationFactor.TWO)) {
       // Only srub pipeline for RATIS THREE pipeline
       return;
     }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -221,6 +221,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
     try {
       OzoneOutputStream ozoneOutputStream = null;
       if (replication == ReplicationFactor.ONE.getValue()
+          || replication == ReplicationFactor.TWO.getValue()
           || replication == ReplicationFactor.THREE.getValue()) {
         ReplicationFactor clientReplication = ReplicationFactor
             .valueOf(replication);


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://docs.google.com/document/d/1YfN5IOckveREuwFWJvWJNHnySo2qSqsQ0e_sxE7XatY/edit?usp=sharing

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3584

## How was this patch tested?

- Normal tests.
```bash
# normal put
bin/ozone sh key put -r TWO /myvol/mybucket/NOTICE22.txt NOTICE.txt
# stop one of the datanode of pipeline's container of /myvol/mybucket/NOTICE22.txt
# wait until the datanode become stale, then to dead state, ensure the pipeline of it is close
# and the container's datanodes of the file are all alive after the replicationManager fire a replicate work.
bin/ozone sh key info /myvol/mybucket/NOTICE22.txt 
{
  "volumeName" : "myvol",
  "bucketName" : "mybucket",
  "name" : "NOTICE22.txt",
  "dataSize" : 17540,
  "creationTime" : "2020-05-28T13:56:00.047Z",
  "modificationTime" : "2020-05-28T13:56:01.922Z",
  "replicationType" : "RATIS",
  "replicationFactor" : 2,
  "ozoneKeyLocations" : [ {
    "containerID" : 1,
    "localID" : 104246421751595008,
    "length" : 17540,
    "offset" : 0
  } ],
  "metadata" : { },
  "fileEncryptionInfo" : null
}
bin/ozone admin container info 1                   
Container id: 1
Pipeline id: 2c1dc5cc-a94a-462a-845c-86027f625306
Container State: QUASI_CLOSED
Datanodes: [006fd0ff-a52c-4bdd-a888-e3a005828696/localhost,
2260916d-5e5d-40a5-b1b4-a4e706862f8a/localhost]
```

- Test by help of debugger
Break while writing file. Stop the leader datanode of the writing pipeline, client will request a new block to scm through om successfully.

Modify the hadoop-env.sh
```bash
export HADOOP_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5004"
```

put a bigger file more than 256MB

```
 bin/ozone sh key put -r TWO /myvol/mybucket/spark-tpc-ds-performance-test-master2.zip  ~/Downloads/spark-tpc-ds-performance-test-master.zip
```

set a break point to the line of `updateFlushLength`  in BlockOutputStream#write method, when break hit two times, it mean there are some chunk persist to the datanode. find the current pipeline's leader and stop it.

```bash
bin/ozone --daemon stop datanode
```

resume the debugger to let the process run, check the file write to the Ozone successfully.
