### PR TITLE
HDDS-3941. Enable core dump when crash in C++

### DIFF
--- a/hadoop-hdds/common/src/main/conf/hadoop-env.sh
+++ b/hadoop-hdds/common/src/main/conf/hadoop-env.sh
@@ -30,6 +30,9 @@
 ## {YARN_xyz|HDFS_xyz} > HADOOP_xyz > hard-coded defaults
 ##
 
+# Enable core dump when crash in C++
+ulimit -c unlimited
+
 # Many of the options here are built from the perspective that users
 # may want to provide OVERWRITING values on the command line.
 # For example:


### PR DESCRIPTION
## What changes were proposed in this pull request?

**What's the problem ?**
This PR is related to HDDS-3933.

When memory leak because of the reason explained in HDDS-3933, Datanode most time generates core.pid because it crash in Rocksdb when create new thread, as the image shows, but generates crash log rarely.
![image](https://user-images.githubusercontent.com/51938049/87117625-97c9c380-c2ab-11ea-96e2-58c197cb6275.png)

But because the default value of `core file size` is zero, so core.pid can not be generated. So when Datanode crash in Rocksdb, we can not get any information about why it crashed. 

**How to fix ?**
Set `ulimit -c unlimited` to enable core dump when crash in RocksDB.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3941

## How was this patch tested?

Existed UT.
