### PR TITLE
HDDS-3982. Disable moveToTrash in o3fs and ofs temporarily

### DIFF
--- a/hadoop-hdds/docs/content/design/ofs.md
+++ b/hadoop-hdds/docs/content/design/ofs.md
@@ -155,6 +155,10 @@ This feature wouldn't degrade server performance as the loop is on the client.
 Think it as a client is issuing multiple requests to the server to get all the
 information.
 
+# Special note
+
+Trash is disabled even if `fs.trash.interval` is set on purpose. (HDDS-3982)
+
 # Link
 
 Design doc is uploaded to the JIRA HDDS-2665:

--- a/hadoop-hdds/docs/content/design/trash.md
+++ b/hadoop-hdds/docs/content/design/trash.md
@@ -23,3 +23,8 @@ author: Matthew Sharp
 The design doc is uploaded to the JIRA: 
 
 https://issues.apache.org/jira/secure/attachment/12985273/Ozone_Trash_Feature.docx
+
+## Special note
+
+Trash is disabled for both o3fs and ofs even if `fs.trash.interval` is set
+on purpose. (HDDS-3982)

--- a/hadoop-hdds/docs/content/interface/OzoneFS.md
+++ b/hadoop-hdds/docs/content/interface/OzoneFS.md
@@ -165,3 +165,6 @@ hdfs dfs -put /etc/hosts /volume1/bucket1/test
 
 For more usage, see: https://issues.apache.org/jira/secure/attachment/12987636/Design%20ofs%20v1.pdf
 
