### PR TITLE
HDDS-3765. Fluentd writing to secure Ozone S3 API fails with 500 Error.

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-s3.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-s3.robot
@@ -24,6 +24,8 @@ Test Timeout        5 minutes
 
 *** Variables ***
 ${ENDPOINT_URL}     http://s3g:9878
+${TEMPDIR}          /tmp
+${TEST_FILE}        NOTICE.txt
 
 *** Keywords ***
 Setup volume names
@@ -37,6 +39,16 @@ Secure S3 test Success
     ${output} =         Execute          aws s3api --endpoint-url ${ENDPOINT_URL} create-bucket --bucket bucket-test123
     ${output} =         Execute          aws s3api --endpoint-url ${ENDPOINT_URL} list-buckets
                         Should contain   ${output}         bucket-test123
+
+Secure S3 put-object test
+    ${testFilePath} =       Set Variable            ${TEMPDIR}/${TEST_FILE}
+                            Copy File               ${TEST_FILE}            ${testFilePath}
+    ${output} =             Execute                 aws s3api --endpoint ${ENDPOINT_URL} put-object --bucket=bucket-test123 --key=tmp1/tmp2/NOTICE.txt --body=${testFilePath}
+    ${output} =             Execute                 aws s3api --endpoint ${ENDPOINT_URL} list-objects --bucket=bucket-test123
+                            Should contain   ${output}         tmp1/tmp2/NOTICE.txt
+    ${output} =             Execute                 aws s3api --endpoint ${ENDPOINT_URL} put-object --bucket=bucket-test123 --key=tmp3//tmp4/NOTICE.txt --body=${testFilePath}
+    ${output} =             Execute                 aws s3api --endpoint ${ENDPOINT_URL} list-objects --bucket=bucket-test123
+                            Should contain   ${output}         tmp3//tmp4/NOTICE.txt
 
 Secure S3 test Failure
     Run Keyword         Setup dummy credentials for S3

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/AWSV4SignatureProcessor.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/AWSV4SignatureProcessor.java
@@ -104,13 +104,7 @@ public class AWSV4SignatureProcessor implements SignatureProcessor {
 
 
     this.queryMap = context.getUriInfo().getQueryParameters();
-    try {
-      this.uri = new URI(context.getUriInfo().getRequestUri()
-          .getPath().replaceAll("\\/+",
-              "/")).normalize().getPath();
-    } catch (URISyntaxException e) {
-      throw S3_AUTHINFO_CREATION_ERROR;
-    }
+    this.uri = context.getUriInfo().getRequestUri().getPath();
 
     this.method = context.getMethod();
     if (v4Header == null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
While writing to secure Ozone s3 gateway, fluentd fails with 500 Error. This happens when there are extra slashes in the requested object path. (More details are in the JIRA)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3765

## How was this patch tested?
Manually tested with fluentd s3 plugin.
Added acceptance tests.