### PR TITLE
HDDS-3794. Topology Aware read does not work correctly in XceiverClientGrpc

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -298,7 +298,9 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     List<DatanodeDetails> datanodeList = null;
 
     DatanodeBlockID blockID = null;
-    if (request.getCmdType() == ContainerProtos.Type.ReadChunk) {
+    if (request.getCmdType() == ContainerProtos.Type.GetBlock) {
+      blockID = request.getGetBlock().getBlockID();
+    } else if  (request.getCmdType() == ContainerProtos.Type.ReadChunk) {
       blockID = request.getReadChunk().getBlockID();
     } else if (request.getCmdType() == ContainerProtos.Type.GetSmallFile) {
       blockID = request.getGetSmallFile().getBlock().getBlockID();

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -314,15 +314,17 @@ public class XceiverClientGrpc extends XceiverClientSpi {
           // Pull the Cached DN to the top of the DN list
           Collections.swap(datanodeList, 0, getBlockDNCacheIndex);
         }
-      } else if (topologyAwareRead) {
-        datanodeList = pipeline.getNodesInOrder();
       }
     }
     if (datanodeList == null) {
-      datanodeList = pipeline.getNodes();
-      // Shuffle datanode list so that clients do not read in the same order
-      // every time.
-      Collections.shuffle(datanodeList);
+      if (topologyAwareRead) {
+        datanodeList = pipeline.getNodesInOrder();
+      } else {
+        datanodeList = pipeline.getNodes();
+        // Shuffle datanode list so that clients do not read in the same order
+        // every time.
+        Collections.shuffle(datanodeList);
+      }
     }
 
     for (DatanodeDetails dn : datanodeList) {
@@ -421,7 +423,8 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     }
   }
 
