### PR TITLE
HDDS-3913. Recon build should ignore proxies

### DIFF
--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -88,6 +88,7 @@
         <artifactId>frontend-maven-plugin</artifactId>
         <version>${frontend-maven-plugin.version}</version>
         <configuration>
+          <npmInheritsProxyConfigFromMaven>false</npmInheritsProxyConfigFromMaven>
           <installDirectory>target</installDirectory>
           <workingDirectory>${basedir}/src/main/resources/webapps/recon/ozone-recon-web</workingDirectory>
         </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Recon frontend-build should ignore proxies to avoid build failures when proxies are configured for maven.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3913

## How was this patch tested?

Tested locally with proxies configured in ~/.m2/settings.xml