### PR TITLE
HDDS-3957. Fix mixed use of Longs.toByteArray and Ints.fromByteArray

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/TopNOrderedContainerDeletionChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/TopNOrderedContainerDeletionChoosingPolicy.java
@@ -45,7 +45,7 @@ public class TopNOrderedContainerDeletionChoosingPolicy
   private static final Comparator<KeyValueContainerData>
         KEY_VALUE_CONTAINER_DATA_COMPARATOR = (KeyValueContainerData c1,
                                                KeyValueContainerData c2) ->
-              Integer.compare(c2.getNumPendingDeletionBlocks(),
+              Long.compare(c2.getNumPendingDeletionBlocks(),
                   c1.getNumPendingDeletionBlocks());
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
@@ -38,7 +38,7 @@ import org.yaml.snakeyaml.nodes.Tag;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static java.lang.Math.max;
 import static org.apache.hadoop.ozone.OzoneConsts.DB_BLOCK_COUNT_KEY;
@@ -72,7 +72,7 @@ public class KeyValueContainerData extends ContainerData {
   /**
    * Number of pending deletion blocks in KeyValueContainer.
    */
-  private final AtomicInteger numPendingDeletionBlocks;
+  private final AtomicLong numPendingDeletionBlocks;
 
   private long deleteTransactionId;
 
@@ -97,7 +97,7 @@ public class KeyValueContainerData extends ContainerData {
       long size, String originPipelineId, String originNodeId) {
     super(ContainerProtos.ContainerType.KeyValueContainer, id, layOutVersion,
         size, originPipelineId, originNodeId);
-    this.numPendingDeletionBlocks = new AtomicInteger(0);
+    this.numPendingDeletionBlocks = new AtomicLong(0);
     this.deleteTransactionId = 0;
   }
 
@@ -105,7 +105,7 @@ public class KeyValueContainerData extends ContainerData {
     super(source);
     Preconditions.checkArgument(source.getContainerType()
         == ContainerProtos.ContainerType.KeyValueContainer);
-    this.numPendingDeletionBlocks = new AtomicInteger(0);
+    this.numPendingDeletionBlocks = new AtomicLong(0);
     this.deleteTransactionId = 0;
   }
 
@@ -187,7 +187,7 @@ public class KeyValueContainerData extends ContainerData {
    *
    * @param numBlocks increment number
    */
-  public void incrPendingDeletionBlocks(int numBlocks) {
+  public void incrPendingDeletionBlocks(long numBlocks) {
     this.numPendingDeletionBlocks.addAndGet(numBlocks);
   }
 
@@ -196,14 +196,14 @@ public class KeyValueContainerData extends ContainerData {
    *
    * @param numBlocks decrement number
    */
-  public void decrPendingDeletionBlocks(int numBlocks) {
+  public void decrPendingDeletionBlocks(long numBlocks) {
     this.numPendingDeletionBlocks.addAndGet(-1 * numBlocks);
   }
 
   /**
    * Get the number of pending deletion blocks.
    */
-  public int getNumPendingDeletionBlocks() {
+  public long getNumPendingDeletionBlocks() {
     return this.numPendingDeletionBlocks.get();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -23,7 +23,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
@@ -171,7 +170,7 @@ public final class KeyValueContainerUtil {
           containerDB.getStore().get(DB_PENDING_DELETE_BLOCK_COUNT_KEY);
       if (pendingDeleteBlockCount != null) {
         kvContainerData.incrPendingDeletionBlocks(
-            Ints.fromByteArray(pendingDeleteBlockCount));
+            Longs.fromByteArray(pendingDeleteBlockCount));
       } else {
         // Set pending deleted block count.
         MetadataKeyFilters.KeyPrefixFilter filter =

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import com.google.common.collect.Lists;
-import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.client.BlockID;
@@ -179,7 +178,7 @@ public class TestBlockDeletingService {
         metadata.getStore().put(OzoneConsts.DB_CONTAINER_BYTES_USED_KEY,
             Longs.toByteArray(blockLength * numOfBlocksPerContainer));
         metadata.getStore().put(DB_PENDING_DELETE_BLOCK_COUNT_KEY,
-            Ints.toByteArray(numOfBlocksPerContainer));
+            Longs.toByteArray(numOfBlocksPerContainer));
       }
     }
   }
@@ -250,6 +249,8 @@ public class TestBlockDeletingService {
 
       // Ensure there are 3 blocks under deletion and 0 deleted blocks
       Assert.assertEquals(3, getUnderDeletionBlocksCount(meta));
+      Assert.assertEquals(3, Longs.fromByteArray(
+          meta.getStore().get(DB_PENDING_DELETE_BLOCK_COUNT_KEY)));
       Assert.assertEquals(0, getDeletedBlocksCount(meta));
 
       // An interval will delete 1 * 2 blocks
@@ -268,7 +269,7 @@ public class TestBlockDeletingService {
 
       // Check finally DB counters.
       // Not checking bytes used, as handler is a mock call.
-      Assert.assertEquals(0, Ints.fromByteArray(
+      Assert.assertEquals(0, Longs.fromByteArray(
           meta.getStore().get(DB_PENDING_DELETE_BLOCK_COUNT_KEY)));
       Assert.assertEquals(0, Longs.fromByteArray(
           meta.getStore().get(DB_BLOCK_COUNT_KEY)));


### PR DESCRIPTION
## What changes were proposed in this pull request?
**What's the problem ?**
When write `DB_PENDING_DELETE_BLOCK_COUNT_KEY` to rocksdb, most code convert value to byte array by `Longs.toByteArray`. But when read,  `parseKVContainerData` use `Ints.fromByteArray`. The result is always wrong, unless the value is zero.  
![image](https://user-images.githubusercontent.com/51938049/87388645-ca3f2d80-c5d7-11ea-9ac1-75fcf348ae79.png)

![image](https://user-images.githubusercontent.com/51938049/87388853-2efa8800-c5d8-11ea-9568-50ee6beca04b.png)

For example, `Longs.toByteArray(1)` return byte array in which only byte[7] is 1, but `Ints.fromByteArray` only parse the first 4 bytes of byte array. So write 1, but read out 0.
![image](https://user-images.githubusercontent.com/51938049/87388967-6701cb00-c5d8-11ea-8597-fb909a531875.png)
![image](https://user-images.githubusercontent.com/51938049/87389100-b1834780-c5d8-11ea-9310-ded8caec57a5.png)


## What is the link to the Apache JIRA


https://issues.apache.org/jira/browse/HDDS-3957

## How was this patch tested?

add assert in current ut.
