### PR TITLE
HDDS-3719. Datanode may fail to stop

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -364,6 +364,10 @@ public class DatanodeStateMachine implements Closeable {
       }
       return getLastState();
     }
+
+    public boolean isTransitionAllowedTo(DatanodeStates newState) {
+      return newState.getValue() > getValue();
+    }
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -152,7 +152,14 @@ public class StateContext {
    * @param state state.
    */
   public void setState(DatanodeStateMachine.DatanodeStates state) {
-    this.state = state;
+    if (this.state != state) {
+      if (this.state.isTransitionAllowedTo(state)) {
+        this.state = state;
+      } else {
+        LOG.warn("Ignore disallowed transition from {} to {}",
+            this.state, state);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Datanode state may go back from shutdown to running due to race condition.  The problem happens if the task executed by `StateContext` reports that next state should be `RUNNING`, but datanode state was set to `SHUTDOWN` in the meantime.  [State machine loop](https://github.com/apache/hadoop-ozone/blob/26d83753792908e840fe6fc9629bed45bb6fa114/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java#L203-L223) will continue trying to execute tasks, which will all fail as the executor is already shut down.

```
2020-06-03 15:28:19,475 [Datanode State Machine Thread - 0] ERROR statemachine.DatanodeStateMachine (DatanodeStateMachine.java:start(221)) - Unable to finish the execution.
java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.ExecutorCompletionService$QueueingFuture@73c36b6c rejected from org.apache.hadoop.util.concurrent.HadoopThreadPoolExecutor@5c021707[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 24]
	at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2063)
	at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:830)
	at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1379)
	at java.util.concurrent.ExecutorCompletionService.submit(ExecutorCompletionService.java:181)
	at org.apache.hadoop.ozone.container.common.states.datanode.RunningDatanodeState.execute(RunningDatanodeState.java:143)
	at org.apache.hadoop.ozone.container.common.statemachine.StateContext.execute(StateContext.java:411)
	at org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine.start(DatanodeStateMachine.java:208)
	at org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine.lambda$startDaemon$0(DatanodeStateMachine.java:375)
	at java.lang.Thread.run(Thread.java:748)
```

The fix disallows going from a later state to previous one.

https://issues.apache.org/jira/browse/HDDS-3719

## How was this patch tested?

Added unit test to reproduce the problem:

https://github.com/adoroszlai/hadoop-ozone/runs/742340251

And verified the fix:

https://github.com/adoroszlai/hadoop-ozone/runs/742342096