### PR TITLE
HDDS-3726. Upload code coverage data to Codecov and enable checks in …

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -247,6 +247,12 @@ jobs:
          env:
            SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+       - name: Upload coverage to Codecov
+         uses: codecov/codecov-action@v1
+         with:
+           file: ./target/coverage/all.xml
+           name: codecov-umbrella
+           fail_ci_if_error: true
        - uses: actions/upload-artifact@master
          with:
            name: coverage

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -220,3 +220,33 @@ jobs:
           with:
             name: it-ozone
             path: mnt/ozone/target/integration
+  coverage:
+    name: coverage
+    runs-on: ubuntu-18.04
+    needs:
+      - it-hdds-om
+      - it-ozone
+      - it-client
+      - it-filesystem-contract
+      - it-filesystem
+      - it-freon
+      - unit
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/buildenv
+        with:
+          args: ./hadoop-ozone/dev-support/checks/build.sh
+      - uses: actions/download-artifact@v2
+        with:
+          path: target/artifacts
+      - run: ./.github/coverage-report.sh
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./target/coverage/all.xml
+          name: codecov-umbrella
+          fail_ci_if_error: true
+      - uses: actions/upload-artifact@master
+        with:
+          name: coverage
+          path: target/coverage

--- a/hadoop-ozone/dev-support/checks/integration.sh
+++ b/hadoop-ozone/dev-support/checks/integration.sh
@@ -23,8 +23,8 @@ REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/integration"}
 mkdir -p "$REPORT_DIR"
 
 export MAVEN_OPTS="-Xmx4096m"
-mvn -B install -DskipTests
-mvn -B -fae test -pl :hadoop-ozone-integration-test,:mini-chaos-tests "$@" \
+mvn -B install -DskipTests -Dskip.yarn
+mvn -B -fae test -Dskip.yarn -pl :hadoop-ozone-integration-test,:mini-chaos-tests "$@" \
   | tee "${REPORT_DIR}/output.log"
 rc=$?
 


### PR DESCRIPTION
…PR workflow of Github Actions

## What changes were proposed in this pull request?

- HDDS-3710 aggregates all jacoco code coverage results into one file "all.xml". This patch uploads that file to [codecov](https://codecov.io/) to keep track / visualize Hadoop Ozone project's coverage data and to compare diffs during pull request reviews.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3726

## How was this patch tested?

This patch was tested by creating pull requests and pushing commits to feature branches to test the coverage reported in codecov.
