### PR TITLE
HDDS-3815. Avoid buffer copy in ContainerCommandRequestProto.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ContainerCommandRequestMessage.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ContainerCommandRequestMessage.java
@@ -61,7 +61,7 @@ public final class ContainerCommandRequestMessage implements Message {
   public static ContainerCommandRequestProto toProto(
       ByteString bytes, RaftGroupId groupId)
       throws InvalidProtocolBufferException {
-    final int i = 4 + bytes.substring(0, Integer.BYTES)
+    final int i = Integer.BYTES + bytes.substring(0, Integer.BYTES)
         .asReadOnlyByteBuffer().getInt();
     final ContainerCommandRequestProto header
         = ContainerCommandRequestProto

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ContainerCommandRequestMessage.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ContainerCommandRequestMessage.java
@@ -61,9 +61,9 @@ public final class ContainerCommandRequestMessage implements Message {
   public static ContainerCommandRequestProto toProto(
       ByteString bytes, RaftGroupId groupId)
       throws InvalidProtocolBufferException {
-    final int i = 4 + bytes.asReadOnlyByteBuffer().getInt();
+    final int i = 4 + bytes.substring(0, Integer.BYTES).asReadOnlyByteBuffer().getInt();
     final ContainerCommandRequestProto header
-        = ContainerCommandRequestProto.parseFrom(bytes.substring(4, i));
+        = ContainerCommandRequestProto.parseFrom(bytes.substring(Integer.BYTES, i));
     // TODO: setting pipeline id can be avoided if the client is sending it.
     //       In such case, just have to validate the pipeline id.
     final ContainerCommandRequestProto.Builder b = header.toBuilder();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ContainerCommandRequestMessage.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ContainerCommandRequestMessage.java
@@ -61,9 +61,11 @@ public final class ContainerCommandRequestMessage implements Message {
   public static ContainerCommandRequestProto toProto(
       ByteString bytes, RaftGroupId groupId)
       throws InvalidProtocolBufferException {
-    final int i = 4 + bytes.substring(0, Integer.BYTES).asReadOnlyByteBuffer().getInt();
+    final int i = 4 + bytes.substring(0, Integer.BYTES)
+        .asReadOnlyByteBuffer().getInt();
     final ContainerCommandRequestProto header
-        = ContainerCommandRequestProto.parseFrom(bytes.substring(Integer.BYTES, i));
+        = ContainerCommandRequestProto
+        .parseFrom(bytes.substring(Integer.BYTES, i));
     // TODO: setting pipeline id can be avoided if the client is sending it.
     //       In such case, just have to validate the pipeline id.
     final ContainerCommandRequestProto.Builder b = header.toBuilder();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid Buffer Copy in ContainerCommandRequestProto.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3815

## How was this patch tested?
Ran unit tests.
