### PR TITLE
HDDS-3062. Fix TestOzoneRpcClientAbstract.testListVolume.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1234,9 +1234,6 @@ public abstract class TestOzoneRpcClientAbstract {
     Assert.assertEquals(toKeyName, key.getName());
   }
 
-  // Listing all volumes in the cluster feature has to be fixed after HDDS-357.
-  // TODO: fix this
-  @Ignore
   @Test
   public void testListVolume() throws IOException {
     String volBase = "vol-" + RandomStringUtils.randomNumeric(3);


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestOzoneRpcClientAbstract.testListVolume is disabled due to intermittent issues.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3062

## How was this patch tested?

Fixes UT
