### PR TITLE
HDDS-3798. Display more accurate timestamp in recon Web

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
@@ -44,7 +44,7 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
         <Tooltip
           placement='bottom' title={moment(lastUpdated).format('lll')}
         >
-          {moment(lastUpdated).format('LT')}
+          {moment(lastUpdated).format('LTS')}
         </Tooltip>
       );
     return (

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
@@ -42,7 +42,7 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
     const lastUpdatedText = lastUpdated === 0 ? 'NA' :
       (
         <Tooltip
-          placement='bottom' title={moment(lastUpdated).format('lll')}
+          placement='bottom' title={moment(lastUpdated).format('ll LTS')}
         >
           {moment(lastUpdated).format('LTS')}
         </Tooltip>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -135,7 +135,7 @@ const COLUMNS = [
     isVisible: true,
     sorter: (a: IDatanode, b: IDatanode) => a.lastHeartbeat - b.lastHeartbeat,
     render: (heartbeat: number) => {
-      return heartbeat > 0 ? moment(heartbeat).format('YYYY/MM/DD HH:mm:ss') : 'NA';
+      return heartbeat > 0 ? moment(heartbeat).format('ll LTS') : 'NA';
     }
   },
   {
@@ -197,7 +197,7 @@ const COLUMNS = [
     isVisible: false,
     sorter: (a: IDatanode, b: IDatanode) => a.setupTime - b.setupTime,
     render: (uptime: number) => {
-      return uptime > 0 ? moment(uptime).format('YYYY/MM/DD HH:mm:ss') : 'NA';
+      return uptime > 0 ? moment(uptime).format('ll LTS') : 'NA';
     }
   }
 ];

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -135,7 +135,7 @@ const COLUMNS = [
     isVisible: true,
     sorter: (a: IDatanode, b: IDatanode) => a.lastHeartbeat - b.lastHeartbeat,
     render: (heartbeat: number) => {
-      return heartbeat > 0 ? moment(heartbeat).format('lll') : 'NA';
+      return heartbeat > 0 ? moment(heartbeat).format('YYYY/MM/DD HH:mm:ss') : 'NA';
     }
   },
   {
@@ -197,7 +197,7 @@ const COLUMNS = [
     isVisible: false,
     sorter: (a: IDatanode, b: IDatanode) => a.setupTime - b.setupTime,
     render: (uptime: number) => {
-      return uptime > 0 ? moment(uptime).format('lll') : 'NA';
+      return uptime > 0 ? moment(uptime).format('YYYY/MM/DD HH:mm:ss') : 'NA';
     }
   }
 ];

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/pipelines/pipelines.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/pipelines/pipelines.tsx
@@ -114,7 +114,7 @@ const COLUMNS = [
     dataIndex: 'lastLeaderElection',
     key: 'lastLeaderElection',
     render: (lastLeaderElection: number) => lastLeaderElection > 0 ?
-      moment(lastLeaderElection).format('lll') : 'NA',
+      moment(lastLeaderElection).format('YYYY/MM/DD HH:mm:ss') : 'NA',
     sorter: (a: IPipelineResponse, b: IPipelineResponse) => a.lastLeaderElection - b.lastLeaderElection
   },
   {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/pipelines/pipelines.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/pipelines/pipelines.tsx
@@ -114,7 +114,7 @@ const COLUMNS = [
     dataIndex: 'lastLeaderElection',
     key: 'lastLeaderElection',
     render: (lastLeaderElection: number) => lastLeaderElection > 0 ?
-      moment(lastLeaderElection).format('YYYY/MM/DD HH:mm:ss') : 'NA',
+      moment(lastLeaderElection).format('ll LTS') : 'NA',
     sorter: (a: IPipelineResponse, b: IPipelineResponse) => a.lastLeaderElection - b.lastLeaderElection
   },
   {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Display more accurate timestamp in recon Web. Currently the web only show timestamp in minutes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3960

## How was this patch tested?

Test with `pnpm run dev`

Here is the result with this patch.
![image](https://user-images.githubusercontent.com/3263540/87500620-87409100-c68f-11ea-843d-f20d9a2a4f7d.png)

