### PR TITLE
HDDS-3734. Improve the performance of SCM with 3.86% by avoid TreeSet.addAll

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -27,8 +27,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.fs.CommonConfigurationKeys;
@@ -592,12 +590,7 @@ public class SCMClientProtocolServer implements
    * @return List of Datanodes that match the NodeState.
    */
   private List<DatanodeDetails> queryNodeState(HddsProtos.NodeState nodeState) {
-    List<DatanodeDetails> returnList = new ArrayList<>();
-    List<DatanodeDetails> tmp = scm.getScmNodeManager().getNodes(nodeState);
-    if ((tmp != null) && (tmp.size() > 0)) {
-      returnList.addAll(tmp);
-    }
-    return returnList;
+    return scm.getScmNodeManager().getNodes(nodeState);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -569,7 +569,7 @@ public class SCMClientProtocolServer implements
    */
   public List<DatanodeDetails> queryNode(HddsProtos.NodeState state) {
     Preconditions.checkNotNull(state, "Node Query set cannot be null");
-    return new ArrayList<>(queryNodeState(state));
+    return queryNodeState(state);
   }
 
   @VisibleForTesting
@@ -589,15 +589,15 @@ public class SCMClientProtocolServer implements
    * Query the System for Nodes.
    *
    * @param nodeState - NodeState that we are interested in matching.
-   * @return Set of Datanodes that match the NodeState.
+   * @return List of Datanodes that match the NodeState.
    */
-  private Set<DatanodeDetails> queryNodeState(HddsProtos.NodeState nodeState) {
-    Set<DatanodeDetails> returnSet = new TreeSet<>();
+  private List<DatanodeDetails> queryNodeState(HddsProtos.NodeState nodeState) {
+    List<DatanodeDetails> returnList = new ArrayList<>();
     List<DatanodeDetails> tmp = scm.getScmNodeManager().getNodes(nodeState);
     if ((tmp != null) && (tmp.size() > 0)) {
-      returnSet.addAll(tmp);
+      returnList.addAll(tmp);
     }
-    return returnSet;
+    return returnList;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

I start a ozone cluster with 1000 datanodes, and run two weeks with heavy workload, and perf scm.
TreeSet.addAll cost 3.86% cpu because of so many datanodes.

we need not TreeSet.addAll, because the DatanodeDetails was got from NodeStateMap::ConcurrentHashMap<NodeState, Set<UUID>> stateMap, the value type of stateMap is a set, so there is no duplicate DatanodeDetails. we can replace TreeSet.addAll with list.addAll

![企业微信截图_15913533425809](https://user-images.githubusercontent.com/51938049/83867624-4bdfa800-a75c-11ea-8676-b17a9304ca72.png)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3734

## How was this patch tested?

Existed UT and IT.