### PR TITLE
HDDS-3787. Make CSI command configurable.

### DIFF
--- a/hadoop-ozone/csi/src/main/java/org/apache/hadoop/ozone/csi/CsiServer.java
+++ b/hadoop-ozone/csi/src/main/java/org/apache/hadoop/ozone/csi/CsiServer.java
@@ -129,6 +129,15 @@ public class CsiServer extends GenericCli implements Callable<Void> {
         tags = ConfigTag.STORAGE)
     private String volumeOwner;
 
+    @Config(key = "mount.command",
+        defaultValue = "goofys --endpoint %s %s %s",
+        description =
+            "This is the mount command which is used to publish volume."
+                + " these %s will be replicated by s3gAddress, volumeId "
+                + " and target path.",
+        tags = ConfigTag.STORAGE)
+    private String mountCommand;
+
     public String getSocketPath() {
       return socketPath;
     }
@@ -137,11 +146,9 @@ public class CsiServer extends GenericCli implements Callable<Void> {
       return volumeOwner;
     }
 
-
     public void setVolumeOwner(String volumeOwner) {
       this.volumeOwner = volumeOwner;
     }
-
 
     public void setSocketPath(String socketPath) {
       this.socketPath = socketPath;
@@ -150,7 +157,6 @@ public class CsiServer extends GenericCli implements Callable<Void> {
     public long getDefaultVolumeSize() {
       return defaultVolumeSize;
     }
-
 
     public void setDefaultVolumeSize(long defaultVolumeSize) {
       this.defaultVolumeSize = defaultVolumeSize;
@@ -162,6 +168,10 @@ public class CsiServer extends GenericCli implements Callable<Void> {
 
     public void setS3gAddress(String s3gAddress) {
       this.s3gAddress = s3gAddress;
+    }
+
+    public String getMountCommand() {
+      return mountCommand;
     }
   }
 }

--- a/hadoop-ozone/csi/src/main/java/org/apache/hadoop/ozone/csi/NodeService.java
+++ b/hadoop-ozone/csi/src/main/java/org/apache/hadoop/ozone/csi/NodeService.java
@@ -80,9 +80,9 @@ public class NodeService extends NodeImplBase {
 
   }
 
-  private void executeCommand(String mountCommand)
+  private void executeCommand(String command)
       throws IOException, InterruptedException {
-    Process exec = Runtime.getRuntime().exec(mountCommand);
+    Process exec = Runtime.getRuntime().exec(command);
     exec.waitFor(10, TimeUnit.SECONDS);
 
     LOG.info("Command is executed with  stdout: {}, stderr: {}",
@@ -90,7 +90,7 @@ public class NodeService extends NodeImplBase {
         IOUtils.toString(exec.getErrorStream(), "UTF-8"));
     if (exec.exitValue() != 0) {
       throw new RuntimeException(String
-          .format("Return code of the command %s was %d", mountCommand,
+          .format("Return code of the command %s was %d", command,
               exec.exitValue()));
     }
   }

--- a/hadoop-ozone/csi/src/main/java/org/apache/hadoop/ozone/csi/NodeService.java
+++ b/hadoop-ozone/csi/src/main/java/org/apache/hadoop/ozone/csi/NodeService.java
@@ -47,11 +47,12 @@ public class NodeService extends NodeImplBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(NodeService.class);
 
+  private final String mountCommand;
   private String s3Endpoint;
 
   public NodeService(CsiConfig configuration) {
     this.s3Endpoint = configuration.getS3gAddress();
-
+    this.mountCommand = configuration.getMountCommand();
   }
 
   @Override
@@ -60,14 +61,14 @@ public class NodeService extends NodeImplBase {
 
     try {
       Files.createDirectories(Paths.get(request.getTargetPath()));
-      String mountCommand =
-          String.format("goofys --endpoint %s %s %s",
+      String command =
+          String.format(mountCommand,
               s3Endpoint,
               request.getVolumeId(),
               request.getTargetPath());
-      LOG.info("Executing {}", mountCommand);
+      LOG.info("Executing {}", command);
 
-      executeCommand(mountCommand);
+      executeCommand(command);
 
       responseObserver.onNext(NodePublishVolumeResponse.newBuilder()
           .build());


### PR DESCRIPTION
## What changes were proposed in this pull request?

It doesn't have to use goofys as the mountable tools to access Ozone. With this PR, we can config an other command to mount file system which could be a fuse program.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3787

## How was this patch tested?

With default configuration, CI checks should be passed.
