### PR TITLE
HDDS-3692: Consider avoiding stream/map/sum in write hotpath

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BufferPool.java
@@ -111,8 +111,11 @@ public class BufferPool {
   }
 
   public long computeBufferData() {
-    return bufferList.stream().mapToInt(ChunkBuffer::position)
-        .sum();
+    long totalBufferSize = 0;
+    for (ChunkBuffer buf : bufferList) {
+      totalBufferSize += buf.position();
+    }
+    return totalBufferSize;
   }
 
   public int getSize() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-3692: Consider avoiding stream/map/sum in write hotpath.
Stream in write hotpath makes it highly CPU intensive. Fixing it in this PR.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3692

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
