### PR TITLE
HDDS-3887. Remove redundant code for HealthyPipelineSafeModeRule

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
@@ -106,10 +106,7 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
 
   @Override
   protected boolean validate() {
-    if (currentHealthyPipelineCount >= healthyPipelineThresholdCount) {
-      return true;
-    }
-    return false;
+    return currentHealthyPipelineCount >= healthyPipelineThresholdCount;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
HealthyPipelineSafeModeRule#validate
```
protected boolean validate() {
  if (currentHealthyPipelineCount >= healthyPipelineThresholdCount) {
    return true;
  }
  return false;
}
```
this method is fat，I think direct return is ok. like this
```
return currentHealthyPipelineCount >= healthyPipelineThresholdCount;
```
## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-3887

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

No testing required
