### PR TITLE
HDDS-3753. remove redundant synchronized for SCMPipelineManager's createPipeline method

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -202,7 +202,7 @@ public class SCMPipelineManager implements PipelineManager {
   }
 
   @Override
-  public synchronized Pipeline createPipeline(ReplicationType type,
+  public Pipeline createPipeline(ReplicationType type,
       ReplicationFactor factor) throws IOException {
     if (!isPipelineCreationAllowed() && factor != ReplicationFactor.ONE) {
       LOG.debug("Pipeline creation is not allowed until safe mode prechecks " +


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove the synchronized qualifier from the createPipeline method since it already uses lock for critical zone protection inside createPipeline.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3753

## How was this patch tested?

 manual tests
