### PR TITLE
HDDS-3944. OM StateMachine unpause fails with NPE

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -40,7 +40,6 @@ import org.apache.ratis.server.protocol.TermIndex;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -49,7 +48,6 @@ import org.junit.rules.Timeout;
 /**
  * Tests the Ratis snaphsots feature in OM.
  */
-@Ignore
 public class TestOMRatisSnapshots {
 
   private MiniOzoneHAClusterImpl cluster = null;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add missing `setIndexToTerm(this::getTermForIndex)` call to `OzoneManagerDoubleBuffer.Builder` chain, and extract duplicate code to a new method.

https://issues.apache.org/jira/browse/HDDS-3944

## How was this patch tested?

Reproduced the problem with integration test:

```
[INFO] Running org.apache.hadoop.ozone.om.TestOMRatisSnapshots
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 29.849 s <<< FAILURE! - in org.apache.hadoop.ozone.om.TestOMRatisSnapshots
[ERROR] testInstallSnapshot(org.apache.hadoop.ozone.om.TestOMRatisSnapshots)  Time elapsed: 29.772 s  <<< ERROR!
java.lang.NullPointerException: When ratis is enabled indexToTerm should not be null
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:897)
	at org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer$Builder.build(OzoneManagerDoubleBuffer.java:154)
	at org.apache.hadoop.ozone.om.ratis.OzoneManagerStateMachine.lambda$unpause$3(OzoneManagerStateMachine.java:338)
	at org.apache.ratis.util.LifeCycle.startAndTransition(LifeCycle.java:214)
	at org.apache.hadoop.ozone.om.ratis.OzoneManagerStateMachine.unpause(OzoneManagerStateMachine.java:331)
	at org.apache.hadoop.ozone.om.TestOMRatisSnapshots.testInstallSnapshot(TestOMRatisSnapshots.java:183)
```

Verified the fix using the same test:

```
[INFO] Running org.apache.hadoop.ozone.om.TestOMRatisSnapshots
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 29.278 s - in org.apache.hadoop.ozone.om.TestOMRatisSnapshots
```

https://github.com/adoroszlai/hadoop-ozone/runs/853845496