### PR TITLE
HDDS-3875. Package classpath files to the jar files instead of uploading them as artifacts

### DIFF
--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -284,7 +284,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               <goal>build-classpath</goal>
             </goals>
             <configuration>
-              <outputFile>${project.build.outputDirectory}/${pom.artifactId}.classpath</outputFile>
+              <outputFile>${project.build.outputDirectory}/${project.artifactId}.classpath</outputFile>
               <prefix>$HDDS_LIB_JARS_DIR</prefix>
               <outputFilterFile>true</outputFilterFile>
               <includeScope>runtime</includeScope>

--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -279,37 +279,15 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <executions>
           <execution>
             <id>add-classpath-descriptor</id>
-            <phase>package</phase>
+            <phase>prepare-package</phase>
             <goals>
               <goal>build-classpath</goal>
             </goals>
             <configuration>
-              <outputFile>${project.build.directory}/classpath</outputFile>
+              <outputFile>${project.build.outputDirectory}/${pom.artifactId}.classpath</outputFile>
               <prefix>$HDDS_LIB_JARS_DIR</prefix>
               <outputFilterFile>true</outputFilterFile>
               <includeScope>runtime</includeScope>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-classpath-artifact</id>
-            <phase>package</phase>
-            <goals>
-              <goal>attach-artifact</goal>
-            </goals>
-            <configuration>
-              <artifacts>
-                <artifact>
-                  <file>${project.build.directory}/classpath</file>
-                  <type>cp</type>
-                  <classifier>classpath</classifier>
-                </artifact>
-              </artifacts>
             </configuration>
           </execution>
         </executions>

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -48,6 +48,11 @@
                 target/ozone-${ozone.version}/share/ozone/classpath
               </outputDirectory>
               <includes>*.classpath</includes>
+              <includeArtifactIds>
+                hadoop-hdds-server-scm,hadoop-ozone-common,hadoop-ozone-csi,hadoop-ozone-datanode,hadoop-ozone-insight,
+                hadoop-ozone-ozone-manager,hadoop-ozone-recon,hadoop-ozone-s3gateway,hadoop-ozone-tools,
+                hadoop-ozone-upgrade
+              </includeArtifactIds>
             </configuration>
           </execution>
           <execution>

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -41,103 +41,13 @@
             <id>copy-classpath-files</id>
             <phase>prepare-package</phase>
             <goals>
-              <goal>copy</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
               <outputDirectory>
                 target/ozone-${ozone.version}/share/ozone/classpath
               </outputDirectory>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>org.apache.hadoop</groupId>
