### PR TITLE
HDDS-3703. Avoid file lookup calls in writeChunk hotpath

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ChunkLayOutVersion.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ChunkLayOutVersion.java
@@ -41,14 +41,14 @@ public enum ChunkLayOutVersion {
   FILE_PER_CHUNK(1, "One file per chunk") {
     @Override
     public File getChunkFile(File chunkDir, BlockID blockID,
-        ChunkInfo info) throws StorageContainerException {
-      return chunkDir.toPath().resolve(info.getChunkName()).toFile();
+        ChunkInfo info) {
+      return new File(chunkDir, info.getChunkName());
     }
   },
   FILE_PER_BLOCK(2, "One file per block") {
     @Override
     public File getChunkFile(File chunkDir, BlockID blockID,
-        ChunkInfo info) throws StorageContainerException {
+        ChunkInfo info) {
       return new File(chunkDir, blockID.getLocalID() + ".block");
     }
   };
@@ -117,12 +117,12 @@ public enum ChunkLayOutVersion {
   }
 
   public abstract File getChunkFile(File chunkDir,
-      BlockID blockID, ChunkInfo info) throws StorageContainerException;
+      BlockID blockID, ChunkInfo info);
 
   public File getChunkFile(ContainerData containerData, BlockID blockID,
       ChunkInfo info) throws StorageContainerException {
-    File chunksLoc = verifyChunkDirExists(containerData);
-    return getChunkFile(chunksLoc, blockID, info);
+    File chunkDir = getChunkDir(containerData);
+    return getChunkFile(chunkDir, blockID, info);
   }
 
   @Override
@@ -130,7 +130,7 @@ public enum ChunkLayOutVersion {
     return "ChunkLayout:v" + version;
   }
 
-  private static File verifyChunkDirExists(ContainerData containerData)
+  private static File getChunkDir(ContainerData containerData)
       throws StorageContainerException {
     Preconditions.checkNotNull(containerData, "Container data can't be null");
 
@@ -140,13 +140,7 @@ public enum ChunkLayOutVersion {
       throw new StorageContainerException("Unable to get Chunks directory.",
           UNABLE_TO_FIND_DATA_DIR);
     }
-    File chunksLoc = new File(chunksPath);
-    if (!chunksLoc.exists()) {
-      LOG.error("Chunks path does not exist");
-      throw new StorageContainerException("Unable to get Chunks directory.",
-          UNABLE_TO_FIND_DATA_DIR);
-    }
-    return chunksLoc;
+    return new File(chunksPath);
   }
 
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -421,10 +421,7 @@ public class KeyValueHandler extends Handler {
       Preconditions.checkNotNull(blockData);
 
       if (!request.getPutBlock().hasEof() || request.getPutBlock().getEof()) {
-        for (ContainerProtos.ChunkInfo chunkInfo : blockData.getChunks()) {
-          chunkManager.finishWriteChunk(kvContainer, blockData.getBlockID(),
-              ChunkInfo.getFromProtoBuf(chunkInfo));
-        }
+        chunkManager.finishWriteChunks(kvContainer, blockData);
       }
 
       long bcsId =
@@ -773,7 +770,7 @@ public class KeyValueHandler extends Handler {
       // here. There is no need to maintain this info in openContainerBlockMap.
       chunkManager
           .writeChunk(kvContainer, blockID, chunkInfo, data, dispatcherContext);
-      chunkManager.finishWriteChunk(kvContainer, blockID, chunkInfo);
+      chunkManager.finishWriteChunks(kvContainer, blockData);
 
       List<ContainerProtos.ChunkInfo> chunks = new LinkedList<>();
       chunks.add(chunkInfoProto);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
@@ -261,6 +261,15 @@ public final class ChunkUtils {
     return Boolean.parseBoolean(overWrite);
   }
 
+  public static void verifyChunkFileExists(File file)
+      throws StorageContainerException {
+    if (!file.exists()) {
+      throw new StorageContainerException(
+          "Chunk file not found: " + file.getPath(),
+          UNABLE_TO_FIND_CHUNK);
+    }
+  }
+
   @VisibleForTesting
   static <T> T processFileExclusively(Path path, Supplier<T> op) {
     for (;;) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDispatcher.java
@@ -70,11 +70,11 @@ public class ChunkManagerDispatcher implements ChunkManager {
   }
 
   @Override
-  public void finishWriteChunk(KeyValueContainer kvContainer, BlockID blockID,
-      ChunkInfo info) throws IOException {
+  public void finishWriteChunks(KeyValueContainer kvContainer,
+      BlockData blockData) throws IOException {
 
     selectHandler(kvContainer)
-        .finishWriteChunk(kvContainer, blockID, info);
+        .finishWriteChunks(kvContainer, blockData);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/ChunkManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/ChunkManager.java
@@ -97,8 +97,8 @@ public interface ChunkManager {
     // if applicable
   }
 
-  default void finishWriteChunk(KeyValueContainer kvContainer, BlockID blockID,
-      ChunkInfo info) throws IOException {
+  default void finishWriteChunks(KeyValueContainer kvContainer,
+      BlockData blockData) throws IOException {
     // no-op
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachine.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachine.java
@@ -154,12 +154,12 @@ public class TestContainerStateMachine {
 
     key.close();
     // Make sure the container is marked unhealthy
-    Assert.assertTrue(
+    Assert.assertEquals(
+        ContainerProtos.ContainerDataProto.State.UNHEALTHY,
         cluster.getHddsDatanodes().get(0).getDatanodeStateMachine()
             .getContainer().getContainerSet()
             .getContainer(omKeyLocationInfo.getContainerID())
-            .getContainerState()
-            == ContainerProtos.ContainerDataProto.State.UNHEALTHY);
+            .getContainerState());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Skip the check for existence of chunks directory that happened on each `getChunkFile` call.  Read and delete operations already verify existence of the chunk file itself.
2. Instead of the above check, verify the existence of the block file after write once per block.  This is needed to allow marking the container unhealthy immediately if file is lost during write, see existing unit test in `TestContainerStateMachine`.
3. Perform `finishWriteChunk` in batch, avoiding unnecessary conversion of all chunks, operate on already converted block data.
4. Replace "absolute path" with "path" as key in `OpenFiles` (for file-per-block).  This is safe because chunk dir location is constructed relative to the container dir (and eventually relative to HDDS volume), so the result is the same.

https://issues.apache.org/jira/browse/HDDS-3703

## How was this patch tested?

Tested locally on docker-compose cluster.

https://github.com/adoroszlai/hadoop-ozone/runs/733420600