### PR TITLE
HDDS-3742. Improve OM performance with 5.29% by avoid stream.collect

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/ServiceInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/ServiceInfo.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
@@ -143,16 +142,18 @@ public final class ServiceInfo {
   public OzoneManagerProtocolProtos.ServiceInfo getProtobuf() {
     OzoneManagerProtocolProtos.ServiceInfo.Builder builder =
         OzoneManagerProtocolProtos.ServiceInfo.newBuilder();
+
+    List<ServicePort> servicePorts = new ArrayList<>();
+    for (Map.Entry<ServicePort.Type, Integer>
+        entry : ports.entrySet()) {
+      servicePorts.add(ServicePort.newBuilder()
+          .setType(entry.getKey())
+          .setValue(entry.getValue()).build());
+    }
+
     builder.setNodeType(nodeType)
         .setHostname(hostname)
-        .addAllServicePorts(
-            ports.entrySet().stream()
-                .map(
-                    entry ->
-                        ServicePort.newBuilder()
-                            .setType(entry.getKey())
-                            .setValue(entry.getValue()).build())
-                .collect(Collectors.toList()));
+        .addAllServicePorts(servicePorts);
     if (nodeType == NodeType.OM && omRoleInfo != null) {
       builder.setOmRole(omRoleInfo);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AllocateBlockRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AllocateBlockResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CheckVolumeAccessRequest;
@@ -448,9 +449,15 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     ServiceListResponse.Builder resp = ServiceListResponse.newBuilder();
 
     ServiceInfoEx serviceInfoEx = impl.getServiceInfo();
-    resp.addAllServiceInfo(serviceInfoEx.getServiceInfoList().stream()
-        .map(ServiceInfo::getProtobuf)
-        .collect(Collectors.toList()));
+
+    List<OzoneManagerProtocolProtos.ServiceInfo> serviceInfoProtos =
+        new ArrayList<>();
+    List<ServiceInfo> serviceInfos = serviceInfoEx.getServiceInfoList();
+    for (ServiceInfo info : serviceInfos) {
+      serviceInfoProtos.add(info.getProtobuf());
+    }
+
+    resp.addAllServiceInfo(serviceInfoProtos);
     if (serviceInfoEx.getCaCertificate() != null) {
       resp.setCaCertificate(serviceInfoEx.getCaCertificate());
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

I start a ozone cluster with 1000 datanodes, and run two weeks with heavy workload, and perf om.

stream().collect(Collectors.toList())) in getProtoBuf cost 5.29% cpu.

![image](https://user-images.githubusercontent.com/51938049/83933415-d7981980-a7da-11ea-8825-a226dc75ae8c.png)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3742

## How was this patch tested?

Existed test
