### PR TITLE
HDDS-3776. Upgrading RocksDB version to avoid java heap issue

### DIFF
--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
@@ -315,7 +315,7 @@ public class TestRDBStore {
       for (int i = 0; i < 50; i++) {
         Assert.assertFalse(db.keyMayExist(
             org.apache.commons.codec.binary.StringUtils
-                .getBytesUtf16("key" + i), new StringBuilder()));
+                .getBytesUtf16("key" + i), null));
       }
       end = System.nanoTime();
       long keyMayExistLatency = end - start;

--- a/pom.xml
+++ b/pom.xml
@@ -1586,7 +1586,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.rocksdb</groupId>
         <artifactId>rocksdbjni</artifactId>
-        <version>6.6.4</version>
+        <version>6.8.1</version>
       </dependency>
       <dependency>
         <groupId>org.xerial</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Description

Currently we have rocksdb 6.6.4 as major version and there are some jvm issues in tests (happened in https://github.com/apache/hadoop-ozone/pull/1019) related to rocksdb core dump. We may upgrade to 6.8.1 to avoid this issue.

```
JRE version: Java(TM) SE Runtime Environment (8.0_211-b12) (build 1.8.0_211-b12)

    Java VM: Java HotSpot(TM) 64-Bit Server VM (25.211-b12 mixed mode bsd-amd64 compressed oops)
    Problematic frame:
    C [librocksdbjni2954960755376440018.jnilib+0x602b8] rocksdb::GetColumnFamilyID(rocksdb::ColumnFamilyHandle*)+0x8

See full dump at https://the-asf.slack.com/files/U0159PV5Z6U/F0152UAJF0S/hs_err_pid90655.log?origin_team=T4S1WH2J3&origin_channel=D014L2URB6E(url)}}
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3776

## How was this patch tested?

CI tests