### PR TITLE
HDDS-3542.Ozone chunkinfo CLI cannot connect to OM when run from non-om node.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
@@ -629,4 +630,8 @@ public interface ClientProtocol {
    * */
   List<OzoneAcl> getAcl(OzoneObj obj) throws IOException;
 
+  /**
+   * Getter for OzoneManagerClient.
+   */
+  OzoneManagerProtocol getOzoneManagerClient();
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
-import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientException;
@@ -40,9 +39,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
-import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
-import org.apache.hadoop.ozone.om.protocolPB.OmTransportFactory;
-import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.shell.keys.KeyHandler;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -84,12 +80,8 @@ public class ChunkKeyHandler  extends KeyHandler {
         ContainerOperationClient(createOzoneConfiguration());
     xceiverClientManager = containerOperationClient
         .getXceiverClientManager();
-    OmTransport omTransport = OmTransportFactory
-        .create(getConf(), UserGroupInformation.getCurrentUser(), null);
-    ozoneManagerClient = TracingUtil.createProxy(
-        new OzoneManagerProtocolClientSideTranslatorPB(
-            omTransport, clientId.toString()),
-        OzoneManagerProtocol.class, getConf());
+    ozoneManagerClient = client.getObjectStore().getClientProxy()
+            .getOzoneManagerClient();
     address.ensureKeyAddress();
     JsonObject jsonObj = new JsonObject();
     JsonElement element;


### PR DESCRIPTION
## What changes were proposed in this pull request?
The chunkinfo tool was not connecting to OM  on a non-om leader client node .The fix  here is to use existing ozoneManagerClient instance instead of creating a new one.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3542

## How was this patch tested?
Tested manually.
