### PR TITLE
HDDS-3865. Export the SCM client IPC port in docker-compose

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-csi/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-csi/docker-compose.yaml
@@ -47,6 +47,7 @@ services:
       - docker-config
     ports:
       - 9876:9876
+      - 9860:9860
     environment:
       ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
     command: ["ozone","scm"]

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/docker-compose.yaml
@@ -59,6 +59,7 @@ services:
       - ../../..:/opt/hadoop
     ports:
       - 9876:9876
+      - 9860:9860
     env_file:
       - docker-config
       - ../common-config

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/docker-compose.yaml
@@ -59,6 +59,7 @@ services:
       - ../../..:/opt/hadoop
     ports:
       - 9876:9876
+      - 9860:9860
     env_file:
       - docker-config
       - ../common-config

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/docker-compose.yaml
@@ -59,6 +59,7 @@ services:
       - ../../..:/opt/hadoop
     ports:
       - 9876:9876
+      - 9860:9860
     env_file:
       - docker-config
       - ../common-config

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha-s3/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha-s3/docker-compose.yaml
@@ -72,6 +72,7 @@ services:
          - ../..:/opt/hadoop
       ports:
          - 9876:9876
+         - 9860:9860
       env_file:
           - ./docker-config
       environment:

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha/docker-compose.yaml
@@ -92,6 +92,7 @@ services:
          - ../..:/opt/hadoop
       ports:
          - 9876:9876
+         - 9860:9860
       env_file:
           - ./docker-config
       environment:

--- a/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-compose.yaml
@@ -123,6 +123,7 @@ services:
          - ../..:/opt/hadoop
       ports:
          - 9876:9876
+         - 9860:9860
       env_file:
           - ./docker-config
       environment:

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
@@ -51,6 +51,7 @@ services:
     <<: *common-config
     ports:
       - 9876:9876
+      - 9860:9860
     environment:
       ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}

--- a/hadoop-ozone/dist/src/main/compose/ozoneblockade/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozoneblockade/docker-compose.yaml
@@ -43,6 +43,7 @@ services:
          - ../..:/opt/hadoop
       ports:
          - 9876:9876
+         - 9860:9860
       env_file:
           - ./docker-config
       environment:

--- a/hadoop-ozone/dist/src/main/compose/ozones3-haproxy/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozones3-haproxy/docker-compose.yaml
@@ -50,6 +50,7 @@ services:
          - ../..:/opt/hadoop
       ports:
          - 9876:9876
+         - 9860:9860
       env_file:
           - ./docker-config
       environment:

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-compose.yaml
@@ -51,5 +51,6 @@ services:
          - ../..:/opt/hadoop
       ports:
          - 9876:9876
+         - 9860:9860
       env_file:
           - ./docker-config

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
@@ -87,6 +87,7 @@ services:
       - ../..:/opt/hadoop
     ports:
       - 9876:9876
+      - 9860:9860
     env_file:
       - docker-config
     environment:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-om-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-om-ha/docker-compose.yaml
@@ -179,6 +179,7 @@ services:
       - ../..:/opt/hadoop
     ports:
       - 9876:9876
+      - 9860:9860
     env_file:
       - docker-config
     environment:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -89,6 +89,7 @@ services:
       - ../..:/opt/hadoop
     ports:
       - 9876:9876
+      - 9860:9860
     env_file:
       - docker-config
     environment:

--- a/hadoop-ozone/fault-injection-test/network-tests/src/test/compose/docker-compose.yaml
+++ b/hadoop-ozone/fault-injection-test/network-tests/src/test/compose/docker-compose.yaml
@@ -36,6 +36,7 @@ services:
       image: ${docker.image}
       ports:
          - 9876:9876
+         - 9860:9860
       env_file:
           - ./docker-config
       environment:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Export the SCM client IPC port in docker-compose, so that I can use ozone admin cli to access the scm service in the docker container.

## What is the link to the Apache JIRA

HDDS-3865

## How was this patch tested?

```bash
cd ./hadoop-ozone/hadoop-ozone/dist/target/ozone-0.6.0-SNAPSHOT/compose/ozone/
./run.sh

cd ./hadoop-ozone/hadoop-ozone/dist/target/ozone-0.6.0-SNAPSHOT
bin/ozone admin pipeline list
```

Expected to see the pipelines.