### PR TITLE
HDDS-3094. Save each output of smoketest executed multiple times

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -101,7 +101,16 @@ execute_robot_test(){
   TEST_NAME="$(basename "$COMPOSE_DIR")-${TEST_NAME%.*}"
   set +e
   OUTPUT_NAME="$COMPOSE_ENV_NAME-$TEST_NAME-$CONTAINER"
-  OUTPUT_PATH="$RESULT_DIR_INSIDE/robot-$OUTPUT_NAME.xml"
+
+  # find unique filename
+  declare -i i=0
+  OUTPUT_FILE="robot-${OUTPUT_NAME}.xml"
+  while [[ -f $RESULT_DIR/$OUTPUT_FILE ]]; do
+    let i++
+    OUTPUT_FILE="robot-${OUTPUT_NAME}-${i}.xml"
+  done
+
+  OUTPUT_PATH="$RESULT_DIR_INSIDE/${OUTPUT_FILE}"
   # shellcheck disable=SC2068
   docker-compose -f "$COMPOSE_FILE" exec -T "$CONTAINER" mkdir -p "$RESULT_DIR_INSIDE" \
     && docker-compose -f "$COMPOSE_FILE" exec -T -e SECURITY_ENABLED="${SECURITY_ENABLED}" -e OM_HA_PARAM="${OM_HA_PARAM}" -e OM_SERVICE_ID="${OM_SERVICE_ID}" "$CONTAINER" robot ${ARGUMENTS[@]} --log NONE -N "$TEST_NAME" --report NONE "${OZONE_ROBOT_OPTS[@]}" --output "$OUTPUT_PATH" "$SMOKETEST_DIR_INSIDE/$TEST"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a numeric suffix to Robot test output file names to avoid overwriting previous runs.

https://issues.apache.org/jira/browse/HDDS-3094

## How was this patch tested?

Ran test in `ozone-topology` env, which calls `readdata` test twice (with different set of running datanodes).

```
$ cd hadoop-ozone/dist/target/ozone*/compose/ozone-topology
$ ./test.sh
...
Output:  /tmp/smoketest/ozone-topology/result/robot-ozone-topology-ozone-topology-readdata-scm.xml
...
Output:  /tmp/smoketest/ozone-topology/result/robot-ozone-topology-ozone-topology-readdata-scm-1.xml
...
```

https://github.com/adoroszlai/hadoop-ozone/runs/783624066