### PR TITLE
HDDS-3836. Modify ContainerPlacementPolicyFactory JavaDoc

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/ContainerPlacementPolicyFactory.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/ContainerPlacementPolicyFactory.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A factory to create container placement instance based on configuration
- * property ozone.scm.container.placement.classname.
+ * property {@link ScmConfigKeys#OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY}.
  */
 public final class ContainerPlacementPolicyFactory {
   private static final Logger LOG =


### PR DESCRIPTION
## What changes were proposed in this pull request?

now ContainerPlacementPolicyFactory‘s javadoc is
```
property ozone.scm.container.placement.classname.
```
but this config name has been changed to 
```
ozone.scm.container.placement.impl
```
so change it to
```
property {@link ScmConfigKeys#OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY}.
```
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3836

## How was this patch tested?

No testing required