-                  <artifactId>hadoop-hdds-server-scm</artifactId>
-                  <version>${hdds.version}</version>
-                  <classifier>classpath</classifier>
-                  <type>cp</type>
-                  <destFileName>hadoop-hdds-server-scm.classpath</destFileName>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.apache.hadoop</groupId>
-                  <artifactId>hadoop-hdds-tools</artifactId>
-                  <version>${hdds.version}</version>
-                  <classifier>classpath</classifier>
-                  <type>cp</type>
-                  <destFileName>hadoop-hdds-tools.classpath</destFileName>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.apache.hadoop</groupId>
-                  <artifactId>hadoop-ozone-s3gateway</artifactId>
-                  <version>${ozone.version}</version>
-                  <classifier>classpath</classifier>
-                  <type>cp</type>
-                  <destFileName>hadoop-ozone-s3gateway.classpath</destFileName>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.apache.hadoop</groupId>
-                  <artifactId>hadoop-ozone-csi</artifactId>
-                  <version>${ozone.version}</version>
-                  <classifier>classpath</classifier>
-                  <type>cp</type>
-                  <destFileName>hadoop-ozone-csi.classpath</destFileName>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.apache.hadoop</groupId>
-                  <artifactId>hadoop-ozone-ozone-manager</artifactId>
-                  <version>${ozone.version}</version>
-                  <classifier>classpath</classifier>
-                  <type>cp</type>
-                  <destFileName>hadoop-ozone-ozone-manager.classpath
-                  </destFileName>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.apache.hadoop</groupId>
-                  <artifactId>hadoop-ozone-tools</artifactId>
-                  <version>${ozone.version}</version>
-                  <classifier>classpath</classifier>
-                  <type>cp</type>
-                  <destFileName>hadoop-ozone-tools.classpath</destFileName>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.apache.hadoop</groupId>
-                  <artifactId>hadoop-ozone-filesystem</artifactId>
-                  <version>${ozone.version}</version>
-                  <classifier>classpath</classifier>
-                  <type>cp</type>
-                  <destFileName>hadoop-ozone-filesystem.classpath</destFileName>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.apache.hadoop</groupId>
-                  <artifactId>hadoop-ozone-common</artifactId>
-                  <version>${ozone.version}</version>
-                  <classifier>classpath</classifier>
-                  <type>cp</type>
-                  <destFileName>hadoop-ozone-common.classpath</destFileName>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.apache.hadoop</groupId>
-                  <artifactId>hadoop-ozone-datanode</artifactId>
-                  <version>${ozone.version}</version>
-                  <classifier>classpath</classifier>
-                  <type>cp</type>
-                  <destFileName>hadoop-ozone-datanode.classpath</destFileName>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.apache.hadoop</groupId>
-                  <artifactId>hadoop-ozone-upgrade</artifactId>
-                  <version>${ozone.version}</version>
-                  <classifier>classpath</classifier>
-                  <type>cp</type>
-                  <destFileName>hadoop-ozone-upgrade.classpath</destFileName>
-                </artifactItem>
-                <artifactItem>
-                  <groupId>org.apache.hadoop</groupId>
-                  <artifactId>hadoop-ozone-insight</artifactId>
-                  <version>${ozone.version}</version>
-                  <classifier>classpath</classifier>
-                  <type>cp</type>
-                  <destFileName>hadoop-ozone-insight.classpath</destFileName>
-                </artifactItem>
-              </artifactItems>
+              <includes>*.classpath</includes>
             </configuration>
           </execution>
           <execution>

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -250,39 +250,6 @@
         </property>
       </activation>
 
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>copy-recon-classpath-file</id>
-                <phase>prepare-package</phase>
-                <goals>
-                  <goal>copy</goal>
-                </goals>
-                <configuration>
-                  <outputDirectory>
-                    target/ozone-${ozone.version}/share/ozone/classpath
-                  </outputDirectory>
-                  <artifactItems>
-                    <artifactItem>
-                      <groupId>org.apache.hadoop</groupId>
-                      <artifactId>hadoop-ozone-recon</artifactId>
-                      <version>${ozone.version}</version>
-                      <classifier>classpath</classifier>
-                      <type>cp</type>
-                      <destFileName>hadoop-ozone-recon.classpath</destFileName>
-                    </artifactItem>
-                  </artifactItems>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-
       <dependencies>
         <dependency>
           <groupId>org.apache.hadoop</groupId>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -313,37 +313,15 @@
         <executions>
           <execution>
             <id>add-classpath-descriptor</id>
-            <phase>package</phase>
+            <phase>prepare-package</phase>
             <goals>
               <goal>build-classpath</goal>
             </goals>
             <configuration>
-              <outputFile>${project.build.directory}/classpath</outputFile>
+              <outputFile>${project.build.outputDirectory}/${pom.artifactId}.classpath</outputFile>
               <prefix>$HDDS_LIB_JARS_DIR</prefix>
               <outputFilterFile>true</outputFilterFile>
               <includeScope>runtime</includeScope>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-classpath-artifact</id>
-            <phase>package</phase>
-            <goals>
-              <goal>attach-artifact</goal>
-            </goals>
-            <configuration>
-              <artifacts>
-                <artifact>
-                  <file>${project.build.directory}/classpath</file>
-                  <type>cp</type>
-                  <classifier>classpath</classifier>
-                </artifact>
-              </artifacts>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

During the earlier release we realized that Apache Nexus couldn't handle the classpath files well.

Classpath files are generated during the build and copied to the final distribution to use separated classpath definition for each of the services.

It turned out that the Apache Nexus couldn't handle it well (INFRA-18344) and HDDS-1510 was an attempt to fix this problem. But during 0.5.0 release we have seen the same problem.

To make the 0.6.0 release more seamless I propose to update the logic and instead of copy the classpath file via an artifact I would pack/unpack them to/from the final artifact jar.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3875

## How was this patch tested?

It's a dist packaging change. CI test is failed which means it works as before:

https://github.com/elek/hadoop-ozone/actions/runs/148630517