### PR TITLE
HDDS-3909. Use ContainerScrubberConfiguration in ChunkManagerFactory

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -227,10 +227,6 @@ public final class HddsConfigKeys {
       "hdds.container.chunk.persistdata";
   public static final boolean HDDS_CONTAINER_PERSISTDATA_DEFAULT = true;
 
-  public static final String HDDS_CONTAINER_SCRUB_ENABLED =
-      "hdds.container.scrub.enabled";
-  public static final boolean HDDS_CONTAINER_SCRUB_ENABLED_DEFAULT = false;
-
   public static final String HDDS_DATANODE_HTTP_ENABLED_KEY =
       "hdds.datanode.http.enabled";
   public static final String HDDS_DATANODE_HTTP_BIND_HOST_KEY =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1344,16 +1344,6 @@
   </property>
 
   <property>
-    <name>hdds.container.scrub.enabled</name>
-    <value>false</value>
-    <tag>DATANODE</tag>
-    <description>
-      Boolean value to enable data and metadata scrubbing in the containers
-      running on each datanode.
-    </description>
-  </property>
-
-  <property>
     <name>hdds.container.action.max.limit</name>
     <value>20</value>
     <tag>DATANODE</tag>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerFactory.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerFactory.java
@@ -22,13 +22,13 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.BlockManager;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.ChunkManager;
+import org.apache.hadoop.ozone.container.ozoneimpl.ContainerScrubberConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_PERSISTDATA;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_PERSISTDATA_DEFAULT;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_SCRUB_ENABLED;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_SCRUB_ENABLED_DEFAULT;
+import static org.apache.hadoop.ozone.container.ozoneimpl.ContainerScrubberConfiguration.HDDS_CONTAINER_SCRUB_ENABLED;
 
 /**
  * Select an appropriate ChunkManager implementation as per config setting.
@@ -57,10 +57,9 @@ public final class ChunkManagerFactory {
         HDDS_CONTAINER_PERSISTDATA_DEFAULT);
 
     if (!persist) {
-      boolean scrubber = conf.getBoolean(
-          HDDS_CONTAINER_SCRUB_ENABLED,
-          HDDS_CONTAINER_SCRUB_ENABLED_DEFAULT);
-      if (scrubber) {
+      ContainerScrubberConfiguration scrubber = conf.getObject(
+          ContainerScrubberConfiguration.class);
+      if (scrubber.isEnabled()) {
         // Data Scrubber needs to be disabled for non-persistent chunks.
         LOG.warn("Failed to set " + HDDS_CONTAINER_PERSISTDATA + " to false."
             + " Please set " + HDDS_CONTAINER_SCRUB_ENABLED

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScrubberConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScrubberConfiguration.java
@@ -28,6 +28,10 @@ import org.apache.hadoop.hdds.conf.ConfigType;
 @ConfigGroup(prefix = "hdds.container.scrub")
 public class ContainerScrubberConfiguration {
 
+  // only for log
+  public static final String HDDS_CONTAINER_SCRUB_ENABLED =
+      "hdds.container.scrub.enabled";
+
   @Config(key = "enabled",
       type = ConfigType.BOOLEAN,
       defaultValue = "false",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use existing type-safe ContainerScrubberConfiguration in ChunkManagerFactory instead of constants-based lookup.

https://issues.apache.org/jira/browse/HDDS-3909

## How was this patch tested?

Tested warning logged with various settings:

```
OZONE-SITE.XML_hdds.container.scrub.enabled=true
OZONE-SITE.XML_hdds.container.chunk.persistdata=false

->

WARN impl.ChunkManagerFactory: Failed to set hdds.container.chunk.persistdata to false. Please set hdds.container.scrub.enabled also to false to enable non-persistent containers.
```

```
OZONE-SITE.XML_hdds.container.scrub.enabled=false
OZONE-SITE.XML_hdds.container.chunk.persistdata=false

->

WARN impl.ChunkManagerFactory: hdds.container.chunk.persistdata is set to false. This should be used only for testing. All user data will be discarded.
```

```
OZONE-SITE.XML_hdds.container.scrub.enabled=true
OZONE-SITE.XML_hdds.container.chunk.persistdata=true

->

<no warning>
```