### PR TITLE
HDDS-3863. Provide script to re-generate Kubernetes resources files

### DIFF
--- a/hadoop-ozone/dist/src/main/k8s/examples/regenerate-all.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/regenerate-all.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+
+if [ ! -x "$(command -v flekszible)" ]; then
+    echo "flekszible tool is required for regenerating Kubernetes files"
+    exit 1
+fi
+
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )
+cd "$SCRIPT_DIR"
+for dir in $(find . -maxdepth 1 -mindepth 1 -type d -printf '%f\n'); do
+   cd "$SCRIPT_DIR/$dir"
+   flekszible generate
+done

--- a/hadoop-ozone/dist/src/main/k8s/examples/regenerate-all.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/regenerate-all.sh
@@ -23,7 +23,9 @@ fi
 
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )
 cd "$SCRIPT_DIR"
-for dir in $(find . -maxdepth 1 -mindepth 1 -type d -printf '%f\n'); do
+
+# shellcheck disable=SC2045,SC2035
+for dir in $(ls -d */); do
    cd "$SCRIPT_DIR/$dir"
    flekszible generate
 done


### PR DESCRIPTION
## What changes were proposed in this pull request?

Kubernetes resource files under `hadoop-ozone/dist/src/main/k8s/examples` generated from `hadoop-ozone/dist/src/main/k8s/definitions`. To make it easy to regenerate all the files (and test PRs) I would provide a shell script which calls the generator tool in each of the subdirectories.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3863

## How was this patch tested?

Execute the shell script.