### PR TITLE
HDDS-3644. Failed to delete chunk file due to chunk size mismatch

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
@@ -216,12 +216,18 @@ public class FilePerChunkStrategy implements ChunkManager {
     }
 
     long len = info.getLen();
-    long offset = 0; // ignore offset in chunk info
     ByteBuffer data = ByteBuffer.allocate((int) len);
 
-    for (File chunkFile : possibleFiles) {
+    for (File file : possibleFiles) {
       try {
-        ChunkUtils.readData(chunkFile, data, offset, len, volumeIOStats);
+        // use offset only if file written by old datanode
+        long offset;
+        if (file.exists() && file.length() == info.getOffset() + len) {
+          offset = info.getOffset();
+        } else {
+          offset = 0;
+        }
+        ChunkUtils.readData(file, data, offset, len, volumeIOStats);
         return ChunkBuffer.wrap(data);
       } catch (StorageContainerException ex) {
         //UNABLE TO FIND chunk is not a problem as we will try with the

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
@@ -265,14 +265,15 @@ public class FilePerChunkStrategy implements ChunkManager {
       return;
     }
 
-    boolean allowed = info.getLen() == chunkFile.length()
+    long chunkFileSize = chunkFile.length();
+    boolean allowed = info.getLen() == chunkFileSize
         // chunk written by new client to old datanode, expected
         // file length is offset + real chunk length; see HDDS-3644
-        || info.getLen() + info.getOffset() == chunkFile.length();
+        || info.getLen() + info.getOffset() == chunkFileSize;
     if (allowed) {
       FileUtil.fullyDelete(chunkFile);
       LOG.info("Deleted chunk file {} (size {}) for chunk {}",
-          chunkFile, chunkFile.length(), info);
+          chunkFile, chunkFileSize, info);
     } else {
       LOG.error("Not Supported Operation. Trying to delete a " +
           "chunk that is in shared file. chunk info : {}", info);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow deleting chunk files if file size is same as offset + length.  This kind of chunk could have been created on old datanode by new client.

Fix read chunk operation after upgrade by using or ignoring chunk offset depending on file size.

https://issues.apache.org/jira/browse/HDDS-3644

## How was this patch tested?

Added unit test case.

Tested upgrade (from 0.5.0 to patched `0466ade7d~1`, as a workaround for HDDS-3499) manually on docker-compose cluster:

* new client can still read before upgrade (this is true for both `master` and patched version)
* new client can read after upgrade (fixed)
* if key is deleted and container closed, chunk files get correctly deleted eventually

```
datanode_1  | ... [BlockDeletingService#4] INFO impl.FilePerChunkStrategy: Deleted chunk file /data/hdds/hdds/50e2d8f9-82a5-488c-aa77-319394ea23c1/current/containerDir0/1/chunks/104252079982641152_chunk_1 (size 4194304) for chunk ChunkInfo{chunkName='104252079982641152_chunk_1, offset=0, len=4194304}
datanode_1  | ... [BlockDeletingService#4] INFO impl.FilePerChunkStrategy: Deleted chunk file /data/hdds/hdds/50e2d8f9-82a5-488c-aa77-319394ea23c1/current/containerDir0/1/chunks/104252079982641152_chunk_2 (size 5242880) for chunk ChunkInfo{chunkName='104252079982641152_chunk_2, offset=4194304, len=1048576}
```

https://github.com/adoroszlai/hadoop-ozone/runs/722746432