### PR TITLE
HDDS-3632. starter scripts can't manage Ozone and HDFS datandodes on the same machine 

### DIFF
--- a/hadoop-ozone/dist/src/shell/hdds/hadoop-functions.sh
+++ b/hadoop-ozone/dist/src/shell/hdds/hadoop-functions.sh
@@ -2702,11 +2702,11 @@ function hadoop_generic_java_subcmd_handler
     priv_outfile="${HADOOP_LOG_DIR}/privileged-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}-${HOSTNAME}.out"
     priv_errfile="${HADOOP_LOG_DIR}/privileged-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}-${HOSTNAME}.err"
     priv_pidfile="${HADOOP_PID_DIR}/privileged-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}.pid"
-    daemon_outfile="${HADOOP_LOG_DIR}/hadoop-${HADOOP_SECURE_USER}-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}-${HOSTNAME}.out"
-    daemon_pidfile="${HADOOP_PID_DIR}/hadoop-${HADOOP_SECURE_USER}-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}.pid"
+    daemon_outfile="${HADOOP_LOG_DIR}/ozone-${HADOOP_SECURE_USER}-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}-${HOSTNAME}.out"
+    daemon_pidfile="${HADOOP_PID_DIR}/ozone-${HADOOP_SECURE_USER}-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}.pid"
   else
-    daemon_outfile="${HADOOP_LOG_DIR}/hadoop-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}-${HOSTNAME}.out"
-    daemon_pidfile="${HADOOP_PID_DIR}/hadoop-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}.pid"
+    daemon_outfile="${HADOOP_LOG_DIR}/ozone-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}-${HOSTNAME}.out"
+    daemon_pidfile="${HADOOP_PID_DIR}/ozone-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}.pid"
   fi
 
   # are we actually in daemon mode?

--- a/hadoop-ozone/dist/src/shell/hdds/hadoop-functions.sh
+++ b/hadoop-ozone/dist/src/shell/hdds/hadoop-functions.sh
@@ -2699,9 +2699,9 @@ function hadoop_generic_java_subcmd_handler
 
     hadoop_verify_secure_prereq
     hadoop_setup_secure_service
-    priv_outfile="${HADOOP_LOG_DIR}/privileged-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}-${HOSTNAME}.out"
-    priv_errfile="${HADOOP_LOG_DIR}/privileged-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}-${HOSTNAME}.err"
-    priv_pidfile="${HADOOP_PID_DIR}/privileged-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}.pid"
+    priv_outfile="${HADOOP_LOG_DIR}/ozone-privileged-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}-${HOSTNAME}.out"
+    priv_errfile="${HADOOP_LOG_DIR}/ozone-privileged-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}-${HOSTNAME}.err"
+    priv_pidfile="${HADOOP_PID_DIR}/ozone-privileged-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}.pid"
     daemon_outfile="${HADOOP_LOG_DIR}/ozone-${HADOOP_SECURE_USER}-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}-${HOSTNAME}.out"
     daemon_pidfile="${HADOOP_PID_DIR}/ozone-${HADOOP_SECURE_USER}-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}.pid"
   else
@@ -2714,9 +2714,9 @@ function hadoop_generic_java_subcmd_handler
   if [[ "${HADOOP_DAEMON_MODE}" != "default" ]]; then
     HADOOP_ROOT_LOGGER="${HADOOP_DAEMON_ROOT_LOGGER}"
     if [[ "${HADOOP_SUBCMD_SECURESERVICE}" = true ]]; then
-      HADOOP_LOGFILE="hadoop-${HADOOP_SECURE_USER}-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}-${HOSTNAME}.log"
+      HADOOP_LOGFILE="ozone-${HADOOP_SECURE_USER}-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}-${HOSTNAME}.log"
     else
-      HADOOP_LOGFILE="hadoop-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}-${HOSTNAME}.log"
+      HADOOP_LOGFILE="ozone-${HADOOP_IDENT_STRING}-${HADOOP_SUBCMD}-${HOSTNAME}.log"
     fi
   fi
 


### PR DESCRIPTION
…
since the service names are same and they both referring to same location for pid files, we can not start both services at once.

Tweak is to export HADOOP_PID_DIR to different location after starting one service and start other one.

It would be better to have different pid file names.

```
Umas-MacBook-Pro ozone-0.5.0-beta % bin/ozone --daemon start datanode
datanode is running as process 25167.  Stop it first.
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3632

## How was this patch tested?

 1. Started a new cluster with `compose/ozonescripts`
 2. Fixed the configuration (will be uploaded in a [separated jira](https://issues.apache.org/jira/browse/HDDS-3857))
 3. Used `./start.sh`
 4. Checked if cluster works (ozone sh + volume, bucket, key create)
 5. Checked if the /tmp/*.pid contains ozone name on the datanodes.