### PR TITLE
HDDS-3562. Datanodes should send ICR when a container replica deletion is successful.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -672,6 +672,9 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     case UNHEALTHY:
       state = ContainerReplicaProto.State.UNHEALTHY;
       break;
+    case DELETED:
+      state = ContainerReplicaProto.State.DELETED;
+      break;
     default:
       throw new StorageContainerException("Invalid Container state found: " +
           containerData.getContainerID(), INVALID_CONTAINER_STATE);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -1066,5 +1066,7 @@ public class KeyValueHandler extends Handler {
     }
     // Avoid holding write locks for disk operations
     container.delete();
+    container.getContainerData().setState(State.DELETED);
+    sendICR(container);
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
@@ -20,11 +20,15 @@ package org.apache.hadoop.ozone.container.keyvalue;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
@@ -40,6 +44,7 @@ import org.apache.hadoop.ozone.container.common.interfaces.Handler;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.test.GenericTestUtils;
@@ -47,6 +52,8 @@ import org.apache.hadoop.test.GenericTestUtils;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_VOLUME_CHOOSING_POLICY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.junit.Assert.assertEquals;
+
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -339,5 +346,55 @@ public class TestKeyValueHandler {
 
     assertEquals("Close container should return Invalid container error",
         ContainerProtos.Result.INVALID_CONTAINER_STATE, response.getResult());
+  }
+
+  @Test
+  public void testDeleteContainer() throws IOException {
+    final String testDir = GenericTestUtils.getTempPath(
+        TestKeyValueHandler.class.getSimpleName() +
+            "-" + UUID.randomUUID().toString());
+    try {
+      final long containerID = 1L;
+      final ConfigurationSource conf = new OzoneConfiguration();
+      final ContainerSet containerSet = new ContainerSet();
+      final VolumeSet volumeSet = Mockito.mock(VolumeSet.class);
+
+      Mockito.when(volumeSet.getVolumesList())
+          .thenReturn(Collections.singletonList(
+              new HddsVolume.Builder(testDir).conf(conf).build()));
+
+      final int[] interval = new int[1];
+      interval[0] = 2;
+      final ContainerMetrics metrics = new ContainerMetrics(interval);
+
+      final AtomicInteger icrReceived = new AtomicInteger(0);
+
+      final KeyValueHandler kvHandler = new KeyValueHandler(conf,
+          UUID.randomUUID().toString(), containerSet, volumeSet, metrics,
+          c -> icrReceived.incrementAndGet());
+      kvHandler.setScmID(UUID.randomUUID().toString());
+
+      final ContainerCommandRequestProto createContainer =
+          ContainerCommandRequestProto.newBuilder()
+              .setCmdType(ContainerProtos.Type.CreateContainer)
+              .setDatanodeUuid(UUID.randomUUID().toString())
+              .setCreateContainer(
+                  ContainerProtos.CreateContainerRequestProto.newBuilder()
+                      .setContainerType(ContainerType.KeyValueContainer)
+                      .build())
+              .setContainerID(containerID)
+              .setPipelineID(UUID.randomUUID().toString())
+              .build();
+
+      kvHandler.handleCreateContainer(createContainer, null);
+      Assert.assertEquals(1, icrReceived.get());
+      Assert.assertNotNull(containerSet.getContainer(containerID));
+
+      kvHandler.deleteContainer(containerSet.getContainer(containerID), true);
+      Assert.assertEquals(2, icrReceived.get());
+      Assert.assertNull(containerSet.getContainer(containerID));
+    } finally {
+      FileUtils.deleteDirectory(new File(testDir));
+    }
   }
 }

--- a/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
@@ -237,6 +237,7 @@ message ContainerDataProto {
     CLOSED = 4;
     UNHEALTHY = 5;
     INVALID = 6;
+    DELETED = 7;
   }
   required int64 containerID = 1;
   repeated KeyValue metadata = 2;

--- a/hadoop-hdds/interface-client/src/main/proto/proto.lock
+++ b/hadoop-hdds/interface-client/src/main/proto/proto.lock
@@ -276,6 +276,10 @@
               {
                 "name": "INVALID",
                 "integer": 6
+              },
+              {
+                "name": "DELETED",
+                "integer": 7
               }
             ]
           },

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -185,6 +185,7 @@ message ContainerReplicaProto {
     CLOSED = 4;
     UNHEALTHY = 5;
     INVALID = 6;
+    DELETED = 7;
   }
   required int64 containerID = 1;
   required State state = 2;

--- a/hadoop-hdds/interface-server/src/main/proto/proto.lock
+++ b/hadoop-hdds/interface-server/src/main/proto/proto.lock
@@ -98,6 +98,10 @@
               {
                 "name": "INVALID",
                 "integer": 6
+              },
+              {
+                "name": "DELETED",
+                "integer": 7
               }
             ]
           },

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -66,14 +66,17 @@ public class IncrementalContainerReportHandler extends
         final DatanodeDetails dd = report.getDatanodeDetails();
         final ContainerID id = ContainerID.valueof(
             replicaProto.getContainerID());
-        nodeManager.addContainer(dd, id);
+        if (!replicaProto.getState().equals(
+            ContainerReplicaProto.State.DELETED)) {
+          nodeManager.addContainer(dd, id);
+        }
         processContainerReplica(dd, replicaProto);
       } catch (ContainerNotFoundException e) {
         success = false;
         LOG.warn("Container {} not found!", replicaProto.getContainerID());
       } catch (NodeNotFoundException ex) {
         success = false;
-        LOG.error("Received ICR from unknown datanode {} {}",
+        LOG.error("Received ICR from unknown datanode {}",
             report.getDatanodeDetails(), ex);
       } catch (IOException e) {
         success = false;
@@ -82,12 +85,7 @@ public class IncrementalContainerReportHandler extends
       }
     }
 
-    if (success) {
-      getContainerManager().notifyContainerReportProcessing(false, true);
-    } else {
-      getContainerManager().notifyContainerReportProcessing(false, false);
-    }
-
+    getContainerManager().notifyContainerReportProcessing(false, success);
   }
 
   protected NodeManager getNodeManager() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Whenever a datanode executes the delete container command and deletes the container replica, it has to immediately send an ICR to update the container replica state in SCM.

## What is the link to the Apache JIRA
HDDS-3562

## How was this patch tested?
Related unit tests added