### PR TITLE
HDDS-3935. Change latest snapshot log to debug

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -144,7 +144,7 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
 
   @Override
   public SnapshotInfo getLatestSnapshot() {
-    LOG.info("Latest Snapshot Info {}", snapshotInfo);
+    LOG.debug("Latest Snapshot Info {}", snapshotInfo);
     return snapshotInfo;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change latest snapshot log in OM state machine to debug, to avoid spamming the log with 2 messages per second:

```
om1_1       | 2020-07-08 15:46:47,097 [grpc-default-executor-3] INFO ratis.OzoneManagerStateMachine: Latest Snapshot Info 0#-1
om2_1       | 2020-07-08 15:46:47,097 [grpc-default-executor-0] INFO ratis.OzoneManagerStateMachine: Latest Snapshot Info 0#-1
om1_1       | 2020-07-08 15:46:47,604 [grpc-default-executor-3] INFO ratis.OzoneManagerStateMachine: Latest Snapshot Info 0#-1
om2_1       | 2020-07-08 15:46:47,604 [grpc-default-executor-0] INFO ratis.OzoneManagerStateMachine: Latest Snapshot Info 0#-1
om1_1       | 2020-07-08 15:46:48,110 [grpc-default-executor-3] INFO ratis.OzoneManagerStateMachine: Latest Snapshot Info 0#-1
om2_1       | 2020-07-08 15:46:48,110 [grpc-default-executor-0] INFO ratis.OzoneManagerStateMachine: Latest Snapshot Info 0#-1
```

https://issues.apache.org/jira/browse/HDDS-3935

## How was this patch tested?

```
$ cd hadoop-ozone/dist/target/ozone-0.6.0-SNAPSHOT/compose/ozone-om-ha-s3
$ docker-compose up -d --scale datanode=3
$ docker-compose logs -f --tail=10 om1 om2 om3
```

https://github.com/adoroszlai/hadoop-ozone/runs/850605500