### PR TITLE
HDDS-3900: Update default value of 'ozone.om.ratis.segment.size' and …

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1610,19 +1610,19 @@
 
   <property>
     <name>ozone.om.ratis.segment.size</name>
-    <value>16KB</value>
+    <value>4MB</value>
     <tag>OZONE, OM, RATIS, PERFORMANCE</tag>
     <description>The size of the raft segment used by Apache Ratis on OM.
-      (16 KB by default)
+      (4 MB by default)
     </description>
   </property>
 
   <property>
     <name>ozone.om.ratis.segment.preallocated.size</name>
-    <value>16KB</value>
+    <value>4MB</value>
     <tag>OZONE, OM, RATIS, PERFORMANCE</tag>
     <description>The size of the buffer which is preallocated for raft segment
-      used by Apache Ratis on OM.(16 KB by default)
+      used by Apache Ratis on OM.(4 MB by default)
     </description>
   </property>
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -113,11 +113,11 @@ public final class OMConfigKeys {
   public static final String OZONE_OM_RATIS_SEGMENT_SIZE_KEY
       = "ozone.om.ratis.segment.size";
   public static final String OZONE_OM_RATIS_SEGMENT_SIZE_DEFAULT
-      = "16KB";
+      = "4MB";
   public static final String OZONE_OM_RATIS_SEGMENT_PREALLOCATED_SIZE_KEY
       = "ozone.om.ratis.segment.preallocated.size";
   public static final String OZONE_OM_RATIS_SEGMENT_PREALLOCATED_SIZE_DEFAULT
-      = "16KB";
+      = "4MB";
 
   // OM Ratis Log Appender configurations
   public static final String


### PR DESCRIPTION
## What changes were proposed in this pull request?
Based on the OM write performance tests on **HDDs** - write heavy workload Synthetic NNLoadGenerator in single node HA, the default 16KB ratis segment size becomes the bottleneck which affects the OM performance.

With 4MB segment size, single node OM HA write performance has improved and produced a performance gain of 2.2x times compares to non-HA on HDDs(phatcat machines).

This jira recommends to update the default value to 4MB.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3900

## How was this patch tested?
Tested done in real cluster - phatcat machines using HDDs. Used Hadoop's Synthetic NNLoadGenerator benchmark tests.
