### PR TITLE
HDDS-3823. Hadoop3 artifact should depend on the ozonefs-shaded

### DIFF
--- a/hadoop-ozone/ozonefs-hadoop3/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3/pom.xml
@@ -34,6 +34,21 @@
       <artifactId>hadoop-ozone-filesystem-shaded</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-auth</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <scope>provided</scope>

--- a/hadoop-ozone/ozonefs-hadoop3/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3/pom.xml
@@ -31,7 +31,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-ozone-filesystem</artifactId>
+      <artifactId>hadoop-ozone-filesystem-shaded</artifactId>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

ozonefs-hadoop3 is an all-in-one ozonefs client which can be used as a single jar file.

Unfortunately it uses wrong dependency (ozonefs-common instead of ozonefs-common-shaded) which means that it downloads additional dependencies (netty-all, ...) if it's used from maven.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3823

## How was this patch tested?

With CI build.