### PR TITLE
HDDS-3883. Update doc and remove useless conf of o3fs.

### DIFF
--- a/hadoop-hdds/docs/content/interface/OzoneFS.md
+++ b/hadoop-hdds/docs/content/interface/OzoneFS.md
@@ -42,10 +42,6 @@ Please add the following entry to the core-site.xml.
 
 {{< highlight xml >}}
 <property>
-  <name>fs.AbstractFileSystem.o3fs.impl</name>
-  <value>org.apache.hadoop.fs.ozone.OzFs</value>
-</property>
-<property>
   <name>fs.defaultFS</name>
   <value>o3fs://bucket.volume</value>
 </property>

--- a/hadoop-hdds/docs/content/interface/OzoneFS.zh.md
+++ b/hadoop-hdds/docs/content/interface/OzoneFS.zh.md
@@ -40,10 +40,6 @@ ozone sh bucket create /volume/bucket
 
 {{< highlight xml >}}
 <property>
-  <name>fs.AbstractFileSystem.o3fs.impl</name>
-  <value>org.apache.hadoop.fs.ozone.OzFs</value>
-</property>
-<property>
   <name>fs.defaultFS</name>
   <value>o3fs://bucket.volume</value>
 </property>

--- a/hadoop-hdds/docs/content/recipe/SparkOzoneFSK8S.md
+++ b/hadoop-hdds/docs/content/recipe/SparkOzoneFSK8S.md
@@ -72,10 +72,6 @@ And create a custom `core-site.xml`.
 
 ```xml
 <configuration>
-    <property>
-        <name>fs.AbstractFileSystem.o3fs.impl</name>
-        <value>org.apache.hadoop.fs.ozone.OzFs</value>
-     </property>
 </configuration>
 ```
 

--- a/hadoop-hdds/docs/content/recipe/SparkOzoneFSK8S.zh.md
+++ b/hadoop-hdds/docs/content/recipe/SparkOzoneFSK8S.zh.md
@@ -71,10 +71,6 @@ kubectl cp om-0:/opt/hadoop/etc/hadoop/ozone-site.xml .
 
 ```xml
 <configuration>
-    <property>
-        <name>fs.AbstractFileSystem.o3fs.impl</name>
-        <value>org.apache.hadoop.fs.ozone.OzFs</value>
-     </property>
 </configuration>
 ```
 kubectl cp om-0:/opt/hadoop/share/ozone/lib/hadoop-ozone-filesystem-hadoop2-VERSION.jar hadoop-ozone-filesystem-hadoop2.jar

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/docker-config
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CORE-SITE.xml_fs.AbstractFileSystem.o3fs.impl=org.apache.hadoop.fs.ozone.OzFs
 MAPRED-SITE.XML_mapreduce.application.classpath=/opt/hadoop/share/hadoop/mapreduce/*:/opt/hadoop/share/hadoop/mapreduce/lib/*:/opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-hadoop2-@project.version@.jar
 
 no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/docker-config
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CORE-SITE.xml_fs.AbstractFileSystem.o3fs.impl=org.apache.hadoop.fs.ozone.OzFs
 MAPRED-SITE.XML_mapreduce.application.classpath=/opt/hadoop/share/hadoop/mapreduce/*:/opt/hadoop/share/hadoop/mapreduce/lib/*:/opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-hadoop3-@project.version@.jar
 
 no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/docker-config
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CORE-SITE.xml_fs.AbstractFileSystem.o3fs.impl=org.apache.hadoop.fs.ozone.OzFs
 MAPRED-SITE.XML_mapreduce.application.classpath=/opt/hadoop/share/hadoop/mapreduce/*:/opt/hadoop/share/hadoop/mapreduce/lib/*:/opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-hadoop3-@project.version@.jar
 
 no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
@@ -66,7 +66,6 @@ HADOOP-POLICY.XML_org.apache.hadoop.yarn.server.api.ResourceTracker.acl=*
 HDFS-SITE.XML_rpc.metrics.quantile.enable=true
 HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300
 
-CORE-SITE.XML_fs.AbstractFileSystem.o3fs.impl=org.apache.hadoop.fs.ozone.OzFs
 CORE-SITE.XML_fs.defaultFS=o3fs://bucket1.volume1/
 
 MAPRED-SITE.XML_mapreduce.framework.name=yarn


### PR DESCRIPTION
## What changes were proposed in this pull request?

The latest usage of O3FS has been updated in HDDS-3704. Based on HDDS-3704, I verified that there were other useless configurations not removed. So delete them here.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3883

## How was this patch tested?
 
update doc no need test.