-  private XceiverClientReply sendCommandAsync(
+  @VisibleForTesting
+  public XceiverClientReply sendCommandAsync(
       ContainerCommandRequestProto request, DatanodeDetails dn)
       throws IOException, InterruptedException {
     checkOpen(dn, request.getEncodedToken());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientGrpc.java
@@ -142,6 +142,7 @@ public class TestXceiverClientGrpc {
         }
       };
       invokeXceiverClientGetBlock(client);
+      invokeXceiverClientGetBlock(client);
       invokeXceiverClientReadChunk(client);
       invokeXceiverClientReadSmallFile(client);
       Assert.assertEquals(1, seenDNs.size());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientGrpc.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.scm;
+
+import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.XceiverClientGrpc;
+import org.apache.hadoop.hdds.scm.XceiverClientReply;
+import org.apache.hadoop.hdds.scm.XceiverClientSpi;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Tests for TestXceiverClientGrpc, to ensure topology aware reads work
+ * select the closest node, and connections are re-used after a getBlock call.
+ */
+public class TestXceiverClientGrpc {
+
+  private Pipeline pipeline;
+  private List<DatanodeDetails> dns;
+  private List<DatanodeDetails> dnsInOrder;
+  private OzoneConfiguration conf = new OzoneConfiguration();
+
+  @Before
+  public void setup() {
+    dns = new ArrayList<>();
+    dns.add(MockDatanodeDetails.randomDatanodeDetails());
+    dns.add(MockDatanodeDetails.randomDatanodeDetails());
+    dns.add(MockDatanodeDetails.randomDatanodeDetails());
+
+    dnsInOrder = new ArrayList<>();
+    for (int i=2; i>=0; i--) {
+      dnsInOrder.add(dns.get(i));
+    }
+
+    pipeline = Pipeline.newBuilder()
+        .setId(PipelineID.randomId())
+        .setType(HddsProtos.ReplicationType.RATIS)
+        .setFactor(HddsProtos.ReplicationFactor.THREE)
+        .setState(Pipeline.PipelineState.CLOSED)
+        .setNodes(dns)
+        .build();
+    pipeline.setNodesInOrder(dnsInOrder);
+  }
+
+  @Test
+  public void testCorrectDnsReturnedFromPipeline() throws IOException {
+    Assert.assertEquals(dnsInOrder.get(0), pipeline.getClosestNode());
+    Assert.assertEquals(dns.get(0), pipeline.getFirstNode());
+    Assert.assertNotEquals(dns.get(0), dnsInOrder.get(0));
+  }
+
+  @Test(timeout=5000)
+  public void testRandomFirstNodeIsCommandTarget() throws IOException {
+    final ArrayList<DatanodeDetails> allDNs = new ArrayList<>(dns);
+    // Using a new Xceiver Client, call it repeatedly until all DNs in the
+    // pipeline have been the target of the command, indicating it is shuffling
+    // the DNs on each call with a new client. This test will timeout if this
+    // is not happening.
+    while(allDNs.size() > 0) {
+      XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
+        @Override
+        public XceiverClientReply sendCommandAsync(
+            ContainerProtos.ContainerCommandRequestProto request,
+            DatanodeDetails dn) {
+          allDNs.remove(dn);
+          return buildValidResponse();
+        }
+      };
+      invokeXceiverClientGetBlock(client);
+    }
+  }
+
+  @Test
+  public void testFirstNodeIsCorrectWithTopologyForCommandTarget()
+      throws IOException {
+    final Set<DatanodeDetails> seenDNs = new HashSet<>();
+    conf.setBoolean(
+        OzoneConfigKeys.OZONE_NETWORK_TOPOLOGY_AWARE_READ_KEY, true);
+    // With a new Client, make 100 calls and ensure the first sortedDN is used
+    // each time. The logic should always use the sorted node, so we can check
+    // only a single DN is ever seen after 100 calls.
+    for (int i=0; i<100; i++) {
+      XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
+        @Override
+        public XceiverClientReply sendCommandAsync(
+            ContainerProtos.ContainerCommandRequestProto request,
+            DatanodeDetails dn) {
+          seenDNs.add(dn);
+          return buildValidResponse();
+        }
+      };
+      invokeXceiverClientGetBlock(client);
+    }
+    Assert.assertEquals(1, seenDNs.size());
+  }
+
+  @Test
+  public void testConnectionReusedAfterGetBlock() throws IOException {
+    // With a new Client, make 100 calls. On each call, ensure that only one
+    // DN is seen, indicating the same DN connection is reused.
+    for (int i=0; i<100; i++) {
+      final Set<DatanodeDetails> seenDNs = new HashSet<>();
+      XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf) {
+        @Override
+        public XceiverClientReply sendCommandAsync(
+            ContainerProtos.ContainerCommandRequestProto request,
+            DatanodeDetails dn) {
+          seenDNs.add(dn);
+          return buildValidResponse();
+        }
+      };
+      invokeXceiverClientGetBlock(client);
+      invokeXceiverClientReadChunk(client);
+      invokeXceiverClientReadSmallFile(client);
+      Assert.assertEquals(1, seenDNs.size());
+    }
+  }
+
+  private void invokeXceiverClientGetBlock(XceiverClientSpi client)
+      throws IOException {
+    ContainerProtocolCalls.getBlock(client,
+        ContainerProtos.DatanodeBlockID.newBuilder()
+            .setContainerID(1)
+            .setLocalID(1)
+            .setBlockCommitSequenceId(1)
+            .build());
+  }
+
+  private void invokeXceiverClientReadChunk(XceiverClientSpi client)
+      throws IOException {
+    BlockID bid = new BlockID(1, 1);
+    bid.setBlockCommitSequenceId(1);
+    ContainerProtocolCalls.readChunk(client,
+        ContainerProtos.ChunkInfo.newBuilder()
+            .setChunkName("Anything")
+            .setChecksumData(ContainerProtos.ChecksumData.newBuilder()
+                .setBytesPerChecksum(512)
+                .setType(ContainerProtos.ChecksumType.CRC32)
+                .build())
+            .setLen(100)
+            .setOffset(100)
+            .build(),
+        bid,
+        null);
+  }
+
+  private void invokeXceiverClientReadSmallFile(XceiverClientSpi client)
+      throws IOException {
+    BlockID bid = new BlockID(1, 1);
+    bid.setBlockCommitSequenceId(1);
+    ContainerProtocolCalls.readSmallFile(client, bid);
+  }
+
+  private XceiverClientReply buildValidResponse() {
+    ContainerProtos.ContainerCommandResponseProto resp =
+        ContainerProtos.ContainerCommandResponseProto.newBuilder()
+            .setCmdType(ContainerProtos.Type.GetBlock)
+            .setResult(ContainerProtos.Result.SUCCESS).build();
+    final CompletableFuture<ContainerProtos.ContainerCommandResponseProto>
+        replyFuture = new CompletableFuture<>();
+    replyFuture.complete(resp);
+    return new XceiverClientReply(replyFuture);
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

In XceiverClientGrpc.java, the calls to read a block or chunks for a Datanode end up in the private method sendCommandWithRetry(). In this method it decides which datanode it should send the request to. To do that, it checks if there is a cached DN connection for the given block and if so it uses that. If there is no cached connection, it should take network topology into account or shuffle the nodes:

```
   List<DatanodeDetails> datanodeList = null;

    DatanodeBlockID blockID = null;
    if (request.getCmdType() == ContainerProtos.Type.ReadChunk) {
      blockID = request.getReadChunk().getBlockID();
    } else if (request.getCmdType() == ContainerProtos.Type.GetSmallFile) {
      blockID = request.getGetSmallFile().getBlock().getBlockID();
    }

    if (blockID != null) {
      // Check if the DN to which the GetBlock command was sent has been cached.
      DatanodeDetails cachedDN = getBlockDNcache.get(blockID);
      if (cachedDN != null) {
        datanodeList = pipeline.getNodes();
        int getBlockDNCacheIndex = datanodeList.indexOf(cachedDN);
        if (getBlockDNCacheIndex > 0) {
          // Pull the Cached DN to the top of the DN list
          Collections.swap(datanodeList, 0, getBlockDNCacheIndex);
        }
      } else if (topologyAwareRead) {
        datanodeList = pipeline.getNodesInOrder();
      }
    }
    if (datanodeList == null) {
      datanodeList = pipeline.getNodes();
      // Shuffle datanode list so that clients do not read in the same order
      // every time.
      Collections.shuffle(datanodeList);
    }
    <call to DN after here>
```

The normal flow for the client is to first make a getBlock() call to the DN and then a readChunk() call.

Due to the logic at the top of the block above, blockID is always going to be null for the getBlock() call, then it never checks the topologyAwareRead section and shuffles the node.

Then for readChunk, it will find the blockID, find a cached DN, which was the result of the shuffle, and then it reuses that DN.

Therefore the topologyAwareRead does not work as expected.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3794

## How was this patch tested?

New unit tests added to reproduce the issue and then prove it is fixed.
