### PR TITLE
HDDS-3671. Introduce SCMStateMachineHandler marker interface.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerV2.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerV2.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ContainerInfoProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
+import org.apache.hadoop.hdds.scm.ha.SCMStateMachineHandler;
 import org.apache.hadoop.hdds.scm.metadata.Replicate;
 
 /**
@@ -42,7 +43,7 @@ import org.apache.hadoop.hdds.scm.metadata.Replicate;
  * 4. The declaration should throw RaftException
  *
  */
-public interface ContainerStateManagerV2 {
+public interface ContainerStateManagerV2 extends SCMStateMachineHandler {
 
   //TODO: Rename this to ContainerStateManager
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAInvocationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAInvocationHandler.java
@@ -38,19 +38,19 @@ public class SCMHAInvocationHandler implements InvocationHandler {
       .getLogger(SCMHAInvocationHandler.class);
 
   private final RequestType requestType;
-  private final Object localHandler;
-  private final SCMRatisServer ratisHandler;
+  private final SCMStateMachineHandler handler;
+  private final SCMRatisServer ratisServer;
 
   /**
    * TODO.
    */
   public SCMHAInvocationHandler(final RequestType requestType,
-                                final Object localHandler,
-                                final SCMRatisServer ratisHandler) {
+                                final SCMStateMachineHandler handler,
+                                final SCMRatisServer ratisServer) {
     this.requestType = requestType;
-    this.localHandler = localHandler;
-    this.ratisHandler = ratisHandler;
-    ratisHandler.registerStateMachineHandler(requestType, localHandler);
+    this.handler = handler;
+    this.ratisServer = ratisServer;
+    ratisServer.registerStateMachineHandler(requestType, handler);
   }
 
   @Override
@@ -73,8 +73,8 @@ public class SCMHAInvocationHandler implements InvocationHandler {
   private Object invokeLocal(Method method, Object[] args)
       throws InvocationTargetException, IllegalAccessException {
     LOG.trace("Invoking method {} on target {} with arguments {}",
-        method, localHandler, args);
-    return method.invoke(localHandler, args);
+        method, handler, args);
+    return method.invoke(handler, args);
   }
 
   /**
@@ -82,8 +82,8 @@ public class SCMHAInvocationHandler implements InvocationHandler {
    */
   private Object invokeRatis(Method method, Object[] args)
       throws Exception {
-    LOG.trace("Invoking method {} on target {}", method, ratisHandler);
-    final SCMRatisResponse response =  ratisHandler.submitRequest(
+    LOG.trace("Invoking method {} on target {}", method, ratisServer);
+    final SCMRatisResponse response =  ratisServer.submitRequest(
         SCMRatisRequest.of(requestType, method.getName(), args));
     if (response.isSuccess()) {
       return response.getResult();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServer.java
@@ -29,7 +29,8 @@ public interface SCMRatisServer {
 
   void start() throws IOException;
 
-  void registerStateMachineHandler(RequestType handlerType, Object handler);
+  void registerStateMachineHandler(RequestType handlerType,
+                                   SCMStateMachineHandler handler);
 
   SCMRatisResponse submitRequest(SCMRatisRequest request)
       throws IOException, ExecutionException, InterruptedException;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -85,8 +85,8 @@ public class SCMRatisServerImpl implements SCMRatisServer {
   }
 
   @Override
-  public void registerStateMachineHandler(final RequestType handlerType,
-                                          final Object handler) {
+  public void registerStateMachineHandler(
+      final RequestType handlerType, final SCMStateMachineHandler handler) {
     scmStateMachine.registerHandler(handlerType, handler);
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -37,13 +37,14 @@ import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
  */
 public class SCMStateMachine extends BaseStateMachine {
 
-  private final Map<RequestType, Object> handlers;
+  private final Map<RequestType, SCMStateMachineHandler> handlers;
 
   public SCMStateMachine() {
     this.handlers = new EnumMap<>(RequestType.class);
   }
 
-  public void registerHandler(RequestType type, Object handler) {
+  public void registerHandler(final RequestType type,
+                              final SCMStateMachineHandler handler) {
     handlers.put(type, handler);
   }
 
@@ -65,7 +66,7 @@ public class SCMStateMachine extends BaseStateMachine {
   private Message process(final SCMRatisRequest request)
       throws Exception {
     try {
-      final Object handler = handlers.get(request.getType());
+      final SCMStateMachineHandler handler = handlers.get(request.getType());
 
       if (handler == null) {
         throw new IOException("No handler found for request type " +

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachineHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachineHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * <p>Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.hdds.scm.ha;
+
+/**
+ * All the SCM StateMachine Handler have to implement this interface. <p>
+ * The SCMStateMachineHandler interface has no methods or fields
+ * and serves only to identify the semantics of being StateMachineHandler
+ * of SCMStateMachine.
+ */
+public interface SCMStateMachineHandler {
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/StateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/StateManager.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.pipeline;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.ha.SCMStateMachineHandler;
 import org.apache.hadoop.hdds.scm.metadata.Replicate;
 
 import java.io.IOException;
@@ -31,7 +32,7 @@ import java.util.NavigableSet;
  * Manages the state of pipelines in SCM.
  * TODO Rename to PipelineStateManager once the old state manager is removed.
  */
-public interface StateManager {
+public interface StateManager extends SCMStateMachineHandler {
 
   /**
    * Adding pipeline would be replicated to Ratis.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/MockSCMHAManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/MockSCMHAManager.java
@@ -91,8 +91,8 @@ public final class MockSCMHAManager implements SCMHAManager {
     }
 
     @Override
-    public void registerStateMachineHandler(final RequestType handlerType,
-                                            final Object handler) {
+    public void registerStateMachineHandler(
+        final RequestType handlerType, final SCMStateMachineHandler handler) {
       handlers.put(handlerType, handler);
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduce `SCMStateMachineHandler` marker interface which can be used to identify the StateMachine handlers in SCM

## What is the link to the Apache JIRA
HDDS-3671

## How was this patch tested?
This change doesn't require any additional tests.