### PR TITLE
HDDS-3848. Add ratis.thirdparty.version in main pom.xml

### DIFF
--- a/hadoop-hdds/interface-client/pom.xml
+++ b/hadoop-hdds/interface-client/pom.xml
@@ -37,7 +37,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-thirdparty-misc</artifactId>
-      <version>0.4.0</version>
+      <version>${ratis.thirdpary.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <!-- Apache Ratis version -->
     <ratis.version>0.6.0-6ab75ae-SNAPSHOT</ratis.version>
+
+    <!-- Apache Ratis thirdparty version -->
+    <ratis.thirdpary.version>0.4.0</ratis.thirdpary.version>
+
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>
     <distMgmtSnapshotsUrl>https://repository.apache.org/content/repositories/snapshots</distMgmtSnapshotsUrl>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Introduce ratis.thirdparty.version in main pom.xml

This will helpful, when ozone is built with custom ratis-thirdparty version. Internally in cloudera when build, we use internal ratis-thirdparty branch. During that time during build time it helps to use custom version.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3848

## How was this patch tested?

Existing CI.
