### PR TITLE
HDDS-3783. Upload coverage even if tests failed

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -224,6 +224,7 @@ jobs:
     name: coverage
     runs-on: ubuntu-18.04
     needs:
+       - build
        - it-ozone
        - it-hdds-om
        - it-client
@@ -231,6 +232,9 @@ jobs:
        - it-filesystem
        - it-freon
        - unit
+    if: |
+      !cancelled() &&
+      needs.build.result == 'success'
     steps:
        - uses: actions/checkout@v2
        - uses: ./.github/buildenv


### PR DESCRIPTION
## What changes were proposed in this pull request?

PRs get code coverage feedback from Codecov thanks to changes implemented in HDDS-3726.  Codecov needs coverage data for each new revision on `master`.  However, _coverage_ check is currently [skipped](https://github.com/apache/hadoop-ozone/runs/759894317?check_suite_focus=true) if any tests fail.  This PR proposes to always execute coverage if basic compilation is OK.  It still waits for various test runs before execution.

https://issues.apache.org/jira/browse/HDDS-3783

## How was this patch tested?

Tested conditions on simplified workflow file with both:

* successful "compilation": [code](https://github.com/adoroszlai/hadoop-ozone/blob/3639f470b02bd7647b662f7d0435d2e776f92b87/.github/workflows/post-commit.yml), [run](https://github.com/adoroszlai/hadoop-ozone/runs/761754406?check_suite_focus=true)
* and failed "compilation": [code](https://github.com/adoroszlai/hadoop-ozone/blob/5856b413ca5a00c763e318428169588bbbb89d3e/.github/workflows/post-commit.yml), [run](https://github.com/adoroszlai/hadoop-ozone/runs/762117230?check_suite_focus=true)

Real CI ("unfortunately" all tests passed):
https://github.com/adoroszlai/hadoop-ozone/runs/761992786