### PR TITLE
HDDS-1815. Add missing license for SVG Logo

### DIFF
--- a/hadoop-hdds/docs/static/ozone-logo-monochrome.svg
+++ b/hadoop-hdds/docs/static/ozone-logo-monochrome.svg
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-1815 was recently committed without CI (730cc0f09), accidentally breaking [`rat` check](https://github.com/apache/hadoop-ozone/runs/736295543).

```
hadoop-hdds/docs/target/rat.txt: !????? /github/workspace/hadoop-hdds/docs/static/ozone-logo-monochrome.svg
```

This PR just adds the missing license, copied from another SVG image.

https://issues.apache.org/jira/browse/HDDS-1815

## How was this patch tested?

```
$ hadoop-ozone/dev-support/checks/rat.sh
...
[INFO] --- apache-rat-plugin:0.13:check (default-cli) @ hadoop-hdds-docs ---
...
[INFO] Rat check: Summary over all files. Unapproved: 0, unknown: 0, generated: 0, approved: 119 licenses.
...
```

https://github.com/adoroszlai/hadoop-ozone/runs/737247301