### PR TITLE
HDDS-3958. Intermittent failure in Recon acceptance test due to mixed stdout and stderr

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/recon/recon-api.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/recon/recon-api.robot
@@ -28,10 +28,10 @@ ${API_ENDPOINT_URL}   http://recon:9888/api/v1
 *** Keywords ***
 Check if Recon picks up container from OM
     Run Keyword if      '${SECURITY_ENABLED}' == 'true'     Kinit HTTP user
-    ${result} =         Execute                             curl --negotiate -u : -v ${API_ENDPOINT_URL}/containers
+    ${result} =         Execute                             curl --negotiate -u : -LSs ${API_ENDPOINT_URL}/containers
                         Should contain      ${result}       \"ContainerID\":1
 
-    ${result} =         Execute                             curl --negotiate -u : -v ${API_ENDPOINT_URL}/utilization/fileCount
+    ${result} =         Execute                             curl --negotiate -u : -LSs ${API_ENDPOINT_URL}/utilization/fileCount
                         Should contain      ${result}       \"fileSize\":2048,\"count\":10
 
 *** Test Cases ***
@@ -43,13 +43,13 @@ Check if Recon picks up OM data
     Wait Until Keyword Succeeds     90sec      10sec        Check if Recon picks up container from OM
 
 Check if Recon picks up DN heartbeats
-    ${result} =         Execute                             curl --negotiate -u : -v ${API_ENDPOINT_URL}/datanodes
+    ${result} =         Execute                             curl --negotiate -u : -LSs ${API_ENDPOINT_URL}/datanodes
                         Should contain      ${result}       datanodes
                         Should contain      ${result}       datanode_1
                         Should contain      ${result}       datanode_2
                         Should contain      ${result}       datanode_3
 
-    ${result} =         Execute                             curl --negotiate -u : -v ${API_ENDPOINT_URL}/pipelines
+    ${result} =         Execute                             curl --negotiate -u : -LSs ${API_ENDPOINT_URL}/pipelines
                         Should contain      ${result}       pipelines
                         Should contain      ${result}       RATIS
                         Should contain      ${result}       OPEN
@@ -57,15 +57,15 @@ Check if Recon picks up DN heartbeats
                         Should contain      ${result}       datanode_2
                         Should contain      ${result}       datanode_3
 
-    ${result} =         Execute                             curl --negotiate -u : -v ${API_ENDPOINT_URL}/clusterState
+    ${result} =         Execute                             curl --negotiate -u : -LSs ${API_ENDPOINT_URL}/clusterState
                         Should contain      ${result}       \"totalDatanodes\":3
                         Should contain      ${result}       \"healthyDatanodes\":3
                         Should contain      ${result}       \"pipelines\":4
 
-    ${result} =         Execute                             curl --negotiate -u : -v ${API_ENDPOINT_URL}/containers/1/replicaHistory
+    ${result} =         Execute                             curl --negotiate -u : -LSs ${API_ENDPOINT_URL}/containers/1/replicaHistory
                         Should contain      ${result}       \"containerId\":1
 
 Check if Recon Web UI is up
     Run Keyword if      '${SECURITY_ENABLED}' == 'true'     Kinit HTTP user
-    ${result} =         Execute                             curl --negotiate -u : -v ${ENDPOINT_URL}
+    ${result} =         Execute                             curl --negotiate -u : -LSs ${ENDPOINT_URL}
                         Should contain      ${result}       Ozone Recon


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make `curl` less verbose to avoid connection-related messages being mixed into the response from Recon.

https://issues.apache.org/jira/browse/HDDS-3958

## How was this patch tested?

