### PR TITLE
HDDS-3546. use shade plugin to build legacy jar

### DIFF
--- a/hadoop-ozone/ozonefs-lib-legacy/pom.xml
+++ b/hadoop-ozone/ozonefs-lib-legacy/pom.xml
@@ -32,8 +32,8 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
+    <shaded.prefix>org.apache.hadoop.ozone.shaded</shaded.prefix>
   </properties>
-
   <build>
     <plugins>
       <plugin>
@@ -44,67 +44,6 @@
             <goals>
               <goal>test-jar</goal>
             </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>include-dependencies</id>
-            <goals>
-              <goal>unpack-dependencies</goal>
-            </goals>
-            <phase>prepare-package</phase>
-            <configuration>
-              <outputDirectory>target/classes/libs</outputDirectory>
-              <includeScope>compile</includeScope>
-              <excludes>META-INF/*.SF,module-info.class</excludes>
-              <excludeArtifactIds>
-                slf4j-api,slf4j-log4j12,log4j-api,log4j-core,log4j,hadoop-ozone-filesystem
-              </excludeArtifactIds>
-              <markersDirectory>
-                ${project.build.directory}/dependency-maven-plugin-markers-lib
-              </markersDirectory>
-            </configuration>
-          </execution>
-
-          <execution>
-            <id>include-ozonefs</id>
-            <goals>
-              <goal>unpack-dependencies</goal>
-            </goals>
-            <phase>prepare-package</phase>
-            <configuration>
-              <outputDirectory>target/classes</outputDirectory>
-              <includeArtifactIds>hadoop-ozone-filesystem,hadoop-ozone-common</includeArtifactIds>
-              <includeScope>compile</includeScope>
-              <excludes>META-INF/*.SF</excludes>
-              <markersDirectory>
-                ${project.build.directory}/dependency-maven-plugin-markers-direct
-              </markersDirectory>
-            </configuration>
-          </execution>
-
-          <execution>
-            <id>include-token</id>
-            <goals>
-              <goal>unpack-dependencies</goal>
-            </goals>
-            <phase>prepare-package</phase>
-            <configuration>
-              <outputDirectory>target/classes</outputDirectory>
-              <includeArtifactIds>hadoop-ozone-common,hadoop-hdds-common</includeArtifactIds>
-              <includeScope>compile</includeScope>
-              <includes>
-                      org/apache/hadoop/ozone/security/OzoneTokenIdentifier.class,org/apache/hadoop/hdds/security/token/OzoneBlockTokenIdentifier.class,org/apache/hadoop/ozone/protocol/proto/OzoneManagerProtocolProtos*,org/apache/hadoop/hdds/protocol/proto/HddsProtos*
-              </includes>
-              <excludes>META-INF/*.SF</excludes>
-              <markersDirectory>
-                ${project.build.directory}/dependency-maven-plugin-markers-token
-              </markersDirectory>
-            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -125,9 +64,110 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer
+                        implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                  <resources>
+                    <resource>META-INF/BC1024KE.DSA</resource>
+                    <resource>META-INF/BC2048KE.DSA</resource>
+                    <resource>META-INF/BC1024KE.SF</resource>
+                    <resource>META-INF/BC2048KE.SF</resource>
+                  </resources>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.XmlAppendingTransformer">
+                  <resource>ozone-default-generated.xml</resource>
+                </transformer>
+              </transformers>
+              <relocations>
+                <relocation>
+                  <pattern>org</pattern>
+                  <shadedPattern>
+                    ${shaded.prefix}.org
+                  </shadedPattern>
+                  <includes>
+                    <include>org.yaml.**.*</include>
+                    <include>org.sqlite.**.*</include>
+                    <include>org.tukaani.**.*</include>
+                    <include>org.bouncycastle.**.*</include>
+                    <include>org.fusesource.leveldbjni.**.*</include>
+                    <include>org.rocksdb.**.*</include>
+                    <include>org.apache.commons.cli.**.*</include>
+                    <include>org.apache.commons.compress.**.*</include>
+                    <include>org.apache.commons.codec.**.*</include>
+                    <include>org.apache.commons.beanutils.**.*</include>
+                    <include>org.apache.commons.collections.**.*</include>
+                    <include>org.apache.commons.digester.**.*</include>
+                    <include>org.apache.commons.logging.**.*</include>
+                    <include>org.apache.commons.pool2.**.*</include>
+                    <include>org.apache.commons.validator.**.*</include>
+                    <include>org.sqlite.**.*</include>
+                    <include>org.apache.thrift.**.*</include>
+                  </includes>
+                </relocation>
+                <relocation>
+                  <pattern>com</pattern>
+                  <shadedPattern>
+                    ${shaded.prefix}.com
+                  </shadedPattern>
+                  <includes>
+                    <include>com.google.common.**.*</include>
+                    <include>com.google.gson.**.*</include>
+                    <include>com.codahale.**.*</include>
+                    <include>com.lmax.**.*</include>
+                    <include>com.github.joshelser.**.*</include>
+                    <include>com.twitter.**.*</include>
+                  </includes>
+                </relocation>
+                <relocation>
+                  <pattern>picocli</pattern>
+                  <shadedPattern>
+                    ${shaded.prefix}.picocli
+                  </shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>info</pattern>
+                  <shadedPattern>
+                    ${shaded.prefix}.info
+                  </shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io</pattern>
+                  <shadedPattern>
+                    ${shaded.prefix}.io
+                  </shadedPattern>
+                </relocation>
+                <!-- handling some special packages with special names -->
+                <relocation>
+                  <pattern>okio</pattern>
+                  <shadedPattern>
+                    ${shaded.prefix}.okio
+                  </shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>okhttp3</pattern>
+                  <shadedPattern>
+                    ${shaded.prefix}.okhttp3
+                  </shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -135,4 +175,5 @@
       <scope>compile</scope>
     </dependency>
   </dependencies>
+
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?
![image](https://user-images.githubusercontent.com/12323514/83216058-f541ff00-a19a-11ea-8a3b-b95136b878f6.png)

Currently, when using o3fs, it will throw exception like above pic shows, it's because the dependency hadoop-ozone-filesystem-lib-legacy-$version.jar using maven dependency plugin to build, it picks all the dependencies , unpack then into a jar. However, this will make some configuration file be overlap because of the same file name, eg. ozone-default-generated.xml. When we use o3fs, it will read default configuration value of SCMClientConfig in ozone-default-generated.xml if we don't config in ozone-site.xml, however, ozone-default-generated.xml is not completed in legacy jar.
So I use maven shaded plugin to replace maven dependency plugin, just like what hadoop-ozone-filesystem-lib-current does. The only difference is 'current' module will exclude some dependencies. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3546

## How was this patch tested?
1. Build the legacy jar.
2. Replace legacy jar in current cluster.
3. remove configuration "scm.container.client.idle.threshold" and "scm.container.client.max.size"
4. restart scm.
5. try o3fs, and it will not throw "client is null" exception