### PR TITLE
HDDS-3876. Display summary of failures as a separate job step

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -43,6 +43,9 @@ jobs:
         - uses: ./.github/buildenv
           with:
              args: ./hadoop-ozone/dev-support/checks/rat.sh
+        - name: Summary of failures
+          run: cat target/${{ github.job }}/summary.txt
+          if: always()
         - uses: actions/upload-artifact@master
           if: always()
           with:
@@ -56,6 +59,9 @@ jobs:
         - uses: ./.github/buildenv
           with:
              args: ./hadoop-ozone/dev-support/checks/author.sh
+        - name: Summary of failures
+          run: cat target/${{ github.job }}/summary.txt
+          if: always()
         - uses: actions/upload-artifact@master
           if: always()
           with:
@@ -69,6 +75,9 @@ jobs:
         - uses: ./.github/buildenv
           with:
              args: ./hadoop-ozone/dev-support/checks/unit.sh
+        - name: Summary of failures
+          run: cat target/${{ github.job }}/summary.txt
+          if: always()
         - uses: actions/upload-artifact@master
           if: always()
           with:
@@ -82,6 +91,9 @@ jobs:
         - uses: ./.github/buildenv
           with:
              args: ./hadoop-ozone/dev-support/checks/checkstyle.sh
+        - name: Summary of failures
+          run: cat target/${{ github.job }}/summary.txt
+          if: always()
         - uses: actions/upload-artifact@master
           if: always()
           with:
@@ -95,6 +107,9 @@ jobs:
         - uses: ./.github/buildenv
           with:
              args: ./hadoop-ozone/dev-support/checks/findbugs.sh
+        - name: Summary of failures
+          run: cat target/${{ github.job }}/summary.txt
+          if: always()
         - uses: actions/upload-artifact@master
           if: always()
           with:
@@ -156,6 +171,9 @@ jobs:
         - uses: ./mnt/ozone/.github/buildenv
           with:
              args: ./mnt/ozone/hadoop-ozone/dev-support/checks/integration.sh -P${{ matrix.profile }}
+        - name: Summary of failures
+          run: cat mnt/ozone/target/${{ github.job }}/summary.txt
+          if: always()
         - uses: actions/upload-artifact@master
           if: always()
           with:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Display summary.txt in a separate step after build/test to make it easier to drill down to failures.

Example:
<img width="598" alt="Screenshot 2020-06-26 at 13 57 26" src="https://user-images.githubusercontent.com/6454655/85855013-cdec4b00-b7b5-11ea-8d3d-02d34dd7f106.png">

https://issues.apache.org/jira/browse/HDDS-3876

## How was this patch tested?

Induced failures in various checks and verified workflow:
https://github.com/adoroszlai/hadoop-ozone/runs/810778747
https://github.com/adoroszlai/hadoop-ozone/runs/810778775
https://github.com/adoroszlai/hadoop-ozone/runs/810778818
https://github.com/adoroszlai/hadoop-ozone/runs/810778849
https://github.com/adoroszlai/hadoop-ozone/runs/810802485

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/runs/810855298