Verified output in [acceptance test](https://github.com/adoroszlai/hadoop-ozone/runs/869256000):

```
<arg>${output}</arg>
</arguments>
<msg timestamp="20200714 14:02:46.735" level="INFO">[{"volume":"vol-3-10121","bucket":"bucket-4-58535","fileSize":16384,"count":5},{"volume":"vol-4-32109","bucket":"bucket-2-76236","fileSize":16384,"count":5},{"volume":"vol-3-10121","bucket":"bucket-3-34240","fileSize":16384,"count":5},{"volume":"vol-2-74673","bucket":"bucket-2-24567","fileSize":16384,"count":5},{"volume":"vol-0-21163","bucket":"bucket-1-46076","fileSize":16384,"count":5},{"volume":"vol-0-21163","bucket":"bucket-3-20203","fileSize":16384,"count":5},{"volume":"vol-1-98932","bucket":"bucket-4-69150","fileSize":16384,"count":5},{"volume":"vol-2-74673","bucket":"bucket-1-35826","fileSize":16384,"count":5},{"volume":"vol-0-21163","bucket":"bucket-0-06750","fileSize":16384,"count":5},{"volume":"vol-1-98932","bucket":"bucket-1-85094","fileSize":16384,"count":5},{"volume":"vol-3-10121","bucket":"bucket-2-49899","fileSize":16384,"count":5},{"volume":"vol-0-21163","bucket":"bucket-2-24533","fileSize":16384,"count":5},{"volume":"vol-3-10121","bucket":"bucket-0-55405","fileSize":16384,"count":5},{"volume":"vol-1-98932","bucket":"bucket-0-69261","fileSize":16384,"count":5},{"volume":"vol-1-98932","bucket":"bucket-3-37904","fileSize":16384,"count":5},{"volume":"vol-1-98932","bucket":"bucket-2-74383","fileSize":16384,"count":5},{"volume":"vol-4-32109","bucket":"bucket-3-53360","fileSize":16384,"count":5},{"volume":"vol-2-74673","bucket":"bucket-4-90899","fileSize":16384,"count":5},{"volume":"vol-0-21163","bucket":"bucket-4-09448","fileSize":16384,"count":5},{"volume":"vol-4-32109","bucket":"bucket-0-21307","fileSize":16384,"count":5},{"volume":"vol-3-10121","bucket":"bucket-1-37420","fileSize":16384,"count":5},{"volume":"vol-4-32109","bucket":"bucket-1-96158","fileSize":16384,"count":5},{"volume":"vol-4-32109","bucket":"bucket-4-81674","fileSize":16384,"count":5},{"volume":"vol-2-74673","bucket":"bucket-0-72641","fileSize":16384,"count":5},{"volume":"vol-2-74673","bucket":"bucket-3-10948","fileSize":16384,"count":5},{"volume":"87083-rpcwoport","bucket":"bb1","fileSize":32768,"count":0},{"volume":"87083-rpcwoport2","bucket":"bb1","fileSize":32768,"count":1},{"volume":"87083-rpcwport","bucket":"bb1","fileSize":32768,"count":0},{"volume":"87083-rpcwoscheme","bucket":"bb1","fileSize":32768,"count":0},{"volume":"fstest370","bucket":"bk1","fileSize":32768,"count":1},{"volume":"fstest1","bucket":"bucket1-ofs","fileSize":1024,"count":4},{"volume":"fstest1","bucket":"bucket1-ofs","fileSize":32768,"count":3},{"volume":"fstest2","bucket":"bucket3-ofs","fileSize":1024,"count":0},{"volume":"fstest1","bucket":"bucket1-o3fs","fileSize":32768,"count":3},{"volume":"fstest1","bucket":"bucket1-o3fs","fileSize":1024,"count":4},{"volume":"fstest2","bucket":"bucket3-o3fs","fileSize":1024,"count":0},{"volume":"s3v","bucket":"bucket-83530","fileSize":1024,"count":2},{"volume":"s3v","bucket":"bucket-89656","fileSize":1024,"count":1},{"volume":"s3v","bucket":"bucket-53511","fileSize":8388608,"count":4},{"volume":"s3v","bucket":"bucket-53511","fileSize":16777216,"count":2},{"volume":"s3v","bucket":"destbucket-83303","fileSize":1024,"count":1},{"volume":"s3v","bucket":"bucket-54425","fileSize":1024,"count":2},{"volume":"s3v","bucket":"bucket-59094","fileSize":1024,"count":1},{"volume":"vol-0-15917","bucket":"bucket-0-74640","fileSize":2048,"count":10}]</msg>
```