### PR TITLE
HDDS-3732. Avoid UUID#toString call in DatanodeDetails#getUuidString.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -44,6 +44,7 @@ public class DatanodeDetails extends NodeImpl implements
    * DataNode's unique identifier in the cluster.
    */
   private final UUID uuid;
+  private final String strUuid;
 
   private String ipAddress;
   private String hostName;
@@ -64,6 +65,7 @@ public class DatanodeDetails extends NodeImpl implements
       String networkLocation, List<Port> ports, String certSerialId) {
     super(hostName, networkLocation, NetConstants.NODE_COST_DEFAULT);
     this.uuid = UUID.fromString(uuid);
+    this.strUuid = uuid;
     this.ipAddress = ipAddress;
     this.hostName = hostName;
     this.ports = ports;
@@ -74,6 +76,7 @@ public class DatanodeDetails extends NodeImpl implements
     super(datanodeDetails.getHostName(), datanodeDetails.getNetworkLocation(),
         datanodeDetails.getCost());
     this.uuid = datanodeDetails.uuid;
+    this.strUuid = datanodeDetails.uuid.toString();
     this.ipAddress = datanodeDetails.ipAddress;
     this.hostName = datanodeDetails.hostName;
     this.ports = datanodeDetails.ports;
@@ -95,7 +98,7 @@ public class DatanodeDetails extends NodeImpl implements
    * @return UUID of DataNode
    */
   public String getUuidString() {
-    return uuid.toString();
+    return strUuid;
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -241,7 +241,7 @@ public class DatanodeDetails extends NodeImpl implements
 
   @Override
   public String toString() {
-    return uuid.toString() + "{" +
+    return strUuid + "{" +
         "ip: " +
         ipAddress +
         ", host: " +


### PR DESCRIPTION
## What changes were proposed in this pull request?
I start a ozone cluster with 1000 datanodes, and run two weeks with heavy workload, and perf scm.
UUID.toString in DatanodeDetails cost 7.23% cpu because of so many datanodes.
![image](https://user-images.githubusercontent.com/51938049/83867132-872da700-a75b-11ea-8a5d-08f1f56657dd.png)



## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3732

## How was this patch tested?

Existed UT and IT.