### PR TITLE
HDDS-3976. KeyValueBlockIterator#nextBlock skips valid blocks

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/BlockIterator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/BlockIterator.java
@@ -42,11 +42,6 @@ public interface BlockIterator<T> {
   void seekToFirst();
 
   /**
-   * Seek to last entry.
-   */
-  void seekToLast();
-
-  /**
    * Get next block in the container.
    * @return next block or null if there are no blocks
    * @throws IOException

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueBlockIterator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueBlockIterator.java
@@ -127,23 +127,6 @@ public class KeyValueBlockIterator implements BlockIterator<BlockData>,
     return result;
   }
 
-  private BlockData findNextBlock() throws IOException {
-    BlockData foundBlock = null;
-
-    while (blockIterator.hasNext() && foundBlock == null) {
-      KeyValue blockKV = blockIterator.next();
-      if (blockFilter.filterKey(null, blockKV.getKey(), null)) {
-        foundBlock = BlockUtils.getBlockData(blockKV.getValue());
-        if (LOG.isTraceEnabled()) {
-          LOG.trace("Block matching with filter found: blockID is : {} for " +
-                  "containerID {}", foundBlock.getLocalID(), containerId);
-        }
-      }
-    }
-
-    return foundBlock;
-  }
-
   @Override
   public boolean hasNext() throws IOException {
     if (wasReset) {
@@ -163,5 +146,26 @@ public class KeyValueBlockIterator implements BlockIterator<BlockData>,
 
   public void close() {
     db.close();
+  }
+
+  /**
+   * @return The next block in the iterator that passes the filter.
+   * @throws IOException
+   */
+  private BlockData findNextBlock() throws IOException {
+    BlockData foundBlock = null;
+
+    while (blockIterator.hasNext() && foundBlock == null) {
+      KeyValue blockKV = blockIterator.next();
+      if (blockFilter.filterKey(null, blockKV.getKey(), null)) {
+        foundBlock = BlockUtils.getBlockData(blockKV.getValue());
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("Block matching with filter found: blockID is : {} for " +
+                  "containerID {}", foundBlock.getLocalID(), containerId);
+        }
+      }
+    }
+
+    return foundBlock;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueBlockIterator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueBlockIterator.java
@@ -62,8 +62,8 @@ public class KeyValueBlockIterator implements BlockIterator<BlockData>,
   private KeyPrefixFilter blockFilter;
   private BlockData nextBlock;
   private long containerId;
-  // If true, indicates that the internal iterator position was moved using seek, and our queued
-  // up default block is no longer valid.
+  // If true, indicates that the internal iterator position was moved using
+  // seek, and our queued up default block is no longer valid.
   private boolean wasReset;
 
   /**
@@ -139,7 +139,8 @@ public class KeyValueBlockIterator implements BlockIterator<BlockData>,
 
   @Override
   public void seekToFirst() {
-    // Cannot call findNextBlock() here, as the IOException would break the interface.
+    // Cannot call findNextBlock() here, as the IOException would break the
+    // interface.
     blockIterator.seekToFirst();
     wasReset = true;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueBlockIterator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueBlockIterator.java
@@ -161,13 +161,6 @@ public class KeyValueBlockIterator implements BlockIterator<BlockData>,
     wasReset = true;
   }
 
-  @Override
-  public void seekToLast() {
-    // Cannot call findNextBlock() here, as the IOException would break the interface.
-    blockIterator.seekToLast();
-    wasReset = true;
-  }
-
   public void close() {
     db.close();
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
@@ -273,6 +273,9 @@ public class TestKeyValueBlockIterator {
     testWithFilter(containerPath, deletedOnly, Arrays.asList(6L, 7L, 8L));
   }
 
+  /**
+   * Helper method to run some iterator tests with a provided filter.
+   */
   private void testWithFilter(String containerPath, MetadataKeyFilters.KeyPrefixFilter filter,
                               List<Long> expectedIDs) throws Exception {
     long containerId = 105L;
@@ -280,6 +283,7 @@ public class TestKeyValueBlockIterator {
     try (KeyValueBlockIterator iterator = new KeyValueBlockIterator(
             containerId, new File(containerPath), filter)) {
 
+      // Test seek.
       iterator.seekToFirst();
       long firstID = iterator.nextBlock().getLocalID();
       assertEquals(expectedIDs.get(0).longValue(), firstID);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
@@ -181,10 +181,6 @@ public class TestKeyValueBlockIterator {
       assertTrue(keyValueBlockIterator.hasNext());
       assertEquals(blockID, keyValueBlockIterator.nextBlock().getLocalID());
 
-      keyValueBlockIterator.seekToLast();
-      assertTrue(keyValueBlockIterator.hasNext());
-      assertEquals(blockID, keyValueBlockIterator.nextBlock().getLocalID());
-
       keyValueBlockIterator.seekToFirst();
       blockID = 0L;
       assertEquals(blockID++, keyValueBlockIterator.nextBlock().getLocalID());
@@ -283,12 +279,6 @@ public class TestKeyValueBlockIterator {
 
     try (KeyValueBlockIterator iterator = new KeyValueBlockIterator(
             containerId, new File(containerPath), filter)) {
-
-      // Test seeking.
-//      iterator.seekToLast();
-//      long lastID = iterator.nextBlock().getLocalID();
-//      assertEquals(expectedIDs.get(expectedIDs.size() - 1).longValue(), lastID);
-//      assertFalse(iterator.hasNext());
 
       iterator.seekToFirst();
       long firstID = iterator.nextBlock().getLocalID();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
@@ -55,7 +55,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import sun.util.resources.cldr.en.CurrencyNames_en_TT;
 
 /**
  * This class is used to test KeyValue container block iterator.
@@ -232,12 +231,14 @@ public class TestKeyValueBlockIterator {
   }
 
   /**
-   * Due to RocksDB internals, prefixed keys may be grouped all at the beginning or end of the
-   * key iteration, depending on the serialization used. Keys of the same prefix are grouped
-   * together. This method runs the same set of tests on the iterator first positively filtering
-   * deleting keys, and then positively filtering deleted keys.
-   * If the sets of keys with deleting prefixes, deleted prefixes, and no prefixes
-   * are not empty, it follows that the filter will encounter both of the following cases:
+   * Due to RocksDB internals, prefixed keys may be grouped all at the
+   * beginning or end of the key iteration, depending on the serialization
+   * used. Keys of the same prefix are grouped
+   * together. This method runs the same set of tests on the iterator first
+   * positively filtering deleting keys, and then positively filtering
+   * deleted keys. If the sets of keys with deleting prefixes, deleted
+   * prefixes, and no prefixes are not empty, it follows that the filter will
+   * encounter both of the following cases:
    *
    * 1. A failing key followed by a passing key.
    * 2. A passing key followed by a failing key.
@@ -255,19 +256,22 @@ public class TestKeyValueBlockIterator {
     int deletingBlocks = 3;
     // IDs 6 - 8
     int deletedBlocks = 3;
-    createContainerWithBlocks(containerId, normalBlocks, deletingBlocks, deletedBlocks);
+    createContainerWithBlocks(containerId, normalBlocks, deletingBlocks,
+            deletedBlocks);
     String containerPath = new File(containerData.getMetadataPath())
             .getParent();
 
     // Test deleting filter.
     final boolean negativeFilter = false;
-    MetadataKeyFilters.KeyPrefixFilter deletingOnly = new MetadataKeyFilters.KeyPrefixFilter(true);
+    MetadataKeyFilters.KeyPrefixFilter deletingOnly =
+            new MetadataKeyFilters.KeyPrefixFilter(true);
     deletingOnly.addFilter(OzoneConsts.DELETING_KEY_PREFIX, negativeFilter);
 
     testWithFilter(containerPath, deletingOnly, Arrays.asList(3L, 4L, 5L));
 
     // Test deleted filter.
-    MetadataKeyFilters.KeyPrefixFilter deletedOnly = new MetadataKeyFilters.KeyPrefixFilter(true);
+    MetadataKeyFilters.KeyPrefixFilter deletedOnly =
+            new MetadataKeyFilters.KeyPrefixFilter(true);
     deletedOnly.addFilter(OzoneConsts.DELETED_KEY_PREFIX, negativeFilter);
 
     testWithFilter(containerPath, deletedOnly, Arrays.asList(6L, 7L, 8L));
@@ -276,7 +280,8 @@ public class TestKeyValueBlockIterator {
   /**
    * Helper method to run some iterator tests with a provided filter.
    */
-  private void testWithFilter(String containerPath, MetadataKeyFilters.KeyPrefixFilter filter,
+  private void testWithFilter(String containerPath,
+                              MetadataKeyFilters.KeyPrefixFilter filter,
                               List<Long> expectedIDs) throws Exception {
     long containerId = 105L;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Fix the bug in KeyValueBlockIterator#nextBlocks that skips keys passing the prefix filter when all prefixed keys do not occur at the end of the key list.
    - New implementation removes indirect recursion in favor of a strictly iterative approach.

2. Remove the unused KeyValueBlockIterator#seekLast method that did not work when the last key in the list failed the filter.

3. Add a more robust unit test that covers the following two cases without depending on the order that the RocksDB RocksIterator returns keys:
    1. The key list contains a key failing the filter followed by a key passing the filter.
    2. The key list contains a key passing the filter followed by a key failing the filter.

4. Minor clarifications in existing unit tests.
    - TestKeyValueBlockIterator#createContainerWithBlocks now uses prefixes that match the names of its parameters.
    - TestKeyValueBlockIterator#createContainerWithBlocks literally creates the number of each block type given in the parameters.

## What is the link to the Apache JIRA

[HDDS-3976](https://issues.apache.org/jira/browse/HDDS-3976)

## How was this patch tested?

KeyValueBlockIterator passed the existing unit tests and the newly created unit test.