### PR TITLE
HDDS-3778. Block distribution in a pipeline among open containers is not uniform.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
@@ -422,44 +422,40 @@ public class SCMContainerManager implements ContainerManager {
 
   @SuppressWarnings("squid:S2445")
   public ContainerInfo getMatchingContainer(final long sizeRequired,
-      String owner, Pipeline pipeline, List<ContainerID> excludedContainers) {
+                                            String owner, Pipeline pipeline, List<ContainerID> excludedContainers) {
     NavigableSet<ContainerID> containerIDs;
+    ContainerInfo containerInfo;
     try {
       synchronized (pipeline) {
         containerIDs = getContainersForOwner(pipeline, owner);
 
         if (containerIDs.size() < numContainerPerOwnerInPipeline) {
-          ContainerInfo containerInfo =
-              containerStateManager.allocateContainer(pipelineManager, owner,
-                  pipeline);
-          // Add to DB
-          addContainerToDB(containerInfo);
-          containerStateManager.updateLastUsedMap(pipeline.getId(),
-              containerInfo.containerID(), owner);
-          return containerInfo;
-        }
-      }
-
-      containerIDs.removeAll(excludedContainers);
-      ContainerInfo containerInfo =
-          containerStateManager.getMatchingContainer(sizeRequired, owner,
-              pipeline.getId(), containerIDs);
-      if (containerInfo == null) {
-        synchronized (pipeline) {
           containerInfo =
-              containerStateManager.allocateContainer(pipelineManager, owner,
-                  pipeline);
+                  containerStateManager.allocateContainer(pipelineManager, owner,
+                          pipeline);
           // Add to DB
           addContainerToDB(containerInfo);
+        } else {
+          containerIDs.removeAll(excludedContainers);
+          containerInfo =
+                  containerStateManager.getMatchingContainer(sizeRequired, owner,
+                          pipeline.getId(), containerIDs);
+          if (containerInfo == null) {
+            containerInfo =
+                    containerStateManager.allocateContainer(pipelineManager, owner,
+                            pipeline);
+            // Add to DB
+            addContainerToDB(containerInfo);
+          }
         }
+        containerStateManager.updateLastUsedMap(pipeline.getId(),
+                containerInfo.containerID(), owner);
+        // TODO: #CLUTIL cleanup entries in lastUsedMap
+        return containerInfo;
       }
-      containerStateManager.updateLastUsedMap(pipeline.getId(),
-          containerInfo.containerID(), owner);
-      // TODO: #CLUTIL cleanup entries in lastUsedMap
-      return containerInfo;
     } catch (Exception e) {
       LOG.warn("Container allocation failed for pipeline={} requiredSize={} {}",
-          pipeline, sizeRequired, e);
+              pipeline, sizeRequired, e);
       return null;
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
@@ -444,8 +444,9 @@ public class SCMContainerManager implements ContainerManager {
                           sizeRequired, owner, pipeline.getId(), containerIDs);
           if (containerInfo == null) {
             containerInfo =
-                    containerStateManager.allocateContainer(pipelineManager, owner,
-                            pipeline);
+                    containerStateManager.
+                            allocateContainer(pipelineManager, owner,
+                                    pipeline);
             // Add to DB
             addContainerToDB(containerInfo);
           }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
@@ -422,7 +422,9 @@ public class SCMContainerManager implements ContainerManager {
 
   @SuppressWarnings("squid:S2445")
   public ContainerInfo getMatchingContainer(final long sizeRequired,
-                                            String owner, Pipeline pipeline, List<ContainerID> excludedContainers) {
+                                            String owner, Pipeline pipeline,
+                                            List<ContainerID>
+                                                      excludedContainers) {
     NavigableSet<ContainerID> containerIDs;
     ContainerInfo containerInfo;
     try {
@@ -431,15 +433,15 @@ public class SCMContainerManager implements ContainerManager {
 
         if (containerIDs.size() < numContainerPerOwnerInPipeline) {
           containerInfo =
-                  containerStateManager.allocateContainer(pipelineManager, owner,
-                          pipeline);
+                  containerStateManager.allocateContainer(
+                          pipelineManager, owner, pipeline);
           // Add to DB
           addContainerToDB(containerInfo);
         } else {
           containerIDs.removeAll(excludedContainers);
           containerInfo =
-                  containerStateManager.getMatchingContainer(sizeRequired, owner,
-                          pipeline.getId(), containerIDs);
+                  containerStateManager.getMatchingContainer(
+                          sizeRequired, owner, pipeline.getId(), containerIDs);
           if (containerInfo == null) {
             containerInfo =
                     containerStateManager.allocateContainer(pipelineManager, owner,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -281,11 +281,13 @@ public class TestBlockManager {
     }
     try {
       CompletableFuture
-              .allOf(futureList.toArray(new CompletableFuture[futureList.size()]))
-              .get();
+              .allOf(futureList.toArray(
+                      new CompletableFuture[futureList.size()])).get();
       Assert.assertTrue(pipelineManager.getPipelines(type).size() == 1);
-      Assert.assertTrue(allocatedBlockMap.size() == numContainerPerOwnerInPipeline);
-      Assert.assertTrue(allocatedBlockMap.values().size() == numContainerPerOwnerInPipeline);
+      Assert.assertTrue(
+              allocatedBlockMap.size() == numContainerPerOwnerInPipeline);
+      Assert.assertTrue(allocatedBlockMap.
+              values().size() == numContainerPerOwnerInPipeline);
       allocatedBlockMap.values().stream().forEach(v -> {
         Assert.assertTrue(v.size() == numContainerPerOwnerInPipeline);
       });

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -19,12 +19,10 @@ package org.apache.hadoop.hdds.scm.block;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.Map;
+import java.util.concurrent.*;
 
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -232,6 +230,59 @@ public class TestBlockManager {
       CompletableFuture
           .allOf(futureList.toArray(new CompletableFuture[futureList.size()]))
           .get();
+    } catch (Exception e) {
+      Assert.fail("testAllocateBlockInParallel failed");
+    }
+  }
+
+  @Test
+  public void testBlockDistribution() throws Exception {
+    int threadCount = numContainerPerOwnerInPipeline * numContainerPerOwnerInPipeline;
+    List<ExecutorService> executors = new ArrayList<>(threadCount);
+    for (int i = 0; i < threadCount; i++) {
+      executors.add(Executors.newSingleThreadExecutor());
+    }
+    pipelineManager.createPipeline(type, factor);
+    TestUtils.openAllRatisPipelines(pipelineManager);
+    Map<Long, List<AllocatedBlock>> allocatedBlockMap = new ConcurrentHashMap<>();
+    List<CompletableFuture<AllocatedBlock>> futureList =
+            new ArrayList<>(threadCount);
+    for (int i = 0; i < threadCount; i++) {
+      final CompletableFuture<AllocatedBlock> future =
+              new CompletableFuture<>();
+     CompletableFuture.supplyAsync(() -> {
+       try {
+          List<AllocatedBlock> blockList;
+          AllocatedBlock block = blockManager
+                    .allocateBlock(DEFAULT_BLOCK_SIZE, type, factor,
+                            OzoneConsts.OZONE,
+                            new ExcludeList());
+            long containerId = block.getBlockID().getContainerID();
+            if (!allocatedBlockMap.containsKey(containerId)) {
+              blockList = new ArrayList<>();
+            } else {
+              blockList = allocatedBlockMap.get(containerId);
+            }
+            blockList.add(block);
+            allocatedBlockMap.put(containerId, blockList);
+            future.complete(block);
+        } catch (IOException e) {
+          future.completeExceptionally(e);
+        }
+        return future;
+     }, executors.get(i));
+      futureList.add(future);
+    }
+    try {
+      CompletableFuture
+              .allOf(futureList.toArray(new CompletableFuture[futureList.size()]))
+              .get();
+      Assert.assertTrue(pipelineManager.getPipelines(type).size() == 1);
+      Assert.assertTrue(allocatedBlockMap.size() == numContainerPerOwnerInPipeline);
+      Assert.assertTrue(allocatedBlockMap.values().size() == numContainerPerOwnerInPipeline);
+      allocatedBlockMap.values().stream().forEach(v -> {
+        Assert.assertTrue(v.size() == numContainerPerOwnerInPipeline);
+      });
     } catch (Exception e) {
       Assert.fail("testAllocateBlockInParallel failed");
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Made allocate block call synchronised over pipeline object.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3778

## How was this patch tested?
Added a unit test.
