### PR TITLE
HDDS-3908. Duplicate dot in Prometheus endpoint config name

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/HddsPrometheusConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/HddsPrometheusConfig.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.hdds.conf;
 /**
  * The configuration class for the Prometheus endpoint.
  */
-@ConfigGroup(prefix = "hdds.prometheus.")
+@ConfigGroup(prefix = "hdds.prometheus")
 public class HddsPrometheusConfig {
 
   @Config(key = "endpoint.token",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove trailing dot from config prefix for `hdds.prometheus`.  I think this should be done before 0.6.0 release.

https://issues.apache.org/jira/browse/HDDS-3908

## How was this patch tested?

```
$ mvn -DskipTests clean package
$ grep hdds.prometheus hadoop-hdds/common/target/classes/ozone-default-generated.xml
    <name>hdds.prometheus.endpoint.token</name>
```