### PR TITLE
HDDS-3793. Use Hadoop 2.7.3 for ozone-mr/hadoop27 acceptance tests

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/.env
@@ -18,5 +18,5 @@ HDDS_VERSION=@hdds.version@
 #TODO: swich to apache/hadoop. Older versions are not supported by apache/hadoop, yet.
 # See: HADOOP-16092 for more details.
 HADOOP_IMAGE=flokkr/hadoop
-HADOOP_VERSION=2.7.7
+HADOOP_VERSION=2.7.3
 OZONE_RUNNER_VERSION=@docker.ozone-runner.version@

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/docker-config
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CORE-SITE.xml_fs.AbstractFileSystem.o3fs.impl=org.apache.hadoop.fs.ozone.BasicOzFs
+CORE-SITE.xml_fs.AbstractFileSystem.o3fs.impl=org.apache.hadoop.fs.ozone.OzFs
 MAPRED-SITE.XML_mapreduce.application.classpath=/opt/hadoop/share/hadoop/mapreduce/*:/opt/hadoop/share/hadoop/mapreduce/lib/*:/opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-hadoop2-@project.version@.jar
 
 no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/docker-config
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CORE-SITE.xml_fs.AbstractFileSystem.o3fs.impl=org.apache.hadoop.fs.ozone.OzFs
+CORE-SITE.xml_fs.AbstractFileSystem.o3fs.impl=org.apache.hadoop.fs.ozone.BasicOzFs
 MAPRED-SITE.XML_mapreduce.application.classpath=/opt/hadoop/share/hadoop/mapreduce/*:/opt/hadoop/share/hadoop/mapreduce/lib/*:/opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-hadoop2-@project.version@.jar
 
 no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/test.sh
@@ -27,8 +27,8 @@ execute_robot_test scm createmrenv.robot
 
 
 #rm is the container name (resource manager) and not the rm command
-execute_command_in_container rm sudo -E apk add --update py-pip
-execute_command_in_container rm sudo -E pip install robotframework
+execute_command_in_container rm sudo -E yum install -y python3-pip
+execute_command_in_container rm sudo -E pip3 install robotframework
 
 # reinitialize the directories to use
 export OZONE_DIR=/opt/ozone
@@ -37,7 +37,7 @@ source "$COMPOSE_DIR/../../testlib.sh"
 
 execute_robot_test rm ozonefs/hadoopo3fs.robot
 
-execute_robot_test rm -v hadoop.version:2.7.7 mapreduce.robot
+execute_robot_test rm -v hadoop.version:2.7.3 mapreduce.robot
 
 stop_docker_env
 

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/test.sh
@@ -25,11 +25,6 @@ start_docker_env
 
 execute_robot_test scm createmrenv.robot
 
-
-#rm is the container name (resource manager) and not the rm command
-execute_command_in_container rm sudo -E yum install -y python3-pip
-execute_command_in_container rm sudo -E pip3 install robotframework
-
 # reinitialize the directories to use
 export OZONE_DIR=/opt/ozone
 # shellcheck source=/dev/null

--- a/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/OzFs.java
+++ b/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/OzFs.java
@@ -40,4 +40,9 @@ public class OzFs extends DelegateToFileSystem {
     super(theUri, new OzoneFileSystem(), conf,
         OzoneConsts.OZONE_URI_SCHEME, false);
   }
+
+  @Override
+  public int getUriDefaultPort() {
+    return -1;
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change `ozone-mr/hadoop27` acceptance test to use Hadoop 2.7.3, the version `hadoop-ozone-filesystem-hadoop2` is built with (since HDDS-3715).

https://issues.apache.org/jira/browse/HDDS-3793

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/769907631