### PR TITLE
HDDS-3854. Fix error return value of KeyValueBlockIterator#hasNext

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueBlockIterator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueBlockIterator.java
@@ -124,7 +124,7 @@ public class KeyValueBlockIterator implements BlockIterator<BlockData>,
     if (nextBlock != null) {
       return true;
     }
-    if (blockIterator.hasNext()) {
+    while (blockIterator.hasNext()) {
       KeyValue block = blockIterator.next();
       if (blockFilter.filterKey(null, block.getKey(), null)) {
         nextBlock = BlockUtils.getBlockData(block.getValue());
@@ -134,7 +134,6 @@ public class KeyValueBlockIterator implements BlockIterator<BlockData>,
         }
         return true;
       }
-      hasNext();
     }
     return false;
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
@@ -209,7 +209,7 @@ public class TestKeyValueBlockIterator {
   @Test
   public void testKeyValueBlockIteratorWithFilter() throws Exception {
     long containerId = 103L;
-    int deletedBlocks = 5;
+    int deletedBlocks = 10;
     int normalBlocks = 5;
     createContainerWithBlocks(containerId, normalBlocks, deletedBlocks);
     String containerPath = new File(containerData.getMetadataPath())
@@ -223,6 +223,7 @@ public class TestKeyValueBlockIterator {
         BlockData blockData = keyValueBlockIterator.nextBlock();
         assertEquals(blockData.getLocalID(), counter++);
       }
+      assertEquals(10, counter);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

hasNext use a recursion, but the recursion hasNext does not return value. So if the first level of hasNext does not  return true, though the  recursion hasNext return true, the first level of hasNext still return false. Besides I think while loop is easier.

![image](https://user-images.githubusercontent.com/51938049/85381372-7ad58680-b570-11ea-8736-102c30756c83.png)



## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3854

## How was this patch tested?

Existed tests.
