### PR TITLE
HDDS-3987. Encrypted bucket creation failed with INVALID_REQUEST Encryption cannot be set for bucket links

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -23,7 +23,11 @@ source "$COMPOSE_DIR/../testlib.sh"
 
 export SECURITY_ENABLED=true
 
+: ${OZONE_BUCKET_KEY_NAME:=key1}
+
 start_docker_env
+
+execute_command_in_container kms hadoop key create ${OZONE_BUCKET_KEY_NAME}
 
 execute_robot_test scm kinit.robot
 

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -114,7 +114,7 @@ execute_robot_test(){
   OUTPUT_PATH="$RESULT_DIR_INSIDE/${OUTPUT_FILE}"
   # shellcheck disable=SC2068
   docker-compose exec -T "$CONTAINER" mkdir -p "$RESULT_DIR_INSIDE" \
-    && docker-compose exec -T "$CONTAINER" robot -v OM_SERVICE_ID:"${OM_SERVICE_ID}" -v SECURITY_ENABLED:"${SECURITY_ENABLED}" -v OM_HA_PARAM:"${OM_HA_PARAM}" ${ARGUMENTS[@]} --log NONE -N "$TEST_NAME" --report NONE "${OZONE_ROBOT_OPTS[@]}" --output "$OUTPUT_PATH" "$SMOKETEST_DIR_INSIDE/$TEST"
+    && docker-compose exec -T "$CONTAINER" robot -v OM_SERVICE_ID:"${OM_SERVICE_ID}" -v SECURITY_ENABLED:"${SECURITY_ENABLED}" -v OM_HA_PARAM:"${OM_HA_PARAM}" -v KEY_NAME:"${OZONE_BUCKET_KEY_NAME}" ${ARGUMENTS[@]} --log NONE -N "$TEST_NAME" --report NONE "${OZONE_ROBOT_OPTS[@]}" --output "$OUTPUT_PATH" "$SMOKETEST_DIR_INSIDE/$TEST"
   local -i rc=$?
 
   FULL_CONTAINER_NAME=$(docker-compose ps | grep "_${CONTAINER}_" | head -n 1 | awk '{print $1}')

--- a/hadoop-ozone/dist/src/main/smoketest/ozone-lib/shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozone-lib/shell.robot
@@ -46,3 +46,8 @@ Verify ACL
     [arguments]         ${object_type}   ${object}    ${type}   ${name}    ${acls}
     ${actual_acls} =    Execute          ozone sh ${object_type} getacl ${object} | jq -r '.[] | select(.type == "${type}") | select(.name == "${name}") | .aclList[]' | xargs
                         Should Be Equal    ${acls}    ${actual_acls}
+
+Create Random Volume
+    ${random} =    Generate Random String  5  [LOWER]
+    Execute        ozone sh volume create o3://${OM_SERVICE_ID}/vol-${random}
+    [return]       vol-${random}

--- a/hadoop-ozone/dist/src/main/smoketest/security/bucket-encryption.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/bucket-encryption.robot
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Test for bucket encryption
+Library             BuiltIn
+Library             String
+Resource            ../commonlib.robot
+Resource            ../lib/os.robot
+Resource            ../ozone-lib/shell.robot
+Test Setup          Setup Test
+Test Timeout        5 minutes
+
+*** Variables ***
+${KEY_NAME}    key1
+${VOLUME}
+
+*** Keywords ***
+Setup Test
+    ${volume} =      Create Random Volume
+    Set Suite Variable    ${VOLUME}    ${volume}
+
+
+*** Test Cases ***
+Create Encrypted Bucket
+    ${output} =      Execute    ozone sh bucket create -k ${KEY_NAME} o3://${OM_SERVICE_ID}/${VOLUME}/encrypted-bucket
+                     Should Not Contain    ${output}    INVALID_REQUEST
+    Bucket Exists    o3://${OM_SERVICE_ID}/${VOLUME}/encrypted-bucket

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -115,8 +115,8 @@ public class OMBucketCreateRequest extends OMClientRequest {
       newBucketInfo.setBeinfo(getBeinfo(kmsProvider, bucketInfo));
     }
 
-    boolean hasSourceVolume = bucketInfo.getSourceVolume() != null;
-    boolean hasSourceBucket = bucketInfo.getSourceBucket() != null;
+    boolean hasSourceVolume = bucketInfo.hasSourceVolume();
+    boolean hasSourceBucket = bucketInfo.hasSourceBucket();
 
     if (hasSourceBucket != hasSourceVolume) {
       throw new OMException("Both source volume and source bucket are " +


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix bucket creation failure with encrytion key.

https://issues.apache.org/jira/browse/HDDS-3987

## How was this patch tested?

Added acceptance test case.

https://github.com/adoroszlai/hadoop-ozone/runs/888804408#step:7:2535