### PR TITLE
HDDS-3781. Update the apiVersion to the newer one

### DIFF
--- a/hadoop-ozone/dist/src/main/k8s/definitions/ozone-csi/csi-node.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/definitions/ozone-csi/csi-node.yaml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: csi-node
 spec:

--- a/hadoop-ozone/dist/src/main/k8s/definitions/prometheus/deployment.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/definitions/prometheus/deployment.yaml
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/csi/csi-node-daemonset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/csi/csi-node-daemonset.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: csi-node
 spec:

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/prometheus-deployment.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/prometheus-deployment.yaml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone/csi/csi-node-daemonset.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone/csi/csi-node-daemonset.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 kind: DaemonSet
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 metadata:
   name: csi-node
 spec:


### PR DESCRIPTION
## What changes were proposed in this pull request?

For some apiVersion has been removed many years ago, so it is not forward-compatible, and i can use it in the newer version kubernetes cluster. For example, v1beta1, v1beta2, v1beta3 are removed in 2015.

## What is the link to the Apache JIRA

https://jira.apache.org/jira/browse/HDDS-3781

## How was this patch tested?

Run the ozone demo in kubernetes cluster successfully.