### PR TITLE
HDDS-3831. Enhance Recon ContainerEndPoint to report on different unhealty container states

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconTasks.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconTasks.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.recon.scm.ReconContainerManager;
 import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
 import org.apache.hadoop.test.LambdaTestUtils;
+import org.hadoop.ozone.recon.schema.ContainerSchemaDefinition;
 import org.hadoop.ozone.recon.schema.tables.pojos.UnhealthyContainers;
 import org.junit.After;
 import org.junit.Before;
@@ -116,7 +117,9 @@ public class TestReconTasks {
     LambdaTestUtils.await(120000, 10000, () -> {
       List<UnhealthyContainers> allMissingContainers =
           reconContainerManager.getContainerSchemaManager()
-              .getAllMissingContainers();
+              .getUnhealthyContainers(
+                  ContainerSchemaDefinition.UnHealthyContainerStates.MISSING,
+                  0, 1000);
       return (allMissingContainers.size() == 1);
     });
 
@@ -125,7 +128,9 @@ public class TestReconTasks {
     LambdaTestUtils.await(120000, 10000, () -> {
       List<UnhealthyContainers> allMissingContainers =
           reconContainerManager.getContainerSchemaManager()
-              .getAllMissingContainers();
+              .getUnhealthyContainers(
+                  ContainerSchemaDefinition.UnHealthyContainerStates.MISSING,
+                  0, 1000);
       return (allMissingContainers.isEmpty());
     });
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
@@ -45,6 +45,8 @@ public final class ReconConstants {
 
   // By default, limit the number of results returned
   public static final String DEFAULT_FETCH_COUNT = "1000";
+  public static final String DEFAULT_BATCH_NUMBER = "1";
+  public static final String RECON_QUERY_BATCH_PARAM = "batchNum";
   public static final String RECON_QUERY_PREVKEY = "prevKey";
   public static final String PREV_CONTAINER_ID_DEFAULT_VALUE = "0";
   public static final String RECON_QUERY_LIMIT = "limit";

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -52,14 +52,21 @@ import org.apache.hadoop.ozone.recon.api.types.KeyMetadata.ContainerBlockMetadat
 import org.apache.hadoop.ozone.recon.api.types.KeysResponse;
 import org.apache.hadoop.ozone.recon.api.types.MissingContainerMetadata;
 import org.apache.hadoop.ozone.recon.api.types.MissingContainersResponse;
+import org.apache.hadoop.ozone.recon.api.types.UnhealthyContainerMetadata;
+import org.apache.hadoop.ozone.recon.api.types.UnhealthyContainersResponse;
+import org.apache.hadoop.ozone.recon.api.types.UnhealthyContainersSummary;
 import org.apache.hadoop.ozone.recon.persistence.ContainerSchemaManager;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.scm.ReconContainerManager;
 import org.apache.hadoop.ozone.recon.spi.ContainerDBServiceProvider;
+import org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates;
 import org.hadoop.ozone.recon.schema.tables.pojos.ContainerHistory;
+import org.hadoop.ozone.recon.schema.tables.pojos.UnhealthyContainers;
 
+import static org.apache.hadoop.ozone.recon.ReconConstants.DEFAULT_BATCH_NUMBER;
 import static org.apache.hadoop.ozone.recon.ReconConstants.DEFAULT_FETCH_COUNT;
 import static org.apache.hadoop.ozone.recon.ReconConstants.PREV_CONTAINER_ID_DEFAULT_VALUE;
+import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_QUERY_BATCH_PARAM;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_QUERY_LIMIT;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_QUERY_PREVKEY;
 
@@ -233,28 +240,117 @@ public class ContainerEndpoint {
   @Path("/missing")
   public Response getMissingContainers() {
     List<MissingContainerMetadata> missingContainers = new ArrayList<>();
-    containerDBServiceProvider.getMissingContainers().forEach(container -> {
-      long containerID = container.getContainerId();
-      try {
-        ContainerInfo containerInfo =
-            containerManager.getContainer(new ContainerID(containerID));
-        long keyCount = containerInfo.getNumberOfKeys();
-        UUID pipelineID = containerInfo.getPipelineID().getId();
+    containerSchemaManager.getUnhealthyContainers(
+        UnHealthyContainerStates.MISSING, 0, Integer.MAX_VALUE)
+        .forEach(container -> {
+          long containerID = container.getContainerId();
+          try {
+            ContainerInfo containerInfo =
+                containerManager.getContainer(new ContainerID(containerID));
+            long keyCount = containerInfo.getNumberOfKeys();
+            UUID pipelineID = containerInfo.getPipelineID().getId();
 
-        List<ContainerHistory> datanodes =
-            containerSchemaManager.getLatestContainerHistory(
-                containerID, containerInfo.getReplicationFactor().getNumber());
-        missingContainers.add(new MissingContainerMetadata(containerID,
-            container.getInStateSince(), keyCount, pipelineID, datanodes));
-      } catch (IOException ioEx) {
-        throw new WebApplicationException(ioEx,
-            Response.Status.INTERNAL_SERVER_ERROR);
-      }
-    });
+            List<ContainerHistory> datanodes =
+                containerSchemaManager.getLatestContainerHistory(containerID,
+                    containerInfo.getReplicationFactor().getNumber());
+            missingContainers.add(new MissingContainerMetadata(containerID,
+                container.getInStateSince(), keyCount, pipelineID, datanodes));
+          } catch (IOException ioEx) {
+            throw new WebApplicationException(ioEx,
+                Response.Status.INTERNAL_SERVER_ERROR);
+          }
+        });
     MissingContainersResponse response =
         new MissingContainersResponse(missingContainers.size(),
             missingContainers);
     return Response.ok(response).build();
+  }
+
+  /**
+   * Return
+   * {@link org.apache.hadoop.ozone.recon.api.types.UnhealthyContainerMetadata}
+   * for all unhealthy containers.
+   *
+   * @param state Return only containers matching the given unhealthy state,
+   *              eg UNDER_REPLICATED, MIS_REPLICATED, OVER_REPLICATED or
+   *              MISSING. Passing null returns all containers.
+   * @param limit The limit of unhealthy containers to return.
+   * @param batchNum The batch number (like "page number") of results to return.
+   *                 Passing 1, will return records 1 to limit. 2 will return
+   *                 limit + 1 to 2 * limit, etc.
+   * @return {@link Response}
+   */
+  @GET
+  @Path("/unhealthy/{state}")
+  public Response getUnhealthyContainers(
+      @PathParam("state") String state,
+      @DefaultValue(DEFAULT_FETCH_COUNT) @QueryParam(RECON_QUERY_LIMIT)
+          int limit,
+      @DefaultValue(DEFAULT_BATCH_NUMBER)
+      @QueryParam(RECON_QUERY_BATCH_PARAM) int batchNum) {
+    int offset = Math.max(((batchNum - 1) * limit), 0);
+
+    List<UnhealthyContainerMetadata> unhealthyMeta = new ArrayList<>();
+    List<UnhealthyContainersSummary> summary;
+    try {
+      UnHealthyContainerStates internalState = null;
+
+      if (state != null) {
+        // If an invalid state is passed in, this will throw
+        // illegalArgumentException and fail the request
+        internalState = UnHealthyContainerStates.valueOf(state);
+      }
+
+      summary = containerSchemaManager.getUnhealthyContainersSummary();
+      List<UnhealthyContainers> containers = containerSchemaManager
+          .getUnhealthyContainers(internalState, offset, limit);
+      for (UnhealthyContainers c : containers) {
+        long containerID = c.getContainerId();
+        ContainerInfo containerInfo =
+            containerManager.getContainer(new ContainerID(containerID));
+        long keyCount = containerInfo.getNumberOfKeys();
+        UUID pipelineID = containerInfo.getPipelineID().getId();
+        List<ContainerHistory> datanodes =
+            containerSchemaManager.getLatestContainerHistory(
+                containerID,
+                containerInfo.getReplicationFactor().getNumber());
+        unhealthyMeta.add(new UnhealthyContainerMetadata(
+            c, datanodes, pipelineID, keyCount));
+      }
+    } catch (IOException ex) {
+      throw new WebApplicationException(ex,
+          Response.Status.INTERNAL_SERVER_ERROR);
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(e, Response.Status.BAD_REQUEST);
+    }
+
+    UnhealthyContainersResponse response =
+        new UnhealthyContainersResponse(unhealthyMeta);
+    for (UnhealthyContainersSummary s : summary) {
+      response.setSummaryCount(s.getContainerState(), s.getCount());
+    }
+    return Response.ok(response).build();
+  }
+
+  /**
+   * Return
+   * {@link org.apache.hadoop.ozone.recon.api.types.UnhealthyContainerMetadata}
+   * for all unhealthy containers.
+
+   * @param limit The limit of unhealthy containers to return.
+   * @param batchNum The batch number (like "page number") of results to return.
+   *                 Passing 1, will return records 1 to limit. 2 will return
+   *                 limit + 1 to 2 * limit, etc.
+   * @return {@link Response}
+   */
+  @GET
+  @Path("/unhealthy")
+  public Response getUnhealthyContainers(
+      @DefaultValue(DEFAULT_FETCH_COUNT) @QueryParam(RECON_QUERY_LIMIT)
+          int limit,
+      @DefaultValue(DEFAULT_BATCH_NUMBER)
+      @QueryParam(RECON_QUERY_BATCH_PARAM) int batchNum) {
+    return getUnhealthyContainers(null, limit, batchNum);
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainerMetadata.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainerMetadata.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.recon.api.types;
+
+import org.hadoop.ozone.recon.schema.tables.pojos.ContainerHistory;
+import org.hadoop.ozone.recon.schema.tables.pojos.UnhealthyContainers;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Metadata object that represents an unhealthy Container.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+public class UnhealthyContainerMetadata {
+
+  @XmlElement(name = "containerID")
+  private long containerID;
+
+  @XmlElement(name = "containerState")
+  private String containerState;
+
+  @XmlElement(name = "unhealthySince")
+  private long unhealthySince;
+
+  @XmlElement(name = "expectedReplicaCount")
+  private long expectedReplicaCount = 0;
+
+  @XmlElement(name = "actualReplicaCount")
+  private long actualReplicaCount = 0;
+
+  @XmlElement(name = "replicaDeltaCount")
+  private long replicaDeltaCount = 0;
+
+  @XmlElement(name = "reason")
+  private String reason;
+
+  @XmlElement(name = "keys")
+  private long keys;
+
+  @XmlElement(name = "pipelineID")
+  private UUID pipelineID;
+
+  @XmlElement(name = "replicas")
+  private List<ContainerHistory> replicas;
+
+  public UnhealthyContainerMetadata(UnhealthyContainers rec,
+      List<ContainerHistory> replicas, UUID pipelineID, long keyCount) {
+    this.containerID = rec.getContainerId();
+    this.containerState = rec.getContainerState();
+    this.unhealthySince = rec.getInStateSince();
+    this.actualReplicaCount = rec.getActualReplicaCount();
+    this.expectedReplicaCount = rec.getExpectedReplicaCount();
+    this.replicaDeltaCount = rec.getReplicaDelta();
+    this.reason = rec.getReason();
+    this.replicas = replicas;
+    this.pipelineID = pipelineID;
+    this.keys = keyCount;
+  }
+
+  public long getContainerID() {
+    return containerID;
+  }
+
+  public long getKeys() {
+    return keys;
+  }
+
+  public List<ContainerHistory> getReplicas() {
+    return replicas;
+  }
+
+  public String getContainerState() {
+    return containerState;
+  }
+
+  public long getExpectedReplicaCount() {
+    return expectedReplicaCount;
+  }
+
+  public long getActualReplicaCount() {
+    return actualReplicaCount;
+  }
+
+  public long getReplicaDeltaCount() {
+    return replicaDeltaCount;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public long getUnhealthySince() {
+    return unhealthySince;
+  }
+
+  public UUID getPipelineID() {
+    return pipelineID;
+  }
+
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainersResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainersResponse.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.recon.api.types;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates;
+
+import java.util.Collection;
+
+/**
+ * Class that represents the API Response structure of Unhealthy Containers.
+ */
+public class UnhealthyContainersResponse {
+  /**
+   * Total count of the missing containers.
+   */
+  @JsonProperty("missingCount")
+  private long missingCount = 0;
+
+  /**
+   * Total count of under replicated containers.
+   */
+  @JsonProperty("underReplicatedCount")
+  private long underReplicatedCount = 0;
+
+  /**
+   * Total count of over replicated containers.
+   */
+  @JsonProperty("overReplicatedCount")
+  private long overReplicatedCount = 0;
+
+  /**
+   * Total count of mis-replicated containers.
+   */
+  @JsonProperty("misReplicatedCount")
+  private long misReplicatedCount = 0;
+
+  /**
+   * A collection of unhealthy containers.
+   */
+  @JsonProperty("containers")
+  private Collection<UnhealthyContainerMetadata> containers;
+
+  public UnhealthyContainersResponse(Collection<UnhealthyContainerMetadata>
+                                       containers) {
+    this.containers = containers;
+  }
+
+  public void setSummaryCount(String state, long count) {
+    if (state.equals(UnHealthyContainerStates.MISSING.toString())) {
+      this.missingCount = count;
+    } else if (state.equals(
+        UnHealthyContainerStates.OVER_REPLICATED.toString())) {
+      this.overReplicatedCount = count;
+    } else if (state.equals(
+        UnHealthyContainerStates.UNDER_REPLICATED.toString())) {
+      this.underReplicatedCount = count;
+    } else if (state.equals(
+        UnHealthyContainerStates.MIS_REPLICATED.toString())) {
+      this.misReplicatedCount = count;
+    }
+  }
+
+  public long getMissingCount() {
+    return missingCount;
+  }
+
+  public long getUnderReplicatedCount() {
+    return underReplicatedCount;
+  }
+
+  public long getOverReplicatedCount() {
+    return overReplicatedCount;
+  }
+
+  public long getMisReplicatedCount() {
+    return misReplicatedCount;
+  }
+
+  public Collection<UnhealthyContainerMetadata> getContainers() {
+    return containers;
+  }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainersSummary.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/UnhealthyContainersSummary.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.recon.api.types;
+
+/**
+ * Simple POJO to receive the results of a Jooq query.
+ */
+public class UnhealthyContainersSummary {
+
+  private Integer count;
+  private String containerState;
+
+  public UnhealthyContainersSummary(String containerState, Integer cnt) {
+    this.containerState = containerState;
+    this.count = cnt;
+  }
+
+  public String getContainerState() {
+    return containerState;
+  }
+
+  public long getCount() {
+    return count.longValue();
+  }
+
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/persistence/ContainerSchemaManager.java
@@ -19,9 +19,11 @@ package org.apache.hadoop.ozone.recon.persistence;
 
 import static org.hadoop.ozone.recon.schema.tables.ContainerHistoryTable.CONTAINER_HISTORY;
 import static org.hadoop.ozone.recon.schema.tables.UnhealthyContainersTable.UNHEALTHY_CONTAINERS;
+import static org.jooq.impl.DSL.count;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import org.apache.hadoop.ozone.recon.api.types.UnhealthyContainersSummary;
 import org.hadoop.ozone.recon.schema.ContainerSchemaDefinition;
 import org.hadoop.ozone.recon.schema.ContainerSchemaDefinition.UnHealthyContainerStates;
 import org.hadoop.ozone.recon.schema.tables.daos.ContainerHistoryDao;
@@ -31,7 +33,9 @@ import org.hadoop.ozone.recon.schema.tables.pojos.UnhealthyContainers;
 import org.hadoop.ozone.recon.schema.tables.records.UnhealthyContainersRecord;
 import org.jooq.Cursor;
 import org.jooq.DSLContext;
+import org.jooq.Record;
 import org.jooq.Record2;
+import org.jooq.SelectQuery;
 import java.util.List;
 
 /**
@@ -52,9 +56,49 @@ public class ContainerSchemaManager {
     this.containerSchemaDefinition = containerSchemaDefinition;
   }
 
-  public List<UnhealthyContainers> getAllMissingContainers() {
-    return unhealthyContainersDao
-        .fetchByContainerState(UnHealthyContainerStates.MISSING.toString());
+  /**
+   * Get a batch of unhealthy containers, starting at offset and returning
+   * limit records. If a null value is passed for state, then unhealthy
+   * containers in all states will be returned. Otherwise, only containers
+   * matching the given state will be returned.
+   * @param state Return only containers in this state, or all containers if
+   *              null
+   * @param offset The starting record to return in the result set. The first
+   *               record is at zero.
+   * @param limit The total records to return
+   * @return List of unhealthy containers.
+   */
+  public List<UnhealthyContainers> getUnhealthyContainers(
+      UnHealthyContainerStates state, int offset, int limit) {
+    DSLContext dslContext = containerSchemaDefinition.getDSLContext();
+    SelectQuery<Record> query = dslContext.selectQuery();
+    query.addFrom(UNHEALTHY_CONTAINERS);
+    if (state != null) {
+      query.addConditions(
+          UNHEALTHY_CONTAINERS.CONTAINER_STATE.eq(state.toString()));
+    }
+    query.addOrderBy(UNHEALTHY_CONTAINERS.CONTAINER_ID.asc(),
+        UNHEALTHY_CONTAINERS.CONTAINER_STATE.asc());
+    query.addOffset(offset);
+    query.addLimit(limit);
+
+    return query.fetchInto(UnhealthyContainers.class);
+  }
+
+  /**
+   * Obtain a count of all containers in each state. If there are no unhealthy
+   * containers an empty list will be returned. If there are unhealthy
+   * containers for a certain state, no entry will be returned for it.
+   * @return Count of unhealthy containers in each state
+   */
+  public List<UnhealthyContainersSummary> getUnhealthyContainersSummary() {
+    DSLContext dslContext = containerSchemaDefinition.getDSLContext();
+    return dslContext
+        .select(UNHEALTHY_CONTAINERS.CONTAINER_STATE.as("containerState"),
+            count().as("cnt"))
+        .from(UNHEALTHY_CONTAINERS)
+        .groupBy(UNHEALTHY_CONTAINERS.CONTAINER_STATE)
+        .fetchInto(UnhealthyContainersSummary.class);
   }
 
   public Cursor<UnhealthyContainersRecord> getAllUnhealthyRecordsCursor() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ContainerDBServiceProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ContainerDBServiceProvider.java
@@ -19,14 +19,12 @@
 package org.apache.hadoop.ozone.recon.spi;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.ozone.recon.api.types.ContainerKeyPrefix;
 import org.apache.hadoop.ozone.recon.api.types.ContainerMetadata;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
-import org.hadoop.ozone.recon.schema.tables.pojos.UnhealthyContainers;
 
 /**
  * The Recon Container DB Service interface.
@@ -164,10 +162,4 @@ public interface ContainerDBServiceProvider {
    */
   void incrementContainerCountBy(long count);
 
-  /**
-   * Get all the missing containers.
-   *
-   * @return List of MissingContainers.
-   */
-  List<UnhealthyContainers> getMissingContainers();
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ContainerDBServiceProviderImpl.java
@@ -30,7 +30,6 @@ import java.io.File;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -50,7 +49,6 @@ import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
 import org.hadoop.ozone.recon.schema.tables.pojos.GlobalStats;
-import org.hadoop.ozone.recon.schema.tables.pojos.UnhealthyContainers;
 import org.jooq.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -356,10 +354,6 @@ public class ContainerDBServiceProviderImpl
       containers.put(containerID, containerMetadata);
     }
     return containers;
-  }
-
-  public List<UnhealthyContainers> getMissingContainers() {
-    return containerSchemaManager.getAllMissingContainers();
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change provides two new endpoints on the Recon "containers" endpoint:

/containers/unhealthy
/containers/unhealthy/{state}

The intention is for these endpoints to replace /containers/missing, but that end point is still in place as we need to change the front end of recon to use this new endpoint first.

Calling either of the above new endpoints will return a summary of all unhealthy containers in the response, eg:

```
  @JsonProperty("missingCount")
  private long missingCount = 0;

  @JsonProperty("underReplicatedCount")
  private long underReplicatedCount = 0;

  @JsonProperty("overReplicatedCount")
  private long overReplicatedCount = 0;

  @JsonProperty("misReplicatedCount")
  private long misReplicatedCount = 0;
```

Followed by either:

 * A list of all unhealthy containers, sorted by `container_id asc , state asc` for the /containers/unhealthy endpoint
 * A list of unhealthy containers in the passed state, sorted by `container_id asc , state asc` for the /containers/unhealthy/{state} endpoint

Note that even when /containers/unhealthy/{state} is passed, the full summary of all containers is returned - it would be possible to only give a summary of the passed state, but I think it makes sense to give the full summary on all calls and just filter the list based on the passed parameter.

For both endpoints, there is a parameter "limit" to control how many containers to return (default 1000) and "batchNum" starting a 1 to get each batch / page of results.

The reason it does not use the previous container_id to start the next batch, is because there may be more than 1 database entry per container, and therefore we would need to pass preContainerId and preState. However it would be possible to change to use this if it is desired.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3831

## How was this patch tested?

New unit tests
