### PR TITLE
HDDS-3716. Compile of Ozone fails with JDK 11+

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -47,7 +47,13 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>guava</artifactId>
       <scope>compile</scope>
     </dependency>
-
+    <!-- for the annotations in OzoneConfiguration -->
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.1.13</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/SimpleConfiguration.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/SimpleConfiguration.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.conf;
 
-import javax.annotation.PostConstruct;
 import java.util.concurrent.TimeUnit;
 
 /**

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationReflectionUtil.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationReflectionUtil.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.conf;
 
-import javax.annotation.PostConstruct;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/PostConstruct.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/PostConstruct.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.conf;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Methods annotated with this annotation will be called after object creation.
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface PostConstruct {
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -16,12 +16,12 @@
  */
 package org.apache.hadoop.ozone.container.common.statemachine;
 
-import javax.annotation.PostConstruct;
-
 import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
-import static org.apache.hadoop.hdds.conf.ConfigTag.DATANODE;
 import org.apache.hadoop.hdds.conf.ConfigType;
+import org.apache.hadoop.hdds.conf.PostConstruct;
+
+import static org.apache.hadoop.hdds.conf.ConfigTag.DATANODE;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

@PostConstruct annotation is removed from JDK (it's Java EE) in the recent JDKs.

It's used by the Configuration annotations, but we don't need to use Java EE annotations:

```
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project hadoop-hdds-config: Compilation failure: Compilation failure: 
[ERROR] /Users/sbanerjee/ozone_fork/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationReflectionUtil.java:[20,24] cannot find symbol
[ERROR]  symbol:  class PostConstruct
[ERROR]  location: package javax.annotation
[ERROR] /Users/sbanerjee/ozone_fork/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationReflectionUtil.java:[139,38] cannot find symbol
[ERROR]  symbol:  class PostConstruct
```

## What is the link to the Apache JIRA

You can guess it, but it's:

https://issues.apache.org/jira/browse/HDDS-3716

## How was this patch tested?

Compiled ozone locally with java13.