### PR TITLE
HDDS-3965. SCM failed to start up for duplicated pipeline detected.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreIterator.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreIterator.java
@@ -74,8 +74,8 @@ public class RDBStoreIterator
 
   @Override
   public ByteArrayKeyValue next() {
-    if (rocksDBIterator.isValid()) {
-      setCurrentEntry();
+    setCurrentEntry();
+    if (currentEntry != null) {
       rocksDBIterator.next();
       return currentEntry;
     }
@@ -97,11 +97,8 @@ public class RDBStoreIterator
   @Override
   public ByteArrayKeyValue seek(byte[] key) {
     rocksDBIterator.seek(key);
-    if (rocksDBIterator.isValid()) {
-      return ByteArrayKeyValue.create(rocksDBIterator.key(),
-          rocksDBIterator.value());
-    }
-    return null;
+    setCurrentEntry();
+    return currentEntry;
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreIterator.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreIterator.java
@@ -24,6 +24,8 @@ import java.util.NoSuchElementException;
 import java.util.function.Consumer;
 
 import org.rocksdb.RocksIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * RocksDB store iterator.
@@ -31,12 +33,16 @@ import org.rocksdb.RocksIterator;
 public class RDBStoreIterator
     implements TableIterator<byte[], ByteArrayKeyValue> {
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(RDBStoreIterator.class);
+
   private RocksIterator rocksDBIterator;
   private RDBTable rocksDBTable;
+  private ByteArrayKeyValue currentEntry;
 
   public RDBStoreIterator(RocksIterator iterator) {
     this.rocksDBIterator = iterator;
-    rocksDBIterator.seekToFirst();
+    seekToFirst();
   }
 
   public RDBStoreIterator(RocksIterator iterator, RDBTable table) {
@@ -52,6 +58,15 @@ public class RDBStoreIterator
     }
   }
 
+  private void setCurrentEntry() {
+    if (rocksDBIterator.isValid()) {
+      currentEntry = ByteArrayKeyValue.create(rocksDBIterator.key(),
+          rocksDBIterator.value());
+    } else {
+      currentEntry = null;
+    }
+  }
+
   @Override
   public boolean hasNext() {
     return rocksDBIterator.isValid();
@@ -60,11 +75,9 @@ public class RDBStoreIterator
   @Override
   public ByteArrayKeyValue next() {
     if (rocksDBIterator.isValid()) {
-      ByteArrayKeyValue value =
-          ByteArrayKeyValue.create(rocksDBIterator.key(), rocksDBIterator
-              .value());
+      setCurrentEntry();
       rocksDBIterator.next();
-      return value;
+      return currentEntry;
     }
     throw new NoSuchElementException("RocksDB Store has no more elements");
   }
@@ -72,11 +85,13 @@ public class RDBStoreIterator
   @Override
   public void seekToFirst() {
     rocksDBIterator.seekToFirst();
+    setCurrentEntry();
   }
 
   @Override
   public void seekToLast() {
     rocksDBIterator.seekToLast();
+    setCurrentEntry();
   }
 
   @Override
@@ -111,8 +126,10 @@ public class RDBStoreIterator
     if (rocksDBTable == null) {
       throw new UnsupportedOperationException("remove");
     }
-    if (rocksDBIterator.isValid()) {
-      rocksDBTable.delete(rocksDBIterator.key());
+    if (currentEntry != null) {
+      rocksDBTable.delete(currentEntry.getKey());
+    } else {
+      LOG.info("Unable to delete currentEntry as it does not exist.");
     }
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreIterator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreIterator.java
@@ -58,12 +58,14 @@ public class TestRDBStoreIterator {
   @Test
   public void testForeachRemainingCallsConsumerWithAllElements() {
     when(rocksDBIteratorMock.isValid())
-        .thenReturn(true, true, true, true, true, true, false);
+        .thenReturn(true, true, true, true, true, true, true, false);
     when(rocksDBIteratorMock.key())
-        .thenReturn(new byte[]{0x00}, new byte[]{0x01}, new byte[]{0x02})
+        .thenReturn(new byte[]{0x00}, new byte[]{0x00}, new byte[]{0x01},
+            new byte[]{0x02})
         .thenThrow(new NoSuchElementException());
     when(rocksDBIteratorMock.value())
-        .thenReturn(new byte[]{0x7f}, new byte[]{0x7e}, new byte[]{0x7d})
+        .thenReturn(new byte[]{0x7f}, new byte[]{0x7f}, new byte[]{0x7e},
+            new byte[]{0x7d})
         .thenThrow(new NoSuchElementException());
 
 
@@ -91,7 +93,7 @@ public class TestRDBStoreIterator {
 
   @Test
   public void testHasNextDependsOnIsvalid(){
-    when(rocksDBIteratorMock.isValid()).thenReturn(true, false);
+    when(rocksDBIteratorMock.isValid()).thenReturn(true, true, false);
 
     RDBStoreIterator iter = new RDBStoreIterator(rocksDBIteratorMock);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -209,6 +209,7 @@ public class SCMPipelineManager implements PipelineManager {
   ) {
     if (!pipelineID.equals(pipeline.getId())) {
       try {
+        LOG.info("Found pipeline in old format key : {}", pipeline.getId());
         it.removeFromDB();
         pipelineStore.put(pipeline.getId(), pipeline);
       } catch (IOException e) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -702,4 +702,9 @@ public class SCMPipelineManager implements PipelineManager {
       startPipelineCreator();
     }
   }
+
+  @VisibleForTesting
+  protected static Logger getLog() {
+    return LOG;
+  }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMStoreImplWithOldPipelineIDKeyFormat.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMStoreImplWithOldPipelineIDKeyFormat.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.hdds.scm.pipeline;
 
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.PIPELINES;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMStoreImplWithOldPipelineIDKeyFormat.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMStoreImplWithOldPipelineIDKeyFormat.java
@@ -1,0 +1,162 @@
+package org.apache.hadoop.hdds.scm.pipeline;
+
+import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.PIPELINES;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.cert.X509Certificate;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.metadata.PipelineCodec;
+import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
+import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
+import org.apache.hadoop.hdds.utils.db.BatchOperationHandler;
+import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
+import org.apache.hadoop.hdds.utils.db.DBDefinition;
+import org.apache.hadoop.hdds.utils.db.DBStore;
+import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
+
+/**
+ * Test SCM Metadata Store that has ONLY the pipeline table whose key uses the
+ * old codec format.
+ */
+public class TestSCMStoreImplWithOldPipelineIDKeyFormat
+    implements SCMMetadataStore {
+
+  private DBStore store;
+  private final OzoneConfiguration configuration;
+  private Table<PipelineID, Pipeline> pipelineTable;
+
+  public TestSCMStoreImplWithOldPipelineIDKeyFormat(
+      OzoneConfiguration config) throws IOException {
+    this.configuration = config;
+    start(configuration);
+  }
+
+  @Override
+  public void start(OzoneConfiguration config)
+      throws IOException {
+    if (this.store == null) {
+      this.store = DBStoreBuilder.createDBStore(config,
+          new SCMDBTestDefinition());
+      pipelineTable = PIPELINES.getTable(store);
+    }
+  }
+
+  @Override
+  public void stop() throws Exception {
+    if (store != null) {
+      store.close();
+      store = null;
+    }
+  }
+
+  @Override
+  public DBStore getStore() {
+    return null;
+  }
+
+  @Override
+  public Table<Long, DeletedBlocksTransaction> getDeletedBlocksTXTable() {
+    return null;
+  }
+
+  @Override
+  public Long getCurrentTXID() {
+    return null;
+  }
+
+  @Override
+  public Long getNextDeleteBlockTXID() {
+    return null;
+  }
+
+  @Override
+  public Table<BigInteger, X509Certificate> getValidCertsTable() {
+    return null;
+  }
+
+  @Override
+  public Table<BigInteger, X509Certificate> getRevokedCertsTable() {
+    return null;
+  }
+
+  @Override
+  public TableIterator getAllCerts(CertificateStore.CertType certType) {
+    return null;
+  }
+
+  @Override
+  public Table<PipelineID, Pipeline> getPipelineTable() {
+    return pipelineTable;
+  }
+
+  @Override
+  public BatchOperationHandler getBatchHandler() {
+    return null;
+  }
+
+  @Override
+  public Table<ContainerID, ContainerInfo> getContainerTable() {
+    return null;
+  }
+
+  /**
+   * Test SCM DB Definition for the above class.
+   */
+  public static class SCMDBTestDefinition implements DBDefinition {
+
+    public static final DBColumnFamilyDefinition<PipelineID, Pipeline>
+        PIPELINES =
+        new DBColumnFamilyDefinition<>(
+            "pipelines",
+            PipelineID.class,
+            new OldPipelineIDCodec(),
+            Pipeline.class,
+            new PipelineCodec());
+
+    @Override
+    public String getName() {
+      return "scm.db";
+    }
+
+    @Override
+    public String getLocationConfigKey() {
+      return ScmConfigKeys.OZONE_SCM_DB_DIRS;
+    }
+
+    @Override
+    public DBColumnFamilyDefinition[] getColumnFamilies() {
+      return new DBColumnFamilyDefinition[] {PIPELINES};
+    }
+  }
+
+  /**
+   * Old Pipeline ID codec that relies on protobuf serialization.
+   */
+  public static class OldPipelineIDCodec implements Codec<PipelineID> {
+    @Override
+    public byte[] toPersistedFormat(PipelineID object) throws IOException {
+      return object.getProtobuf().toByteArray();
+    }
+
+    @Override
+    public PipelineID fromPersistedFormat(byte[] rawData) throws IOException {
+      return null;
+    }
+
+    @Override
+    public PipelineID copyObject(PipelineID object) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+}
+


### PR DESCRIPTION
## What changes were proposed in this pull request?
After the patch from HDDS-3925, SCM failed to start up with an exception stating that a 'duplicated pipeline has been detected'.

**RCA**
On investigating this along with @nandakumar131, the issue was found to be in the implementation of the RocksDBIterator wrapper that we have over the native RocksIterator. While calling next(), the current value is returned, and the pointer is moved ahead. Hence, the removeFromDB method actually deletes the next entry from the DB every time! During the last removeFromDB call invoked after the last "next()" call, the current pointer is pointing to garbage. This means that when SCM starts up with this schema change, the removeFromDB actually deletes the next pipeline from the DB everytime, thereby leaving the "first" pipeline entry in old format undeleted. On restart again, this causes a duplicate pipeline exception. I will attach detailed logs from the problematic state and the fix. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3965

## How was this patch tested?
Manually tested.
Added unit tests.

## Logs
[Logs which show the issue.txt](https://github.com/apache/hadoop-ozone/files/4933468/Logs.which.show.the.issue.txt)
[Logs with fix.txt](https://github.com/apache/hadoop-ozone/files/4933470/Logs.with.fix.txt)
