### PR TITLE
HDDS-3930. Fix OMKeyDeletesRequest.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -296,6 +296,8 @@ public final class OzoneConsts {
   public static final String MULTIPART_UPLOAD_PART_NUMBER = "partNumber";
   public static final String MULTIPART_UPLOAD_PART_NAME = "partName";
   public static final String BUCKET_ENCRYPTION_KEY = "bucketEncryptionKey";
+  public static final String DELETED_KEYS_LIST = "deletedKeysList";
+  public static final String UNDELETED_KEYS_LIST = "unDeletedKeysList";
 
 
 

--- a/hadoop-hdds/interface-client/src/main/proto/proto.lock
+++ b/hadoop-hdds/interface-client/src/main/proto/proto.lock
@@ -1477,6 +1477,21 @@
         ],
         "messages": [
           {
+            "name": "UUID",
+            "fields": [
+              {
+                "id": 1,
+                "name": "mostSigBits",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "leastSigBits",
+                "type": "int64"
+              }
+            ]
+          },
+          {
             "name": "DatanodeDetailsProto",
             "fields": [
               {
@@ -1514,6 +1529,11 @@
                 "id": 7,
                 "name": "networkLocation",
                 "type": "string"
+              },
+              {
+                "id": 100,
+                "name": "uuid128",
+                "type": "UUID"
               }
             ]
           },
@@ -1565,6 +1585,11 @@
                 "id": 1,
                 "name": "id",
                 "type": "string"
+              },
+              {
+                "id": 100,
+                "name": "uuid128",
+                "type": "UUID"
               }
             ]
           },
@@ -1630,6 +1655,11 @@
                 "id": 8,
                 "name": "creationTimeStamp",
                 "type": "uint64"
+              },
+              {
+                "id": 100,
+                "name": "leaderID128",
+                "type": "UUID"
               }
             ]
           },

--- a/hadoop-hdds/interface-client/src/main/proto/proto.lock
+++ b/hadoop-hdds/interface-client/src/main/proto/proto.lock
@@ -1477,21 +1477,6 @@
         ],
         "messages": [
           {
-            "name": "UUID",
-            "fields": [
-              {
-                "id": 1,
-                "name": "mostSigBits",
-                "type": "int64"
-              },
-              {
-                "id": 2,
-                "name": "leastSigBits",
-                "type": "int64"
-              }
-            ]
-          },
-          {
             "name": "DatanodeDetailsProto",
             "fields": [
               {
@@ -1529,11 +1514,6 @@
                 "id": 7,
                 "name": "networkLocation",
                 "type": "string"
-              },
-              {
-                "id": 100,
-                "name": "uuid128",
-                "type": "UUID"
               }
             ]
           },
@@ -1585,11 +1565,6 @@
                 "id": 1,
                 "name": "id",
                 "type": "string"
-              },
-              {
-                "id": 100,
-                "name": "uuid128",
-                "type": "UUID"
               }
             ]
           },
@@ -1655,11 +1630,6 @@
                 "id": 8,
                 "name": "creationTimeStamp",
                 "type": "uint64"
-              },
-              {
-                "id": 100,
-                "name": "leaderID128",
-                "type": "UUID"
               }
             ]
           },

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -76,6 +76,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDeleteKeys;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -18,8 +18,21 @@
 
 package org.apache.hadoop.ozone.client.rpc;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.CipherOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.security.InvalidKeyException;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import org.apache.hadoop.crypto.CryptoInputStream;
 import org.apache.hadoop.crypto.CryptoOutputStream;
 import org.apache.hadoop.crypto.key.KeyProvider;
@@ -63,7 +76,6 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
-import org.apache.hadoop.ozone.om.helpers.OmDeleteKeys;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
@@ -94,27 +106,14 @@ import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.web.utils.OzoneUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import org.apache.logging.log4j.util.Strings;
 import org.apache.ratis.protocol.ClientId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.crypto.Cipher;
