### PR TITLE
HDDS-3955. Unable to list intermediate paths on keys created using S3G.

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2483,9 +2483,10 @@
     <name>ozone.om.enable.filesystem.paths</name>
     <tag>OZONE, OM</tag>
     <value>false</value>
-    <description>If true, OM will normalize the key paths and also create
-      intermediate directories. This flag will be helpful when objects
-      created by S3G need to be accessed using OFS/O3Fs.
+    <description>If true, key names will be interpreted as file system paths.
+      "/" will be treated as a special character and paths will be normalized
+      and must follow Unix filesystem path naming conventions. This flag will
+      be helpful when objects created by S3G need to be accessed using OFS/O3Fs.
       If false, it will fallback to default behavior of Key/MPU create
       requests where key paths are not normalized and any intermediate
       directories will not be created or any file checks happens to check

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2480,15 +2480,16 @@
   </property>
 
   <property>
-    <name>ozone.om.create.intermediate.directories</name>
+    <name>ozone.om.enable.filesystem.paths</name>
     <tag>OZONE, OM</tag>
     <value>false</value>
-    <description>If true, then intermediate directories will be created
-      during Key/MPU create requests. This flag will be helpful when objects
+    <description>If true, OM will normalize the key paths and also create
+      intermediate directories. This flag will be helpful when objects
       created by S3G need to be accessed using OFS/O3Fs.
       If false, it will fallback to default behavior of Key/MPU create
-      requests where any intermediate directories will not be created or any
-      file checks happens to check filesystem semantics.
+      requests where key paths are not normalized and any intermediate
+      directories will not be created or any file checks happens to check
+      filesystem semantics.
     </description>
   </property>
 </configuration>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2478,4 +2478,17 @@
       rules in Amazon S3's object key naming guide.
     </description>
   </property>
