### PR TITLE
HDDS-3872. Reduce output of coverage.sh

### DIFF
--- a/hadoop-ozone/dev-support/checks/coverage.sh
+++ b/hadoop-ozone/dev-support/checks/coverage.sh
@@ -27,7 +27,9 @@ REPORT_DIR="$DIR/../../../target/coverage"
 mkdir -p "$REPORT_DIR"
 
 #Install jacoco cli
-mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.2:copy -Dartifact=org.jacoco:org.jacoco.cli:0.8.5:jar:nodeps
+mvn --non-recursive --no-transfer-progress \
+  org.apache.maven.plugins:maven-dependency-plugin:3.1.2:copy \
+  -Dartifact=org.jacoco:org.jacoco.cli:0.8.5:jar:nodeps
 
 jacoco() {
   java -jar target/dependency/org.jacoco.cli-0.8.5-nodeps.jar "$@"


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Suppress output of download progress
2. Only build top-level project (previously all submodules were `SKIPPED` by the plugin)

https://issues.apache.org/jira/browse/HDDS-3872

## How was this patch tested?

Output of maven-dependency-plugin copy command is now only [28 lines](https://github.com/adoroszlai/hadoop-ozone/runs/811182393#step:5:6) vs. [6K+ lines earlier](https://github.com/apache/hadoop-ozone/runs/811002033#step:5:6).