### PR TITLE
HDDS-3871. Add resource core-site during loading of ozoneconfiguration.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
@@ -100,6 +100,12 @@ public class OzoneConfiguration extends Configuration
     } catch (IOException e) {
       e.printStackTrace();
     }
+    // Adding core-site here because properties from core-site are
+    // distributed to executors by spark driver. Ozone properties which are
+    // added to core-site, will be overriden by properties from adding Resource
+    // ozone-default.xml. So, adding core-site again will help to resolve
+    // this override issue.
+    addResource("core-site.xml");
     addResource("ozone-site.xml");
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add core-site resources during the loading of ozone configuration.

This is done because in few scenarios/environments spark executor pods(when spark on k8s, does not have any ozone-site.xml in the classpath) To help in environments where ozone-site.xml will not be available and where we add ozone properties to core-site, this PR will help.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3871

## How was this patch tested?

Tested it on the secure cluster where ozone properties are added to core-site and ran spark job wordcount which reads from o3fs. Verified that it is successfully run.

