### PR TITLE
HDDS-3862. Prepare checks for running some tests multiple times

### DIFF
--- a/hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
+++ b/hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
@@ -27,17 +27,18 @@ _realpath() {
 }
 
 ## generate summary txt file
-find "." -name 'TEST*.xml' -print0 \
+find "." -not -path '*/iteration*' -name 'TEST*.xml' -print0 \
     | xargs -n1 -0 "grep" -l -E "<failure|<error" \
     | awk -F/ '{sub("'"TEST-"'",""); sub(".xml",""); print $NF}' \
     | tee "$REPORT_DIR/summary.txt"
 
 #Copy heap dump and dump leftovers
-find "." -name "*.hprof" \
+find "." -not -path '*/iteration*' \
+    \( -name "*.hprof" \
     -or -name "*.dump" \
     -or -name "*.dumpstream" \
-    -or -name "hs_err_*.log" \
-  -exec cp {} "$REPORT_DIR/" \;
+    -or -name "hs_err_*.log" \) \
+  -exec mv {} "$REPORT_DIR/" \;
 
 ## Add the tests where the JVM is crashed
 grep -A1 'Crashed tests' "${REPORT_DIR}/output.log" \
@@ -58,11 +59,12 @@ grep -e 'Running org' -e 'Tests run: .* in org' "${REPORT_DIR}/output.log" \
 
 #Collect of all of the report files of FAILED tests
 for failed_test in $(< ${REPORT_DIR}/summary.txt); do
-  for file in $(find "." -name "${failed_test}.txt" -or -name "${failed_test}-output.txt" -or -name "TEST-${failed_test}.xml"); do
+  for file in $(find "." -not -path '*/iteration*' \
+      \( -name "${failed_test}.txt" -or -name "${failed_test}-output.txt" -or -name "TEST-${failed_test}.xml" \)); do
     dir=$(dirname "${file}")
     dest_dir=$(_realpath --relative-to="${PWD}" "${dir}/../..") || continue
     mkdir -p "${REPORT_DIR}/${dest_dir}"
-    cp "${file}" "${REPORT_DIR}/${dest_dir}"/
+    mv "${file}" "${REPORT_DIR}/${dest_dir}"/
   done
 done
 

--- a/hadoop-ozone/dev-support/checks/integration.sh
+++ b/hadoop-ozone/dev-support/checks/integration.sh
@@ -14,27 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o pipefail
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd "$DIR/../../.." || exit 1
-
-REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/integration"}
-mkdir -p "$REPORT_DIR"
-
-export MAVEN_OPTS="-Xmx4096m"
-mvn -B install -DskipTests -Dskip.npx -Dskip.installnpx
-mvn -B -fae test -Dskip.npx -Dskip.installnpx -pl :hadoop-ozone-integration-test,:mini-chaos-tests "$@" \
-  | tee "${REPORT_DIR}/output.log"
-rc=$?
-
-#Archive combined jacoco records
-mvn -B -N jacoco:merge -Djacoco.destFile=$REPORT_DIR/jacoco-combined.exec
-
-# shellcheck source=hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
-source "$DIR/_mvn_unit_report.sh"
-
-if [[ -s "$REPORT_DIR/summary.txt" ]] ; then
-    exit 1
-fi
-exit ${rc}
+CHECK=integration
+source "${DIR}/junit.sh" -pl :hadoop-ozone-integration-test,:mini-chaos-tests "$@"