-import javax.crypto.CipherInputStream;
-import javax.crypto.CipherOutputStream;
-import java.io.IOException;
-import java.net.URI;
-import java.security.InvalidKeyException;
-import java.security.SecureRandom;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 
 /**
  * Ozone RPC Client Implementation, it connects to OM, SCM and DataNode

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -18,21 +18,8 @@
 
 package org.apache.hadoop.ozone.client.rpc;
 
-import javax.crypto.Cipher;
-import javax.crypto.CipherInputStream;
-import javax.crypto.CipherOutputStream;
-import java.io.IOException;
-import java.net.URI;
-import java.security.InvalidKeyException;
-import java.security.SecureRandom;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import org.apache.hadoop.crypto.CryptoInputStream;
 import org.apache.hadoop.crypto.CryptoOutputStream;
 import org.apache.hadoop.crypto.key.KeyProvider;
@@ -76,6 +63,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDeleteKeys;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
@@ -106,14 +94,27 @@ import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.web.utils.OzoneUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import org.apache.logging.log4j.util.Strings;
 import org.apache.ratis.protocol.ClientId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.CipherOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.security.InvalidKeyException;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 
 /**
  * Ozone RPC Client Implementation, it connects to OM, SCM and DataNode
@@ -730,16 +731,9 @@ public class RpcClient implements ClientProtocol {
           throws IOException {
     HddsClientUtils.verifyResourceName(volumeName, bucketName);
     Preconditions.checkNotNull(keyNameList);
-    List<OmKeyArgs> keyArgsList = new ArrayList<>();
-    for (String keyName: keyNameList) {
-      OmKeyArgs keyArgs = new OmKeyArgs.Builder()
-          .setVolumeName(volumeName)
-          .setBucketName(bucketName)
-          .setKeyName(keyName)
-          .build();
-      keyArgsList.add(keyArgs);
-    }
-    ozoneManagerClient.deleteKeys(keyArgsList);
+    OmDeleteKeys omDeleteKeys = new OmDeleteKeys(volumeName, bucketName,
+        keyNameList);
+    ozoneManagerClient.deleteKeys(omDeleteKeys);
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
@@ -38,6 +38,7 @@ public enum OMAction implements AuditAction {
   UPDATE_BUCKET,
   UPDATE_KEY,
   PURGE_KEYS,
+  DELETE_KEYS,
 
   // S3 Bucket
   CREATE_S3_BUCKET,

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
@@ -223,6 +223,8 @@ public class OMException extends IOException {
 
     INVALID_VOLUME_NAME,
 
-    REPLAY // When ratis logs are replayed.
+    REPLAY, // When ratis logs are replayed.
+
+    PARTIAL_DELETE
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
@@ -223,8 +223,8 @@ public class OMException extends IOException {
 
     INVALID_VOLUME_NAME,
 
-    REPLAY, // When ratis logs are replayed.
+    PARTIAL_DELETE,
 
-    PARTIAL_DELETE
+    REPLAY // When ratis logs are replayed.
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDeleteKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDeleteKeys.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.ozone.om.helpers;
 
 import java.util.List;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDeleteKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDeleteKeys.java
@@ -1,0 +1,33 @@
+package org.apache.hadoop.ozone.om.helpers;
+
+import java.util.List;
+
+/**
+ * Represent class which has info of Keys to be deleted from Client.
+ */
+public class OmDeleteKeys {
+
+  private String volume;
+  private String bucket;
+
+  private List<String> keyNames;
+
+
+  public OmDeleteKeys(String volume, String bucket, List<String> keyNames) {
+    this.volume = volume;
+    this.bucket = bucket;
+    this.keyNames = keyNames;
+  }
+
+  public String getVolume() {
+    return volume;
+  }
+
+  public String getBucket() {
+    return bucket;
+  }
+
+  public List< String > getKeyNames() {
+    return keyNames;
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -18,10 +18,6 @@
 
 package org.apache.hadoop.ozone.om.protocol;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.List;
-
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
@@ -29,6 +25,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.DBUpdates;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDeleteKeys;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -51,6 +48,10 @@ import org.apache.hadoop.ozone.security.OzoneDelegationTokenSelector;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.security.KerberosInfo;
 import org.apache.hadoop.security.token.TokenInfo;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
 
 /**
  * Protocol to talk to OM.
@@ -229,10 +230,10 @@ public interface OzoneManagerProtocol
    * multiple keys and a single key. Used by deleting files
    * through OzoneFileSystem.
    *
-   * @param args the list args of the key.
+   * @param deleteKeys
    * @throws IOException
    */
-  void deleteKeys(List<OmKeyArgs> args) throws IOException;
+  void deleteKeys(OmDeleteKeys deleteKeys) throws IOException;
 
   /**
    * Deletes an existing empty bucket from volume.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -18,6 +18,10 @@
 
 package org.apache.hadoop.ozone.om.protocol;
 
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
@@ -48,10 +52,6 @@ import org.apache.hadoop.ozone.security.OzoneDelegationTokenSelector;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.security.KerberosInfo;
 import org.apache.hadoop.security.token.TokenInfo;
-
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.List;
 
 /**
  * Protocol to talk to OM.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -17,12 +17,10 @@
  */
 package org.apache.hadoop.ozone.om.protocolPB;
 
-import java.io.IOException;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.protobuf.ByteString;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
@@ -33,6 +31,7 @@ import org.apache.hadoop.ozone.om.helpers.DBUpdates;
 import org.apache.hadoop.ozone.om.helpers.KeyValueUtil;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDeleteKeys;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -71,8 +70,9 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateV
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DBUpdatesRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DBUpdatesResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteBucketRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeysRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeyRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeysRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteVolumeRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetAclRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetAclResponse;
@@ -137,10 +137,12 @@ import org.apache.hadoop.ozone.security.proto.SecurityProtos.GetDelegationTokenR
 import org.apache.hadoop.ozone.security.proto.SecurityProtos.RenewDelegationTokenRequestProto;
 import org.apache.hadoop.security.token.Token;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TOKEN_ERROR_OTHER;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.ACCESS_DENIED;
@@ -717,22 +719,17 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
    * Deletes existing key/keys. This interface supports delete
    * multiple keys and a single key.
    *
-   * @param args the list args of the key.
+   * @param deleteKeys
    * @throws IOException
    */
   @Override
-  public void deleteKeys(List<OmKeyArgs> args) throws IOException {
+  public void deleteKeys(OmDeleteKeys deleteKeys) throws IOException {
     DeleteKeysRequest.Builder req = DeleteKeysRequest.newBuilder();
-    List <KeyArgs> keyArgsList = new ArrayList<KeyArgs>();
-    for (OmKeyArgs omKeyArgs : args) {
-      KeyArgs keyArgs = KeyArgs.newBuilder()
-          .setVolumeName(omKeyArgs.getVolumeName())
-          .setBucketName(omKeyArgs.getBucketName())
-          .setKeyName(omKeyArgs.getKeyName()).build();
-      keyArgsList.add(keyArgs);
-    }
-    req.addAllKeyArgs(keyArgsList);
-
+    DeleteKeyArgs deletedKeys = DeleteKeyArgs.newBuilder()
+        .setBucketName(deleteKeys.getBucket())
+        .setVolumeName(deleteKeys.getVolume())
+        .addAllKeys(deleteKeys.getKeyNames()).build();
+    req.setDeleteKeys(deletedKeys);
     OMRequest omRequest = createOMRequest(Type.DeleteKeys)
         .setDeleteKeysRequest(req)
         .build();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -17,10 +17,12 @@
  */
 package org.apache.hadoop.ozone.om.protocolPB;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
@@ -137,11 +139,10 @@ import org.apache.hadoop.ozone.security.proto.SecurityProtos.GetDelegationTokenR
 import org.apache.hadoop.ozone.security.proto.SecurityProtos.RenewDelegationTokenRequestProto;
 import org.apache.hadoop.security.token.Token;
 
-import java.io.IOException;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.protobuf.ByteString;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TOKEN_ERROR_OTHER;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -70,8 +70,8 @@ import static org.junit.Assert.fail;
 public class TestOzoneFileSystem {
 
   /**
-    * Set a timeout for each test.
-    */
+   * Set a timeout for each test.
+   */
   @Rule
   public Timeout timeout = new Timeout(300000);
 
@@ -87,7 +87,7 @@ public class TestOzoneFileSystem {
 
   @Test(timeout = 300_000)
   public void testCreateFileShouldCheckExistenceOfDirWithSameName()
-          throws Exception {
+      throws Exception {
     /*
      * Op 1. create file -> /d1/d2/d3/d4/key2
      * Op 2. create dir -> /d1/d2/d3/d4/key2
@@ -193,11 +193,11 @@ public class TestOzoneFileSystem {
   }
 
   private void setupOzoneFileSystem()
-          throws IOException, TimeoutException, InterruptedException {
+      throws IOException, TimeoutException, InterruptedException {
     OzoneConfiguration conf = new OzoneConfiguration();
     cluster = MiniOzoneCluster.newBuilder(conf)
-            .setNumDatanodes(3)
-            .build();
+        .setNumDatanodes(3)
+        .build();
     cluster.waitForClusterToBeReady();
     // create a volume and a bucket to be used by OzoneFileSystem
     OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster);
@@ -205,8 +205,8 @@ public class TestOzoneFileSystem {
     bucketName = bucket.getName();
 
     String rootPath = String.format("%s://%s.%s/",
-            OzoneConsts.OZONE_URI_SCHEME, bucket.getName(),
-            bucket.getVolumeName());
+        OzoneConsts.OZONE_URI_SCHEME, bucket.getName(),
+        bucket.getVolumeName());
 
     // Set the fs.defaultFS and start the filesystem
     conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -18,14 +18,7 @@
 
 package org.apache.hadoop.fs.ozone;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.TimeoutException;
-
+import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -44,6 +37,22 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.test.LambdaTestUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
@@ -54,15 +63,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import org.apache.hadoop.test.LambdaTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Ozone file system tests that are not covered by contract tests.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -18,7 +18,14 @@
 
 package org.apache.hadoop.fs.ozone;
 
-import org.apache.commons.io.IOUtils;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.TimeoutException;
+
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -37,22 +44,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.apache.hadoop.test.LambdaTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
@@ -63,6 +54,15 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import org.apache.hadoop.test.LambdaTestUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Ozone file system tests that are not covered by contract tests.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -44,7 +44,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.apache.hadoop.test.LambdaTestUtils;
+
 import org.apache.commons.io.IOUtils;
 
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
@@ -57,6 +57,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.apache.hadoop.test.LambdaTestUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -18,7 +18,14 @@
 
 package org.apache.hadoop.fs.ozone;
 
-import org.apache.commons.io.IOUtils;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.TimeoutException;
+
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -38,21 +45,7 @@ import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.TimeoutException;
+import org.apache.commons.io.IOUtils;
 
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
@@ -63,6 +56,14 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Ozone file system tests that are not covered by contract tests.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -18,14 +18,7 @@
 
 package org.apache.hadoop.fs.ozone;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.TimeoutException;
-
+import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -44,8 +37,22 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.test.LambdaTestUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import org.apache.commons.io.IOUtils;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
@@ -56,15 +63,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import org.apache.hadoop.test.LambdaTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Ozone file system tests that are not covered by contract tests.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
@@ -51,6 +51,7 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.DIRE
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.PARTIAL_DELETE;
 import static org.junit.Assert.fail;
 
 /**
@@ -187,8 +188,9 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
       ozoneBucket.deleteKeys(keyList2);
       fail("testFilesDelete");
     } catch (OMException ex) {
-      // The expected exception KEY_NOT_FOUND.
-      Assert.assertEquals(KEY_NOT_FOUND, ex.getResult());
+      // The expected exception PARTIAL_DELETE, as if not able to delete, we
+      // return error codee PARTIAL_DElETE.
+      Assert.assertEquals(PARTIAL_DELETE, ex.getResult());
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
@@ -50,7 +50,6 @@ import static org.apache.hadoop.ozone.MiniOzoneHAClusterImpl.NODE_FAILURE_TIMEOU
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.DIRECTORY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
-import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.PARTIAL_DELETE;
 import static org.junit.Assert.fail;
 

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -303,6 +303,8 @@ enum Status {
 
     INVALID_VOLUME_NAME = 61;
 
+    PARTIAL_DELETE = 62;
+
     // When transactions are replayed
     REPLAY = 100;
 }
@@ -848,7 +850,18 @@ message DeleteKeyRequest {
 }
 
 message DeleteKeysRequest {
-    repeated KeyArgs keyArgs = 1;
+    optional DeleteKeyArgs deleteKeys = 1;
+}
+
+message DeleteKeyArgs {
+    required string volumeName = 1;
+    required string bucketName = 2;
+    repeated string keys = 3;
+}
+
+message DeleteKeysResponse {
+    optional DeleteKeyArgs unDeletedKeys = 1;
+    optional bool status = 2;
 }
 
 message DeleteKeyResponse {
@@ -866,9 +879,6 @@ message DeletedKeys {
     repeated string keys = 3;
 }
 
-message DeleteKeysResponse {
-    optional bool status = 1;
-}
 
 
 message PurgeKeysRequest {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -867,9 +867,9 @@ message DeletedKeys {
 }
 
 message DeleteKeysResponse {
-    repeated KeyInfo deletedKeys = 1;
-    repeated KeyInfo unDeletedKeys = 2;
+    optional bool status = 1;
 }
+
 
 message PurgeKeysRequest {
     repeated DeletedKeys deletedKeys = 1;

--- a/hadoop-ozone/interface-client/src/main/proto/proto.lock
+++ b/hadoop-ozone/interface-client/src/main/proto/proto.lock
@@ -1229,11 +1229,6 @@
                 "id": 9,
                 "name": "updateID",
                 "type": "uint64"
-              },
-              {
-                "id": 10,
-                "name": "modificationTime",
-                "type": "uint64"
               }
             ]
           },
@@ -1337,11 +1332,6 @@
               {
                 "id": 3,
                 "name": "quotaInBytes",
-                "type": "uint64"
-              },
-              {
-                "id": 4,
-                "name": "modificationTime",
                 "type": "uint64"
               }
             ]
@@ -1513,11 +1503,6 @@
               {
                 "id": 10,
                 "name": "updateID",
-                "type": "uint64"
-              },
-              {
-                "id": 11,
-                "name": "modificationTime",
                 "type": "uint64"
               }
             ]

--- a/hadoop-ozone/interface-client/src/main/proto/proto.lock
+++ b/hadoop-ozone/interface-client/src/main/proto/proto.lock
@@ -417,6 +417,10 @@
                 "integer": 61
               },
               {
+                "name": "PARTIAL_DELETE",
+                "integer": 62
+              },
+              {
                 "name": "REPLAY",
                 "integer": 100
               }
@@ -1229,6 +1233,11 @@
                 "id": 9,
                 "name": "updateID",
                 "type": "uint64"
+              },
+              {
+                "id": 10,
+                "name": "modificationTime",
+                "type": "uint64"
               }
             ]
           },
@@ -1332,6 +1341,11 @@
               {
                 "id": 3,
                 "name": "quotaInBytes",
+                "type": "uint64"
+              },
+              {
+                "id": 4,
+                "name": "modificationTime",
                 "type": "uint64"
               }
             ]
@@ -1503,6 +1517,11 @@
               {
                 "id": 10,
                 "name": "updateID",
+                "type": "uint64"
+              },
+              {
+                "id": 11,
+                "name": "modificationTime",
                 "type": "uint64"
               }
             ]
@@ -2419,9 +2438,44 @@
             "fields": [
               {
                 "id": 1,
-                "name": "keyArgs",
-                "type": "KeyArgs",
+                "name": "deleteKeys",
+                "type": "DeleteKeyArgs"
+              }
+            ]
+          },
+          {
+            "name": "DeleteKeyArgs",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "bucketName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "keys",
+                "type": "string",
                 "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "DeleteKeysResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "unDeletedKeys",
+                "type": "DeleteKeyArgs"
+              },
+              {
+                "id": 2,
+                "name": "status",
+                "type": "bool"
               }
             ]
           },
@@ -2463,16 +2517,6 @@
                 "name": "keys",
                 "type": "string",
                 "is_repeated": true
-              }
-            ]
-          },
-          {
-            "name": "DeleteKeysResponse",
-            "fields": [
-              {
-                "id": 1,
-                "name": "status",
-                "type": "bool"
               }
             ]
           },

--- a/hadoop-ozone/interface-client/src/main/proto/proto.lock
+++ b/hadoop-ozone/interface-client/src/main/proto/proto.lock
@@ -2486,15 +2486,8 @@
             "fields": [
               {
                 "id": 1,
-                "name": "deletedKeys",
-                "type": "KeyInfo",
-                "is_repeated": true
-              },
-              {
-                "id": 2,
-                "name": "unDeletedKeys",
-                "type": "KeyInfo",
-                "is_repeated": true
+                "name": "status",
+                "type": "bool"
               }
             ]
           },

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -214,6 +214,10 @@ public class OMMetrics {
     this.numKeys.incr(val- oldVal);
   }
 
+  public void decNumKeys(long val) {
+    this.numKeys.incr(-val);
+  }
+
   public long getNumVolumes() {
     return numVolumes.value();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2229,8 +2229,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    */
   @Override
   public void deleteKeys(OmDeleteKeys deleteKeys) throws IOException {
-    throw new NotImplementedException("OzoneManager does not require this to " +
-        "be implemented. As write requests use a new approach");
+    throw new UnsupportedOperationException("OzoneManager does not require " +
+        "this to be implemented. As write requests use a new approach");
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -169,7 +169,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.BlockingService;
 import com.google.protobuf.ProtocolMessageEnum;
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
 
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -17,34 +17,15 @@
 
 package org.apache.hadoop.ozone.om;
 
-import javax.management.ObjectName;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import java.security.KeyPair;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.cert.CertificateException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.ConcurrentHashMap;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.protobuf.BlockingService;
+import com.google.protobuf.ProtocolMessageEnum;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension;
@@ -107,6 +88,7 @@ import org.apache.hadoop.ozone.om.ha.OMNodeDetails;
 import org.apache.hadoop.ozone.om.helpers.DBUpdates;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDeleteKeys;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -161,15 +143,42 @@ import org.apache.hadoop.util.JvmPauseMonitor;
 import org.apache.hadoop.util.KMSUtil;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.ShutdownHookManager;
+import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
+import org.apache.ratis.server.protocol.TermIndex;
+import org.apache.ratis.util.FileUtils;
+import org.apache.ratis.util.LifeCycle;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.protobuf.BlockingService;
-import com.google.protobuf.ProtocolMessageEnum;
-import org.apache.commons.lang3.StringUtils;
+import javax.management.ObjectName;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdds.HddsUtils.getScmAddressForBlockClients;
@@ -207,13 +216,6 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVA
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TOKEN_ERROR_OTHER;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneManagerService.newReflectiveBlockingService;
-import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
-import org.apache.ratis.server.protocol.TermIndex;
-import org.apache.ratis.util.FileUtils;
-import org.apache.ratis.util.LifeCycle;
-import org.bouncycastle.pkcs.PKCS10CertificationRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Ozone Manager is the metadata manager of ozone.
@@ -2220,16 +2222,13 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   /**
    * Deletes an existing key.
    *
-   * @param args - List attributes of the key.
+   * @param deleteKeys - List of keys to be deleted from volume and a bucket.
    * @throws IOException
    */
   @Override
-  public void deleteKeys(List<OmKeyArgs> args) throws IOException {
-    if (args != null) {
-      for (OmKeyArgs keyArgs : args) {
-        deleteKey(keyArgs);
-      }
-    }
+  public void deleteKeys(OmDeleteKeys deleteKeys) throws IOException {
+    throw new NotImplementedException("OzoneManager does not require this to " +
+        "be implemented. As write requests use a new approach");
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -18,15 +18,8 @@
 
 package org.apache.hadoop.ozone.om.request;
 
-import java.io.IOException;
-import java.net.InetAddress;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -36,23 +29,22 @@ import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.AuditMessage;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.WithObjectID;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .DeleteKeysResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .OMRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .OMResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.security.UserGroupInformation;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.REPLAY;
 
@@ -220,36 +212,6 @@ public abstract class OMClientRequest implements RequestAuditor {
     if (errorMsg != null) {
       omResponse.setMessage(errorMsg);
     }
-    omResponse.setStatus(OzoneManagerRatisUtils.exceptionToResponseStatus(ex));
-    return omResponse.build();
-  }
-
-  /**
-   * Set parameters needed for return error response to client.
-   *
-   * @param omResponse
-   * @param ex         - IOException
-   * @param unDeletedKeys    - Set<OmKeyInfo>
-   * @return error response need to be returned to client - OMResponse.
-   */
-  protected OMResponse createOperationKeysErrorOMResponse(
-      @Nonnull OMResponse.Builder omResponse,
-      @Nonnull IOException ex, @Nonnull Set<OmKeyInfo> unDeletedKeys) {
-    omResponse.setSuccess(false);
-    StringBuffer errorMsg = new StringBuffer();
-    DeleteKeysResponse.Builder resp = DeleteKeysResponse.newBuilder();
-    for (OmKeyInfo key : unDeletedKeys) {
-      if(key != null) {
-        resp.addUnDeletedKeys(key.getProtobuf());
-      }
-    }
-    if (errorMsg != null) {
-      omResponse.setMessage(errorMsg.toString());
-    }
-    // TODO: Currently all delete operations in OzoneBucket.java are void. Here
-    //  we put the List of unDeletedKeys into Response. These KeyInfo can be
-    //  used to continue deletion if client support delete retry.
-    omResponse.setDeleteKeysResponse(resp.build());
     omResponse.setStatus(OzoneManagerRatisUtils.exceptionToResponseStatus(ex));
     return omResponse.build();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -126,6 +126,7 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
           deleteStatus = false;
           LOG.error("Received a request to delete a Key does not exist {}",
               objectKey);
+          deleteKeys.remove(keyName);
           unDeletedKeys.addKeys(keyName);
           continue;
         }
@@ -135,10 +136,10 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
           checkKeyAcls(ozoneManager, volumeName, bucketName, keyName,
               IAccessAuthorizer.ACLType.DELETE, OzoneObj.ResourceType.KEY);
           omKeyInfoList.add(omKeyInfo);
-          deleteKeys.remove(keyName);
         } catch (Exception ex) {
           deleteStatus = false;
           LOG.error("Acl check failed for Key: {}", objectKey, ex);
+          deleteKeys.remove(keyName);
           unDeletedKeys.addKeys(keyName);
         }
       }
@@ -166,8 +167,10 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
       exception = ex;
       createErrorOMResponse(omResponse, ex);
 
+      // reset deleteKeys as request failed.
+      deleteKeys = new ArrayList<>();
       // Add all keys which are failed due to any other exception .
-      for (int i = indexFailed; i < deleteKeys.size(); i++) {
+      for (int i = indexFailed; i < length; i++) {
         unDeletedKeys.addKeys(deleteKeyArgs.getKeys(indexFailed));
       }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -177,9 +177,10 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
     } catch (IOException ex) {
       result = Result.FAILURE;
       exception = ex;
-      omClientResponse = new OMKeysDeleteResponse(
-          omResponse.setDeleteKeysResponse(DeleteKeysResponse.newBuilder()
-              .setStatus(false).build()).build());
+      createErrorOMResponse(omResponse, ex);
+      omResponse.setDeleteKeysResponse(DeleteKeysResponse.newBuilder()
+          .setStatus(false).build()).build();
+      omClientResponse = new OMKeysDeleteResponse(omResponse.build());
 
     } finally {
       if (acquiredLock) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -196,14 +196,14 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
 
     switch (result) {
     case SUCCESS:
-      omMetrics.setNumKeys(deleteKeys.size());
+      omMetrics.decNumKeys(deleteKeys.size());
       if (LOG.isDebugEnabled()) {
         LOG.debug("Keys delete success. Volume:{}, Bucket:{}, Keys:{}",
             volumeName, bucketName, auditMap.get(DELETED_KEYS_LIST));
       }
       break;
     case FAILURE:
-      omMetrics.setNumKeys(deleteKeys.size());
+      omMetrics.decNumKeys(deleteKeys.size());
       omMetrics.incNumKeyDeleteFails();
       if (LOG.isDebugEnabled()) {
         LOG.error("Keys delete failed. Volume:{}, Bucket:{}, DeletedKey:{}, " +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -138,7 +138,7 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
 
       for (indexFailed = 0; indexFailed < deleteKeyArgsList.size();
            indexFailed++) {
-        KeyArgs deleteKeyArgs = deleteKeyArgsList.get(0);
+        KeyArgs deleteKeyArgs = deleteKeyArgsList.get(indexFailed);
         auditMap = buildKeyArgsAuditMap(deleteKeyArgs);
         volumeName = deleteKeyArgs.getVolumeName();
         bucketName = deleteKeyArgs.getBucketName();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -219,8 +219,8 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
       break;
     case FAILURE:
       omMetrics.incNumKeyDeleteFails();
-      LOG.error("Key delete failed. Volume:{}, Bucket:{}, Key{}." +
-          " Exception:{}", volumeName, bucketName, keyName, exception);
+      LOG.error("Key delete failed. Volume:{}, Bucket:{}, Key:{}",
+          volumeName, bucketName, keyName, exception);
       break;
     default:
       LOG.error("Unrecognized Result for OMKeyDeleteRequest: {}",

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -128,8 +128,9 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
     try {
 
       // Validate bucket and volume exists or not.
-
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      if (deleteKeyArgsList.size() > 0) {
+        validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      }
 
 
       // Check if any of the key in the batch cannot be deleted. If exists the

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -112,6 +112,14 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
         getOmRequest());
     OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
 
+    // As right now, only client exposed API is for a single volume and
+    // bucket. So, all entries will have same volume name and bucket name.
+    // So, we can validate once.
+    if (deleteKeyArgsList.size() > 0) {
+      volumeName = deleteKeyArgsList.get(0).getVolumeName();
+      bucketName = deleteKeyArgsList.get(0).getBucketName();
+    }
+
     boolean acquiredLock =
         omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK, volumeName,
             bucketName);
@@ -120,6 +128,7 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
     try {
 
       // Validate bucket and volume exists or not.
+
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
 
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponse.java
@@ -18,17 +18,13 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
-import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
-import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
-import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 
 import javax.annotation.Nonnull;
@@ -36,7 +32,6 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
-import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 
 /**
  * Response for DeleteKey request.
@@ -48,10 +43,10 @@ public class OMKeysDeleteResponse extends OMClientResponse {
   private long trxnLogIndex;
 
   public OMKeysDeleteResponse(@Nonnull OMResponse omResponse,
-                              @Nonnull List<OmKeyInfo> omKeyInfoList,
+                              @Nonnull List<OmKeyInfo> keyDeleteList,
                               long trxnLogIndex, boolean isRatisEnabled) {
     super(omResponse);
-    this.omKeyInfoList = omKeyInfoList;
+    this.omKeyInfoList = keyDeleteList;
     this.isRatisEnabled = isRatisEnabled;
     this.trxnLogIndex = trxnLogIndex;
   }
@@ -69,65 +64,36 @@ public class OMKeysDeleteResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
                            BatchOperation batchOperation) throws IOException {
 
+    String volumeName = "";
+    String bucketName = "";
+    String keyName = "";
     for (OmKeyInfo omKeyInfo : omKeyInfoList) {
-      // Set the UpdateID to current transactionLogIndex
-      omKeyInfo.setUpdateID(trxnLogIndex, isRatisEnabled);
+      volumeName = omKeyInfo.getVolumeName();
+      bucketName = omKeyInfo.getBucketName();
+      keyName = omKeyInfo.getKeyName();
 
-      // For OmResponse with failure, this should do nothing. This method is
-      // not called in failure scenario in OM code.
-      if (getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK) {
-        boolean acquiredLock = false;
-        String volumeName = "";
-        String bucketName = "";
+      String deleteKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
+          keyName);
 
-        try {
-          volumeName = omKeyInfo.getVolumeName();
-          bucketName = omKeyInfo.getBucketName();
-          String keyName = omKeyInfo.getKeyName();
-          acquiredLock =
-              omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
-                  volumeName, bucketName);
-          // Update table cache.
-          omMetadataManager.getKeyTable().addCacheEntry(
-              new CacheKey<>(omMetadataManager.getOzoneKey(
-                  volumeName, bucketName, keyName)),
-              new CacheValue<>(Optional.absent(), trxnLogIndex));
+      omMetadataManager.getKeyTable().deleteWithBatch(batchOperation,
+          deleteKey);
 
-          String ozoneKey = omMetadataManager.getOzoneKey(
-              omKeyInfo.getVolumeName(), omKeyInfo.getBucketName(),
-              omKeyInfo.getKeyName());
-          omMetadataManager.getKeyTable().deleteWithBatch(batchOperation,
-              ozoneKey);
-          // If a deleted key is put in the table where a key with the same
-          // name already exists, then the old deleted key information would
-          // be lost. To avoid this, first check if a key with same name
-          // exists. deletedTable in OM Metadata stores <KeyName,
-          // RepeatedOMKeyInfo>. The RepeatedOmKeyInfo is the structure that
-          // allows us to store a list of OmKeyInfo that can be tied to same
-          // key name. For a keyName if RepeatedOMKeyInfo structure is null,
-          // we create a new instance, if it is not null, then we simply add
-          // to the list and store this instance in deletedTable.
-          RepeatedOmKeyInfo repeatedOmKeyInfo =
-              omMetadataManager.getDeletedTable().get(ozoneKey);
-          repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-              omKeyInfo, repeatedOmKeyInfo, omKeyInfo.getUpdateID(),
-              isRatisEnabled);
-          omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
-              ozoneKey, repeatedOmKeyInfo);
-          if (acquiredLock) {
-            omMetadataManager.getLock().releaseWriteLock(
-                BUCKET_LOCK, volumeName, bucketName);
-            acquiredLock = false;
-          }
-        } finally {
-          if (acquiredLock) {
-            omMetadataManager.getLock()
-                .releaseWriteLock(BUCKET_LOCK, volumeName,
-                    bucketName);
-          }
-        }
-      }
+      // If a deleted key is put in the table where a key with the same
+      // name already exists, then the old deleted key information would
+      // be lost. To avoid this, first check if a key with same name
+      // exists. deletedTable in OM Metadata stores <KeyName,
+      // RepeatedOMKeyInfo>. The RepeatedOmKeyInfo is the structure that
+      // allows us to store a list of OmKeyInfo that can be tied to same
+      // key name. For a keyName if RepeatedOMKeyInfo structure is null,
+      // we create a new instance, if it is not null, then we simply add
+      // to the list and store this instance in deletedTable.
+      RepeatedOmKeyInfo repeatedOmKeyInfo =
+          omMetadataManager.getDeletedTable().get(deleteKey);
+      repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
+          omKeyInfo, repeatedOmKeyInfo, omKeyInfo.getUpdateID(),
+          isRatisEnabled);
+      omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
+          deleteKey, repeatedOmKeyInfo);
     }
   }
-
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponse.java
@@ -90,7 +90,7 @@ public class OMKeysDeleteResponse extends OMClientResponse {
       RepeatedOmKeyInfo repeatedOmKeyInfo =
           omMetadataManager.getDeletedTable().get(deleteKey);
       repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
-          omKeyInfo, repeatedOmKeyInfo, omKeyInfo.getUpdateID(),
+          omKeyInfo, repeatedOmKeyInfo, trxnLogIndex,
           isRatisEnabled);
       omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
           deleteKey, repeatedOmKeyInfo);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponse.java
@@ -64,7 +64,8 @@ public class OMKeysDeleteResponse extends OMClientResponse {
 
   public void checkAndUpdateDB(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
-    if (getOMResponse().getStatus() == OK || getOMResponse().getStatus() == PARTIAL_DELETE) {
+    if (getOMResponse().getStatus() == OK ||
+        getOMResponse().getStatus() == PARTIAL_DELETE) {
       addToDBBatch(omMetadataManager, batchOperation);
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponse.java
@@ -32,6 +32,8 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.OK;
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.PARTIAL_DELETE;
 
 /**
  * Response for DeleteKey request.
@@ -58,6 +60,13 @@ public class OMKeysDeleteResponse extends OMClientResponse {
   public OMKeysDeleteResponse(@Nonnull OMResponse omResponse) {
     super(omResponse);
     checkStatusNotOK();
+  }
+
+  public void checkAndUpdateDB(OMMetadataManager omMetadataManager,
+      BatchOperation batchOperation) throws IOException {
+    if (getOMResponse().getStatus() == OK || getOMResponse().getStatus() == PARTIAL_DELETE) {
+      addToDBBatch(omMetadataManager, batchOperation);
+    }
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequest.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.key;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeysRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.DeleteKeys;
+
+/**
+ * Class tests OMKeysDeleteRequest.
+ */
+public class TestOMKeysDeleteRequest extends TestOMKeyRequest {
+
+
+  private List<KeyArgs> keyArgsList;
+  private OMRequest omRequest;
+
+  @Test
+  public void testKeysDeleteRequest() throws Exception {
+
+    createPreRequisites();
+
+    OMKeysDeleteRequest omKeysDeleteRequest =
+        new OMKeysDeleteRequest(omRequest);
+
+
+    OMClientResponse omClientResponse =
+        omKeysDeleteRequest.validateAndUpdateCache(ozoneManager, 0L,
+            ozoneManagerDoubleBufferHelper);
+
+
+
+    Assert.assertTrue(omClientResponse.getOMResponse().getSuccess());
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omClientResponse.getOMResponse().getStatus());
+
+    // Check all keys are deleted.
+    for (KeyArgs keyArgs : keyArgsList) {
+      Assert.assertNull(omMetadataManager.getKeyTable()
+          .get(omMetadataManager.getOzoneKey(volumeName, bucketName,
+              keyArgs.getKeyName())));
+    }
+
+  }
+
+  @Test
+  public void testKeysDeleteRequestFail() throws Exception {
+
+    createPreRequisites();
+
+    KeyArgs dummyKeyArgs = KeyArgs.newBuilder().setVolumeName(volumeName)
+        .setKeyName("dummy").setBucketName(bucketName).build();
+
+    // Add a key which not exist, which causes batch delete to fail.
+    keyArgsList.add(dummyKeyArgs);
+
+    omRequest = omRequest.toBuilder()
+            .setDeleteKeysRequest(DeleteKeysRequest.newBuilder()
+                .addAllKeyArgs(keyArgsList).build()).build();
+
+    OMKeysDeleteRequest omKeysDeleteRequest =
+        new OMKeysDeleteRequest(omRequest);
+
+    OMClientResponse omClientResponse =
+        omKeysDeleteRequest.validateAndUpdateCache(ozoneManager, 0L,
+        ozoneManagerDoubleBufferHelper);
+
+    Assert.assertFalse(omClientResponse.getOMResponse().getSuccess());
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND,
+        omClientResponse.getOMResponse().getStatus());
+
+
+    keyArgsList.remove(dummyKeyArgs);
+
+    // Key Delete failed, so all keys should be present.
+    for (KeyArgs keyArgs : keyArgsList) {
+      Assert.assertNotNull(omMetadataManager.getKeyTable()
+          .get(omMetadataManager.getOzoneKey(volumeName, bucketName,
+              keyArgs.getKeyName())));
+    }
+  }
+
+  private void createPreRequisites() throws Exception {
+    // Add volume, bucket and key entries to OM DB.
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
+
+    int count = 10;
+
+    keyArgsList = new ArrayList<>();
+
+    // Create 10 keys
+    String parentDir = "/user";
+    String key = "";
+    for (int i = 0; i < count; i++) {
+      key = parentDir.concat("/key" + i);
+      TestOMRequestUtils.addKeyToTableCache(volumeName, bucketName,
+          parentDir.concat("/key" + i), HddsProtos.ReplicationType.RATIS,
+          HddsProtos.ReplicationFactor.THREE, omMetadataManager);
+      keyArgsList.add(KeyArgs.newBuilder().setBucketName(bucketName)
+          .setVolumeName(volumeName).setKeyName(key).build());
+    }
+
+    omRequest =
+        OMRequest.newBuilder().setClientId(UUID.randomUUID().toString())
+            .setCmdType(DeleteKeys)
+            .setDeleteKeysRequest(DeleteKeysRequest.newBuilder()
+                .addAllKeyArgs(keyArgsList).build()).build();
+  }
+
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeysDeleteRequest.java
@@ -111,8 +111,8 @@ public class TestOMKeysDeleteRequest extends TestOMKeyRequest {
               deleteKey)));
     }
 
-    DeleteKeyArgs unDeletedKeys =
-        omClientResponse.getOMResponse().getDeleteKeysResponse().getUnDeletedKeys();
+    DeleteKeyArgs unDeletedKeys = omClientResponse.getOMResponse()
+        .getDeleteKeysResponse().getUnDeletedKeys();
     Assert.assertEquals(1,
         unDeletedKeys.getKeysCount());
     Assert.assertEquals("dummy", unDeletedKeys.getKeys(0));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponse.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.response.key;
+
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
+import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeysResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND;
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.OK;
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.DeleteKeys;
+
+/**
+ * Class to test OMKeysDeleteResponse.
+ */
+public class TestOMKeysDeleteResponse extends TestOMKeyResponse {
+
+
+  private List<OmKeyInfo> omKeyInfoList;
+  private List<String> ozoneKeys;
+
+
+  private void createPreRequisities() throws Exception {
+    String parent = "/user";
+    String key = "key";
+
+    omKeyInfoList = new ArrayList<>();
+    ozoneKeys = new ArrayList<>();
+    String ozoneKey = "";
+    for (int i = 0; i < 10; i++) {
+      keyName = parent.concat(key + i);
+      TestOMRequestUtils.addKeyToTable(false, volumeName,
+          bucketName, keyName, 0L, RATIS, THREE, omMetadataManager);
+      ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName, keyName);
+      omKeyInfoList.add(omMetadataManager.getKeyTable().get(ozoneKey));
+      ozoneKeys.add(ozoneKey);
+    }
+  }
+
+  @Test
+  public void testKeysDeleteResponse() throws Exception {
+
+    createPreRequisities();
+
+    OMResponse omResponse =
+        OMResponse.newBuilder().setCmdType(DeleteKeys).setStatus(OK)
+            .setSuccess(true)
+            .setDeleteKeysResponse(DeleteKeysResponse.newBuilder()
+                .setStatus(true)).build();
+    OMClientResponse omKeysDeleteResponse =
+        new OMKeysDeleteResponse(omResponse, omKeyInfoList, 10L, true);
+
+    omKeysDeleteResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+
+
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+    for (String ozKey : ozoneKeys) {
+      Assert.assertNull(omMetadataManager.getKeyTable().get(ozKey));
+
+      RepeatedOmKeyInfo repeatedOmKeyInfo =
+          omMetadataManager.getDeletedTable().get(ozKey);
+      Assert.assertNotNull(repeatedOmKeyInfo);
+
+      Assert.assertEquals(1, repeatedOmKeyInfo.getOmKeyInfoList().size());
+      Assert.assertEquals(10L,
+          repeatedOmKeyInfo.getOmKeyInfoList().get(0).getUpdateID());
+
+    }
+
+  }
+
+  @Test
+  public void testKeysDeleteResponseFail() throws Exception {
+    createPreRequisities();
+
+    OMResponse omResponse =
+        OMResponse.newBuilder().setCmdType(DeleteKeys).setStatus(KEY_NOT_FOUND)
+            .setSuccess(false)
+            .setDeleteKeysResponse(DeleteKeysResponse.newBuilder()
+                .setStatus(false)).build();
+
+
+    OMClientResponse omKeysDeleteResponse =
+        new OMKeysDeleteResponse(omResponse, omKeyInfoList, 10L, true);
+
+    omKeysDeleteResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+
+
+    for (String ozKey : ozoneKeys) {
+      Assert.assertNotNull(omMetadataManager.getKeyTable().get(ozKey));
+
+      RepeatedOmKeyInfo repeatedOmKeyInfo =
+          omMetadataManager.getDeletedTable().get(ozKey);
+      Assert.assertNull(repeatedOmKeyInfo);
+
+    }
+
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. The cache of the key should be updated in ValidateAndUpdateCache, as we return response once after adding to cache, and before DoubleBuffer flushes to disk using OmClientResponse#addToDBBatch.
2. Changed return type of DeleteKeysResponse, as anyway when success we are not returning delete list and also when failure, we fail complete batch. So we can just return status.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3930

## How was this patch tested?

Existing tests.
