### PR TITLE
HDDS-3910. JooqCodeGenerator interrupted but still alive

### DIFF
--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -48,6 +48,7 @@
           <executable>java</executable>
           <classpathScope>compile</classpathScope>
           <mainClass>org.hadoop.ozone.recon.codegen.JooqCodeGenerator</mainClass>
+          <cleanupDaemonThreads>false</cleanupDaemonThreads>
           <arguments>
             <argument>${project.build.directory}/generated-sources/java</argument>
           </arguments>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set `cleanupDaemonThreads` to false so that the maven doesn't interrupt the daemon threads on quit.
_(Disabling cleanupDaemonThreads suppresses this warning)_

When maven has no more work to do, the VM will normally terminate any remaining daemon threads.
After the jooq code generator generates classes for recon, it is inactive, so I don't think it will interfere with subsequent activity.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3910

## How was this patch tested?

Compiled successfully.

In my test results, the time spent on the affected part is reduced from `17 s 994 ms` to `2 s 943 ms`.

![image](https://user-images.githubusercontent.com/14295594/86730413-15e65a00-c061-11ea-8280-8a63d0600344.png)
