### PR TITLE
HDDS-3795. No coverage reported for Ozone FS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1911,7 +1911,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               <goal>prepare-agent</goal>
             </goals>
             <configuration>
-              <includes>org.apache.hadoop.hdds.*,org.apache.hadoop.ozone.*</includes>
+              <includes>org.apache.hadoop.hdds.*,org.apache.hadoop.ozone.*,org.apache.hadoop.fs.ozone.*</includes>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone FS has some tests, but [0% coverage](https://codecov.io/gh/apache/hadoop-ozone/tree/96f07d5c27ba8f2ab9d77df25e10d4cb94489e5f/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone).  This change fixes the problem.

https://issues.apache.org/jira/browse/HDDS-3795

## How was this patch tested?

Ran `TestOzoneFSInputStream`, verified that non-zero coverage is reported for `OzoneFSInputStream` (`coverage.sh` is taken from HDDS-3796):

```
mvn -Dskip.npx -Dskip.installnpx -DskipShade clean package
hadoop-ozone/dev-support/checks/unit.sh -DfailIfNoTests=false -Dtest=TestOzoneFSInputStream
hadoop-ozone/dev-support/checks/coverage.sh
open target/coverage/all/org.apache.hadoop.fs.ozone/OzoneFSInputStream.html
```

Now the package has [70% coverage](https://codecov.io/gh/adoroszlai/hadoop-ozone/tree/HDDS-3795/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone).

https://github.com/adoroszlai/hadoop-ozone/runs/767653969