### PR TITLE
HDDS-3769. hadoop-hdds interface-client fail to build with JDK11.

### DIFF
--- a/hadoop-hdds/interface-client/pom.xml
+++ b/hadoop-hdds/interface-client/pom.xml
@@ -39,6 +39,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>ratis-thirdparty-misc</artifactId>
       <version>0.4.0</version>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix build issue with JDK11. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3769

## How was this patch tested?

Build with JDK11 and JDK8.