+## Special note
+
+Trash is disabled even if `fs.trash.interval` is set on purpose. (HDDS-3982)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
+import org.apache.hadoop.fs.Trash;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -64,6 +65,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERVAL_KEY;
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 import static org.apache.hadoop.fs.ozone.Constants.LISTING_PAGE_SIZE;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
@@ -87,6 +89,7 @@ public class TestRootedOzoneFileSystem {
   private RootedOzoneFileSystem ofs;
   private ObjectStore objectStore;
   private static BasicRootedOzoneClientAdapterImpl adapter;
+  private Trash trash;
 
   private String volumeName;
   private Path volumePath;
@@ -98,6 +101,7 @@ public class TestRootedOzoneFileSystem {
   @Before
   public void init() throws Exception {
     conf = new OzoneConfiguration();
+    conf.setInt(FS_TRASH_INTERVAL_KEY, 1);
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(3)
         .build();
@@ -122,6 +126,7 @@ public class TestRootedOzoneFileSystem {
     //  hence this workaround.
     conf.set("fs.ofs.impl", "org.apache.hadoop.fs.ozone.RootedOzoneFileSystem");
     fs = FileSystem.get(conf);
+    trash = new Trash(conf);
     ofs = (RootedOzoneFileSystem) fs;
     adapter = (BasicRootedOzoneClientAdapterImpl) ofs.getAdapter();
   }
@@ -997,6 +1002,38 @@ public class TestRootedOzoneFileSystem {
     Assert.assertEquals(0, fs.getTrashRoots(true).size());
     // Restore owner
     Assert.assertTrue(volume1.setOwner(prevOwner));
+  }
+
+  /**
+   * Check that no files are actually moved to trash since it is disabled by
+   * fs.rename(src, dst, options).
+   */
+  @Test
+  public void testRenameToTrashDisabled() throws IOException {
+    // Create a file
+    String testKeyName = "testKey1";
+    Path path = new Path(bucketPath, testKeyName);
+    try (FSDataOutputStream stream = fs.create(path)) {
+      stream.write(1);
+    }
+
+    // Call moveToTrash. We can't call protected fs.rename() directly
+    trash.moveToTrash(path);
+
+    // Construct paths
+    String username = UserGroupInformation.getCurrentUser().getShortUserName();
+    Path trashRoot = new Path(bucketPath, TRASH_PREFIX);
+    Path userTrash = new Path(trashRoot, username);
+    Path userTrashCurrent = new Path(userTrash, "Current");
+    Path trashPath = new Path(userTrashCurrent, testKeyName);
+
+    // Trash Current directory should still have been created.
+    Assert.assertTrue(ofs.exists(userTrashCurrent));
+    // Check under trash, the key should be deleted instead
+    Assert.assertFalse(ofs.exists(trashPath));
+
+    // Cleanup
+    ofs.delete(trashRoot, true);
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -38,6 +38,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -468,6 +469,7 @@ public class TestOzoneShellHA {
   }
 
   @Test
+  @Ignore("HDDS-3982. Disable moveToTrash in o3fs and ofs temporarily")
   public void testDeleteToTrashOrSkipTrash() throws Exception {
     final String hostPrefix = OZONE_OFS_URI_SCHEME + "://" + omServiceId;
     OzoneConfiguration clientConf = getClientConfForOFS(hostPrefix, conf);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Options.Rename;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -395,6 +396,32 @@ public class BasicOzoneFileSystem extends FileSystem {
       createFakeParentDirectory(src);
     }
     return result;
+  }
+
+  /**
+   * Intercept rename to trash calls from TrashPolicyDefault,
+   * convert them to delete calls instead.
+   */
+  @Deprecated
+  protected void rename(final Path src, final Path dst,
+      final Rename... options) throws IOException {
+    boolean hasMoveToTrash = false;
+    if (options != null) {
+      for (Rename option : options) {
+        if (option == Rename.TO_TRASH) {
+          hasMoveToTrash = true;
+          break;
+        }
+      }
+    }
+    if (!hasMoveToTrash) {
+      // if doesn't have TO_TRASH option, just pass the call to super
+      super.rename(src, dst, options);
+    } else {
+      // intercept when TO_TRASH is found
+      LOG.info("Move to trash is disabled for o3fs, deleting instead: {}", src);
+      delete(src, true);
+    }
   }
 
   private class DeleteIterator extends OzoneListingIterator {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -421,7 +421,7 @@ public class BasicOzoneFileSystem extends FileSystem {
       // intercept when TO_TRASH is found
       LOG.info("Move to trash is disabled for o3fs, deleting instead: {}. "
           + "Files or directories will NOT be retained in trash. "
-          + "Ignore the following TrashPolicyDefault message.", src);
+          + "Ignore the following TrashPolicyDefault message, if any.", src);
       delete(src, true);
     }
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -419,7 +419,9 @@ public class BasicOzoneFileSystem extends FileSystem {
       super.rename(src, dst, options);
     } else {
       // intercept when TO_TRASH is found
-      LOG.info("Move to trash is disabled for o3fs, deleting instead: {}", src);
+      LOG.info("Move to trash is disabled for o3fs, deleting instead: {}. "
+          + "Files or directories will NOT be retained in trash. "
+          + "Ignore the following TrashPolicyDefault message.", src);
       delete(src, true);
     }
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -370,6 +371,32 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       createFakeParentDirectory(src);
     }
     return result;
+  }
+
+  /**
+   * Intercept rename to trash calls from TrashPolicyDefault,
+   * convert them to delete calls instead.
+   */
+  @Deprecated
+  protected void rename(final Path src, final Path dst,
+      final Options.Rename... options) throws IOException {
+    boolean hasMoveToTrash = false;
+    if (options != null) {
+      for (Options.Rename option : options) {
+        if (option == Options.Rename.TO_TRASH) {
+          hasMoveToTrash = true;
+          break;
+        }
+      }
+    }
+    if (!hasMoveToTrash) {
+      // if doesn't have TO_TRASH option, just pass the call to super
+      super.rename(src, dst, options);
+    } else {
+      // intercept when TO_TRASH is found
+      LOG.info("Move to trash is disabled for ofs, deleting instead: {}", src);
+      delete(src, true);
+    }
   }
 
   private class DeleteIterator extends OzoneListingIterator {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -396,7 +396,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       // intercept when TO_TRASH is found
       LOG.info("Move to trash is disabled for ofs, deleting instead: {}. "
           + "Files or directories will NOT be retained in trash. "
-          + "Ignore the following TrashPolicyDefault message.", src);
+          + "Ignore the following TrashPolicyDefault message, if any.", src);
       delete(src, true);
     }
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -394,7 +394,9 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       super.rename(src, dst, options);
     } else {
       // intercept when TO_TRASH is found
-      LOG.info("Move to trash is disabled for ofs, deleting instead: {}", src);
+      LOG.info("Move to trash is disabled for ofs, deleting instead: {}. "
+          + "Files or directories will NOT be retained in trash. "
+          + "Ignore the following TrashPolicyDefault message.", src);
       delete(src, true);
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

A proper server-side trash cleanup solution (HDDS-3915) might not land any time soon.

This jira aims to completely disable "move to trash" when a client is deleting files and {{fs.trash.interval > 0}} by intercepting the deprecated {{fs.rename(src, dst, options)}} call used by {{TrashPolicyDefault#moveToTrash}}.

This should be reverted when trash cleanup is implemented.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3982

## How was this patch tested?

1. Added new tests.

2. Also tested manually:

As [usual](https://github.com/apache/hadoop-ozone/pull/1181), compile -> launch docker-compose cluster -> exec bash on om

```
$ mvn clean install -Pdist -DskipTests -e -Dmaven.javadoc.skip=true -DskipShade
$ cd hadoop-ozone/dist/target/ozone-*-SNAPSHOT/compose/ozone
$ docker-compose up -d
$ docker-compose exec om /bin/bash
```

Add `fs.trash.interval` to client config:
```
$ vi /etc/hadoop/core-site.xml
# Add a line in <configuration> tag and save:
<property><name>fs.trash.interval</name><value>1</value></property>
```

### o3fs

```
$ ozone sh volume create volume1
$ ozone sh bucket create /volume1/bucket2
$ ozone fs -mkdir -p o3fs://bucket2.volume1.om/dir3
$ ozone fs -touch o3fs://bucket2.volume1.om/dir3/key5
$ ozone fs -rm o3fs://bucket2.volume1.om/dir3/key5
2020-07-17 19:22:29,778 [main] INFO Configuration.deprecation: io.bytes.per.checksum is deprecated. Instead, use dfs.bytes-per-checksum
2020-07-17 19:22:29,867 [main] INFO ozone.BasicOzoneFileSystem: Move to trash is disabled for o3fs, deleting instead: o3fs://bucket2.volume1.om/dir3/key5
2020-07-17 19:22:29,881 [main] INFO fs.TrashPolicyDefault: Moved: 'o3fs://bucket2.volume1.om/dir3/key5' to trash at: /.Trash/hadoop/Current/dir3/key5
```

Verification: key is deleted, but trash directory is created:
```
$ ozone fs -ls -R o3fs://bucket2.volume1.om/.Trash/hadoop/Current/
drwxrwxrwx   - hadoop hadoop          0 2020-07-17 19:22 o3fs://bucket2.volume1.om/.Trash/hadoop/Current/dir3
```

### OFS

```
$ ozone fs -mkdir -p ofs://om/volume1/bucket2/dir3
$ ozone fs -touch ofs://om/volume1/bucket2/dir3/key5
$ ozone fs -rm ofs://om/volume1/bucket2/dir3/key5
2020-07-17 19:26:59,193 [main] INFO Configuration.deprecation: io.bytes.per.checksum is deprecated. Instead, use dfs.bytes-per-checksum
2020-07-17 19:26:59,306 [main] INFO ozone.BasicRootedOzoneFileSystem: Move to trash is disabled for ofs, deleting instead: ofs://om/volume1/bucket2/dir3/key5
2020-07-17 19:26:59,334 [main] INFO fs.TrashPolicyDefault: Moved: 'ofs://om/volume1/bucket2/dir3/key5' to trash at: ofs://om/volume1/bucket2/.Trash/hadoop/Current/volume1/bucket2/dir3/key5
```

Verification: key is deleted, but trash directory is created:
```
$ ozone fs -ls -R ofs://om/volume1/bucket2/.Trash/hadoop/Current/
drwxrwxrwx   - hadoop hadoop          0 2020-07-17 19:26 ofs://om/volume1/bucket2/.Trash/hadoop/Current/volume1
drwxrwxrwx   - hadoop hadoop          0 2020-07-17 19:26 ofs://om/volume1/bucket2/.Trash/hadoop/Current/volume1/bucket2
drwxrwxrwx   - hadoop hadoop          0 2020-07-17 19:26 ofs://om/volume1/bucket2/.Trash/hadoop/Current/volume1/bucket2/dir3
```

## Known Issues

* `TrashPolicyDefault` already creates the empty directories in trash before calling `fs.rename(src, dst, options)`.
  * These are empty dirs so they shouldn't be a big problem.
  * We could do something about `fs.mkdirs` as well to solve this but I'm not sure if we should go down this path.
* `TrashPolicyDefault` still prints "Moved ... to trash" message, as shown above, which may be confusing to users.