### PR TITLE
HDDS-3699. Change write chunk failure logging level to ERROR in BlockOutputStream.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -640,11 +640,9 @@ public class BlockOutputStream extends OutputStream {
         }
         return e;
       }, responseExecutor).exceptionally(e -> {
-        if (LOG.isDebugEnabled()) {
-          LOG.debug(
-              "writing chunk failed " + chunkInfo.getChunkName() + " blockID "
-                  + blockID + " with exception " + e.getLocalizedMessage());
-        }
+        LOG.info("writing chunk failed " + chunkInfo.getChunkName() +
+                " blockID " + blockID + " with exception "
+                + e.getLocalizedMessage());
         CompletionException ce = new CompletionException(e);
         setIoException(ce);
         throw ce;

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -640,7 +640,7 @@ public class BlockOutputStream extends OutputStream {
         }
         return e;
       }, responseExecutor).exceptionally(e -> {
-        LOG.info("writing chunk failed " + chunkInfo.getChunkName() +
+        LOG.error("writing chunk failed " + chunkInfo.getChunkName() +
                 " blockID " + blockID + " with exception "
                 + e.getLocalizedMessage());
         CompletionException ce = new CompletionException(e);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Changing logging level  for a  write chunk  failure to INFO in BlockOutputStream.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3699

## How was this patch tested?
not required.
