### PR TITLE
HDDS-3686. Insert an argument of ozone shell to accept jvm arguments

### DIFF
--- a/hadoop-ozone/dist/src/shell/hdds/hadoop-functions.sh
+++ b/hadoop-ozone/dist/src/shell/hdds/hadoop-functions.sh
@@ -2573,6 +2573,12 @@ function hadoop_parse_args
         shift
         ((HADOOP_PARSE_COUNTER=HADOOP_PARSE_COUNTER+1))
       ;;
+      --jvmargs)
+        shift
+        hadoop_add_param HADOOP_OPTS "$1" "$1"
+        shift
+        ((HADOOP_PARSE_COUNTER=HADOOP_PARSE_COUNTER+2))
+      ;;
       --config)
         shift
         confdir=$1

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -31,8 +31,7 @@ function hadoop_usage
   hadoop_add_option "--hosts filename" "list of hosts to use in worker mode"
   hadoop_add_option "--loglevel level" "set the log4j level for this command"
   hadoop_add_option "--workers" "turn on worker mode"
-  hadoop_add_option "--jvmargs" "jvm arguments, append JVM options to any existing options defined in the HADOOP_OPTS environment variable. Any defined in HADOOP_CLIENT_OPTS will be append after these jvmargs"
-
+  hadoop_add_option "--jvmargs jvm arguments", "append JVM options to any existing options defined in the HADOOP_OPTS environment variable. Any defined in HADOOP_CLIENT_OPTS will be append after these jvmargs"
 
   hadoop_add_subcommand "auditparser" client "runs audit parser tool"
   hadoop_add_subcommand "classpath" client "prints the class path needed to get the hadoop jar and the required libraries"

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -31,7 +31,8 @@ function hadoop_usage
   hadoop_add_option "--hosts filename" "list of hosts to use in worker mode"
   hadoop_add_option "--loglevel level" "set the log4j level for this command"
   hadoop_add_option "--workers" "turn on worker mode"
-  hadoop_add_option "--jvmargs" "jvm arguments"
+  hadoop_add_option "--jvmargs" "jvm arguments, append JVM options to any existing options defined in the HADOOP_OPTS environment variable. Any defined in HADOOP_CLIENT_OPTS will be append after these jvmargs"
+
 
   hadoop_add_subcommand "auditparser" client "runs audit parser tool"
   hadoop_add_subcommand "classpath" client "prints the class path needed to get the hadoop jar and the required libraries"

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -31,7 +31,7 @@ function hadoop_usage
   hadoop_add_option "--hosts filename" "list of hosts to use in worker mode"
   hadoop_add_option "--loglevel level" "set the log4j level for this command"
   hadoop_add_option "--workers" "turn on worker mode"
-  hadoop_add_option "--jvmargs jvm arguments", "append JVM options to any existing options defined in the HADOOP_OPTS environment variable. Any defined in HADOOP_CLIENT_OPTS will be append after these jvmargs"
+  hadoop_add_option "--jvmargs arguments" "append JVM options to any existing options defined in the HADOOP_OPTS environment variable. Any defined in HADOOP_CLIENT_OPTS will be append after these jvmargs"
 
   hadoop_add_subcommand "auditparser" client "runs audit parser tool"
   hadoop_add_subcommand "classpath" client "prints the class path needed to get the hadoop jar and the required libraries"

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -31,6 +31,7 @@ function hadoop_usage
   hadoop_add_option "--hosts filename" "list of hosts to use in worker mode"
   hadoop_add_option "--loglevel level" "set the log4j level for this command"
   hadoop_add_option "--workers" "turn on worker mode"
+  hadoop_add_option "--jvmargs" "jvm arguments"
 
   hadoop_add_subcommand "auditparser" client "runs audit parser tool"
   hadoop_add_subcommand "classpath" client "prints the class path needed to get the hadoop jar and the required libraries"


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a great feature, i believe everyone would like this new "--jvmargs" argument, we can specify some arguments you like, mostly, i put the "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005" into HADOOP_OPTS, now i doesn't have to do like that.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3686

## How was this patch tested?

```bash
bin/ozone --jvmargs "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005" admin pipeline list
Listening for transport dt_socket at address: 5005
```
then, use intellij idea to attach it and enjoy debugging, have a nice day.