--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u -o pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$DIR/../../.." || exit 1
+
+: ${CHECK:="unit"}
+: ${ITERATIONS:="1"}
+
+export MAVEN_OPTS="-Xmx4096m"
+MAVEN_OPTIONS='-B -Dskip.npx -Dskip.installnpx'
+mvn ${MAVEN_OPTIONS} -DskipTests clean install
+
+REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/${CHECK}"}
+mkdir -p "$REPORT_DIR"
+
+rc=0
+for i in $(seq 1 ${ITERATIONS}); do
+  if [[ ${ITERATIONS} -gt 1 ]]; then
+    original_report_dir="${REPORT_DIR}"
+    REPORT_DIR="${original_report_dir}/iteration${i}"
+    mkdir -p "${REPORT_DIR}"
+  fi
+
+  mvn ${MAVEN_OPTIONS} -fae "$@" test \
+    | tee "${REPORT_DIR}/output.log"
+  irc=$?
+
+  # shellcheck source=hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
+  source "${DIR}/_mvn_unit_report.sh"
+
+  if [[ ${ITERATIONS} -gt 1 ]]; then
+    REPORT_DIR="${original_report_dir}"
+    echo "Iteration ${i} exit code: ${irc}" | tee -a "${REPORT_DIR}/output.log"
+  fi
+
+  if [[ ${rc} == 0 ]]; then
+    rc=${irc}
+  fi
+done
+
+#Archive combined jacoco records
+mvn -B -N jacoco:merge -Djacoco.destFile=$REPORT_DIR/jacoco-combined.exec
+
+if [[ -s "$REPORT_DIR/summary.txt" ]] ; then
+  exit 1
+fi
+exit ${rc}

--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -43,10 +43,13 @@ for i in $(seq 1 ${ITERATIONS}); do
 
   # shellcheck source=hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
   source "${DIR}/_mvn_unit_report.sh"
+  if [[ ${irc} == 0 ]] && [[ -s "${REPORT_DIR}/summary.txt" ]]; then
+    irc=1
+  fi
 
   if [[ ${ITERATIONS} -gt 1 ]]; then
     REPORT_DIR="${original_report_dir}"
-    echo "Iteration ${i} exit code: ${irc}" | tee -a "${REPORT_DIR}/output.log"
+    echo "Iteration ${i} exit code: ${irc}" | tee -a "${REPORT_DIR}/summary.txt"
   fi
 
   if [[ ${rc} == 0 ]]; then
@@ -57,7 +60,4 @@ done
 #Archive combined jacoco records
 mvn -B -N jacoco:merge -Djacoco.destFile=$REPORT_DIR/jacoco-combined.exec
 
-if [[ -s "$REPORT_DIR/summary.txt" ]] ; then
-  exit 1
-fi
 exit ${rc}

--- a/hadoop-ozone/dev-support/checks/unit.sh
+++ b/hadoop-ozone/dev-support/checks/unit.sh
@@ -14,26 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o pipefail
-
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd "$DIR/../../.." || exit 1
-
-REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/unit"}
-mkdir -p "$REPORT_DIR"
-
-export MAVEN_OPTS="-Xmx4096m"
-mvn -B -DskipShade -Dskip.npx -Dskip.installnpx -fae test -pl \!:hadoop-ozone-integration-test,\!:mini-chaos-tests "$@" \
-  | tee "${REPORT_DIR}/output.log"
-rc=$?
-
-#Archive combined jacoco records
-mvn -B -N jacoco:merge -Djacoco.destFile=$REPORT_DIR/jacoco-combined.exec
-
-# shellcheck source=hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
-source "$DIR/_mvn_unit_report.sh"
-
-if [[ -s "$REPORT_DIR/summary.txt" ]] ; then
-    exit 1
-fi
-exit ${rc}
+CHECK=unit
+source "${DIR}/junit.sh" -pl \!:hadoop-ozone-integration-test,\!:mini-chaos-tests "$@"


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Improve `unit.sh` and `integration.sh` to allow running tests multiple times after a single compilation.
   * Number of runs is controlled by `ITERATIONS` environment variable (defaults to 1).
   * Failed test output from each iteration is saved into a separate directory (`iterationN`), but only if repetitions are requested, ie. no change for regular, single run.
   * Each run is followed by a one-liner summary, eg.: `Iteration 1 exit code: 0`
2. Reduce duplication by extracting common logic into separate `junit.sh` script.

https://issues.apache.org/jira/browse/HDDS-3862

## How was this patch tested?

Regular CI runs:
* [unit](https://github.com/adoroszlai/hadoop-ozone/runs/806245518)
* eg. [integration (client)](https://github.com/adoroszlai/hadoop-ozone/runs/806264131)

Repeated tests:
* [TestCloseContainerByPipeline](https://github.com/adoroszlai/hadoop-ozone/runs/806313923), failed 5/20
* [TestCSMMetrics](https://github.com/adoroszlai/hadoop-ozone/runs/804181186), passed 20/20