### PR TITLE
HDDS-3796. Allow running coverage locally

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -257,7 +257,7 @@ jobs:
        - uses: actions/download-artifact@v2
          with:
             path: target/artifacts
-       - run: ./.github/coverage-report.sh
+       - run: ./hadoop-ozone/dev-support/checks/coverage.sh
        - uses: ./.github/buildenv
          if: github.repository == 'apache/hadoop-ozone'
          with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -257,7 +257,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           path: target/artifacts
-      - run: ./.github/coverage-report.sh
+      - run: ./hadoop-ozone/dev-support/checks/coverage.sh
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/hadoop-ozone/dev-support/checks/coverage.sh
+++ b/hadoop-ozone/dev-support/checks/coverage.sh
@@ -14,15 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#This script can merge the downloaded jacoco files from other artifacts
-#Works only in github environment where the jacoco .exec files are downloaded
-#from job artifacts
+# This script merges the combined jacoco files (output of unit.sh and others)
+# and generates a report in HTML and XML formats
+
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-cd "$DIR/.." || exit 1
+cd "$DIR/../../.." || exit 1
 
 set -ex
 
-REPORT_DIR="$DIR/../target/coverage"
+REPORT_DIR="$DIR/../../../target/coverage"
 
 mkdir -p "$REPORT_DIR"
 
@@ -34,7 +34,7 @@ jacoco() {
 }
 
 #Merge all the jacoco.exec files
-jacoco merge $(find target/artifacts -name jacoco-combined.exec) --destfile "$REPORT_DIR/jacoco-all.exec"
+jacoco merge $(find target -name jacoco-combined.exec) --destfile "$REPORT_DIR/jacoco-all.exec"
 
 rm -rf target/coverage-classes || true
 mkdir -p target/coverage-classes


### PR DESCRIPTION
## What changes were proposed in this pull request?

`coverage-report.sh` is currently GitHub-specific, but can be fixed to work locally by a minor change in where it looks for `jacoco-combined.exec` files.

Also rename to `coverage.sh` and relocate to the common `checks` directory, since it's no longer GitHub-specific.

https://issues.apache.org/jira/browse/HDDS-3796

## How was this patch tested?

Verified that `coverage.sh` works fine locally after a complete build and running some tests:

```
mvn -Dskip.npx -Dskip.installnpx -DskipShade clean package
hadoop-ozone/dev-support/checks/unit.sh -DfailIfNoTests=false -Dtest='TestConfigFileAppender,TestOzoneConfiguration'
hadoop-ozone/dev-support/checks/coverage.sh
open target/coverage/all/org.apache.hadoop.hdds.conf/index.html
```

Verified that coverage check is OK in post-commit:
https://github.com/adoroszlai/hadoop-ozone/runs/767705840

and that it uploaded data to codecov.io:
https://codecov.io/gh/adoroszlai/hadoop-ozone/branch/HDDS-3796