### PR TITLE
HDDS-3812. Disable netty resource leak detector in datanode.

### DIFF
--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -104,7 +104,9 @@ function ozonecmd_case
       # for disabling netty PooledByteBufAllocator thread caches for non-netty threads.
       # This parameter significantly reduces GC pressure for Datanode.
       # Corresponding Ratis issue https://issues.apache.org/jira/browse/RATIS-534.
-      HDDS_DN_OPTS="${HDDS_DN_OPTS} -Dlog4j.configurationFile=${HADOOP_CONF_DIR}/dn-audit-log4j2.properties -Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false"
+      # TODO: Fix the problem related to netty resource leak detector throwing
+      # exception as mentioned in HDDS-3812
+      HDDS_DN_OPTS="-Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false -Dio.netty.noResourceLeakDetection=false -Dlog4j.configurationFile=${HADOOP_CONF_DIR}/dn-audit-log4j2.properties ${HDDS_DN_OPTS}"
       HADOOP_OPTS="${HADOOP_OPTS} ${HDDS_DN_OPTS}"
       HADOOP_CLASSNAME=org.apache.hadoop.ozone.HddsDatanodeService
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-datanode"

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -106,7 +106,7 @@ function ozonecmd_case
       # Corresponding Ratis issue https://issues.apache.org/jira/browse/RATIS-534.
       # TODO: Fix the problem related to netty resource leak detector throwing
       # exception as mentioned in HDDS-3812
-      HDDS_DN_OPTS="-Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false -Dio.netty.noResourceLeakDetection=false -Dlog4j.configurationFile=${HADOOP_CONF_DIR}/dn-audit-log4j2.properties ${HDDS_DN_OPTS}"
+      HDDS_DN_OPTS="-Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false -Dorg.apache.ratis.thirdparty.io.netty.leakDetection.level=disabled -Dlog4j.configurationFile=${HADOOP_CONF_DIR}/dn-audit-log4j2.properties ${HDDS_DN_OPTS}"
       HADOOP_OPTS="${HADOOP_OPTS} ${HDDS_DN_OPTS}"
       HADOOP_CLASSNAME=org.apache.hadoop.ozone.HddsDatanodeService
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-datanode"


### PR DESCRIPTION
## What changes were proposed in this pull request?

By default netty enables resource leak detector. However, this ends up throwing exception everytime to track the location.  

For every write and for every bytebuf allocation in netty, it ends up going via this path which can hurt during concurrency and for perf.

https://github.com/netty/netty/blob/b82258b72fdf4c733d9c4a641c6b8725b036485f/common/src/main/java/io/netty/util/ResourceLeakDetector.java#L106

https://github.com/netty/netty/blob/b82258b72fdf4c733d9c4a641c6b8725b036485f/common/src/main/java/io/netty/util/ResourceLeakDetector.java#L591

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3812

## How was this patch tested?

Manually verified that ResourceLeakDetector#isEnabled was false after setting the system property.