+
+  <property>
+    <name>ozone.om.create.intermediate.directories</name>
+    <tag>OZONE, OM</tag>
+    <value>false</value>
+    <description>If true, then intermediate directories will be created
+      during Key/MPU create requests. This flag will be helpful when objects
+      created by S3G need to be accessed using OFS/O3Fs.
+      If false, it will fallback to default behavior of Key/MPU create
+      requests where any intermediate directories will not be created or any
+      file checks happens to check filesystem semantics.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -242,8 +242,8 @@ public final class OMConfigKeys {
 
   // This config needs to be enabled, when S3G created objects used via
   // FileSystem API.
-  public static final String OZONE_OM_CREATE_INTERMEDIATE_DIRECTORY =
-      "ozone.om.create.intermediate.directories";
-  public static final boolean OZONE_OM_CREATE_INTERMEDIATE_DIRECTORY_DEFAULT =
+  public static final String OZONE_OM_ENABLE_FILESYSTEM_PATHS =
+      "ozone.om.enable.filesystem.paths";
+  public static final boolean OZONE_OM_ENABLE_FILESYSTEM_PATHS_DEFAULT =
       false;
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -239,4 +239,11 @@ public final class OMConfigKeys {
           "ozone.om.keyname.character.check.enabled";
   public static final boolean OZONE_OM_KEYNAME_CHARACTER_CHECK_ENABLED_DEFAULT =
           false;
+
+  // This config needs to be enabled, when S3G created objects will be used
+  // FileSystem.
+  public static final String OZONE_OM_CREATE_INTERMEDIATE_DIRECTORY =
+      "ozone.om.create.intermediate.directories";
+  public static final boolean OZONE_OM_CREATE_INTERMEDIATE_DIRECTORY_DEFAULT =
+      false;
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -240,8 +240,8 @@ public final class OMConfigKeys {
   public static final boolean OZONE_OM_KEYNAME_CHARACTER_CHECK_ENABLED_DEFAULT =
           false;
 
-  // This config needs to be enabled, when S3G created objects will be used
-  // FileSystem.
+  // This config needs to be enabled, when S3G created objects used via
+  // FileSystem API.
   public static final String OZONE_OM_CREATE_INTERMEDIATE_DIRECTORY =
       "ozone.om.create.intermediate.directories";
   public static final boolean OZONE_OM_CREATE_INTERMEDIATE_DIRECTORY_DEFAULT =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -40,6 +40,8 @@ import org.junit.rules.Timeout;
 import java.net.URI;
 import java.util.Arrays;
 
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_SCHEME;
+
 /**
  * Class tests create with object store and getFileStatus.
  */
@@ -86,7 +88,7 @@ public class TestOzoneFSWithObjectStoreCreate {
     OzoneBucket bucket =
         TestDataUtil.createVolumeAndBucket(cluster, volumeName, bucketName);
 
-    rootPath = String.format("%s://%s.%s/", OzoneConsts.OZONE_URI_SCHEME, bucketName,
+    rootPath = String.format("%s://%s.%s/", OZONE_URI_SCHEME, bucketName,
         volumeName);
     fs = FileSystem.get(new URI(rootPath), conf);
     o3fs = (OzoneFileSystem) fs;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -1,0 +1,123 @@
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OMMetrics;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.net.URI;
+import java.util.Arrays;
+
+public class TestOzoneFSWithS3G {
+
+  @Rule
+  public Timeout timeout = new Timeout(300000);
+
+  private String rootPath;
+  private String userName;
+
+  private boolean setDefaultFs;
+
+  private boolean useAbsolutePath;
+
+  private MiniOzoneCluster cluster = null;
+
+  private FileSystem fs;
+
+  private OzoneFileSystem o3fs;
+
+  private String volumeName;
+
+  private String bucketName;
+
+  private OzoneFSStorageStatistics statistics;
+
+  private OMMetrics omMetrics;
+
+  @Before
+  public void init() throws Exception {
+    volumeName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+
+    OzoneConfiguration conf = new OzoneConfiguration();
+
+    conf.setBoolean(OMConfigKeys.OZONE_OM_CREATE_INTERMEDIATE_DIRECTORY, true);
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(3)
+        .build();
+    cluster.waitForClusterToBeReady();
+
+    // create a volume and a bucket to be used by OzoneFileSystem
+    OzoneBucket bucket =
+        TestDataUtil.createVolumeAndBucket(cluster, volumeName, bucketName);
+
+    rootPath = String.format("%s://%s.%s/", OzoneConsts.OZONE_URI_SCHEME, bucketName,
+        volumeName);
+    fs = FileSystem.get(new URI(rootPath), conf);
+    o3fs = (OzoneFileSystem) fs;
+  }
+
+
+  @Test
+  public void test() throws Exception {
+
+    OzoneVolume ozoneVolume =
+        cluster.getRpcClient().getObjectStore().getVolume(volumeName);
+
+    OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
+
+    String key1 = "dir1/dir2/file1";
+    String key2 = "dir1/dir2/file2";
+    int length = 10;
+    OzoneOutputStream ozoneOutputStream = ozoneBucket.createKey(key1, length);
+    byte[] b = new byte[10];
+    Arrays.fill(b, (byte)96);
+    ozoneOutputStream.write(b);
+    ozoneOutputStream.close();
+
+    ozoneOutputStream = ozoneBucket.createKey(key2, length);
+    ozoneOutputStream.write(b);
+    ozoneOutputStream.close();
+
+    // Adding "/" here otherwise Path will be considered as relative path and
+    // workingDir will be added.
+    key1 = "/dir1/dir2/file1";
+    Path p = new Path(key1);
+    Assert.assertTrue(fs.getFileStatus(p).isFile());
+
+    p = p.getParent();
+    checkAncestors(p);
+
+
+    key2 = "/dir1/dir2/file2";
+    p = new Path(key2);
+    Assert.assertTrue(fs.getFileStatus(p).isFile());
+    checkAncestors(p);
+
+  }
+
+  private void checkAncestors(Path p) throws Exception {
+    p = p.getParent();
+    while(p.getParent() != null) {
+      FileStatus fileStatus = fs.getFileStatus(p);
+      Assert.assertTrue(fileStatus.isDirectory());
+      p = p.getParent();
+    }
+  }
+
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -1,7 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.fs.ozone;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -23,7 +40,10 @@ import org.junit.rules.Timeout;
 import java.net.URI;
 import java.util.Arrays;
 
-public class TestOzoneFSWithS3G {
+/**
+ * Class tests create with object store and getFileStatus.
+ */
+public class TestOzoneFSWithObjectStoreCreate {
 
   @Rule
   public Timeout timeout = new Timeout(300000);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -200,6 +200,8 @@ import static org.apache.hadoop.ozone.OzoneConsts.OM_METRICS_FILE;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_METRICS_TEMP_FILE;
 import static org.apache.hadoop.ozone.OzoneConsts.RPC_PORT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HANDLER_COUNT_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HANDLER_COUNT_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_KEYTAB_FILE_KEY;
@@ -3493,5 +3495,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   @VisibleForTesting
   void setExitManagerForTesting(ExitManager exitManagerForTesting) {
     this.exitManager = exitManagerForTesting;
+
+
+  public boolean getEnableFileSystemPaths() {
+    return configuration.getBoolean(OZONE_OM_ENABLE_FILESYSTEM_PATHS,
+        OZONE_OM_ENABLE_FILESYSTEM_PATHS_DEFAULT);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3495,6 +3495,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   @VisibleForTesting
   void setExitManagerForTesting(ExitManager exitManagerForTesting) {
     this.exitManager = exitManagerForTesting;
+  }
 
 
   public boolean getEnableFileSystemPaths() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -271,6 +271,7 @@ public abstract class OMClientRequest implements RequestAuditor {
     return auditMap;
   }
 
+  @SuppressWarnings("HardcodedFileSeparator")
   public static String getNormalizedKey(boolean enableFileSystemPaths,
       String keyName) {
     if (enableFileSystemPaths) {
@@ -278,7 +279,8 @@ public abstract class OMClientRequest implements RequestAuditor {
       if (keyName.startsWith("/")) {
         normalizedKeyName = Paths.get(keyName).toUri().normalize().getPath();
       } else {
-        normalizedKeyName = Paths.get("/", keyName).toUri().normalize().getPath();
+        normalizedKeyName = Paths.get("/", keyName).toUri()
+            .normalize().getPath();
       }
       if (!keyName.equals(normalizedKeyName)) {
         LOG.debug("Normalized key {} to {} ", keyName, normalizedKeyName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.request;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -48,6 +49,7 @@ import java.nio.file.Paths;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 
 /**
  * OMClientRequest provides methods which every write OM request should
@@ -271,15 +273,15 @@ public abstract class OMClientRequest implements RequestAuditor {
     return auditMap;
   }
 
-  @SuppressWarnings("HardcodedFileSeparator")
+  @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
   public static String getNormalizedKey(boolean enableFileSystemPaths,
       String keyName) {
     if (enableFileSystemPaths) {
       String normalizedKeyName;
-      if (keyName.startsWith("/")) {
+      if (keyName.startsWith(OM_KEY_PREFIX)) {
         normalizedKeyName = Paths.get(keyName).toUri().normalize().getPath();
       } else {
-        normalizedKeyName = Paths.get("/", keyName).toUri()
+        normalizedKeyName = Paths.get(OM_KEY_PREFIX, keyName).toUri()
             .normalize().getPath();
       }
       if (!keyName.equals(normalizedKeyName)) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -273,23 +273,29 @@ public abstract class OMClientRequest implements RequestAuditor {
     return auditMap;
   }
 
-  @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
+
   public static String getNormalizedKey(boolean enableFileSystemPaths,
       String keyName) {
     if (enableFileSystemPaths) {
-      String normalizedKeyName;
-      if (keyName.startsWith(OM_KEY_PREFIX)) {
-        normalizedKeyName = Paths.get(keyName).toUri().normalize().getPath();
-      } else {
-        normalizedKeyName = Paths.get(OM_KEY_PREFIX, keyName).toUri()
-            .normalize().getPath();
-      }
-      if (!keyName.equals(normalizedKeyName)) {
-        LOG.debug("Normalized key {} to {} ", keyName, normalizedKeyName);
-      }
-      return normalizedKeyName.substring(1);
+      return getNormalizedKey(keyName);
     } else {
       return keyName;
     }
+  }
+
+  @SuppressFBWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
+  public static String getNormalizedKey(String keyName) {
+    String normalizedKeyName;
+    if (keyName.startsWith(OM_KEY_PREFIX)) {
+      normalizedKeyName = Paths.get(keyName).toUri().normalize().getPath();
+    } else {
+      normalizedKeyName = Paths.get(OM_KEY_PREFIX, keyName).toUri()
+          .normalize().getPath();
+    }
+    if (!keyName.equals(normalizedKeyName)) {
+      LOG.debug("Normalized key {} to {} ", keyName,
+          normalizedKeyName.substring(1));
+    }
+    return normalizedKeyName.substring(1);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -141,7 +141,6 @@ public class OMFileCreateRequest extends OMKeyRequest {
               ozoneManager.getPreallocateBlocksMax(),
               ozoneManager.isGrpcBlockTokenEnabled(),
               ozoneManager.getOMNodeId());
-
     KeyArgs.Builder newKeyArgs = keyArgs.toBuilder()
         .setModificationTime(Time.now()).setType(type).setFactor(factor)
         .setDataSize(requestedSize);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -141,6 +141,7 @@ public class OMFileCreateRequest extends OMKeyRequest {
               ozoneManager.getPreallocateBlocksMax(),
               ozoneManager.isGrpcBlockTokenEnabled(),
               ozoneManager.getOMNodeId());
+
     KeyArgs.Builder newKeyArgs = keyArgs.toBuilder()
         .setModificationTime(Time.now()).setType(type).setFactor(factor)
         .setDataSize(requestedSize);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -197,7 +197,7 @@ public final class OMFileRequest {
   /**
    * Return codes used by verifyFilesInPath method.
    */
-  enum OMDirectoryResult {
+  public enum OMDirectoryResult {
 
     // In below examples path is assumed as "a/b/c" in volume volume1 and
     // bucket b1.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -79,15 +79,11 @@ public final class OMFileRequest {
       String dbDirKeyName = omMetadataManager.getOzoneDirKey(volumeName,
           bucketName, pathName);
 
-      if (omMetadataManager.getKeyTable().isExist(dbKeyName)) {
-        // Found a file in the given path.
-        // Check if this is actual file or a file in the given path
-        if (dbKeyName.equals(fileNameFromDetails)) {
-          result = OMDirectoryResult.FILE_EXISTS;
-        } else {
-          result = OMDirectoryResult.FILE_EXISTS_IN_GIVENPATH;
-        }
-      } else if (omMetadataManager.getKeyTable().isExist(dbDirKeyName)) {
+      // Check first for dir. This is to handle leading "/" in path, which
+      // creates an entry in key table. Do we need to create this or skip
+      // creation totally. This is not a problem with filecreate, as the Path
+      // in FileSystem takes care and also we remove leading "/" in filesystem.
+      if (omMetadataManager.getKeyTable().isExist(dbDirKeyName)) {
         // Found a directory in the given path.
         // Check if this is actual directory or a directory in the given path
         if (dbDirKeyName.equals(dirNameFromDetails)) {
@@ -98,6 +94,14 @@ public final class OMFileRequest {
               .getAcls();
           LOG.trace("Acls inherited from parent " + dbDirKeyName + " are : "
               + inheritAcls);
+        }
+      } else if (omMetadataManager.getKeyTable().isExist(dbKeyName)) {
+        // Found a file in the given path.
+        // Check if this is actual file or a file in the given path
+        if (dbKeyName.equals(fileNameFromDetails)) {
+          result = OMDirectoryResult.FILE_EXISTS;
+        } else {
+          result = OMDirectoryResult.FILE_EXISTS_IN_GIVENPATH;
         }
       } else {
         if (!dbDirKeyName.equals(dirNameFromDetails)) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -79,11 +79,15 @@ public final class OMFileRequest {
       String dbDirKeyName = omMetadataManager.getOzoneDirKey(volumeName,
           bucketName, pathName);
 
-      // Check first for dir. This is to handle leading "/" in path, which
-      // creates an entry in key table. Do we need to create this or skip
-      // creation totally. This is not a problem with filecreate, as the Path
-      // in FileSystem takes care and also we remove leading "/" in filesystem.
-      if (omMetadataManager.getKeyTable().isExist(dbDirKeyName)) {
+      if (omMetadataManager.getKeyTable().isExist(dbKeyName)) {
+        // Found a file in the given path.
+        // Check if this is actual file or a file in the given path
+        if (dbKeyName.equals(fileNameFromDetails)) {
+          result = OMDirectoryResult.FILE_EXISTS;
+        } else {
+          result = OMDirectoryResult.FILE_EXISTS_IN_GIVENPATH;
+        }
+      } else if (omMetadataManager.getKeyTable().isExist(dbDirKeyName)) {
         // Found a directory in the given path.
         // Check if this is actual directory or a directory in the given path
         if (dbDirKeyName.equals(dirNameFromDetails)) {
@@ -94,14 +98,6 @@ public final class OMFileRequest {
               .getAcls();
           LOG.trace("Acls inherited from parent " + dbDirKeyName + " are : "
               + inheritAcls);
-        }
-      } else if (omMetadataManager.getKeyTable().isExist(dbKeyName)) {
-        // Found a file in the given path.
-        // Check if this is actual file or a file in the given path
-        if (dbKeyName.equals(fileNameFromDetails)) {
-          result = OMDirectoryResult.FILE_EXISTS;
-        } else {
-          result = OMDirectoryResult.FILE_EXISTS_IN_GIVENPATH;
         }
       } else {
         if (!dbDirKeyName.equals(dirNameFromDetails)) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -113,8 +113,8 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
     // Set modification time and normalize key if required.
     KeyArgs.Builder newKeyArgs = keyArgs.toBuilder()
         .setModificationTime(Time.now())
-        .setKeyName(getNormalizedKey(ozoneManager.getEnableFileSystemPaths(),
-            keyArgs.getKeyName()));
+        .setKeyName(validateAndNormalizeKey(
+            ozoneManager.getEnableFileSystemPaths(), keyArgs.getKeyName()));
 
     AllocateBlockRequest.Builder newAllocatedBlockRequest =
         AllocateBlockRequest.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -110,9 +110,11 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
             ozoneManager.getPreallocateBlocksMax(),
             ozoneManager.isGrpcBlockTokenEnabled(), ozoneManager.getOMNodeId());
 
-    // Set modification time
+    // Set modification time and normalize key if required.
     KeyArgs.Builder newKeyArgs = keyArgs.toBuilder()
-        .setModificationTime(Time.now());
+        .setModificationTime(Time.now())
+        .setKeyName(getNormalizedKey(ozoneManager.getEnableFileSystemPaths(),
+            keyArgs.getKeyName()));
 
     AllocateBlockRequest.Builder newAllocatedBlockRequest =
         AllocateBlockRequest.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -91,7 +91,9 @@ public class OMKeyCommitRequest extends OMKeyRequest {
     }
 
     KeyArgs.Builder newKeyArgs =
-        keyArgs.toBuilder().setModificationTime(Time.now());
+        keyArgs.toBuilder().setModificationTime(Time.now())
+            .setKeyName(getNormalizedKey(
+                ozoneManager.getEnableFileSystemPaths(), keyArgs.getKeyName()));
 
     return getOmRequest().toBuilder()
         .setCommitKeyRequest(commitKeyRequest.toBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -92,7 +92,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
 
     KeyArgs.Builder newKeyArgs =
         keyArgs.toBuilder().setModificationTime(Time.now())
-            .setKeyName(getNormalizedKey(
+            .setKeyName(validateAndNormalizeKey(
                 ozoneManager.getEnableFileSystemPaths(), keyArgs.getKeyName()));
 
     return getOmRequest().toBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -203,12 +203,10 @@ public class OMKeyCreateRequest extends OMKeyRequest {
       volumeName = keyArgs.getVolumeName();
       bucketName = keyArgs.getBucketName();
 
-      if (ozoneManager.getEnableFileSystemPaths()) {
-        if (keyName.length() == 0) {
-          // Check if this is the root of the filesystem.
-          throw new OMException("Can not write to directory: " + keyName,
-              OMException.ResultCodes.NOT_A_FILE);
-        }
+      if (keyName.length() == 0) {
+        // Check if this is the root of the filesystem.
+        throw new OMException("Provided KeyName is empty string. Can not " +
+            "write to directory", OMException.ResultCodes.NOT_A_FILE);
       }
 
       // check Acl

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -73,7 +73,6 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_CREATE_INTERMEDIA
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.DIRECTORY_EXISTS;
-import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.FILE_EXISTS;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.FILE_EXISTS_IN_GIVENPATH;
 
 /**
@@ -171,6 +170,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
   }
 
   @Override
+  @SuppressWarnings("methodlength")
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
       long trxnLogIndex, OzoneManagerDoubleBufferHelper omDoubleBufferHelper) {
     CreateKeyRequest createKeyRequest = getOmRequest().getCreateKeyRequest();
@@ -227,7 +227,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
               OZONE_OM_CREATE_INTERMEDIATE_DIRECTORY_DEFAULT);
 
       // If FILE_EXISTS we just override like how we used to do for Key Create.
-      List<OzoneAcl> inheritAcls;
+      List< OzoneAcl > inheritAcls;
       if (createIntermediateDir) {
         OMFileRequest.OMPathInfo pathInfo =
             OMFileRequest.verifyFilesInPath(omMetadataManager, volumeName,
@@ -240,10 +240,11 @@ public class OMKeyCreateRequest extends OMKeyRequest {
         if (omDirectoryResult == DIRECTORY_EXISTS) {
           throw new OMException("Can not write to directory: " + keyName,
               NOT_A_FILE);
-        } else if (omDirectoryResult == FILE_EXISTS_IN_GIVENPATH) {
+        } else
+          if (omDirectoryResult == FILE_EXISTS_IN_GIVENPATH) {
             throw new OMException("Can not create file: " + keyName +
                 " as there is already file in the given path", NOT_A_FILE);
-        }
+          }
 
         missingParentInfos = OMDirectoryCreateRequest
             .getAllParentInfo(ozoneManager, keyArgs,
@@ -258,7 +259,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
       }
 
       omKeyInfo = prepareKeyInfo(omMetadataManager, keyArgs, dbKeyInfo,
-          keyArgs.getDataSize(), locations,  getFileEncryptionInfo(keyArgs),
+          keyArgs.getDataSize(), locations, getFileEncryptionInfo(keyArgs),
           ozoneManager.getPrefixManager(), bucketInfo, trxnLogIndex,
           ozoneManager.isRatisEnabled());
 
@@ -317,7 +318,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
       break;
     case FAILURE:
       LOG.error("Key creation failed. Volume:{}, Bucket:{}, Key{}. " +
-              "Exception:{}", volumeName, bucketName, keyName, exception);
+          "Exception:{}", volumeName, bucketName, keyName, exception);
       break;
     default:
       LOG.error("Unrecognized Result for OMKeyCreateRequest: {}",

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -107,7 +107,8 @@ public class OMKeyCreateRequest extends OMKeyRequest {
       keyPath = validateAndNormalizeKey(
           ozoneManager.getEnableFileSystemPaths(), keyPath);
       if (keyPath.endsWith("/")) {
-        throw new OMException("Invalid KeyPath: " + keyPath,
+        throw new OMException("Invalid KeyPath, key names with trailing / " +
+            "are not allowed." + keyPath,
             OMException.ResultCodes.INVALID_KEY_NAME);
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -203,6 +203,14 @@ public class OMKeyCreateRequest extends OMKeyRequest {
       volumeName = keyArgs.getVolumeName();
       bucketName = keyArgs.getBucketName();
 
+      if (ozoneManager.getEnableFileSystemPaths()) {
+        if (keyName.length() == 0) {
+          // Check if this is the root of the filesystem.
+          throw new OMException("Can not write to directory: " + keyName,
+              OMException.ResultCodes.NOT_A_FILE);
+        }
+      }
+
       // check Acl
       checkKeyAcls(ozoneManager, volumeName, bucketName, keyName,
           IAccessAuthorizer.ACLType.CREATE, OzoneObj.ResourceType.KEY);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -238,8 +238,9 @@ public class OMKeyCreateRequest extends OMKeyRequest {
 
         // Check if a file or directory exists with same key name.
         if (omDirectoryResult == DIRECTORY_EXISTS) {
-          throw new OMException("Can not write to directory: " + keyName,
-              NOT_A_FILE);
+          throw new OMException("Cannot write to " +
+              "directory. createIntermediateDirs behavior is enabled and " +
+              "hence / has special interpretation: " + keyName, NOT_A_FILE);
         } else
           if (omDirectoryResult == FILE_EXISTS_IN_GIVENPATH) {
             throw new OMException("Can not create file: " + keyName +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -75,7 +75,9 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
     OzoneManagerProtocolProtos.KeyArgs keyArgs = deleteKeyRequest.getKeyArgs();
 
     OzoneManagerProtocolProtos.KeyArgs.Builder newKeyArgs =
-        keyArgs.toBuilder().setModificationTime(Time.now());
+        keyArgs.toBuilder().setModificationTime(Time.now())
+            .setKeyName(getNormalizedKey(
+                ozoneManager.getEnableFileSystemPaths(), keyArgs.getKeyName()));
 
     return getOmRequest().toBuilder()
         .setDeleteKeyRequest(deleteKeyRequest.toBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -76,7 +76,7 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
 
     OzoneManagerProtocolProtos.KeyArgs.Builder newKeyArgs =
         keyArgs.toBuilder().setModificationTime(Time.now())
-            .setKeyName(getNormalizedKey(
+            .setKeyName(validateAndNormalizeKey(
                 ozoneManager.getEnableFileSystemPaths(), keyArgs.getKeyName()));
 
     return getOmRequest().toBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -90,13 +90,13 @@ public class OMKeyRenameRequest extends OMKeyRequest {
     // Set modification time and normalize key if needed.
     KeyArgs.Builder newKeyArgs = renameKeyArgs.toBuilder()
             .setModificationTime(Time.now())
-        .setKeyName(getNormalizedKey(ozoneManager.getEnableFileSystemPaths(),
+        .setKeyName(validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
             renameKeyArgs.getKeyName()));
 
     return getOmRequest().toBuilder()
         .setRenameKeyRequest(renameKeyRequest.toBuilder()
             .setKeyArgs(newKeyArgs)
-            .setToKeyName(getNormalizedKey(
+            .setToKeyName(validateAndNormalizeKey(
                 ozoneManager.getEnableFileSystemPaths(),
                 renameKeyRequest.getToKeyName())))
         .setUserInfo(getUserInfo()).build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -90,7 +90,8 @@ public class OMKeyRenameRequest extends OMKeyRequest {
     // Set modification time and normalize key if needed.
     KeyArgs.Builder newKeyArgs = renameKeyArgs.toBuilder()
             .setModificationTime(Time.now())
-        .setKeyName(validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
+        .setKeyName(validateAndNormalizeKey(
+            ozoneManager.getEnableFileSystemPaths(),
             renameKeyArgs.getKeyName()));
 
     return getOmRequest().toBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -85,13 +85,21 @@ public class OMKeyRenameRequest extends OMKeyRequest {
       OmUtils.validateKeyName(renameKeyRequest.getToKeyName());
     }
 
-    // Set modification time.
-    KeyArgs.Builder newKeyArgs = renameKeyRequest.getKeyArgs().toBuilder()
-            .setModificationTime(Time.now());
+    KeyArgs renameKeyArgs = renameKeyRequest.getKeyArgs();
+
+    // Set modification time and normalize key if needed.
+    KeyArgs.Builder newKeyArgs = renameKeyArgs.toBuilder()
+            .setModificationTime(Time.now())
+        .setKeyName(getNormalizedKey(ozoneManager.getEnableFileSystemPaths(),
+            renameKeyArgs.getKeyName()));
 
     return getOmRequest().toBuilder()
         .setRenameKeyRequest(renameKeyRequest.toBuilder()
-            .setKeyArgs(newKeyArgs)).setUserInfo(getUserInfo()).build();
+            .setKeyArgs(newKeyArgs)
+            .setToKeyName(getNormalizedKey(
+                ozoneManager.getEnableFileSystemPaths(),
+                renameKeyRequest.getToKeyName())))
+        .setUserInfo(getUserInfo()).build();
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -67,7 +67,7 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
   }
 
   @Override
-  public OMRequest preExecute(OzoneManager ozoneManager) {
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     MultipartInfoInitiateRequest multipartInfoInitiateRequest =
         getOmRequest().getInitiateMultiPartUploadRequest();
     Preconditions.checkNotNull(multipartInfoInitiateRequest);
@@ -76,7 +76,7 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
     KeyArgs.Builder newKeyArgs = keyArgs.toBuilder()
             .setMultipartUploadID(UUID.randomUUID().toString() + "-" +
                 UniqueId.next()).setModificationTime(Time.now())
-            .setKeyName(getNormalizedKey(
+            .setKeyName(validateAndNormalizeKey(
                 ozoneManager.getEnableFileSystemPaths(), keyArgs.getKeyName()));
 
     return getOmRequest().toBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.s3.multipart.S3InitiateMultipartUploadResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.MultipartInfoInitiateRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.MultipartInfoInitiateResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -46,6 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.security.Key;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
@@ -72,10 +74,12 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
         getOmRequest().getInitiateMultiPartUploadRequest();
     Preconditions.checkNotNull(multipartInfoInitiateRequest);
 
-    OzoneManagerProtocolProtos.KeyArgs.Builder newKeyArgs =
-        multipartInfoInitiateRequest.getKeyArgs().toBuilder()
+    KeyArgs keyArgs = multipartInfoInitiateRequest.getKeyArgs();
+    KeyArgs.Builder newKeyArgs = keyArgs.toBuilder()
             .setMultipartUploadID(UUID.randomUUID().toString() + "-" +
-                UniqueId.next()).setModificationTime(Time.now());
+                UniqueId.next()).setModificationTime(Time.now())
+            .setKeyName(getNormalizedKey(
+                ozoneManager.getEnableFileSystemPaths(), keyArgs.getKeyName()));
 
     return getOmRequest().toBuilder()
         .setUserInfo(getUserInfo())
@@ -92,7 +96,7 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
     MultipartInfoInitiateRequest multipartInfoInitiateRequest =
         getOmRequest().getInitiateMultiPartUploadRequest();
 
-    OzoneManagerProtocolProtos.KeyArgs keyArgs =
+    KeyArgs keyArgs =
         multipartInfoInitiateRequest.getKeyArgs();
 
     Preconditions.checkNotNull(keyArgs.getMultipartUploadID());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.s3.multipart.S3InitiateMultipartUploadResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.MultipartInfoInitiateRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.MultipartInfoInitiateResponse;
@@ -47,7 +46,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.security.Key;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
@@ -74,7 +74,7 @@ public class S3MultipartUploadAbortRequest extends OMKeyRequest {
     return getOmRequest().toBuilder().setAbortMultiPartUploadRequest(
         getOmRequest().getAbortMultiPartUploadRequest().toBuilder()
             .setKeyArgs(keyArgs.toBuilder().setModificationTime(Time.now())
-                .setKeyName(getNormalizedKey(
+                .setKeyName(validateAndNormalizeKey(
                     ozoneManager.getEnableFileSystemPaths(),
                     keyArgs.getKeyName()))))
         .setUserInfo(getUserInfo()).build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
@@ -73,7 +73,10 @@ public class S3MultipartUploadAbortRequest extends OMKeyRequest {
 
     return getOmRequest().toBuilder().setAbortMultiPartUploadRequest(
         getOmRequest().getAbortMultiPartUploadRequest().toBuilder()
-            .setKeyArgs(keyArgs.toBuilder().setModificationTime(Time.now())))
+            .setKeyArgs(keyArgs.toBuilder().setModificationTime(Time.now())
+                .setKeyName(getNormalizedKey(
+                    ozoneManager.getEnableFileSystemPaths(),
+                    keyArgs.getKeyName()))))
         .setUserInfo(getUserInfo()).build();
 
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -70,7 +70,7 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
   }
 
   @Override
-  public OMRequest preExecute(OzoneManager ozoneManager) {
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     MultipartCommitUploadPartRequest multipartCommitUploadPartRequest =
         getOmRequest().getCommitMultiPartUploadRequest();
 
@@ -78,7 +78,7 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
     return getOmRequest().toBuilder().setCommitMultiPartUploadRequest(
         multipartCommitUploadPartRequest.toBuilder()
             .setKeyArgs(keyArgs.toBuilder().setModificationTime(Time.now())
-                .setKeyName(getNormalizedKey(
+                .setKeyName(validateAndNormalizeKey(
                     ozoneManager.getEnableFileSystemPaths(),
                     keyArgs.getKeyName()))))
         .setUserInfo(getUserInfo()).build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -74,10 +74,13 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
     MultipartCommitUploadPartRequest multipartCommitUploadPartRequest =
         getOmRequest().getCommitMultiPartUploadRequest();
 
+    KeyArgs keyArgs = multipartCommitUploadPartRequest.getKeyArgs();
     return getOmRequest().toBuilder().setCommitMultiPartUploadRequest(
         multipartCommitUploadPartRequest.toBuilder()
-            .setKeyArgs(multipartCommitUploadPartRequest.getKeyArgs()
-                .toBuilder().setModificationTime(Time.now())))
+            .setKeyArgs(keyArgs.toBuilder().setModificationTime(Time.now())
+                .setKeyName(getNormalizedKey(
+                    ozoneManager.getEnableFileSystemPaths(),
+                    keyArgs.getKeyName()))))
         .setUserInfo(getUserInfo()).build();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -81,7 +81,10 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
     return getOmRequest().toBuilder()
         .setCompleteMultiPartUploadRequest(multipartUploadCompleteRequest
             .toBuilder().setKeyArgs(keyArgs.toBuilder()
-                .setModificationTime(Time.now())))
+                .setModificationTime(Time.now())
+                .setKeyName(getNormalizedKey(
+                    ozoneManager.getEnableFileSystemPaths(),
+                    keyArgs.getKeyName()))))
         .setUserInfo(getUserInfo()).build();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -82,7 +82,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         .setCompleteMultiPartUploadRequest(multipartUploadCompleteRequest
             .toBuilder().setKeyArgs(keyArgs.toBuilder()
                 .setModificationTime(Time.now())
-                .setKeyName(getNormalizedKey(
+                .setKeyName(validateAndNormalizeKey(
                     ozoneManager.getEnableFileSystemPaths(),
                     keyArgs.getKeyName()))))
         .setUserInfo(getUserInfo()).build();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestNormalizePaths.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestNormalizePaths.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.hadoop.ozone.om.request;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.hadoop.ozone.om.request.OMClientRequest.getNormalizedKey;
+
+/**
+ * Class to test normalize paths.
+ */
+public class TestNormalizePaths {
+
+  @Test
+  public void testNormalizePaths() {
+
+    Assert.assertEquals("a/b/c/d",
+        getNormalizedKey(true, "/a/b/c/d"));
+    Assert.assertEquals("a/b/c/d",
+        getNormalizedKey(true, "////a/b/c/d"));
+    Assert.assertEquals("a/b/c/d",
+        getNormalizedKey(true, "////a/b/////c/d"));
+    Assert.assertEquals("a/b/c/...../d",
+        getNormalizedKey(true, "////a/b/////c/...../d"));
+    Assert.assertEquals("a/b/d",
+        getNormalizedKey(true, "/a/b/c/../d"));
+    Assert.assertEquals("a/d",
+        getNormalizedKey(true, "/a/b/c/../../d"));
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestNormalizePaths.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestNormalizePaths.java
@@ -30,7 +30,7 @@ import static org.apache.hadoop.ozone.om.request.OMClientRequest.getNormalizedKe
 public class TestNormalizePaths {
 
   @Test
-  public void testNormalizePaths() {
+  public void testNormalizePathsEnabled() {
 
     Assert.assertEquals("a/b/c/d",
         getNormalizedKey(true, "/a/b/c/d"));
@@ -44,5 +44,24 @@ public class TestNormalizePaths {
         getNormalizedKey(true, "/a/b/c/../d"));
     Assert.assertEquals("a/d",
         getNormalizedKey(true, "/a/b/c/../../d"));
+  }
+
+
+
+  @Test
+  public void testNormalizePathsDisable() {
+
+    Assert.assertEquals("/a/b/c/d",
+        getNormalizedKey(false, "/a/b/c/d"));
+    Assert.assertEquals("////a/b/c/d",
+        getNormalizedKey(false, "////a/b/c/d"));
+    Assert.assertEquals("////a/b/////c/d",
+        getNormalizedKey(false, "////a/b/////c/d"));
+    Assert.assertEquals("////a/b/////c/...../d",
+        getNormalizedKey(false, "////a/b/////c/...../d"));
+    Assert.assertEquals("/a/b/c/../d",
+        getNormalizedKey(false, "/a/b/c/../d"));
+    Assert.assertEquals("/a/b/c/../../d",
+        getNormalizedKey(false, "/a/b/c/../../d"));
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestNormalizePaths.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestNormalizePaths.java
@@ -44,8 +44,16 @@ public class TestNormalizePaths {
         getNormalizedKey(true, "////a/b/////c/...../d"));
     Assert.assertEquals("a/b/d",
         getNormalizedKey(true, "/a/b/c/../d"));
-    Assert.assertEquals("a/d",
-        getNormalizedKey(true, "/a/b/c/../../d"));
+    Assert.assertEquals("../../d",
+        getNormalizedKey(true, "/a/b/c/../../../../../d"));
+    Assert.assertEquals("../a/b/c",
+        getNormalizedKey(true, "../a/b/c/"));
+    Assert.assertEquals("../a/b/c",
+        getNormalizedKey(true, "/../a/b/c/"));
+    Assert.assertEquals("a",
+        getNormalizedKey(true, "a"));
+    Assert.assertEquals("",
+        getNormalizedKey(true, ""));
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestNormalizePaths.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestNormalizePaths.java
@@ -54,6 +54,8 @@ public class TestNormalizePaths {
         getNormalizedKey(true, "a"));
     Assert.assertEquals("",
         getNormalizedKey(true, ""));
+    Assert.assertEquals("",
+        getNormalizedKey(true, "/"));
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestNormalizePaths.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestNormalizePaths.java
@@ -33,6 +33,8 @@ public class TestNormalizePaths {
   public void testNormalizePathsEnabled() {
 
     Assert.assertEquals("a/b/c/d",
+        getNormalizedKey(true, "a/b/c/d"));
+    Assert.assertEquals("a/b/c/d",
         getNormalizedKey(true, "/a/b/c/d"));
     Assert.assertEquals("a/b/c/d",
         getNormalizedKey(true, "////a/b/c/d"));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestNormalizePaths.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestNormalizePaths.java
@@ -19,61 +19,91 @@
 
 package org.apache.hadoop.ozone.om.request;
 
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
-import static org.apache.hadoop.ozone.om.request.OMClientRequest.getNormalizedKey;
+import static org.apache.hadoop.ozone.om.request.OMClientRequest.validateAndNormalizeKey;
+import static org.junit.Assert.fail;
 
 /**
  * Class to test normalize paths.
  */
 public class TestNormalizePaths {
 
+  @Rule
+  public ExpectedException exceptionRule = ExpectedException.none();
+
   @Test
-  public void testNormalizePathsEnabled() {
+  public void testNormalizePathsEnabled() throws Exception {
 
     Assert.assertEquals("a/b/c/d",
-        getNormalizedKey(true, "a/b/c/d"));
+        validateAndNormalizeKey(true, "a/b/c/d"));
     Assert.assertEquals("a/b/c/d",
-        getNormalizedKey(true, "/a/b/c/d"));
+        validateAndNormalizeKey(true, "/a/b/c/d"));
     Assert.assertEquals("a/b/c/d",
-        getNormalizedKey(true, "////a/b/c/d"));
+        validateAndNormalizeKey(true, "////a/b/c/d"));
     Assert.assertEquals("a/b/c/d",
-        getNormalizedKey(true, "////a/b/////c/d"));
+        validateAndNormalizeKey(true, "////a/b/////c/d"));
     Assert.assertEquals("a/b/c/...../d",
-        getNormalizedKey(true, "////a/b/////c/...../d"));
+        validateAndNormalizeKey(true, "////a/b/////c/...../d"));
     Assert.assertEquals("a/b/d",
-        getNormalizedKey(true, "/a/b/c/../d"));
-    Assert.assertEquals("../../d",
-        getNormalizedKey(true, "/a/b/c/../../../../../d"));
-    Assert.assertEquals("../a/b/c",
-        getNormalizedKey(true, "../a/b/c/"));
-    Assert.assertEquals("../a/b/c",
-        getNormalizedKey(true, "/../a/b/c/"));
+        validateAndNormalizeKey(true, "/a/b/c/../d"));
     Assert.assertEquals("a",
-        getNormalizedKey(true, "a"));
-    Assert.assertEquals("",
-        getNormalizedKey(true, ""));
-    Assert.assertEquals("",
-        getNormalizedKey(true, "/"));
+        validateAndNormalizeKey(true, "a"));
+    Assert.assertEquals("a/b",
+        validateAndNormalizeKey(true, "/a/./b"));
+    Assert.assertEquals("a/b",
+        validateAndNormalizeKey(true, ".//a/./b"));
+    Assert.assertEquals("a/",
+        validateAndNormalizeKey(true, "/a/."));
+    Assert.assertEquals("b/c",
+        validateAndNormalizeKey(true, "//./b/c/"));
+    Assert.assertEquals("a/b/c/d",
+        validateAndNormalizeKey(true, "a/b/c/d/"));
+    Assert.assertEquals("a/b/c/...../d",
+        validateAndNormalizeKey(true, "////a/b/////c/...../d/"));
+  }
+
+  @Test
+  public void testNormalizeKeyInvalidPaths() throws OMException {
+    checkInvalidPath("/a/b/c/../../../../../d");
+    checkInvalidPath("../a/b/c/");
+    checkInvalidPath("/../..a/b/c/");
+    checkInvalidPath("//");
+    checkInvalidPath("/////");
+    checkInvalidPath("");
+    checkInvalidPath("/");
+    checkInvalidPath("/:/:");
+  }
+
+  private void checkInvalidPath(String keyName) {
+    try {
+      validateAndNormalizeKey(true, keyName);
+      fail("checkInvalidPath failed for path " + keyName);
+    } catch (OMException ex) {
+      Assert.assertTrue(ex.getMessage().contains("Invalid KeyPath"));
+    }
   }
 
 
 
   @Test
-  public void testNormalizePathsDisable() {
+  public void testNormalizePathsDisable() throws OMException {
 
     Assert.assertEquals("/a/b/c/d",
-        getNormalizedKey(false, "/a/b/c/d"));
+        validateAndNormalizeKey(false, "/a/b/c/d"));
     Assert.assertEquals("////a/b/c/d",
-        getNormalizedKey(false, "////a/b/c/d"));
+        validateAndNormalizeKey(false, "////a/b/c/d"));
     Assert.assertEquals("////a/b/////c/d",
-        getNormalizedKey(false, "////a/b/////c/d"));
+        validateAndNormalizeKey(false, "////a/b/////c/d"));
     Assert.assertEquals("////a/b/////c/...../d",
-        getNormalizedKey(false, "////a/b/////c/...../d"));
+        validateAndNormalizeKey(false, "////a/b/////c/...../d"));
     Assert.assertEquals("/a/b/c/../d",
-        getNormalizedKey(false, "/a/b/c/../d"));
+        validateAndNormalizeKey(false, "/a/b/c/../d"));
     Assert.assertEquals("/a/b/c/../../d",
-        getNormalizedKey(false, "/a/b/c/../../d"));
+        validateAndNormalizeKey(false, "/a/b/c/../../d"));
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -347,7 +347,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
   @Test
   public void testKeyCreateWithIntermediateDir() throws Exception {
 
-    String keyName = "a/b/c/file1";
+    String keyName = "/a/b/c/file1";
     OMRequest omRequest = createKeyRequest(false, 0, keyName);
 
     OzoneConfiguration configuration = new OzoneConfiguration();
@@ -393,8 +393,8 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     TestOMRequestUtils.addKeyToTable(false, volumeName, bucketName, keyName,
         0L, RATIS, THREE, omMetadataManager);
 
-    // Now try with a file exists in path. Should fail.
-    keyName = "a/b/c/file1/file2";
+    // Now create another file in same dir path.
+    keyName = "/a/b/c/file2";
     omRequest = createKeyRequest(false, 0, keyName);
 
     omKeyCreateRequest = new OMKeyCreateRequest(omRequest);
@@ -407,8 +407,24 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
         omKeyCreateRequest.validateAndUpdateCache(ozoneManager,
             101L, ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(omClientResponse.getOMResponse().getStatus(),
-        NOT_A_FILE);
+    Assert.assertEquals(OK, omClientResponse.getOMResponse().getStatus());
+
+    // Now try with a file exists in path. Should fail.
+    keyName = "/a/b/c/file1/file2";
+    omRequest = createKeyRequest(false, 0, keyName);
+
+    omKeyCreateRequest = new OMKeyCreateRequest(omRequest);
+
+    omRequest = omKeyCreateRequest.preExecute(ozoneManager);
+
+    omKeyCreateRequest = new OMKeyCreateRequest(omRequest);
+
+    omClientResponse =
+        omKeyCreateRequest.validateAndUpdateCache(ozoneManager,
+            101L, ozoneManagerDoubleBufferHelper);
+
+    Assert.assertEquals(NOT_A_FILE,
+        omClientResponse.getOMResponse().getStatus());
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.junit.Assert;
 import org.junit.Test;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -379,9 +379,18 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     createAndCheck(keyName);
 
 
+    // Empty keyName.
+    keyName = "";
+    checkNotAFile(keyName);
+
     // Create a file, where a file already exists in the path.
     // Now try with a file exists in path. Should fail.
     keyName = "/a/b/c/file1/file3";
+    createAndCheck(keyName);
+
+  }
+
+  private void checkNotAFile(String keyName) throws Exception {
     OMRequest omRequest = createKeyRequest(false, 0, keyName);
 
     OMKeyCreateRequest omKeyCreateRequest = new OMKeyCreateRequest(omRequest);
@@ -396,7 +405,6 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
 
     Assert.assertEquals(NOT_A_FILE,
         omClientResponse.getOMResponse().getStatus());
-
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -422,6 +422,12 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     keyName = "";
     checkNotAValidPath(keyName);
 
+    keyName = "../a/b";
+    checkNotAValidPath(keyName);
+
+    keyName = "/../a/b";
+    checkNotAValidPath(keyName);
+
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_CREATE_INTERMEDIATE_DIRECTORY;
-import static org.apache.hadoop.ozone.om.request.TestOMRequestUtils.addKeyToTable;
 import static org.apache.hadoop.ozone.om.request.TestOMRequestUtils.addVolumeAndBucketToDB;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.NOT_A_FILE;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.OK;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -355,6 +355,10 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager);
 
+
+    keyName = "dir1/dir2/dir3/file1";
+    createAndCheck(keyName);
+
     // Key with leading '/'.
     String keyName = "/a/b/c/file1";
     createAndCheck(keyName);
@@ -424,7 +428,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     // Check open key entry
     String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,
         keyName, omRequest.getCreateKeyRequest().getClientID());
-   OmKeyInfo omKeyInfo = omMetadataManager.getOpenKeyTable().get(openKey);
+    OmKeyInfo omKeyInfo = omMetadataManager.getOpenKeyTable().get(openKey);
     Assert.assertNotNull(omKeyInfo);
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequest.java
@@ -36,7 +36,7 @@ public class TestS3InitiateMultipartUploadRequest
     extends TestS3MultipartRequest {
 
   @Test
-  public void testPreExecute() {
+  public void testPreExecute() throws Exception {
     doPreExecuteInitiateMPU(UUID.randomUUID().toString(),
         UUID.randomUUID().toString(), UUID.randomUUID().toString());
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
@@ -107,7 +107,7 @@ public class TestS3MultipartRequest {
    * @return OMRequest - returned from preExecute.
    */
   protected OMRequest doPreExecuteInitiateMPU(
-      String volumeName, String bucketName, String keyName) {
+      String volumeName, String bucketName, String keyName) throws Exception {
     OMRequest omRequest =
         TestOMRequestUtils.createInitiateMPURequest(volumeName, bucketName,
             keyName);
@@ -141,7 +141,8 @@ public class TestS3MultipartRequest {
    */
   protected OMRequest doPreExecuteCommitMPU(
       String volumeName, String bucketName, String keyName,
-      long clientID, String multipartUploadID, int partNumber) {
+      long clientID, String multipartUploadID, int partNumber)
+      throws Exception {
 
     // Just set dummy size
     long dataSize = 100L;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
@@ -38,7 +38,7 @@ public class TestS3MultipartUploadCommitPartRequest
     extends TestS3MultipartRequest {
 
   @Test
-  public void testPreExecute() {
+  public void testPreExecute() throws Exception {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     String keyName = UUID.randomUUID().toString();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Keys created via the S3 Gateway currently use the createKey OM API to create the ozone key. Hence, when using a hdfs client to list intermediate directories in the key, OM returns key not found error. This was encountered while using fluentd to write Hive logs to Ozone via the s3 gateway.

Added a new config in OM to control the behavior of key create to create intermediate directories or not. In this way, keys created via ozone S3G can be accessed through fs API.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3955

## How was this patch tested?

Added UT and IT.
