### PR TITLE
HDDS-3981. Add more debug level log to XceiverClientGrpc for debug purpose

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -442,7 +442,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     UUID dnId = dn.getUuid();
     if (LOG.isDebugEnabled()) {
       LOG.debug("Send command {} to datanode {}",
-          request.getCmdType(), dn);
+          request.getCmdType(), dn.getIpAddress());
     }
     final CompletableFuture<ContainerCommandResponseProto> replyFuture =
         new CompletableFuture<>();


### PR DESCRIPTION
## What changes were proposed in this pull request?

When I profile the s3g performance, i find in some log of XceiverClientGrpc, I cannot find the related datanode ip, so i use datanode instead of the UUID and networkFullPath.

Also, i add a debug level log to show the request has been executed and output the try counts.

## What is the link to the Apache JIRA

HDDS-3981

## How was this patch tested?

No need, all changes only related to log.