### PR TITLE
HDDS-3824: OM read requests should make SCM#refreshPipeline outside BUCKET_LOCK

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1747,8 +1747,8 @@ public class KeyManagerImpl implements KeyManager {
     // Key is not found, throws exception
     if (LOG.isDebugEnabled()) {
       LOG.debug("Unable to get file status for the key: volume: {}, bucket:" +
-                      " {}, key: {}, with error: No such file exists.", volumeName,
-              bucketName, keyName);
+                      " {}, key: {}, with error: No such file exists.",
+              volumeName, bucketName, keyName);
     }
     throw new OMException("Unable to get file status: volume: " +
             volumeName + " bucket: " + bucketName + " key: " + keyName,
@@ -1895,7 +1895,7 @@ public class KeyManagerImpl implements KeyManager {
     String bucketName = args.getBucketName();
     String keyName = args.getKeyName();
     OzoneFileStatus fileStatus = getOzoneFileStatus(volumeName, bucketName,
-            keyName,false);
+            keyName, false);
       //if key is not of type file or if key is not found we throw an exception
     if (fileStatus != null && fileStatus.isFile()) {
       if (args.getRefreshPipeline()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -638,10 +638,11 @@ public class KeyManagerImpl implements KeyManager {
     String keyName = args.getKeyName();
     metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
         bucketName);
+    OmKeyInfo value = null;
     try {
       String keyBytes = metadataManager.getOzoneKey(
           volumeName, bucketName, keyName);
-      OmKeyInfo value = metadataManager.getKeyTable().get(keyBytes);
+      value = metadataManager.getKeyTable().get(keyBytes);
       if (value == null) {
         LOG.debug("volume:{} bucket:{} Key:{} not found",
             volumeName, bucketName, keyName);
@@ -659,15 +660,6 @@ public class KeyManagerImpl implements KeyManager {
           });
         }
       }
-      // Refresh container pipeline info from SCM
-      // based on OmKeyArgs.refreshPipeline flag
-      if (args.getRefreshPipeline()) {
-        refreshPipeline(value);
-      }
-      if (args.getSortDatanodes()) {
-        sortDatanodeInPipeline(value, clientAddress);
-      }
-      return value;
     } catch (IOException ex) {
       if (ex instanceof OMException) {
         throw ex;
@@ -680,6 +672,16 @@ public class KeyManagerImpl implements KeyManager {
       metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
           bucketName);
     }
+    // Refresh container pipeline info from SCM
+    // based on OmKeyArgs.refreshPipeline flag
+    // value won't be null as the check is done inside try/catch block.
+    if (args.getRefreshPipeline()) {
+      refreshPipeline(value);
+    }
+    if (args.getSortDatanodes()) {
+      sortDatanodeInPipeline(value, clientAddress);
+    }
+    return value;
   }
 
   /**
@@ -1695,6 +1697,16 @@ public class KeyManagerImpl implements KeyManager {
     String bucketName = args.getBucketName();
     String keyName = args.getKeyName();
 
+    return getOzoneFileStatus(volumeName, bucketName, keyName,
+            args.getRefreshPipeline());
+  }
+
+  private OzoneFileStatus getOzoneFileStatus(String volumeName,
+                                             String bucketName,
+                                             String keyName,
+                                             boolean refreshPipeline)
+      throws IOException {
+    OmKeyInfo fileKeyInfo = null;
     metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
         bucketName);
     try {
@@ -1706,36 +1718,41 @@ public class KeyManagerImpl implements KeyManager {
 
       // Check if the key is a file.
       String fileKeyBytes = metadataManager.getOzoneKey(
-          volumeName, bucketName, keyName);
-      OmKeyInfo fileKeyInfo = metadataManager.getKeyTable().get(fileKeyBytes);
-      if (fileKeyInfo != null) {
-        if (args.getRefreshPipeline()) {
-          refreshPipeline(fileKeyInfo);
+              volumeName, bucketName, keyName);
+      fileKeyInfo = metadataManager.getKeyTable().get(fileKeyBytes);
+
+      // Check if the key is a directory.
+      if (fileKeyInfo == null) {
+        String dirKey = OzoneFSUtils.addTrailingSlashIfNeeded(keyName);
+        String dirKeyBytes = metadataManager.getOzoneKey(
+                volumeName, bucketName, dirKey);
+        OmKeyInfo dirKeyInfo = metadataManager.getKeyTable().get(dirKeyBytes);
+        if (dirKeyInfo != null) {
+          return new OzoneFileStatus(dirKeyInfo, scmBlockSize, true);
         }
-        // this is a file
-        return new OzoneFileStatus(fileKeyInfo, scmBlockSize, false);
       }
-
-      String dirKey = OzoneFSUtils.addTrailingSlashIfNeeded(keyName);
-      String dirKeyBytes = metadataManager.getOzoneKey(
-          volumeName, bucketName, dirKey);
-      OmKeyInfo dirKeyInfo = metadataManager.getKeyTable().get(dirKeyBytes);
-      if (dirKeyInfo != null) {
-        return new OzoneFileStatus(dirKeyInfo, scmBlockSize, true);
-      }
-
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Unable to get file status for the key: volume: {}, bucket:" +
-                " {}, key: {}, with error: No such file exists.", volumeName,
-            bucketName, keyName);
-      }
-      throw new OMException("Unable to get file status: volume: " +
-          volumeName + " bucket: " + bucketName + " key: " + keyName,
-          FILE_NOT_FOUND);
     } finally {
       metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
-          bucketName);
+              bucketName);
+
+      // if the key is a file then do refresh pipeline info in OM by asking SCM
+      if (fileKeyInfo != null) {
+        if (refreshPipeline) {
+          refreshPipeline(fileKeyInfo);
+        }
+        return new OzoneFileStatus(fileKeyInfo, scmBlockSize, false);
+      }
     }
+
+    // Key is not found, throws exception
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Unable to get file status for the key: volume: {}, bucket:" +
+                      " {}, key: {}, with error: No such file exists.", volumeName,
+              bucketName, keyName);
+    }
+    throw new OMException("Unable to get file status: volume: " +
+            volumeName + " bucket: " + bucketName + " key: " + keyName,
+            FILE_NOT_FOUND);
   }
 
   /**
@@ -1877,26 +1894,18 @@ public class KeyManagerImpl implements KeyManager {
     String volumeName = args.getVolumeName();
     String bucketName = args.getBucketName();
     String keyName = args.getKeyName();
-
-    metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
-        bucketName);
-    try {
-      OzoneFileStatus fileStatus = getFileStatus(args);
-      if (fileStatus.isFile()) {
-        if (args.getRefreshPipeline()) {
-          refreshPipeline(fileStatus.getKeyInfo());
-        }
-        if (args.getSortDatanodes()) {
-          sortDatanodeInPipeline(fileStatus.getKeyInfo(), clientAddress);
-        }
-        return fileStatus.getKeyInfo();
-      }
+    OzoneFileStatus fileStatus = getOzoneFileStatus(volumeName, bucketName,
+            keyName,false);
       //if key is not of type file or if key is not found we throw an exception
-    } finally {
-      metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
-          bucketName);
+    if (fileStatus != null && fileStatus.isFile()) {
+      if (args.getRefreshPipeline()) {
+        refreshPipeline(fileStatus.getKeyInfo());
+      }
+      if (args.getSortDatanodes()) {
+        sortDatanodeInPipeline(fileStatus.getKeyInfo(), clientAddress);
+      }
+      return fileStatus.getKeyInfo();
     }
-
     throw new OMException("Can not write to directory: " + keyName,
         ResultCodes.NOT_A_FILE);
   }
@@ -2067,9 +2076,6 @@ public class KeyManagerImpl implements KeyManager {
       for (Map.Entry<String, OzoneFileStatus> entry : cacheKeyMap.entrySet()) {
         // No need to check if a key is deleted or not here, this is handled
         // when adding entries to cacheKeyMap from DB.
-        if (args.getRefreshPipeline()) {
-          refreshPipeline(entry.getValue().getKeyInfo());
-        }
         fileStatusList.add(entry.getValue());
         countEntries++;
         if (countEntries >= numEntries) {
@@ -2082,6 +2088,11 @@ public class KeyManagerImpl implements KeyManager {
     } finally {
       metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
           bucketName);
+    }
+    if (args.getRefreshPipeline()) {
+      for(OzoneFileStatus fileStatus : fileStatusList){
+        refreshPipeline(fileStatus.getKeyInfo());
+      }
     }
     return fileStatusList;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refresh pipeline info does a call to SCM and it can be moved outside the BUCKET_LOCK, this would help to improve the performance of read/write mix workloads.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3824

## How was this patch tested?

Using TestOzoneFileSystem unit test cases.
