### PR TITLE
HDDS-3828. Configuration parsing of ozone insight should be based on fields

### DIFF
--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/ConfigurationSubCommand.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/ConfigurationSubCommand.java
@@ -60,15 +60,26 @@ public class ConfigurationSubCommand extends BaseInsightSubCommand
     return null;
   }
 
-  private void showConfig(Class clazz, Type type) {
+  protected void showConfig(Class clazz, Type type) {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.addResource(getHost(conf, new Component(type)) + "/conf");
+    printConfig(clazz, conf);
+  }
+
+  /**
+   * Print all the configuration annotated on the class or any superclass.
+   */
+  protected void printConfig(Class clazz, OzoneConfiguration conf) {
     ConfigGroup configGroup =
         (ConfigGroup) clazz.getAnnotation(ConfigGroup.class);
     if (configGroup == null) {
       return;
     }
+    printConfig(configGroup, clazz, conf);
+  }
 
+  private void printConfig(ConfigGroup configGroup, Class clazz,
+      OzoneConfiguration conf) {
     String prefix = configGroup.prefix();
 
     for (Field field : clazz.getDeclaredFields()) {
@@ -82,10 +93,12 @@ public class ConfigurationSubCommand extends BaseInsightSubCommand
         System.out.println(config.description());
         System.out.println();
         System.out.println();
-
+      }
+      final Class superclass = clazz.getSuperclass();
+      if (superclass != Object.class) {
+        printConfig(configGroup, superclass, conf);
       }
     }
-
   }
 
 }

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/ConfigurationSubCommand.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/ConfigurationSubCommand.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.ozone.insight;
 
+import java.lang.reflect.Field;
+import java.util.concurrent.Callable;
+
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
@@ -24,9 +27,6 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.insight.Component.Type;
 
 import picocli.CommandLine;
-
-import java.lang.reflect.Method;
-import java.util.concurrent.Callable;
 
 /**
  * Subcommand to show configuration values/documentation.
@@ -71,9 +71,9 @@ public class ConfigurationSubCommand extends BaseInsightSubCommand
 
     String prefix = configGroup.prefix();
 
-    for (Method method : clazz.getMethods()) {
-      if (method.isAnnotationPresent(Config.class)) {
-        Config config = method.getAnnotation(Config.class);
+    for (Field field : clazz.getDeclaredFields()) {
+      if (field.isAnnotationPresent(Config.class)) {
+        Config config = field.getAnnotation(Config.class);
         String key = prefix + "." + config.key();
         System.out.println(">>> " + key);
         System.out.println("       default: " + config.defaultValue());

--- a/hadoop-ozone/insight/src/test/java/org/apache/hadoop/ozone/insight/TestConfigurationSubCommand.java
+++ b/hadoop-ozone/insight/src/test/java/org/apache/hadoop/ozone/insight/TestConfigurationSubCommand.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.insight;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.apache.hadoop.hdds.conf.Config;
+import org.apache.hadoop.hdds.conf.ConfigGroup;
+import org.apache.hadoop.hdds.conf.ConfigTag;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test insight report which prints out configs.
+ */
+public class TestConfigurationSubCommand {
+
+  private static final PrintStream OLD_OUT = System.out;
+
+  private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+  @Before
+  public void setup() throws Exception {
+    System.setOut(new PrintStream(out));
+  }
+
+  @After
+  public void reset() {
+    System.setOut(OLD_OUT);
+  }
+
+  @Test
+  public void testPrintConfig() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set("ozone.scm.client.address", "omclient");
+    ConfigurationSubCommand subCommand = new ConfigurationSubCommand();
+
+    subCommand.printConfig(CustomConfig.class, conf);
+
+    final String output = out.toString();
+    Assert.assertTrue(output.contains(">>> ozone.scm.client.address"));
+    Assert.assertTrue(output.contains("default: localhost"));
+    Assert.assertTrue(output.contains("current: omclient"));
+    Assert.assertTrue(output.contains(">>> ozone.scm.client.secure"));
+    Assert.assertTrue(output.contains("default: true"));
+    Assert.assertTrue(output.contains("current: true"));
+  }
+
+  /**
+   * Example configuration parent.
+   */
+  public static class ParentConfig {
+    @Config(key = "secure", defaultValue = "true", description = "Make "
+        + "everything secure.", tags = ConfigTag.MANAGEMENT)
+    private boolean secure = true;
+
+    public boolean isSecure() {
+      return secure;
+    }
+  }
+
+  /**
+   * Example configuration.
+   */
+  @ConfigGroup(prefix = "ozone.scm.client")
+  public static class CustomConfig extends ParentConfig {
+
+    @Config(key = "address", defaultValue = "localhost", description = "Client "
+        + "addres (To test string injection).", tags = ConfigTag.MANAGEMENT)
+    private String clientAddress;
+
+    public String getClientAddress() {
+      return clientAddress;
+    }
+
+    public void setClientAddress(String clientAddress) {
+      this.clientAddress = clientAddress;
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone insight command can print out configuration related to a specific ozone component with parsing the @Config object.

But the usage of config annotations has been changed since HDDS-2661. We should check the annotated fields not methods.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3828

## How was this patch tested?

With docker-compose based test:

https://www.youtube.com/watch?v=ZLknuMIl_jw&list=PLCaV-jpCBO8UK5Ged2A_iv3eHuozzMsYv&index=5&t=3s