### PR TITLE
HDDS-3818. Schedule daily 2 builds from master branch build

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -14,7 +14,9 @@
 # limitations under the License.
 name: build-branch
 on:
-  - push
+  push:
+  schedule:
+    - cron: 30 0,12 * * *
 jobs:
   build:
     name: compile


### PR DESCRIPTION
## What changes were proposed in this pull request?

@mukul1987  suggested to schedule cron based build to have more frequent data points to identify flaky tests.

We can start with two additional daily build which can be independent of the commit frequency (today we build master only after the commits).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3818

## How was this patch tested?

Pushed a similar change to my fork to check if the syntax is valid.