### PR TITLE
[POC] HDDS-3915. Simple trash emptier on OM

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-config
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+CORE-SITE.XML_fs.defaultFS=ofs://om
+CORE-SITE.XML_fs.trash.interval=1
+
 CORE-SITE.XML_fs.ofs.impl=org.apache.hadoop.fs.ozone.RootedOzoneFileSystem
 CORE-SITE.XML_fs.o3fs.impl=org.apache.hadoop.fs.ozone.OzoneFileSystem
 OZONE-SITE.XML_ozone.om.address=om

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-config
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CORE-SITE.XML_fs.defaultFS=ofs://om
-CORE-SITE.XML_fs.trash.interval=1
-
 CORE-SITE.XML_fs.ofs.impl=org.apache.hadoop.fs.ozone.RootedOzoneFileSystem
 CORE-SITE.XML_fs.o3fs.impl=org.apache.hadoop.fs.ozone.OzoneFileSystem
 OZONE-SITE.XML_ozone.om.address=om

--- a/hadoop-ozone/dist/src/shell/hdds/hadoop-functions.sh
+++ b/hadoop-ozone/dist/src/shell/hdds/hadoop-functions.sh
@@ -2791,6 +2791,14 @@ function hadoop_assembly_classpath() {
   fi
   hadoop_add_classpath "${MAIN_ARTIFACT}"
 
+  # Add two Ozone FileSystem jars to CLASSPATH for trash cleanup thread
+  OZONE_FS_ARTIFACT_NAME="hadoop-ozone-filesystem"
+  FS_ARTIFACTS=$(find "$ARTIFACT_LIB_DIR" -name "${OZONE_FS_ARTIFACT_NAME}-*.jar")
+  while IFS= read -r FS_ARTIFACT; do
+    hadoop_debug "Adding $OZONE_FS_ARTIFACT_NAME jar to CLASSPATH: $FS_ARTIFACT"
+    hadoop_add_classpath "${FS_ARTIFACT}"
+  done <<< "$FS_ARTIFACTS"
+
   #Add optional jars to the classpath
   OPTIONAL_CLASSPATH_DIR="${HADOOP_HDFS_HOME}/share/ozone/lib/${ARTIFACT_NAME}"
   if [[ -d "$OPTIONAL_CLASSPATH_DIR" ]]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implementation something similar to HDFS's `NameNode#startTrashEmptier` in OzoneManager to enable automatic trash clean up.

Pros:
* Easiest to implement. Uses Hadoop trash policy and FS getTrashRoots impl.
* OM needs to load two client FS jars. But really just uses the `getTrashRoots()` impl.

Cons:
* Before HDDS-2939 Ozone FS namespace is done, renaming is expensive if there are a lot of files in the `Current` checkpoint.
  * This con can be overcome by overriding `TrashPolicyDefault` (specify custom `fs.trash.classname`) on the client & OM: client directly create a timestamp every time it deletes files to trash, eliminating renaming; OM periodically checks for older timestamps and removes them.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3915

## How was this patch tested?

Tested manually so far. Steps:

```bash
$ mvn clean install -Pdist -DskipTests -e -Dmaven.javadoc.skip=true -DskipShade
$ cd hadoop-ozone/dist/target/ozone-*-SNAPSHOT/compose/ozone
$ vi docker-config
# Add two lines of config:
CORE-SITE.XML_fs.defaultFS=ofs://om
CORE-SITE.XML_fs.trash.interval=1
```

Note on the configs:
`fs.defaultFS` has to be picked up by OM as it resolves this path to be the FS for trash cleanup thread.
`fs.trash.interval` is also picked up by OM as `fs.trash.checkpoint.interval` in this case.
`fs.trash.interval` also needs to be picked up by the client to enable move to trash.

Spin up the docker-compose cluster:
```bash
$ docker-compose up -d
# Wait for ~30s for OM to init and start. Then run the below command to see that the cleaner thread is started
$ docker-compose logs om | grep fs.TrashPolicyDefault
om_1        | 2020-07-09 05:19:53,348 [Listener at om/9862] INFO fs.TrashPolicyDefault: The configured checkpoint interval is 0 minutes. Using an interval of 1 minutes that is used for deletion instead
om_1        | 2020-07-09 05:19:53,348 [Listener at om/9862] INFO fs.TrashPolicyDefault: Namenode trash configuration: Deletion interval = 1 minutes, Emptier interval = 1 minutes.
```

Now let's use the client to move a file to trash. `fs.trash.interval=1` (1 min for testing purpose) is configured on both OM and client in the container.
```bash
$ docker-compose exec om /bin/bash
$ ozone fs -mkdir -p ofs://om/volume1/bucket2/dir3
2020-07-09 05:33:01,592 [main] INFO rpc.RpcClient: Creating Volume: volume1, with hadoop as owner.
2020-07-09 05:33:01,778 [main] INFO rpc.RpcClient: Creating Bucket: volume1/bucket2, with Versioning false and Storage Type set to DISK and Encryption set to false
$ ozone fs -touch ofs://om/volume1/bucket2/dir3/key5
$ ozone fs -rm ofs://om/volume1/bucket2/dir3/key5
2020-07-09 05:33:42,721 [main] INFO Configuration.deprecation: io.bytes.per.checksum is deprecated. Instead, use dfs.bytes-per-checksum
2020-07-09 05:33:42,934 [main] INFO fs.TrashPolicyDefault: Moved: 'ofs://om/volume1/bucket2/dir3/key5' to trash at: ofs://om/volume1/bucket2/.Trash/hadoop/Current/volume1/bucket2/dir3/key5
```

In a minute OM trash cleanup thread will checkpoint the trash:
```bash
2020-07-09 05:34:00,055 [Trash Emptier] INFO fs.TrashPolicyDefault: TrashPolicyDefault#deleteCheckpoint for trashRoot: ofs://om/volume1/bucket2/.Trash/hadoop
2020-07-09 05:34:00,173 [Trash Emptier] INFO fs.TrashPolicyDefault: Created trash checkpoint: /volume1/bucket2/.Trash/hadoop/200709053400
```

Confirm the checkpoint on the client:
```bash
$ ozone fs -ls /volume1/bucket2/.Trash/hadoop/
Found 1 items
drwxrwxrwx   - hadoop hadoop          0 2020-07-09 05:34 /volume1/bucket2/.Trash/hadoop/200709053400
```

In the next minute the checkpoint is deleted:
```bash
2020-07-09 05:35:00,035 [Trash Emptier] INFO fs.TrashPolicyDefault: TrashPolicyDefault#deleteCheckpoint for trashRoot: ofs://om/volume1/bucket2/.Trash/hadoop
2020-07-09 05:35:00,096 [Trash Emptier] INFO fs.TrashPolicyDefault: Deleted trash checkpoint: /volume1/bucket2/.Trash/hadoop/200709053400
```