### PR TITLE
HDDS-3813. Upgrade Ratis third-party, too

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <ratis.version>1.0.0</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
-    <ratis.thirdparty.version>0.4.0</ratis.thirdparty.version>
+    <ratis.thirdparty.version>0.5.0</ratis.thirdparty.version>
 
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ratis 1.0 uses version 0.5 of the Ratis third-party jar.  For upgrading Ozone to Ratis 1.0, we need to upgrade third-party, too.

https://github.com/apache/incubator-ratis/commit/e53cd95f

https://issues.apache.org/jira/browse/HDDS-3813

## How was this patch tested?

Ran `ozone-csi` acceptance test locally.