### PR TITLE
HDDS-3785. Update topology.aware.read parameter in ozone-topology compose config

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-config
@@ -31,7 +31,7 @@ OZONE-SITE.XML_hdds.profiler.endpoint.enabled=true
 OZONE-SITE.XML_ozone.scm.container.placement.impl=org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementRackAware
 OZONE-SITE.XML_net.topology.node.switch.mapping.impl=org.apache.hadoop.net.TableMapping
 OZONE-SITE.XML_net.topology.table.file.name=/opt/hadoop/compose/ozone-topology/network-config
-OZONE-SITE.XML_dfs.network.topology.aware.read.enable=true
+OZONE-SITE.XML_ozone.network.topology.aware.read=true
 
 HDFS-SITE.XML_rpc.metrics.quantile.enable=true
 HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-1865 updated the parameter dfs.network.topology.aware.read.enable to ozone.network.topology.aware.read, but in the docker-compose config for ozone-topology, the old parameter is still used.

This Jira is to update it to the new value.

From OzoneConfigKeys.java, we can see the correct value for this parameter:

```
  public static final String OZONE_NETWORK_TOPOLOGY_AWARE_READ_KEY =
      "ozone.network.topology.aware.read";
  public static final boolean OZONE_NETWORK_TOPOLOGY_AWARE_READ_DEFAULT = false;
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3785?

## How was this patch tested?

existing tests and manual tests.
