### PR TITLE
HDDS-3931. Maven warning due to deprecated expression pom.artifactId

### DIFF
--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -318,7 +318,7 @@
               <goal>build-classpath</goal>
             </goals>
             <configuration>
-              <outputFile>${project.build.outputDirectory}/${pom.artifactId}.classpath</outputFile>
+              <outputFile>${project.build.outputDirectory}/${project.artifactId}.classpath</outputFile>
               <prefix>$HDDS_LIB_JARS_DIR</prefix>
               <outputFilterFile>true</outputFilterFile>
               <includeScope>runtime</includeScope>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix Maven warning caused by deprecated expression `pom.artifactId`:

```
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.apache.hadoop:hadoop-ozone-interface-client:jar:0.6.0-SNAPSHOT
[WARNING] The expression ${pom.artifactId} is deprecated. Please use ${project.artifactId} instead.
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.apache.hadoop:hadoop-ozone-common:jar:0.6.0-SNAPSHOT
[WARNING] The expression ${pom.artifactId} is deprecated. Please use ${project.artifactId} instead.
...
```

https://issues.apache.org/jira/browse/HDDS-3931

## How was this patch tested?

```
$ mvn -DskipTests clean package
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
...
[INFO] BUILD SUCCESS
```

https://github.com/adoroszlai/hadoop-ozone/runs/844565409