### PR TITLE
HDDS-3773. Add OMDBDefinition to define structure of om.db.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.codec;
+
+import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
+import org.apache.hadoop.hdds.utils.db.DBDefinition;
+import org.apache.hadoop.hdds.utils.db.LongCodec;
+import org.apache.hadoop.hdds.utils.db.StringCodec;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
+import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
+import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
+
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
+
+/**
+ * Class defines the structure and types of the om.db.
+ */
+public class OMDBDefinition implements DBDefinition {
+
+  public static final DBColumnFamilyDefinition<String, RepeatedOmKeyInfo>
+            DELETED_TABLE =
+            new DBColumnFamilyDefinition<>(
+                    "deletedTable",
+                    String.class,
+                    new StringCodec(),
+                    RepeatedOmKeyInfo.class,
+                    new RepeatedOmKeyInfoCodec());
+
+  public static final DBColumnFamilyDefinition<String,
+            OzoneManagerProtocolProtos.UserVolumeInfo>
+            USER_TABLE =
+            new DBColumnFamilyDefinition<>(
+                    "userTable",
+                    String.class,
+                    new StringCodec(),
+                    OzoneManagerProtocolProtos.UserVolumeInfo.class,
+                    new UserVolumeInfoCodec());
+
+  public static final DBColumnFamilyDefinition<String, OmVolumeArgs>
+            VOLUME_TABLE =
+            new DBColumnFamilyDefinition<>(
+                    "volumeTable",
+                    String.class,
+                    new StringCodec(),
+                    OmVolumeArgs.class,
+                    new OmVolumeArgsCodec());
+
+  public static final DBColumnFamilyDefinition<String, String>
+            S3_TABLE=
+            new DBColumnFamilyDefinition<>(
+                    "s3Table",
+                    String.class,
+                    new StringCodec(),
+                    String.class,
+                    new StringCodec());
+
+  public static final DBColumnFamilyDefinition<String, OmKeyInfo>
+            OPEN_KEY_TABLE =
+            new DBColumnFamilyDefinition<>(
+                    "openKeyTable",
+                    String.class,
+                    new StringCodec(),
+                    OmKeyInfo.class,
+                    new OmKeyInfoCodec());
+
+  public static final DBColumnFamilyDefinition<String, OmKeyInfo>
+            KEY_TABLE =
+            new DBColumnFamilyDefinition<>(
+                    "keyTable",
+                    String.class,
+                    new StringCodec(),
+                    OmKeyInfo.class,
+                    new OmKeyInfoCodec());
+
+  public static final DBColumnFamilyDefinition<String, OmBucketInfo>
+            BUCKET_TABLE =
+            new DBColumnFamilyDefinition<>(
+                    "bucketTable",
+                    String.class,
+                    new StringCodec(),
+                    OmBucketInfo.class,
+                    new OmBucketInfoCodec());
+
+  public static final DBColumnFamilyDefinition<String, OmMultipartKeyInfo>
+            MULTIPART_INFO_TABLE =
+            new DBColumnFamilyDefinition<>(
+                    "multipartInfoTable",
+                    String.class,
+                    new StringCodec(),
+                    OmMultipartKeyInfo.class,
+                    new OmMultipartKeyInfoCodec());
+
+  public static final DBColumnFamilyDefinition<String, OmPrefixInfo>
+            PREFIX_TABLE =
+            new DBColumnFamilyDefinition<>(
+                    "prefixTable",
+                    String.class,
+                    new StringCodec(),
+                    OmPrefixInfo.class,
+                    new OmPrefixInfoCodec());
+
+  public static final DBColumnFamilyDefinition<OzoneTokenIdentifier, Long>
+            DTOKEN_TABLE =
+            new DBColumnFamilyDefinition<>(
+                    "dTokenTable",
+                    OzoneTokenIdentifier.class,
+                    new TokenIdentifierCodec(),
+                    Long.class,
+                    new LongCodec());
+
+  public static final DBColumnFamilyDefinition<String, S3SecretValue>
+            S3_SECRET_TABLE =
+            new DBColumnFamilyDefinition<>(
+                    "s3SecretTable",
+                    String.class,
+                    new StringCodec(),
+                    S3SecretValue.class,
+                    new S3SecretValueCodec());
+
+
+  @Override
+  public String getName() {
+    return "om.db";
+  }
+
+  @Override
+  public String getLocationConfigKey() {
+    return OMConfigKeys.OZONE_OM_DB_DIRS;
+  }
+
+  @Override
+  public DBColumnFamilyDefinition[] getColumnFamilies() {
+    return new DBColumnFamilyDefinition[] {DELETED_TABLE, USER_TABLE,
+        VOLUME_TABLE, S3_TABLE, OPEN_KEY_TABLE, KEY_TABLE,
+        BUCKET_TABLE, MULTIPART_INFO_TABLE, PREFIX_TABLE, DTOKEN_TABLE,
+        S3_SECRET_TABLE};
+  }
+}
+

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBDefinitionFactory.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBDefinitionFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug;
+
+import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
+import org.apache.hadoop.hdds.utils.db.DBDefinition;
+import org.apache.hadoop.ozone.om.codec.OMDBDefinition;
+
+import java.util.HashMap;
+
+/**
+ * Utility class to get appropriate DBDefinition.
+ */
+public final class DBDefinitionFactory {
+
+  private DBDefinitionFactory() {
+  }
+
+  private static HashMap<String, DBDefinition> dbMap;
+
+  static {
+    dbMap = new HashMap<>();
+    dbMap.put(new SCMDBDefinition().getName(), new SCMDBDefinition());
+    dbMap.put(new OMDBDefinition().getName(), new OMDBDefinition());
+  }
+
+  public static DBDefinition getDefinition(String dbName){
+    if (dbMap.containsKey(dbName)){
+      return dbMap.get(dbName);
+    }
+    return null;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -20,12 +20,13 @@ package org.apache.hadoop.ozone.debug;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
 import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.DBDefinition;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.rocksdb.*;
 import picocli.CommandLine;
+
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -87,6 +88,10 @@ public class DBScanner implements Callable<Void> {
   }
 
   private void constructColumnFamilyMap(DBDefinition dbDefinition) {
+    if (dbDefinition == null){
+      System.out.println("Incorrect Db Path");
+      return;
+    }
     this.columnFamilyMap = new HashMap<>();
     DBColumnFamilyDefinition[] columnFamilyDefinitions = dbDefinition
             .getColumnFamilies();
@@ -120,9 +125,8 @@ public class DBScanner implements Callable<Void> {
           List<ColumnFamilyHandle> columnFamilyHandleList,
           RocksDB rocksDB, String dbPath) throws IOException {
     dbPath = removeTrailingSlashIfNeeded(dbPath);
-    if (dbPath.endsWith(new SCMDBDefinition().getName())){
-      this.constructColumnFamilyMap(new SCMDBDefinition());
-    }
+    this.constructColumnFamilyMap(DBDefinitionFactory.
+            getDefinition(new File(dbPath).getName()));
     if (this.columnFamilyMap !=null) {
       if (!this.columnFamilyMap.containsKey(tableName)) {
         System.out.print("Table with specified name does not exist");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.utils.db.DBDefinition;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.rocksdb.*;
 import picocli.CommandLine;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;


### PR DESCRIPTION
## What changes were proposed in this pull request?
In order to support the rocksdb tool which displays data for a given db file ([HDDS-3622](https://github.com/apache/hadoop-ozone/pull/945)) , the appropriate DBDefinition file must be defined. The change here is to extend the tool for om.db.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3773

## How was this patch tested?
Manual test.
