### PR TITLE
HDDS-3741. Reload old OM state if Install Snapshot from Leader fails

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -366,4 +366,7 @@ public final class OzoneConsts {
 
   public static final String CONTAINER_DB_TYPE_ROCKSDB = "RocksDB";
   public static final String CONTAINER_DB_TYPE_LEVELDB = "LevelDB";
+
+  // An on-disk transient marker file used when replacing DB with checkpoint
+  public static final String DB_TRANSIENT_MARKER = "dbInconsistentMarker";
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/ExitManager.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/ExitManager.java
@@ -1,0 +1,16 @@
+package org.apache.hadoop.ozone.util;
+
+import org.apache.ratis.util.ExitUtils;
+import org.slf4j.Logger;
+
+/**
+ * An Exit Manager used to shutdown service in case of unrecoverable error.
+ * This class will be helpful to test exit functionality.
+ */
+public class ExitManager {
+
+  public void exitSystem(int status, String message, Throwable throwable,
+      Logger log) {
+    ExitUtils.terminate(1, message, throwable, log);
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/ExitManager.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/ExitManager.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.ozone.util;
 
 import org.apache.ratis.util.ExitUtils;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -16,7 +16,6 @@
  */
 package org.apache.hadoop.ozone.om;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,8 +33,11 @@ import org.apache.hadoop.ozone.client.VolumeArgs;
 import org.apache.hadoop.ozone.om.ratis.OMTransactionInfo;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import static org.apache.hadoop.ozone.om.TestOzoneManagerHAWithData.createKey;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.junit.After;
 import org.junit.Assert;
@@ -45,6 +47,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.Timeout;
+import org.slf4j.event.Level;
 
 /**
  * Tests the Ratis snaphsots feature in OM.
@@ -59,6 +62,10 @@ public class TestOMRatisSnapshots {
   private String scmId;
   private String omServiceId;
   private int numOfOMs = 3;
+  private OzoneBucket ozoneBucket;
+  private String volumeName;
+  private String bucketName;
+
   private static final long SNAPSHOT_THRESHOLD = 50;
   private static final int LOG_PURGE_GAP = 50;
 
@@ -95,6 +102,20 @@ public class TestOMRatisSnapshots {
     cluster.waitForClusterToBeReady();
     objectStore = OzoneClientFactory.getRpcClient(omServiceId, conf)
         .getObjectStore();
+
+    volumeName = "volume" + RandomStringUtils.randomNumeric(5);
+    bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+
+    VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
+        .setOwner("user" + RandomStringUtils.randomNumeric(5))
+        .setAdmin("admin" + RandomStringUtils.randomNumeric(5))
+        .build();
+
+    objectStore.createVolume(volumeName, createVolumeArgs);
+    OzoneVolume retVolumeinfo = objectStore.getVolume(volumeName);
+
+    retVolumeinfo.createBucket(bucketName);
+    ozoneBucket = retVolumeinfo.getBucket(bucketName);
   }
 
   /**
@@ -125,37 +146,13 @@ public class TestOMRatisSnapshots {
     OzoneManager followerOM = cluster.getOzoneManager(followerNodeId);
 
     // Do some transactions so that the log index increases
-    String userName = "user" + RandomStringUtils.randomNumeric(5);
-    String adminName = "admin" + RandomStringUtils.randomNumeric(5);
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-    String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
-
-    VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
-        .setOwner(userName)
-        .setAdmin(adminName)
-        .build();
-
-    objectStore.createVolume(volumeName, createVolumeArgs);
-    OzoneVolume retVolumeinfo = objectStore.getVolume(volumeName);
-
-    retVolumeinfo.createBucket(bucketName);
-    OzoneBucket ozoneBucket = retVolumeinfo.getBucket(bucketName);
-
-    long leaderOMappliedLogIndex =
-        leaderRatisServer.getLastAppliedTermIndex().getIndex();
-
-    List<String> keys = new ArrayList<>();
-    while (leaderOMappliedLogIndex < 2000) {
-      keys.add(createKey(ozoneBucket));
-      leaderOMappliedLogIndex =
-          leaderRatisServer.getLastAppliedTermIndex().getIndex();
-    }
+    List<String> keys = writeKeysToIncreaseLogIndex(leaderRatisServer, 200);
 
     // Get the latest db checkpoint from the leader OM.
     OMTransactionInfo omTransactionInfo =
         OMTransactionInfo.readTransactionInfo(leaderOM.getMetadataManager());
     TermIndex leaderOMTermIndex =
-        TermIndex.newTermIndex(omTransactionInfo.getCurrentTerm(),
+        TermIndex.newTermIndex(omTransactionInfo.getTerm(),
             omTransactionInfo.getTransactionIndex());
     long leaderOMSnaphsotIndex = leaderOMTermIndex.getIndex();
     long leaderOMSnapshotTermIndex = leaderOMTermIndex.getTerm();
@@ -169,30 +166,20 @@ public class TestOMRatisSnapshots {
     // The recently started OM should be lagging behind the leader OM.
     long followerOMLastAppliedIndex =
         followerOM.getOmRatisServer().getLastAppliedTermIndex().getIndex();
-    Assert.assertTrue(
+    assertTrue(
         followerOMLastAppliedIndex < leaderOMSnaphsotIndex);
 
     // Install leader OM's db checkpoint on the lagging OM.
-    File oldDbLocation = followerOM.getMetadataManager().getStore()
-        .getDbLocation();
-    followerOM.getOmRatisServer().getOmStateMachine().pause();
-    followerOM.getMetadataManager().getStore().close();
-    followerOM.replaceOMDBWithCheckpoint(leaderOMSnaphsotIndex, oldDbLocation,
-        leaderDbCheckpoint.getCheckpointLocation());
+    followerOM.installCheckpoint(leaderOMNodeId, leaderDbCheckpoint);
 
-    // Reload the follower OM with new DB checkpoint from the leader OM.
-    followerOM.reloadOMState(leaderOMSnaphsotIndex, leaderOMSnapshotTermIndex);
-    followerOM.getOmRatisServer().getOmStateMachine().unpause(
-        leaderOMSnaphsotIndex, leaderOMSnapshotTermIndex);
-
-    // After the new checkpoint is loaded and state machine is unpaused, the
-    // follower OM lastAppliedIndex must match the snapshot index of the
-    // checkpoint.
+    // After the new checkpoint is installed, the follower OM
+    // lastAppliedIndex must >= the snapshot index of the checkpoint. It
+    // could be great than snapshot index if there is any conf entry from ratis.
     followerOMLastAppliedIndex = followerOM.getOmRatisServer()
         .getLastAppliedTermIndex().getIndex();
-    Assert.assertEquals(leaderOMSnaphsotIndex, followerOMLastAppliedIndex);
-    Assert.assertEquals(leaderOMSnapshotTermIndex,
-        followerOM.getOmRatisServer().getLastAppliedTermIndex().getTerm());
+    assertTrue(followerOMLastAppliedIndex >= leaderOMSnaphsotIndex);
+    assertTrue(followerOM.getOmRatisServer().getLastAppliedTermIndex()
+        .getTerm() >= leaderOMSnapshotTermIndex);
 
     // Verify that the follower OM's DB contains the transactions which were
     // made while it was inactive.
@@ -205,5 +192,71 @@ public class TestOMRatisSnapshots {
       Assert.assertNotNull(followerOMMetaMngr.getKeyTable().get(
           followerOMMetaMngr.getOzoneKey(volumeName, bucketName, key)));
     }
+  }
+
+  @Test
+  public void testInstallOldCheckpointFailure() throws Exception {
+    // Get the leader OM
+    String leaderOMNodeId = OmFailoverProxyUtil
+        .getFailoverProxyProvider(objectStore.getClientProxy())
+        .getCurrentProxyOMNodeId();
+
+    OzoneManager leaderOM = cluster.getOzoneManager(leaderOMNodeId);
+
+    // Find the inactive OM and start it
+    String followerNodeId = leaderOM.getPeerNodes().get(0).getOMNodeId();
+    if (cluster.isOMActive(followerNodeId)) {
+      followerNodeId = leaderOM.getPeerNodes().get(1).getOMNodeId();
+    }
+    cluster.startInactiveOM(followerNodeId);
+
+    OzoneManager followerOM = cluster.getOzoneManager(followerNodeId);
+    OzoneManagerRatisServer followerRatisServer = followerOM.getOmRatisServer();
+
+    // Do some transactions so that the log index increases on follower OM
+    writeKeysToIncreaseLogIndex(followerRatisServer, 100);
+
+    TermIndex leaderCheckpointTermIndex = leaderOM.getOmRatisServer()
+        .getLastAppliedTermIndex();
+    DBCheckpoint leaderDbCheckpoint = leaderOM.getMetadataManager().getStore()
+        .getCheckpoint(false);
+
+    // Do some more transactions to increase the log index further on
+    // follower OM such that it is more than the checkpoint index taken on
+    // leader OM.
+    writeKeysToIncreaseLogIndex(followerOM.getOmRatisServer(),
+        leaderCheckpointTermIndex.getIndex() + 100);
+
+    GenericTestUtils.setLogLevel(OzoneManager.LOG, Level.INFO);
+    GenericTestUtils.LogCapturer logCapture =
+        GenericTestUtils.LogCapturer.captureLogs(OzoneManager.LOG);
+
+    // Install the old checkpoint on the follower OM. This should fail as the
+    // followerOM is already ahead of that transactionLogIndex and the OM
+    // state should be reloaded.
+    TermIndex followerTermIndex = followerRatisServer.getLastAppliedTermIndex();
+    TermIndex newTermIndex = followerOM.installCheckpoint(
+        leaderOMNodeId, leaderDbCheckpoint);
+
+    String errorMsg = "Cannot proceed with InstallSnapshot as OM is at " +
+        "TermIndex " + followerTermIndex + " and checkpoint has lower " +
+        "TermIndex";
+    Assert.assertTrue(logCapture.getOutput().contains(errorMsg));
+    Assert.assertNull("OM installed checkpoint even though checkpoint " +
+        "logIndex is less than it's lastAppliedIndex", newTermIndex);
+    Assert.assertEquals(followerTermIndex, followerRatisServer.getLastAppliedTermIndex());
+  }
+
+  private List<String> writeKeysToIncreaseLogIndex(
+      OzoneManagerRatisServer omRatisServer, long targetLogIndex)
+      throws IOException, InterruptedException {
+    List<String> keys = new ArrayList<>();
+    long logIndex = omRatisServer.getLastAppliedTermIndex().getIndex();
+    while (logIndex < targetLogIndex) {
+      keys.add(createKey(ozoneBucket));
+      Thread.sleep(100);
+      logIndex = omRatisServer.getLastAppliedTermIndex().getIndex();
+    }
+    return keys;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -18,7 +18,6 @@ package org.apache.hadoop.ozone.om;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -256,7 +255,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
       // marker indicates that the DB is in an inconsistent state and hence
       // the OM process should be terminated.
       File markerFile = new File(metaDir, DB_TRANSIENT_MARKER);
-      if (Files.exists(markerFile.toPath())) {
+      if (markerFile.exists()) {
         LOG.error("File {} marks that OM DB is in an inconsistent state.");
         // Note - The marker file should be deleted only after fixing the DB.
         // In an HA setup, this can be done by replacing this DB with a

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -290,10 +290,16 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
 
   public static DBStore loadDB(OzoneConfiguration configuration, File metaDir)
       throws IOException {
+    return loadDB(configuration, metaDir, OM_DB_NAME);
+  }
+
+  public static DBStore loadDB(OzoneConfiguration configuration, File metaDir,
+      String dbName)
+      throws IOException {
     RocksDBConfiguration rocksDBConfiguration =
         configuration.getObject(RocksDBConfiguration.class);
     DBStoreBuilder dbStoreBuilder = DBStoreBuilder.newBuilder(configuration,
-        rocksDBConfiguration).setName(OM_DB_NAME)
+        rocksDBConfiguration).setName(dbName)
         .setPath(Paths.get(metaDir.getPath()));
     DBStore dbStore = addOMTablesAndCodecs(dbStoreBuilder).build();
     return dbStore;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -18,6 +18,7 @@ package org.apache.hadoop.ozone.om;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -77,9 +78,11 @@ import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OPEN_KEY_EXPIRE_THRESHOLD_SECONDS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OPEN_KEY_EXPIRE_THRESHOLD_SECONDS_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConsts.DB_TRANSIENT_MARKER;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 
+import org.apache.ratis.util.ExitUtils;
 import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -248,6 +251,20 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
     // db, so we need to create the store object and initialize DB.
     if (store == null) {
       File metaDir = OMStorage.getOmDbDir(configuration);
+
+      // Check if there is a DB Inconsistent Marker in the metaDir. This
+      // marker indicates that the DB is in an inconsistent state and hence
+      // the OM process should be terminated.
+      File markerFile = new File(metaDir, DB_TRANSIENT_MARKER);
+      if (Files.exists(markerFile.toPath())) {
+        LOG.error("File {} marks that OM DB is in an inconsistent state.");
+        // Note - The marker file should be deleted only after fixing the DB.
+        // In an HA setup, this can be done by replacing this DB with a
+        // checkpoint from another OM.
+        String errorMsg = "Cannot load OM DB as it is in an inconsistent " +
+            "state.";
+        ExitUtils.terminate(1, errorMsg, LOG);
+      }
 
       RocksDBConfiguration rocksDBConfiguration =
           configuration.getObject(RocksDBConfiguration.class);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -294,8 +294,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   }
 
   public static DBStore loadDB(OzoneConfiguration configuration, File metaDir,
-      String dbName)
-      throws IOException {
+      String dbName) throws IOException {
     RocksDBConfiguration rocksDBConfiguration =
         configuration.getObject(RocksDBConfiguration.class);
     DBStoreBuilder dbStoreBuilder = DBStoreBuilder.newBuilder(configuration,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3102,14 +3102,17 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * state via this checkpoint. Before re-initializing OM state, the OM Ratis
    * server should be stopped so that no new transactions can be applied.
    */
-  TermIndex installCheckpoint(String leaderId,
-      DBCheckpoint omDBCheckpoint) throws Exception {
+  TermIndex installCheckpoint(String leaderId, DBCheckpoint omDBCheckpoint)
+      throws Exception {
 
     Path checkpointLocation = omDBCheckpoint.getCheckpointLocation();
-    OMTransactionInfo omTransactionInfo = getTrxnInfoFromCheckpoint(
-        checkpointLocation);
+    OMTransactionInfo checkpointTrxnInfo = OzoneManagerRatisUtils
+        .getTrxnInfoFromCheckpoint(configuration, checkpointLocation);
 
-    return installCheckpoint(leaderId, checkpointLocation, omTransactionInfo);
+    LOG.info("Installing checkpoint with OMTransactionInfo {}",
+        checkpointTrxnInfo);
+
+    return installCheckpoint(leaderId, checkpointLocation, checkpointTrxnInfo);
   }
 
   TermIndex installCheckpoint(String leaderId, Path checkpointLocation,
@@ -3220,19 +3223,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     keyManager.stop();
     stopSecretManager();
     metadataManager.stop();
-  }
-
-  @VisibleForTesting
-  OMTransactionInfo getTrxnInfoFromCheckpoint(Path dbPath)
-      throws Exception {
-    Path dbDir = dbPath.getParent();
-    String dbName = dbPath.getFileName().toString();
-    if (dbDir == null) {
-      throw new IOException("Checkpoint {} does not have proper DB location");
-    }
-
-    return OzoneManagerRatisUtils.getTransactionInfoFromDB(configuration,
-        dbDir, dbName);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OMTransactionInfo.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OMTransactionInfo.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 
 import java.io.IOException;
 import java.util.Objects;
+import org.apache.ratis.server.protocol.TermIndex;
 
 import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_KEY;
 import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_SPLIT_KEY;
@@ -33,7 +34,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_SPLIT_KEY;
  */
 public final class OMTransactionInfo {
 
-  private long currentTerm; // term associated with the ratis log index.
+  private long term; // term associated with the ratis log index.
   // Transaction index corresponds to ratis log index
   private long transactionIndex;
 
@@ -43,12 +44,12 @@ public final class OMTransactionInfo {
     Preconditions.checkState(tInfo.length==2,
         "Incorrect TransactionInfo value");
 
-    currentTerm = Long.parseLong(tInfo[0]);
+    term = Long.parseLong(tInfo[0]);
     transactionIndex = Long.parseLong(tInfo[1]);
   }
 
   private OMTransactionInfo(long currentTerm, long transactionIndex) {
-    this.currentTerm = currentTerm;
+    this.term = currentTerm;
     this.transactionIndex = transactionIndex;
   }
 
@@ -56,8 +57,8 @@ public final class OMTransactionInfo {
    * Get current term.
    * @return currentTerm
    */
-  public long getCurrentTerm() {
-    return currentTerm;
+  public long getTerm() {
+    return term;
   }
 
   /**
@@ -68,6 +69,10 @@ public final class OMTransactionInfo {
     return transactionIndex;
   }
 
+  public TermIndex getTermIndex() {
+    return TermIndex.newTermIndex(term, transactionIndex);
+  }
+
   /**
    * Generate String form of transaction info which need to be persisted in OM
    * DB finally in byte array.
@@ -75,7 +80,7 @@ public final class OMTransactionInfo {
    */
   private String generateTransactionInfo() {
     StringBuilder stringBuilder = new StringBuilder();
-    stringBuilder.append(currentTerm);
+    stringBuilder.append(term);
     stringBuilder.append(TRANSACTION_INFO_SPLIT_KEY);
     stringBuilder.append(transactionIndex);
 
@@ -109,13 +114,13 @@ public final class OMTransactionInfo {
       return false;
     }
     OMTransactionInfo that = (OMTransactionInfo) o;
-    return currentTerm == that.currentTerm &&
+    return term == that.term &&
         transactionIndex == that.transactionIndex;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(currentTerm, transactionIndex);
+    return Objects.hash(term, transactionIndex);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -379,7 +379,7 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
     }
 
     CompletableFuture<TermIndex> future = CompletableFuture.supplyAsync(
-        () -> ozoneManager.installSnapshot(leaderNodeId),
+        () -> ozoneManager.installSnapshotFromLeader(leaderNodeId),
         installSnapshotExecutor);
     return future;
   }
@@ -521,9 +521,9 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
             ozoneManager.getMetadataManager());
     if (omTransactionInfo != null) {
       setLastAppliedTermIndex(TermIndex.newTermIndex(
-          omTransactionInfo.getCurrentTerm(),
+          omTransactionInfo.getTerm(),
           omTransactionInfo.getTransactionIndex()));
-      snapshotInfo.updateTermIndex(omTransactionInfo.getCurrentTerm(),
+      snapshotInfo.updateTermIndex(omTransactionInfo.getTerm(),
           omTransactionInfo.getTransactionIndex());
     }
     LOG.info("LastAppliedIndex is set from TransactionInfo from OM DB as {}",

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -232,17 +232,17 @@ public final class OzoneManagerRatisUtils {
    */
   public static OMTransactionInfo getTrxnInfoFromCheckpoint(
       OzoneConfiguration conf, Path dbPath) throws Exception {
-    Path dbDir = dbPath.getParent();
-    if (dbDir != null && dbPath.getFileName() != null) {
-      String dbName = dbPath.getFileName().toString();
-      OMTransactionInfo checkpointTrxnInfo = getTransactionInfoFromDB(conf, dbDir,
-          dbName);
 
-      return checkpointTrxnInfo;
-    } else {
-      throw new IOException("Checkpoint " + dbPath + " does not have proper " +
-          "DB location");
+    if (dbPath != null) {
+      Path dbDir = dbPath.getParent();
+      Path dbFile = dbPath.getFileName();
+      if (dbDir != null && dbFile != null) {
+        return getTransactionInfoFromDB(conf, dbDir, dbFile.toString());
+      }
     }
+    
+    throw new IOException("Checkpoint " + dbPath + " does not have proper " +
+        "DB location");
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -233,16 +233,16 @@ public final class OzoneManagerRatisUtils {
   public static OMTransactionInfo getTrxnInfoFromCheckpoint(
       OzoneConfiguration conf, Path dbPath) throws Exception {
     Path dbDir = dbPath.getParent();
-    if (dbDir == null) {
+    if (dbDir != null && dbPath.getFileName() != null) {
+      String dbName = dbPath.getFileName().toString();
+      OMTransactionInfo checkpointTrxnInfo = getTransactionInfoFromDB(conf, dbDir,
+          dbName);
+
+      return checkpointTrxnInfo;
+    } else {
       throw new IOException("Checkpoint " + dbPath + " does not have proper " +
           "DB location");
     }
-    String dbName = dbPath.getFileName().toString();
-
-    OMTransactionInfo checkpointTrxnInfo = getTransactionInfoFromDB(conf, dbDir,
-        dbName);
-
-    return checkpointTrxnInfo;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -233,10 +233,11 @@ public final class OzoneManagerRatisUtils {
   public static OMTransactionInfo getTrxnInfoFromCheckpoint(
       OzoneConfiguration conf, Path dbPath) throws Exception {
     Path dbDir = dbPath.getParent();
-    String dbName = dbPath.getFileName().toString();
     if (dbDir == null) {
-      throw new IOException("Checkpoint {} does not have proper DB location");
+      throw new IOException("Checkpoint " + dbPath + " does not have proper " +
+          "DB location");
     }
+    String dbName = dbPath.getFileName().toString();
 
     OMTransactionInfo checkpointTrxnInfo = getTransactionInfoFromDB(conf, dbDir,
         dbName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -228,12 +228,13 @@ public final class OzoneManagerRatisUtils {
   }
 
   /**
-   * Obtain Transaction info from downloaded snapshot DB.
+   * Obtain Transaction info from DB.
    * @param tempConfig
+   * @param dbDir path to DB
    * @return OMTransactionInfo
    * @throws Exception
    */
-  public static OMTransactionInfo getTransactionInfoFromDownloadedSnapshot(
+  public static OMTransactionInfo getTransactionInfoFromDB(
       OzoneConfiguration tempConfig, Path dbDir) throws Exception {
     DBStore dbStore =
         OmMetadataManagerImpl.loadDB(tempConfig, dbDir.toFile());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -235,9 +235,10 @@ public final class OzoneManagerRatisUtils {
    * @throws Exception
    */
   public static OMTransactionInfo getTransactionInfoFromDB(
-      OzoneConfiguration tempConfig, Path dbDir) throws Exception {
-    DBStore dbStore =
-        OmMetadataManagerImpl.loadDB(tempConfig, dbDir.toFile());
+      OzoneConfiguration tempConfig, Path dbDir, String dbName)
+      throws Exception {
+    DBStore dbStore = OmMetadataManagerImpl.loadDB(tempConfig, dbDir.toFile(),
+        dbName);
 
     Table<String, OMTransactionInfo> transactionInfoTable =
         dbStore.getTable(TRANSACTION_INFO_TABLE,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OzoneManagerSnapshotProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OzoneManagerSnapshotProvider.java
@@ -113,8 +113,10 @@ public class OzoneManagerSnapshotProvider {
   public DBCheckpoint getOzoneManagerDBSnapshot(String leaderOMNodeID)
       throws IOException {
     String snapshotTime = Long.toString(System.currentTimeMillis());
-    String snapshotFileName = Paths.get(omSnapshotDir.getAbsolutePath(),
-        snapshotTime, OM_DB_NAME).toFile().getAbsolutePath();
+    String snapshotFileName = OM_DB_NAME + "-" + leaderOMNodeID
+        + "-" + snapshotTime;
+    String snapshotFilePath = Paths.get(omSnapshotDir.getAbsolutePath(),
+        snapshotFileName).toFile().getAbsolutePath();
     File targetFile = new File(snapshotFileName + ".tar.gz");
 
     String omCheckpointUrl = peerNodesMap.get(leaderOMNodeID)
@@ -141,11 +143,11 @@ public class OzoneManagerSnapshotProvider {
     });
 
     // Untar the checkpoint file.
-    Path untarredDbDir = Paths.get(snapshotFileName);
+    Path untarredDbDir = Paths.get(snapshotFilePath);
     FileUtil.unTar(targetFile, untarredDbDir.toFile());
     FileUtils.deleteQuietly(targetFile);
 
-    LOG.info("Sucessfully downloaded latest checkpoint from leader OM: {}",
+    LOG.info("Successfully downloaded latest checkpoint from leader OM: {}",
         leaderOMNodeID);
 
     RocksDBCheckpoint omCheckpoint = new RocksDBCheckpoint(untarredDbDir);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -76,7 +76,7 @@ public class TestOmMetadataManager {
     OMTransactionInfo omTransactionInfo =
         omMetadataManager.getTransactionInfoTable().get(TRANSACTION_INFO_KEY);
 
-    Assert.assertEquals(3, omTransactionInfo.getCurrentTerm());
+    Assert.assertEquals(3, omTransactionInfo.getTerm());
     Assert.assertEquals(250, omTransactionInfo.getTransactionIndex());
 
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
@@ -139,7 +139,7 @@ public class TestOzoneManagerDoubleBufferWithDummyResponse {
 
     Assert.assertEquals(lastAppliedIndex,
         omTransactionInfo.getTransactionIndex());
-    Assert.assertEquals(term, omTransactionInfo.getCurrentTerm());
+    Assert.assertEquals(term, omTransactionInfo.getTerm());
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
@@ -202,7 +202,7 @@ public class TestOzoneManagerDoubleBufferWithOMResponse {
 
     Assert.assertEquals(lastAppliedIndex,
         omTransactionInfo.getTransactionIndex());
-    Assert.assertEquals(term, omTransactionInfo.getCurrentTerm());
+    Assert.assertEquals(term, omTransactionInfo.getTerm());
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Follower OM issues a pause on its services before installing new checkpoint from Leader OM (Install Snapshot). If this installation fails for some reason, the OM stays in paused state. It should be unpaused and the old state should be reloaded.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3741

## How was this patch tested?

Unit tests added.
