### PR TITLE
HDDS-3926. OM Token Identifier table should use in-house serialization.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneTokenIdentifier.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneTokenIdentifier.java
@@ -21,20 +21,21 @@ import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
+import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.WritableUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMTokenProto;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMTokenProto.Type;
 import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier;
 
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMTokenProto.Type.S3AUTHINFO;
+
 
 /**
  * The token identifier for Ozone Master.
@@ -85,115 +86,50 @@ public class OzoneTokenIdentifier extends
    * @return byte[]
    */
   public byte[] toUniqueSerializedKey() {
-    ByteBuffer result =
-        ByteBuffer.allocate(4096);
-    result.order(ByteOrder.BIG_ENDIAN);
+    DataOutputBuffer buf = new DataOutputBuffer();
     try {
-      result.putLong(getIssueDate());
-      result.putInt(getMasterKeyId());
-      result.putInt(getSequenceNumber());
-
-      result.putLong(getMaxDate());
-
-      result.putInt(getOwner().toString().length());
-      result.put(getOwner().toString().getBytes(StandardCharsets.UTF_8));
-
-      result.putInt(getRealUser().toString().length());
-      result.put(getRealUser().toString().getBytes(StandardCharsets.UTF_8));
-
-      result.putInt(getRenewer().toString().length());
-      result.put(getRenewer().toString().getBytes(StandardCharsets.UTF_8));
-
-      result.putInt(getTokenType().getNumber());
+      super.write(buf);
+      WritableUtils.writeVInt(buf, getTokenType().getNumber());
       // Set s3 specific fields.
       if (getTokenType().equals(S3AUTHINFO)) {
-        result.putInt(getAwsAccessId().length());
-        result.put(getAwsAccessId().getBytes(StandardCharsets.UTF_8));
-
-        result.putInt(getSignature().length());
-        result.put(getSignature().getBytes(StandardCharsets.UTF_8));
-
-        result.putInt(getStrToSign().length());
-        result.put(getStrToSign().getBytes(StandardCharsets.UTF_8));
+        WritableUtils.writeString(buf, getAwsAccessId());
+        WritableUtils.writeString(buf, getSignature());
+        WritableUtils.writeString(buf, getStrToSign());
       } else {
-        result.putInt(getOmCertSerialId().length());
-        result.put(getOmCertSerialId().getBytes(StandardCharsets.UTF_8));
+        WritableUtils.writeString(buf, getOmCertSerialId());
         if (getOmServiceId() != null) {
-          result.putInt(getOmServiceId().length());
-          result.put(getOmServiceId().getBytes(StandardCharsets.UTF_8));
-        } else {
-          result.putInt(0);
+          WritableUtils.writeString(buf, getOmServiceId());
         }
       }
-    } catch (IndexOutOfBoundsException e) {
+    } catch (java.io.IOException e) {
       throw new IllegalArgumentException(
           "Can't encode the the raw data ", e);
     }
-    return result.array();
+    return buf.getData();
   }
 
   /** Instead of relying on proto deserialization, this
    *  provides  explicit deserialization for OzoneTokenIdentifier.
    * @return byte[]
    */
