### PR TITLE
HDDS-3969. Add validName check for FileSystem requests

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFSUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFSUtils.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.om.helpers;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.util.StringUtils;
 
 import java.nio.file.Paths;
 
@@ -85,5 +86,34 @@ public final class OzoneFSUtils {
 
   public static boolean isFile(String keyName) {
     return !keyName.endsWith(OZONE_URI_DELIMITER);
+  }
+
+  /**
+   * Whether the pathname is valid.  Currently prohibits relative paths,
+   * names which contain a ":" or "//", or other non-canonical paths.
+   */
+  public static boolean isValidName(String src) {
+    // Path must be absolute.
+    if (!src.startsWith(Path.SEPARATOR)) {
+      return false;
+    }
+
+    // Check for ".." "." ":" "/"
+    String[] components = StringUtils.split(src, '/');
+    for (int i = 0; i < components.length; i++) {
+      String element = components[i];
+      if (element.equals(".")  ||
+          (element.contains(":"))  ||
+          (element.contains("/") || element.equals(".."))) {
+        return false;
+      }
+      // The string may start or end with a /, but not have
+      // "//" in the middle.
+      if (element.isEmpty() && i != components.length - 1 &&
+          i != 0) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneFsUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneFsUtils.java
@@ -1,0 +1,21 @@
+package org.apache.hadoop.ozone.om.helpers;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test OzoneFsUtils.
+ */
+public class TestOzoneFsUtils {
+
+  @Test
+  public void testPaths() {
+    Assert.assertTrue(OzoneFSUtils.isValidName("/a/b"));
+    Assert.assertFalse(OzoneFSUtils.isValidName("../../../a/b"));
+    Assert.assertFalse(OzoneFSUtils.isValidName("/./."));
+    Assert.assertFalse(OzoneFSUtils.isValidName("/:/"));
+    Assert.assertFalse(OzoneFSUtils.isValidName("a/b"));
+    Assert.assertFalse(OzoneFSUtils.isValidName("/a:/b"));
+    Assert.assertFalse(OzoneFSUtils.isValidName("/a//b"));
+  }
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneFsUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneFsUtils.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.ozone.om.helpers;
 
 import org.junit.Assert;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.InvalidPathException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -158,6 +159,31 @@ public class TestOzoneFileSystem {
     Path subdir = new Path("/d1/d2/");
     boolean status = fs.mkdirs(subdir);
     assertTrue("Shouldn't send error if dir exists", status);
+  }
+
+  @Test
+  public void testCreateWithInvalidPaths() throws Exception {
+    setupOzoneFileSystem();
+    Path parent = new Path("../../../../../d1/d2/");
+    Path file1 = new Path(parent, "key1");
+    checkInvalidPath(file1);
+
+    file1 = new Path("/:/:");
+    checkInvalidPath(file1);
+  }
+
+  private void checkInvalidPath(Path path) throws Exception {
+    FSDataOutputStream outputStream = null;
+    try  {
+      outputStream = fs.create(path, false);
+      fail("testCreateWithInvalidPaths failed for path" + path);
+    } catch (Exception ex) {
+      Assert.assertTrue(ex instanceof InvalidPathException);
+    } finally {
+      if (outputStream != null) {
+        outputStream.close();
+      }
+    }
   }
 
   @Test(timeout = 300_000)

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.InvalidPathException;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
@@ -38,6 +39,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Progressable;
@@ -721,7 +723,13 @@ public class BasicOzoneFileSystem extends FileSystem {
       path = new Path(workingDir, path);
     }
     // removing leading '/' char
-    String key = path.toUri().getPath().substring(1);
+    String key = path.toUri().getPath();
+
+    if (OzoneFSUtils.isValidName(key)) {
+      key = path.toUri().getPath().substring(1);
+    } else {
+      throw new InvalidPathException("Invalid path Name" + key);
+    }
     LOG.trace("path for key:{} is:{}", key, path);
     return key;
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -726,12 +726,12 @@ public class BasicOzoneFileSystem extends FileSystem {
     String key = path.toUri().getPath();
 
     if (OzoneFSUtils.isValidName(key)) {
-      key = path.toUri().getPath().substring(1);
+      key = path.toUri().getPath();
     } else {
       throw new InvalidPathException("Invalid path Name" + key);
     }
     LOG.trace("path for key:{} is:{}", key, path);
-    return key;
+    return key.substring(1);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

This Jira is to validate KeyNames which are created with OzoneFileSystem.
Similar to how hdfs handles using DFSUtil. isValidName()

Made only changes in the client.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3969

## How was this patch tested?

Added tests.
