### PR TITLE
HDDS-3986. Frequent failure in TestCommitWatcher#testReleaseBuffersOnException

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitWatcher.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitWatcher.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.ratis.protocol.AlreadyClosedException;
 import org.apache.ratis.protocol.NotReplicatedException;
 import org.apache.ratis.protocol.RaftRetryFailureException;
+import org.apache.ratis.protocol.TimeoutIOException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -312,14 +313,17 @@ public class TestCommitWatcher {
       watcher.watchForCommit(replies.get(1).getLogIndex() + 100);
       Assert.fail("Expected exception not thrown");
     } catch(IOException ioe) {
-      // with retry count set to lower limit and a lower watch request
+      // with retry count set to noRetry and a lower watch request
       // timeout, watch request will eventually
-      // fail with RaftRetryFailure exception from ratis client or the client
+      // fail with TimeoutIOException from ratis client or the client
       // can itself get AlreadyClosedException from the Ratis Server
+      // and the write may fail with RaftRetryFailureException
       Throwable t = HddsClientUtils.checkForException(ioe);
-      Assert.assertTrue(t instanceof RaftRetryFailureException ||
-              t instanceof AlreadyClosedException ||
-              t instanceof NotReplicatedException);
+      Assert.assertTrue("Unexpected exception: " + t.getClass(),
+          t instanceof RaftRetryFailureException ||
+          t instanceof TimeoutIOException ||
+          t instanceof AlreadyClosedException ||
+          t instanceof NotReplicatedException);
     }
     if (ratisClient.getReplicatedMinCommitIndex() < replies.get(1)
         .getLogIndex()) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitWatcher.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitWatcher.java
@@ -122,8 +122,8 @@ public class TestCommitWatcher {
 
     RatisClientConfig ratisClientConfig =
         conf.getObject(RatisClientConfig.class);
-    ratisClientConfig.setWriteRequestTimeoutInMs(TimeUnit.SECONDS.toMillis(30));
-    ratisClientConfig.setWatchRequestTimeoutInMs(TimeUnit.SECONDS.toMillis(30));
+    ratisClientConfig.setWriteRequestTimeoutInMs(TimeUnit.SECONDS.toMillis(10));
+    ratisClientConfig.setWatchRequestTimeoutInMs(TimeUnit.SECONDS.toMillis(10));
     conf.setFromObject(ratisClientConfig);
 
     conf.set(OzoneConfigKeys.OZONE_CLIENT_CHECKSUM_TYPE, "NONE");


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Fix frequent failure in `TestCommitWatcher`, caused by the following.

Watch request times out with `TimeoutIOException`:

https://github.com/apache/incubator-ratis/blob/6ab75ae9da4b380056279b02f208dc9b1329325b/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolClient.java#L336-L339

which results in no retry per the policy:

https://github.com/apache/hadoop-ozone/blob/caf471111cdb9168ec013f4526bb997aa513e079/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java#L291-L309

The original exception is then propagated to client instead of `RaftRetryFailureException`:

https://github.com/apache/incubator-ratis/blob/6ab75ae9/ratis-client/src/main/java/org/apache/ratis/client/impl/RaftClientImpl.java#L324-L330

Thus the assertion for exception type fails.

2. Also reduce request timeout to reduce the time required for the test.

https://issues.apache.org/jira/browse/HDDS-3986

## How was this patch tested?

Ran TestCommitWatcher 20 times:
https://github.com/adoroszlai/hadoop-ozone/runs/888869761#step:5:4