### PR TITLE
HDDS-3717. CSI smoketest fails if socket file is not created on time

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/csi.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/csi.robot
@@ -23,7 +23,7 @@ Test Timeout        1 minutes
 
 *** Keywords ***
 CSI Socket check
-   Execute                          find -name /tmp/csi.sock
+   Execute                          [ -S /tmp/csi.sock ]
 
 *** Test Cases ***
 Check if CSI server is started


### PR DESCRIPTION
## What changes were proposed in this pull request?



HDDS-3461 introduced a new CSI smoketest (to be sure that the CSI daemon can be started).

It was reverted because a failure on the master and commited after an additional check is added to wait until the CSI socket is created.

Unfortunately this check is bad. In some cases it can fail:

For example in here:

https://github.com/jsoft88/hadoop-ozone/runs/734147343?check_suite_focus=true

```
connection error: desc = "transport: Error while dialing dial unix /tmp/csi.sock: connect: no such file or directory" 
```
Thanks to @jsoft88 , who reported this problem.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3717

## How was this patch tested?

This is the important part. I tested the earlier version, but due to other errors in my `/tmp` it showed false positive result.

Now I tested it with executing robot test:

```
robot hadoop-ozone/dist/src/main/smoketest/csi.robot
```

You can see that without the patch it passes the `Check if CSI server is started` phase even if `/tmp/csi.socket` is not created locally.

After apply the patch, you can do the same:

```
robot hadoop-ozone/dist/src/main/smoketest/csi.robot
```

The same check at the beginning should be pending and failed 3 minutes. 

You can also create a socket during the 3 minutes: `nc -U /tmp/csi.sock -l`

In this case the check will be passed.