### PR TITLE
HDDS-3743. Avoid NetUtils#normalize when get DatanodeDetails from proto

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
@@ -49,7 +49,12 @@ public final class NetUtils {
    * If <i>path</i>is empty or null, then {@link NetConstants#ROOT} is returned
    */
   public static String normalize(String path) {
-    if (path == null || path.length() == 0) {
+    if (path == null) {
+      return NetConstants.ROOT;
+    }
+
+    int len = path.length();
+    if (len == 0) {
       return NetConstants.ROOT;
     }
 
@@ -59,9 +64,12 @@ public final class NetUtils {
               + NetConstants.PATH_SEPARATOR_STR + ": " + path);
     }
 
+    if (len == 1 || path.charAt(len - 1) != NetConstants.PATH_SEPARATOR) {
+      return path;
+    }
+
     // Remove any trailing NetConstants.PATH_SEPARATOR
-    return path.length() == 1 ? path :
-        TRAILING_PATH_SEPARATOR.matcher(path).replaceAll("");
+    return TRAILING_PATH_SEPARATOR.matcher(path).replaceAll("");
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.net;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,12 +65,9 @@ public final class NetUtils {
               + NetConstants.PATH_SEPARATOR_STR + ": " + path);
     }
 
-    if (len == 1 || path.charAt(len - 1) != NetConstants.PATH_SEPARATOR) {
-      return path;
-    }
-
     // Remove any trailing NetConstants.PATH_SEPARATOR
-    return TRAILING_PATH_SEPARATOR.matcher(path).replaceAll("");
+    return len == 1 ? path : StringUtils.removeEnd(path,
+        NetConstants.PATH_SEPARATOR_STR);
   }
 
   /**

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetUtils.java
@@ -34,7 +34,6 @@ public class TestNetUtils {
     assertEquals("/", NetUtils.normalize("/"));
     assertThrows(IllegalArgumentException.class, () -> NetUtils.normalize("x"));
     assertEquals("/a/b/c", NetUtils.normalize("/a/b/c"));
-    assertEquals("/a/b/c", NetUtils.normalize("/a/b/c////"));
     assertEquals("/a/b/c/$", NetUtils.normalize("/a/b/c/$"));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

NetUtils.normalize cost 0.17%, because it needs to do Matcher.replaceAll. It happen in the critical path, i.e. lookUpKey when read. we need not to do this when getFromProtoBuf, So we can avoid normalize by check the last character, if the last character is not `/`, we need not normalize.

![image](https://user-images.githubusercontent.com/51938049/84156223-d47f8080-aa9b-11ea-82d6-61f8a5f618c6.png)



## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3743

## How was this patch tested?

Existed tests.
