### PR TITLE
HDDS-3968. LDB scan fails to read from transactionInfoTable.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.utils.db.DBDefinition;
 import org.apache.hadoop.hdds.utils.db.LongCodec;
 import org.apache.hadoop.hdds.utils.db.StringCodec;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
@@ -31,6 +32,7 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 
+import org.apache.hadoop.ozone.om.ratis.OMTransactionInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 
@@ -139,6 +141,15 @@ public class OMDBDefinition implements DBDefinition {
                     S3SecretValue.class,
                     new S3SecretValueCodec());
 
+  public static final DBColumnFamilyDefinition<String, OMTransactionInfo>
+      TRANSACTION_INFO_TABLE =
+      new DBColumnFamilyDefinition<>(
+          OmMetadataManagerImpl.TRANSACTION_INFO_TABLE,
+          String.class,
+          new StringCodec(),
+          OMTransactionInfo.class,
+          new OMTransactionInfoCodec());
+
 
   @Override
   public String getName() {
@@ -155,7 +166,7 @@ public class OMDBDefinition implements DBDefinition {
     return new DBColumnFamilyDefinition[] {DELETED_TABLE, USER_TABLE,
         VOLUME_TABLE, S3_TABLE, OPEN_KEY_TABLE, KEY_TABLE,
         BUCKET_TABLE, MULTIPART_INFO_TABLE, PREFIX_TABLE, DTOKEN_TABLE,
-        S3_SECRET_TABLE};
+        S3_SECRET_TABLE, TRANSACTION_INFO_TABLE};
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

LDB Scan tool failing to read from transactionInfo table.
```

[root@bv-cml-1 ~]# ozone debug ldb --db=/var/lib/hadoop-ozone/om/data/om.db/ scan --column_family=transactionInfoTable
Table with specified name does not exist
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3968

## How was this patch tested?

Tested on the cluster, now able to scan the content of TransactionInfo table.

```
[root@bv-cml-1 ~]# ozone debug ldb --db=/var/lib/hadoop-ozone/om/data/om.db/ scan --column_family=transactionInfoTable
{
  "currentTerm": 7,
  "transactionIndex": 75
}
```

