### PR TITLE
HDDS-3868. Implement getTrashRoot and getTrashRoots in o3fs

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-config
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+CORE-SITE.XML_fs.trash.interval=1440
 CORE-SITE.XML_fs.ofs.impl=org.apache.hadoop.fs.ozone.RootedOzoneFileSystem
 CORE-SITE.XML_fs.o3fs.impl=org.apache.hadoop.fs.ozone.OzoneFileSystem
 OZONE-SITE.XML_ozone.om.address=om

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-config
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CORE-SITE.XML_fs.trash.interval=1440
 CORE-SITE.XML_fs.ofs.impl=org.apache.hadoop.fs.ozone.RootedOzoneFileSystem
 CORE-SITE.XML_fs.o3fs.impl=org.apache.hadoop.fs.ozone.OzoneFileSystem
 OZONE-SITE.XML_ozone.om.address=om

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -566,21 +566,14 @@ public class TestOzoneFileSystem {
     }
   }
 
-  public void testGetTrashRoot() {
-    UserGroupInformation ugi;
-    try {
-      ugi = UserGroupInformation.getCurrentUser();
-    } catch (IOException ex) {
-      throw new RuntimeException("Can't get current UGI.", ex);
-    }
-    String username = ugi.getShortUserName();
-    Path expectedTrashRoot = new Path(OZONE_URI_DELIMITER, TRASH_PREFIX);
+  public void testGetTrashRoot() throws IOException {
+    String username = UserGroupInformation.getCurrentUser().getShortUserName();
+    Path trashRoot = new Path(OZONE_URI_DELIMITER, TRASH_PREFIX);
     // Input path doesn't matter, o3fs.getTrashRoot() only cares about username
     Path inPath1 = new Path("o3fs://bucket2.volume1/path/to/key");
     // Test with current user
     Path outPath1 = o3fs.getTrashRoot(inPath1);
-    Path expectedOutPath1 = new Path(
-        expectedTrashRoot, username);
+    Path expectedOutPath1 = new Path(trashRoot, username);
     Assert.assertEquals(expectedOutPath1, outPath1);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 
 import org.apache.commons.io.IOUtils;
@@ -566,20 +567,20 @@ public class TestOzoneFileSystem {
   }
 
   public void testGetTrashRoot() {
+    UserGroupInformation ugi;
+    try {
+      ugi = UserGroupInformation.getCurrentUser();
+    } catch (IOException ex) {
+      throw new RuntimeException("Can't get current UGI.", ex);
+    }
+    String username = ugi.getShortUserName();
     Path expectedTrashRoot = new Path(OZONE_URI_DELIMITER, TRASH_PREFIX);
-    // Input path doesn't matter, only thing o3fs.getTrashRoot cares about is
-    //  env user.name
+    // Input path doesn't matter, o3fs.getTrashRoot() only cares about username
     Path inPath1 = new Path("o3fs://bucket2.volume1/path/to/key");
     // Test with current user
     Path outPath1 = o3fs.getTrashRoot(inPath1);
     Path expectedOutPath1 = new Path(
-        expectedTrashRoot, System.getProperty("user.name"));
+        expectedTrashRoot, username);
     Assert.assertEquals(expectedOutPath1, outPath1);
-    // Test with testuser1
-    System.setProperty("user.name", "testuser1");
-    Path outPath2 = o3fs.getTrashRoot(inPath1);
-    Path expectedOutPath2 = new Path(
-        expectedTrashRoot, System.getProperty("user.name"));
-    Assert.assertEquals(expectedOutPath2, outPath2);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -45,7 +45,9 @@ import org.apache.hadoop.test.GenericTestUtils;
 
 import org.apache.commons.io.IOUtils;
 
+import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -163,6 +165,7 @@ public class TestOzoneFileSystem {
     testOzoneFsServiceLoader();
     o3fs = (OzoneFileSystem) fs;
 
+    testGetTrashRoot();
     testGetDirectoryModificationTime();
 
     testListStatusOnRoot();
@@ -560,5 +563,23 @@ public class TestOzoneFileSystem {
       fileStatuses = o3fs.listStatus(mdir1);
       assertTrue(modificationTime <= fileStatuses[0].getModificationTime());
     }
+  }
+
+  public void testGetTrashRoot() {
+    Path expectedTrashRoot = new Path(OZONE_URI_DELIMITER, TRASH_PREFIX);
+    // Input path doesn't matter, only thing o3fs.getTrashRoot cares about is
+    //  env user.name
+    Path inPath1 = new Path("o3fs://bucket2.volume1/path/to/key");
+    // Test with current user
+    Path outPath1 = o3fs.getTrashRoot(inPath1);
+    Path expectedOutPath1 = new Path(
+        expectedTrashRoot, System.getProperty("user.name"));
+    Assert.assertEquals(expectedOutPath1, outPath1);
+    // Test with testuser1
+    System.setProperty("user.name", "testuser1");
+    Path outPath2 = o3fs.getTrashRoot(inPath1);
+    Path expectedOutPath2 = new Path(
+        expectedTrashRoot, System.getProperty("user.name"));
+    Assert.assertEquals(expectedOutPath2, outPath2);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -613,5 +613,8 @@ public class TestOzoneFileSystem {
     // allUsers = true should return all user trash
     res = o3fs.getTrashRoots(true);
     Assert.assertEquals(6, res.size());
+
+    // Clean up
+    o3fs.delete(trashRoot, true);
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -616,7 +616,8 @@ public class BasicOzoneFileSystem extends FileSystem {
   @Override
   public Path getTrashRoot(Path path) {
     final Path pathToTrash = new Path(OZONE_URI_DELIMITER, TRASH_PREFIX);
-    return new Path(pathToTrash, System.getProperty("user.name"));
+    return new Path(pathToTrash, getUsername());
+  }
   }
 
   /**

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -634,7 +634,7 @@ public class BasicOzoneFileSystem extends FileSystem {
     try {
       if (!allUsers) {
         Path userTrash = new Path(trashRoot, userName);
-        if (exists(userTrash)) {
+        if (exists(userTrash) && getFileStatus(userTrash).isDirectory()) {
           ret.add(getFileStatus(userTrash));
         }
       } else {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -607,6 +607,19 @@ public class BasicOzoneFileSystem extends FileSystem {
   }
 
   /**
+   * Get the root directory of Trash for a path.
+   * Returns /.Trash/<username>
+   * Caller appends either Current or checkpoint timestamp for trash destination
+   * @param path the trash root of the path to be determined.
+   * @return trash root
+   */
+  @Override
+  public Path getTrashRoot(Path path) {
+    final Path pathToTrash = new Path(OZONE_URI_DELIMITER, TRASH_PREFIX);
+    return new Path(pathToTrash, System.getProperty("user.name"));
+  }
+
+  /**
    * Creates a directory. Directory is represented using a key with no value.
    *
    * @param path directory path to be created

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -51,6 +51,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -618,6 +619,38 @@ public class BasicOzoneFileSystem extends FileSystem {
     final Path pathToTrash = new Path(OZONE_URI_DELIMITER, TRASH_PREFIX);
     return new Path(pathToTrash, getUsername());
   }
+
+  /**
+   * Get all the trash roots for current user or all users.
+   *
+   * @param allUsers return trash roots for all users if true.
+   * @return all the trash root directories.
+   *         Returns .Trash of users if {@code /.Trash/$USER} exists.
+   */
+  @Override
+  public Collection<FileStatus> getTrashRoots(boolean allUsers) {
+    Path trashRoot = new Path(OZONE_URI_DELIMITER, TRASH_PREFIX);
+    List<FileStatus> ret = new ArrayList<>();
+    try {
+      if (!allUsers) {
+        Path userTrash = new Path(trashRoot, userName);
+        if (exists(userTrash)) {
+          ret.add(getFileStatus(userTrash));
+        }
+      } else {
+        if (exists(trashRoot)) {
+          FileStatus[] candidates = listStatus(trashRoot);
+          for (FileStatus candidate : candidates) {
+            if (candidate.isDirectory()) {
+              ret.add(candidate);
+            }
+          }
+        }
+      }
+    } catch (IOException ex) {
+      LOG.warn("Can't get all trash roots", ex);
+    }
+    return ret;
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Override the default Hadoop FS impl.

Currently o3fs moves trash under:
```
o3fs://bucketName.volumeName.om/user/userName/.Trash/Current/...
```

New trash location will be:
```
o3fs://bucketName.volumeName.om/.Trash/userName/Current/...
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3868

## How was this patch tested?

Added a simple test `testGetTrashRoot`.