-  public static OzoneTokenIdentifier fromUniqueSerializedKey(byte[] rawData) {
-    OzoneTokenIdentifier result = newInstance();
-    ByteBuffer inbuf = ByteBuffer.wrap(rawData);
-    inbuf.order(ByteOrder.BIG_ENDIAN);
-    result.setIssueDate(inbuf.getLong());
-    result.setMasterKeyId(inbuf.getInt());
-    result.setSequenceNumber(inbuf.getInt());
-
-    result.setMaxDate(inbuf.getLong());
-
-    int strsize = 0;
-    strsize = inbuf.getInt();
-    byte[] ownerBytes = new byte[strsize];
-    inbuf.get(ownerBytes);
-    result.setOwner(new Text(ownerBytes));
-
-    strsize = inbuf.getInt();
-    byte[] ruserBytes = new byte[strsize];
-    inbuf.get(ruserBytes);
-    result.setRealUser(new Text(ruserBytes));
-
-    strsize = inbuf.getInt();
-    byte[] renewerBytes = new byte[strsize];
-    inbuf.get(renewerBytes);
-    result.setRenewer(new Text(renewerBytes));
-
+  public OzoneTokenIdentifier fromUniqueSerializedKey(byte[] rawData)
+      throws IOException {
+    DataInputBuffer in = new DataInputBuffer();
+    in.reset(rawData, rawData.length);
+    super.readFields(in);
+    int type = WritableUtils.readVInt(in);
     // Set s3 specific fields.
-    if (inbuf.getInt() == S3AUTHINFO.getNumber()) {
-      strsize = inbuf.getInt();
-      byte[] awsAccessIdBytes = new byte[strsize];
-      inbuf.get(awsAccessIdBytes);
-      result.setAwsAccessId(new String(awsAccessIdBytes,
-          StandardCharsets.UTF_8));
-
-      strsize = inbuf.getInt();
-      byte[] signatureBytes = new byte[strsize];
-      inbuf.get(signatureBytes);
-      result.setSignature(new String(signatureBytes, StandardCharsets.UTF_8));
-
-      strsize = inbuf.getInt();
-      byte[] strToSignBytes = new byte[strsize];
-      inbuf.get(strToSignBytes);
-      result.setStrToSign(new String(strToSignBytes, StandardCharsets.UTF_8));
+    if (type == S3AUTHINFO.getNumber()) {
+      this.tokenType = Type.S3AUTHINFO;
+      setAwsAccessId(WritableUtils.readString(in));
+      setSignature(WritableUtils.readString(in));
+      setStrToSign(WritableUtils.readString(in));
     } else {
-      strsize = inbuf.getInt();
-      byte[] omCertIdBytes = new byte[strsize];
-      inbuf.get(omCertIdBytes);
-      result.setOmCertSerialId(new String(omCertIdBytes,
-          StandardCharsets.UTF_8));
-      int nextStrsize = inbuf.getInt();
-      if (nextStrsize != 0) {
-        byte[] omServiceIdBytes = new byte[nextStrsize];
-        inbuf.get(omServiceIdBytes);
-        result.setOmServiceId(new String(omServiceIdBytes,
-            StandardCharsets.UTF_8));
-      }
+      this.tokenType = Type.DELEGATION_TOKEN;
+      setOmCertSerialId(WritableUtils.readString(in));
+      setOmServiceId(WritableUtils.readString(in));
     }
-    return result;
+    return this;
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneTokenIdentifier.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneTokenIdentifier.java
@@ -97,9 +97,7 @@ public class OzoneTokenIdentifier extends
         WritableUtils.writeString(buf, getStrToSign());
       } else {
         WritableUtils.writeString(buf, getOmCertSerialId());
-        if (getOmServiceId() != null) {
-          WritableUtils.writeString(buf, getOmServiceId());
-        }
+        WritableUtils.writeString(buf, getOmServiceId());
       }
     } catch (java.io.IOException e) {
       throw new IllegalArgumentException(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/TokenIdentifierCodec.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/TokenIdentifierCodec.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.ozone.om.codec;
 
 import com.google.common.base.Preconditions;
+import com.google.protobuf.InvalidProtocolBufferException;
+
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.hdds.utils.db.Codec;
 
@@ -44,6 +46,13 @@ public class TokenIdentifierCodec implements Codec<OzoneTokenIdentifier> {
     try {
       OzoneTokenIdentifier object = OzoneTokenIdentifier.newInstance();
       return object.fromUniqueSerializedKey(rawData);
+    } catch (IOException ex) {
+      try {
+        return OzoneTokenIdentifier.readProtoBuf(rawData);
+      } catch (InvalidProtocolBufferException e) {
+        throw new IllegalArgumentException(
+            "Can't encode the the raw data from the byte array", e);
+      }
     } catch (BufferUnderflowException e) {
       throw new IllegalArgumentException(
           "Can't encode the the raw data from the byte array", e);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/TokenIdentifierCodec.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/TokenIdentifierCodec.java
@@ -42,7 +42,8 @@ public class TokenIdentifierCodec implements Codec<OzoneTokenIdentifier> {
     Preconditions.checkNotNull(rawData,
         "Null byte array can't converted to real object.");
     try {
-      return OzoneTokenIdentifier.fromUniqueSerializedKey(rawData);
+      OzoneTokenIdentifier object = OzoneTokenIdentifier.newInstance();
+      return object.fromUniqueSerializedKey(rawData);
     } catch (BufferUnderflowException e) {
       throw new IllegalArgumentException(
           "Can't encode the the raw data from the byte array", e);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/TokenIdentifierCodec.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/TokenIdentifierCodec.java
@@ -18,11 +18,11 @@
 package org.apache.hadoop.ozone.om.codec;
 
 import com.google.common.base.Preconditions;
-import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.hdds.utils.db.Codec;
 
 import java.io.IOException;
+import java.nio.BufferUnderflowException;
 
 /**
  * Codec to encode TokenIdentifierCodec as byte array.
@@ -33,7 +33,7 @@ public class TokenIdentifierCodec implements Codec<OzoneTokenIdentifier> {
   public byte[] toPersistedFormat(OzoneTokenIdentifier object) {
     Preconditions
         .checkNotNull(object, "Null object can't be converted to byte array.");
-    return object.getBytes();
+    return object.toUniqueSerializedKey();
   }
 
   @Override
@@ -42,8 +42,8 @@ public class TokenIdentifierCodec implements Codec<OzoneTokenIdentifier> {
     Preconditions.checkNotNull(rawData,
         "Null byte array can't converted to real object.");
     try {
-      return OzoneTokenIdentifier.readProtoBuf(rawData);
-    } catch (InvalidProtocolBufferException e) {
+      return OzoneTokenIdentifier.fromUniqueSerializedKey(rawData);
+    } catch (BufferUnderflowException e) {
       throw new IllegalArgumentException(
           "Can't encode the the raw data from the byte array", e);
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneTokenIdentifier.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneTokenIdentifier.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.ozone.om.codec.TokenIdentifierCodec;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.security.ssl.TestSSLFactory;
 import org.apache.hadoop.security.token.Token;
@@ -326,5 +327,23 @@ public class TestOzoneTokenIdentifier {
     OzoneTokenIdentifier idDecode = new OzoneTokenIdentifier();
     idDecode.readFields(in);
     Assert.assertEquals(idEncode, idDecode);
+  }
+
+  @Test
+  public void testTokenPersistence() throws IOException {
+    OzoneTokenIdentifier idWrite = getIdentifierInst();
+    idWrite.setOmServiceId("defaultServiceId");
+
+    byte[] oldIdBytes = idWrite.getBytes();
+    TokenIdentifierCodec idCodec = new TokenIdentifierCodec();
+
+    OzoneTokenIdentifier idRead = null;
+    try {
+      idRead =  idCodec.fromPersistedFormat(oldIdBytes);
+    } catch (IOException ex) {
+      Assert.fail("Should not fail to load old token format");
+    }
+    Assert.assertEquals("Deserialize Serialized Token should equal.",
+        idWrite, idRead);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone Manager Token Identifier table should use in-house serialization rather than rely on proto serialization for key.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3926

## How was this patch tested?

CleanBuild and Integration Tests
