### PR TITLE
HDDS-2978. Intermittent failure in TestResourceLimitCache

### DIFF
--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceLimitCache.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceLimitCache.java
@@ -20,7 +20,11 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
  * Test for ResourceLimitCache.
@@ -71,7 +75,7 @@ public class TestResourceLimitCache {
       } catch (InterruptedException e) {
         return null;
       }
-    });
+    },pool);
     Assert.assertTrue(!future.isDone());
     Thread.sleep(100);
     Assert.assertTrue(!future.isDone());

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceLimitCache.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceLimitCache.java
@@ -75,7 +75,7 @@ public class TestResourceLimitCache {
       } catch (InterruptedException e) {
         return null;
       }
-    },pool);
+    }, pool);
     Assert.assertTrue(!future.isDone());
     Thread.sleep(100);
     Assert.assertTrue(!future.isDone());

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceLimitCache.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceLimitCache.java
@@ -20,9 +20,7 @@ import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 
 /**
  * Test for ResourceLimitCache.
@@ -60,25 +58,27 @@ public class TestResourceLimitCache {
     resourceCache.remove(4);
 
     GenericTestUtils.waitFor(future::isDone, 100, 1000);
-    // map has the ket 1
+    // map has the key 1
     Assert.assertTrue(future.isDone() && !future.isCompletedExceptionally());
     Assert.assertNotNull(resourceCache.get(1));
 
     // Create a future which blocks to put 4. Currently map has acquired 7
     // permits out of 10
+    ExecutorService pool = Executors.newCachedThreadPool();
     future = CompletableFuture.supplyAsync(() -> {
       try {
         return resourceCache.put(4, "a");
       } catch (InterruptedException e) {
-        e.printStackTrace();
+        return null;
       }
-      return null;
     });
     Assert.assertTrue(!future.isDone());
     Thread.sleep(100);
     Assert.assertTrue(!future.isDone());
 
-    // Cancel the future for putting key 4
+    // Shutdown the thread pool for putting key 4
+    pool.shutdownNow();
+    // Mark the future as cancelled
     future.cancel(true);
     // remove key 1 so currently map has acquired 6 permits out of 10
     resourceCache.remove(1);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Calling `CompletableFuture.cancel()` will mark the future as cancelled,but does not interrupt the running task.

The Javadoc for the method [CompletableFuture#cancel()](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html#cancel-boolean-) states:
```
Parameters:
mayInterruptIfRunning - this value has no effect in this implementation because interrupts are not used to control processing.
```

In this PR, I'm trying to make asynchronous tasks run in a specified thread pool by given the `executor` when using the `supplyAsync(...)` method.

Finally, use `Executor.shutdownNow()` to interrupt the operation of putting key (_put<4,a>_).
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2978

## How was this patch tested?

Manual unit test 17000+ times -> Tests passed.

![image](https://user-images.githubusercontent.com/14295594/85982728-e4dea780-ba18-11ea-8782-e81a07d901bc.png)

