### PR TITLE
HDDS-3879. Introduce SCM and OM layoutVersion zero to the VERSION file

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Storage.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Storage.java
@@ -48,6 +48,7 @@ public abstract class Storage {
   public static final String STORAGE_DIR_CURRENT = "current";
   protected static final String STORAGE_FILE_VERSION = "VERSION";
   public static final String CONTAINER_DIR = "containerDir";
+  private static final int LAYOUT_VERSION = 0;
 
   private final NodeType nodeType;
   private final File root;
@@ -74,7 +75,7 @@ public abstract class Storage {
       this.storageInfo = new StorageInfo(type, getVersionFile());
     } else {
       this.storageInfo = new StorageInfo(
-          nodeType, StorageInfo.newClusterID(), Time.now());
+          nodeType, StorageInfo.newClusterID(), Time.now(), LAYOUT_VERSION);
       setNodeProperties();
     }
   }
@@ -114,6 +115,10 @@ public abstract class Storage {
     } else {
       storageInfo.setClusterId(clusterId);
     }
+  }
+
+  public int getLayoutVersion() {
+    return storageInfo.getLayoutVersion();
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/StorageInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/StorageInfo.java
@@ -52,6 +52,10 @@ public class StorageInfo {
    * Property to hold creation time of the storage.
    */
   private static final String CREATION_TIME = "cTime";
+  /**
+   * Property to hold the layout version.
+   */
+  private static final String LAYOUT_VERSION = "layoutVersion";
 
   /**
    * Constructs StorageInfo instance.
@@ -64,13 +68,14 @@ public class StorageInfo {
 
    * @throws IOException - on Error.
    */
-  public StorageInfo(NodeType type, String cid, long cT)
+  public StorageInfo(NodeType type, String cid, long cT, int layout)
       throws IOException {
     Preconditions.checkNotNull(type);
     Preconditions.checkNotNull(cid);
     properties.setProperty(NODE_TYPE, type.name());
     properties.setProperty(CLUSTER_ID, cid);
     properties.setProperty(CREATION_TIME, String.valueOf(cT));
+    properties.setProperty(LAYOUT_VERSION, Integer.toString(layout));
   }
 
   public StorageInfo(NodeType type, File propertiesFile)
@@ -79,6 +84,7 @@ public class StorageInfo {
     verifyNodeType(type);
     verifyClusterId();
     verifyCreationTime();
+    verifyLayoutVersion();
   }
 
   public NodeType getNodeType() {
@@ -95,6 +101,22 @@ public class StorageInfo {
       return Long.parseLong(creationTime);
     }
     return null;
+  }
+
+  public int getLayoutVersion() {
+    String layout = properties.getProperty(LAYOUT_VERSION);
+    if(layout != null) {
+      return Integer.parseInt(layout);
+    }
+    return 0;
+  }
+
+  private void verifyLayoutVersion() {
+    String layout = getProperty(LAYOUT_VERSION);
+    if (layout == null) {
+      // For now, default it to "0"
+      setProperty(LAYOUT_VERSION, "0");
+    }
   }
 
   public String getProperty(String key) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -642,8 +642,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
         }
         scmStorageConfig.initialize();
         LOG.info("SCM initialization succeeded. Current cluster id for sd={}"
-                + ";cid={}", scmStorageConfig.getStorageDir(),
-                scmStorageConfig.getClusterID());
+            + ";cid={};layoutVersion={}", scmStorageConfig.getStorageDir(),
+            scmStorageConfig.getClusterID(),
+            scmStorageConfig.getLayoutVersion());
         return true;
       } catch (IOException ioe) {
         LOG.error("Could not initialize SCM version file", ioe);
@@ -651,8 +652,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       }
     } else {
       LOG.info("SCM already initialized. Reusing existing cluster id for sd={}"
-              + ";cid={}", scmStorageConfig.getStorageDir(),
-              scmStorageConfig.getClusterID());
+          + ";cid={};layoutVersion={}", scmStorageConfig.getStorageDir(),
+          scmStorageConfig.getClusterID(),
+          scmStorageConfig.getLayoutVersion());
       return true;
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -916,7 +916,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         System.out.println(
             "OM initialization succeeded.Current cluster id for sd="
                 + omStorage.getStorageDir() + ";cid=" + omStorage
-                .getClusterID());
+                .getClusterID() + ";layoutVersion=" + omStorage
+                .getLayoutVersion());
 
         return true;
       } catch (IOException ioe) {
@@ -933,7 +934,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       System.out.println(
           "OM already initialized.Reusing existing cluster id for sd="
               + omStorage.getStorageDir() + ";cid=" + omStorage
-              .getClusterID());
+              .getClusterID() + ";layoutVersion=" + omStorage
+              .getLayoutVersion());
       return true;
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When SCM or OM is initialized, ensure a property like the following is written to the version file:

layoutVersion=0

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3879

## How was this patch tested?

Manually inspected the version file after the change.
