### PR TITLE
HDDS-3720. Datanode configuration object has wrong values

### DIFF
--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/SimpleConfiguration.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/SimpleConfiguration.java
@@ -51,7 +51,7 @@ public class SimpleConfiguration extends SimpleConfigurationParent {
   @PostConstruct
   public void validate() {
     if (port < 0) {
-      throw new NumberFormatException("Please use a postitive port number");
+      throw new NumberFormatException("Please use a positive port number");
     }
   }
 

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationReflectionUtil.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationReflectionUtil.java
@@ -21,6 +21,7 @@ import javax.annotation.PostConstruct;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 /**
  * Reflection utilities for configuration injection.
@@ -50,6 +51,12 @@ public final class ConfigurationReflectionUtil {
       String prefix) {
     for (Field field : configurationClass.getDeclaredFields()) {
       if (field.isAnnotationPresent(Config.class)) {
+        if ((field.getModifiers() & Modifier.FINAL) != 0) {
+          throw new ConfigurationException(String.format(
+              "Trying to set final field %s#%s, probably indicates misplaced " +
+                  "@Config annotation",
+              configurationClass.getSimpleName(), field.getName()));
+        }
 
         String fieldLocation =
             configurationClass + "." + field.getName();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -30,8 +30,16 @@ import org.slf4j.LoggerFactory;
  */
 @ConfigGroup(prefix = "hdds.datanode")
 public class DatanodeConfiguration {
-  static final Logger LOG =
+
+  private static final Logger LOG =
       LoggerFactory.getLogger(DatanodeConfiguration.class);
+
+  static final String REPLICATION_STREAMS_LIMIT_KEY =
+      "hdds.datanode.replication.streams.limit";
+  static final String CONTAINER_DELETE_THREADS_MAX_KEY =
+      "hdds.datanode.container.delete.threads.max";
+
+  static final int REPLICATION_MAX_STREAMS_DEFAULT = 10;
 
   /**
    * The maximum number of replication commands a single datanode can execute
@@ -44,9 +52,10 @@ public class DatanodeConfiguration {
       description = "The maximum number of replication commands a single " +
           "datanode can execute simultaneously"
   )
-  private final int replicationMaxStreamsDefault = 10;
+  private int replicationMaxStreams = REPLICATION_MAX_STREAMS_DEFAULT;
 
-  private int replicationMaxStreams = replicationMaxStreamsDefault;
+  static final int CONTAINER_DELETE_THREADS_DEFAULT = 2;
+
   /**
    * The maximum number of threads used to delete containers on a datanode
    * simultaneously.
@@ -58,24 +67,22 @@ public class DatanodeConfiguration {
       description = "The maximum number of threads used to delete containers " +
           "on a datanode"
   )
-  private final int containerDeleteThreadsDefault = 2;
-
-  private int containerDeleteThreads = containerDeleteThreadsDefault;
+  private int containerDeleteThreads = CONTAINER_DELETE_THREADS_DEFAULT;
 
   @PostConstruct
   public void validate() {
-    if (replicationMaxStreamsDefault < 1) {
-      LOG.warn("hdds.datanode.replication.streams.limit must be greater than" +
-          "zero and was set to {}. Defaulting to {}",
-          replicationMaxStreamsDefault, replicationMaxStreamsDefault);
-      replicationMaxStreams = replicationMaxStreamsDefault;
+    if (replicationMaxStreams < 1) {
+      LOG.warn(REPLICATION_STREAMS_LIMIT_KEY + " must be greater than zero " +
+              "and was set to {}. Defaulting to {}",
+          replicationMaxStreams, REPLICATION_MAX_STREAMS_DEFAULT);
+      replicationMaxStreams = REPLICATION_MAX_STREAMS_DEFAULT;
     }
 
     if (containerDeleteThreads < 1) {
-      LOG.warn("hdds.datanode.container.delete.threads.max must be greater " +
-              "than zero and was set to {}. Defaulting to {}",
-          containerDeleteThreads, containerDeleteThreadsDefault);
-      containerDeleteThreads = containerDeleteThreadsDefault;
+      LOG.warn(CONTAINER_DELETE_THREADS_MAX_KEY + " must be greater than zero" +
+              " and was set to {}. Defaulting to {}",
+          containerDeleteThreads, CONTAINER_DELETE_THREADS_DEFAULT);
+      containerDeleteThreads = CONTAINER_DELETE_THREADS_DEFAULT;
     }
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.common.statemachine;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.junit.Test;
+
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.CONTAINER_DELETE_THREADS_DEFAULT;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.CONTAINER_DELETE_THREADS_MAX_KEY;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.REPLICATION_MAX_STREAMS_DEFAULT;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.REPLICATION_STREAMS_LIMIT_KEY;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for {@link DatanodeConfiguration}.
+ */
+public class TestDatanodeConfiguration {
+
+  @Test
+  public void acceptsValidValues() {
+    // GIVEN
+    int validReplicationLimit = 123;
+    int validDeleteThreads = 42;
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setInt(REPLICATION_STREAMS_LIMIT_KEY, validReplicationLimit);
+    conf.setInt(CONTAINER_DELETE_THREADS_MAX_KEY, validDeleteThreads);
+
+    // WHEN
+    DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);
+
+    // THEN
+    assertEquals(validReplicationLimit, subject.getReplicationMaxStreams());
+    assertEquals(validDeleteThreads, subject.getContainerDeleteThreads());
+  }
+
+  @Test
+  public void overridesInvalidValues() {
+    // GIVEN
+    int invalidReplicationLimit = -5;
+    int invalidDeleteThreads = 0;
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setInt(REPLICATION_STREAMS_LIMIT_KEY, invalidReplicationLimit);
+    conf.setInt(CONTAINER_DELETE_THREADS_MAX_KEY, invalidDeleteThreads);
+
+    // WHEN
+    DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);
+
+    // THEN
+    assertEquals(REPLICATION_MAX_STREAMS_DEFAULT,
+        subject.getReplicationMaxStreams());
+    assertEquals(CONTAINER_DELETE_THREADS_DEFAULT,
+        subject.getContainerDeleteThreads());
+  }
+
+  @Test
+  public void isCreatedWitDefaultValues() {
+    // GIVEN
+    OzoneConfiguration conf = new OzoneConfiguration();
+
+    // WHEN
+    DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);
+
+    // THEN
+    assertEquals(REPLICATION_MAX_STREAMS_DEFAULT,
+        subject.getReplicationMaxStreams());
+    assertEquals(CONTAINER_DELETE_THREADS_DEFAULT,
+        subject.getContainerDeleteThreads());
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. `@Config` annotation was assigned to the wrong fields (the ones with default values) in `DatanodeConfiguration` - fixed.
2. Added check for possible coding error: `@Config` on `final` field.  This catches the above problem if the class is instantiated in tests.
3. Added unit test.

https://issues.apache.org/jira/browse/HDDS-3720

## How was this patch tested?

1. Verified that default values are used (without warning) by default:

```
datanode_1  | ... INFO statemachine.DatanodeStateMachine: container.delete.threads: 2
datanode_1  | ... INFO statemachine.DatanodeStateMachine: replication.streams.limit: 10
```

2. Verified that valid custom values are accepted:

```
datanode_1  | ... INFO statemachine.DatanodeStateMachine: container.delete.threads: 123
datanode_1  | ... INFO statemachine.DatanodeStateMachine: replication.streams.limit: 42
```

3. Verified that invalid custom values produce warnings, and config is reset to default:

```
datanode_1  | ... WARN statemachine.DatanodeConfiguration: hdds.datanode.replication.streams.limit must be greater than zero and was set to 0. Defaulting to 10
datanode_1  | ... WARN statemachine.DatanodeConfiguration: hdds.datanode.container.delete.threads.max must be greater than zero and was set to -1. Defaulting to 2
datanode_1  | ... INFO statemachine.DatanodeStateMachine: container.delete.threads: 2
datanode_1  | ... INFO statemachine.DatanodeStateMachine: replication.streams.limit: 10
```

Added unit test for the same cases.

https://github.com/adoroszlai/hadoop-ozone/runs/741212448