### PR TITLE
HDDS-3918. ConcurrentModificationException in ContainerReportHandler.…

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
@@ -67,7 +67,7 @@ public class NodeStateMap {
    */
   private void initStateMap() {
     for (NodeState state : NodeState.values()) {
-      stateMap.put(state, new HashSet<>());
+      stateMap.put(state, ConcurrentHashMap.newKeySet());
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
@@ -88,7 +88,7 @@ public class NodeStateMap {
         throw new NodeAlreadyExistsException("Node UUID: " + id);
       }
       nodeMap.put(id, new DatanodeInfo(datanodeDetails));
-      nodeToContainer.put(id, new ConcurrentHashMap().newKeySet());
+      nodeToContainer.put(id, ConcurrentHashMap.newKeySet());
       stateMap.get(nodeState).add(id);
     } finally {
       lock.writeLock().unlock();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
@@ -88,7 +88,7 @@ public class NodeStateMap {
         throw new NodeAlreadyExistsException("Node UUID: " + id);
       }
       nodeMap.put(id, new DatanodeInfo(datanodeDetails));
-      nodeToContainer.put(id, new HashSet<>());
+      nodeToContainer.put(id, new ConcurrentHashMap().newKeySet());
       stateMap.get(nodeState).add(id);
     } finally {
       lock.writeLock().unlock();


### PR DESCRIPTION
…onMessage.

## What changes were proposed in this pull request?

Use thread safe HashSet for NodeStateMap#nodeToContainer map

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3918

## How was this patch tested?

Unit test ([TestCME.java](https://issues.apache.org/jira/secure/attachment/13007245/TestCME.java) attached to the linked JIRA.)

