### PR TITLE
HDDS-3735. Improve SCM performance with 3.7% by remove unnecessary lock and unlock

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -495,6 +495,15 @@ public class ContainerStateManager {
     return containers.getContainerInfo(containerID);
   }
 
+  /**
+   * Returns whether container exist for the given container id.
+   * @param containerID id of the container
+   * @return true if container exists, otherwise false
+   */
+  boolean isContainerExist(final ContainerID containerID) {
+    return containers.isContainerExist(containerID);
+  }
+
   void close() throws IOException {
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
@@ -204,9 +204,7 @@ public class SCMContainerManager implements ContainerManager {
   public boolean exists(ContainerID containerID) {
     lock.lock();
     try {
-      return (containerStateManager.getContainer(containerID) != null);
-    } catch (ContainerNotFoundException e) {
-      return false;
+      return containerStateManager.isContainerExist(containerID);
     } finally {
       lock.unlock();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
@@ -183,13 +183,21 @@ public class ContainerStateMap {
    */
   public ContainerInfo getContainerInfo(final ContainerID containerID)
       throws ContainerNotFoundException {
-    lock.readLock().lock();
-    try {
-      checkIfContainerExist(containerID);
-      return containerMap.get(containerID);
-    } finally {
-      lock.readLock().unlock();
+    ContainerInfo info = containerMap.get(containerID);
+    if (info == null) {
+      throw new ContainerNotFoundException("Container with id #" +
+          containerID.getId() + " not found.");
     }
+    return info;
+  }
+
+  /**
+   * Returns whether container exist for the given container id.
+   * @param containerID id of the container
+   * @return true if container exists, otherwise false
+   */
+  public boolean isContainerExist(final ContainerID containerID) {
+    return containerMap.containsKey(containerID);
   }
 
   /**
@@ -202,14 +210,13 @@ public class ContainerStateMap {
   public Set<ContainerReplica> getContainerReplicas(
       final ContainerID containerID) throws ContainerNotFoundException {
     Preconditions.checkNotNull(containerID);
-    lock.readLock().lock();
-    try {
-      checkIfContainerExist(containerID);
-      return Collections
-          .unmodifiableSet(replicaMap.get(containerID));
-    } finally {
-      lock.readLock().unlock();
+    Set<ContainerReplica> replicas = replicaMap.get(containerID);
+    if (replicas == null) {
+      throw new ContainerNotFoundException("Container with id #" +
+          containerID.getId() + " not found.");
     }
+
+    return Collections.unmodifiableSet(replicas);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
@@ -130,13 +130,11 @@ public class NodeStateMap {
    * @throws NodeNotFoundException if the node is not present
    */
   public DatanodeInfo getNodeInfo(UUID uuid) throws NodeNotFoundException {
-    lock.readLock().lock();
-    try {
-      checkIfNodeExist(uuid);
-      return nodeMap.get(uuid);
-    } finally {
-      lock.readLock().unlock();
+    DatanodeInfo info = nodeMap.get(uuid);
+    if (info == null) {
+      throw new NodeNotFoundException("Node UUID: " + uuid);
     }
+    return info;
   }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

I start a ozone cluster with 1000 datanodes, and run two weeks with heavy workload, and perf scm.  lock and unlock in 3 places cost about 3.7% cpu, but the lock and unlock is unnecessary, because read lock is to avoid read incomplete data when write, but here get value from ConcurrentHashMap is thread safe, we do not need read lock. So this patch remove these lock.

1. lock and unlock in ContainerStateMap::getContainerInfo
![image](https://user-images.githubusercontent.com/51938049/84017193-e46e6600-a9b0-11ea-81a4-613c2e585a97.png)

![image](https://user-images.githubusercontent.com/51938049/84017198-e801ed00-a9b0-11ea-89fd-eec66b6b783c.png)

2. lock and unlock in ContainerStateMap::getContainerReplicas
![image](https://user-images.githubusercontent.com/51938049/84017213-ed5f3780-a9b0-11ea-9135-ef23d9a956d0.png)

![image](https://user-images.githubusercontent.com/51938049/84017226-f18b5500-a9b0-11ea-9bcd-fa141f36d0ee.png)

3. lock and unlock in NodeStateMap::getNodeInfo
![image](https://user-images.githubusercontent.com/51938049/84017239-f6500900-a9b0-11ea-8647-e9e355af64a9.png)

![image](https://user-images.githubusercontent.com/51938049/84017252-f9e39000-a9b0-11ea-90bf-73afca849d98.png)





## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3735

## How was this patch tested?

Existed UT and IT