### PR TITLE
HDDS-3797. Fix the mismatched dependency versions in submodule hadoop-ozone-filesystem-hadoop2

### DIFF
--- a/hadoop-ozone/ozonefs-hadoop2/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop2/pom.xml
@@ -60,6 +60,12 @@
       <version>2.7.3</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-auth</artifactId>
+      <scope>provided</scope>
+      <version>2.7.3</version>
+    </dependency>
+    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <scope>provided</scope>

--- a/hadoop-ozone/ozonefs-hadoop2/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop2/pom.xml
@@ -54,6 +54,12 @@
       <version>2.7.3</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-annotations</artifactId>
+      <scope>provided</scope>
+      <version>2.7.3</version>
+    </dependency>
+    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
## What changes were proposed in this pull request?

~~Fix the compile error for submodule hadoop-ozone-filesystem-hadoop2.~~
Fix the mismatched dependency versions in submodule hadoop-ozone-filesystem-hadoop2

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3797

## How was this patch tested?

~~After this fix,  `mvn -pl "hadoop-ozone/ozonefs-hadoop2" clean install` can finish the compilation~~
After this fix, `mvn dependency:tree` will show correct dependency info.
```
[INFO] +- org.apache.hadoop:hadoop-common:jar:2.7.3:provided
[INFO] |  +- org.apache.hadoop:hadoop-annotations:jar:3.2.1:provided
...
[INFO] |  +- org.apache.hadoop:hadoop-auth:jar:3.2.1:provided
```
