### PR TITLE
HDDS-3857. Datanode in compose/ozonescripts can't be started

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-config
@@ -25,12 +25,5 @@ OZONE-SITE.XML_ozone.metadata.dirs=/data/metadata
 OZONE-SITE.XML_ozone.scm.client.address=scm
 OZONE-SITE.XML_ozone.replication=1
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
-OZONE-SITE.XML_hdds.datanode.plugins=org.apache.hadoop.ozone.web.OzoneHddsDatanodeService
-
-HDFS-SITE.XML_dfs.namenode.rpc-address=namenode:9000
-HDFS-SITE.XML_dfs.namenode.name.dir=/data/namenode
-HDFS-SITE.XML_rpc.metrics.quantile.enable=true
-HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300
-HDFS-SITE.XML_dfs.datanode.plugins=org.apache.hadoop.ozone.HddsDatanodeService
 
 no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1


### PR DESCRIPTION
## What changes were proposed in this pull request?

Datanode in compose/ozonscripts can't be started due to an old configuration (OzoneHddsDatanodeService is removed in HDDS-738)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3857

## How was this patch tested?

```
cd compose/ozonescripts
docker-compose up -d
docker-compose scale datanode=3
./start.sh
```

Wait and check if cluster is usable.