### PR TITLE
HDDS-3694. Reduce dn-audit log

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerExcep
 import org.apache.hadoop.hdds.security.token.TokenVerifier;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
-import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.ozone.audit.AuditAction;
 import org.apache.hadoop.ozone.audit.AuditEventStatus;
 import org.apache.hadoop.ozone.audit.AuditLogger;
@@ -66,7 +65,6 @@ import io.opentracing.Span;
 import io.opentracing.util.GlobalTracer;
 import static org.apache.hadoop.hdds.scm.protocolPB.ContainerCommandResponseBuilders.malformedRequest;
 import static org.apache.hadoop.hdds.scm.protocolPB.ContainerCommandResponseBuilders.unsupportedRequest;
-import static org.apache.hadoop.hdds.server.ServerUtils.getRemoteUserName;
 
 import org.apache.ratis.thirdparty.com.google.protobuf.ProtocolMessageEnum;
 import org.slf4j.Logger;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -585,7 +585,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
     AuditMessage amsg;
     switch (result) {
     case SUCCESS:
-      if(action.getAction().contains("CONTAINER")) {
+      if(isAllowed(action.getAction())) {
         if(eventType == EventType.READ &&
             AUDIT.getLogger().isInfoEnabled(AuditMarker.READ.getMarker())) {
           amsg = buildAuditMessageForSuccess(action, params);
@@ -617,13 +617,14 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
     }
   }
 
+  //TODO: use GRPC to fetch user and ip details
   @Override
   public AuditMessage buildAuditMessageForSuccess(AuditAction op,
       Map<String, String> auditMap) {
 
     return new AuditMessage.Builder()
-        .setUser(getRemoteUserName())
-        .atIp(Server.getRemoteAddress())
+        .setUser(null)
+        .atIp(null)
         .forOperation(op)
         .withParams(auditMap)
         .withResult(AuditEventStatus.SUCCESS)
@@ -635,8 +636,8 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
       Map<String, String> auditMap, Throwable throwable) {
 
     return new AuditMessage.Builder()
-        .setUser(getRemoteUserName())
-        .atIp(Server.getRemoteAddress())
+        .setUser(null)
+        .atIp(null)
         .forOperation(op)
         .withParams(auditMap)
         .withResult(AuditEventStatus.FAILURE)
@@ -647,5 +648,24 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
   enum EventType {
     READ,
     WRITE
+  }
+
+  /**
+   * Checks if the action is allowed for audit.
+   * @param action
+   * @return true or false accordingly.
+   */
+  private boolean isAllowed(String action) {
+    switch(action) {
+    case "CLOSE_CONTAINER":
+    case "CREATE_CONTAINER":
+    case "LIST_CONTAINER":
+    case "DELETE_CONTAINER":
+    case "READ_CONTAINER":
+    case "UPDATE_CONTAINER":
+    case "DELETE_BLOCK":
+      return true;
+    default: return false;
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

reduced dn audit log:
As discussed in community call
1. Reduce audit to Container related operations for all success + failure events and DELETE_BLOCK related events.
2. Audit for all other operations (blocks, chunks etc) only on failures/errors.
3. Addressed few sonar code smells.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3694

## How was this patch tested?

Build and deployed 3 node cluster, created a few keys. Confirmed that DN audit log no longer logs for CHUNK/BLOCK related operations.
