### PR TITLE
Revert "HDDS-3263. Fix TestCloseContainerByPipeline.java."

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -57,6 +58,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_L
 /**
  * Test container closing.
  */
+@Ignore
 public class TestCloseContainerByPipeline {
 
   private static MiniOzoneCluster cluster;


### PR DESCRIPTION
Revert apache/hadoop-ozone#1119 because TestCloseContainerByPipeline failed 3 out of 6 times on master since it was enabled:

https://github.com/apache/hadoop-ozone/runs/804094128
https://github.com/apache/hadoop-ozone/runs/804286962
https://github.com/apache/hadoop-ozone/runs/804621643