### PR TITLE
HDDS-3759. Avoid UUID#toString call in PipelineID#getProtobuf

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineID.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineID.java
@@ -28,9 +28,11 @@ import java.util.UUID;
 public final class PipelineID {
 
   private UUID id;
+  private String strID;
 
   private PipelineID(UUID id) {
     this.id = id;
+    this.strID = id.toString();
   }
 
   public static PipelineID randomId() {
@@ -46,7 +48,7 @@ public final class PipelineID {
   }
 
   public HddsProtos.PipelineID getProtobuf() {
-    return HddsProtos.PipelineID.newBuilder().setId(id.toString()).build();
+    return HddsProtos.PipelineID.newBuilder().setId(strID).build();
   }
 
   public static PipelineID getFromProtobuf(HddsProtos.PipelineID protos) {
@@ -55,7 +57,7 @@ public final class PipelineID {
 
   @Override
   public String toString() {
-    return "PipelineID=" + id;
+    return "PipelineID=" + strID;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
I start a ozone cluster with 1000 datanodes, and run two weeks with heavy workload, and perf scm.
`UUID.toString` in `PipelineID::getProtobuf` cost 0.13% cpu, and `getContainerWithPipelineBatch` cost 1.76%, so `UUID.toString` cost about 0.13 / 1.76 = 7.4% in `getContainerWithPipelineBatch`. Because `getContainerWithPipelineBatch` happens in the main chain of read, so we need to improve it.

![image](https://user-images.githubusercontent.com/51938049/84117318-ec3b1280-aa63-11ea-85e5-bf3860511bea.png)

![image](https://user-images.githubusercontent.com/51938049/84117326-efce9980-aa63-11ea-970d-953481cd43bd.png)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3759

## How was this patch tested?

Existed tests.