### PR TITLE
HDDS-3997. Ozone certificate needs additional flags and SAN extension…

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/BaseApprover.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/BaseApprover.java
@@ -60,6 +60,15 @@ public abstract class BaseApprover implements CertificateApprover {
   }
 
   /**
+   * Returns the PKI policy profile.
+   *
+   * @return PKIProfile
+   */
+  public PKIProfile getProfile() {
+    return profile;
+  }
+
+  /**
    * Returns the Security config.
    *
    * @return SecurityConfig

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultApprover.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultApprover.java
@@ -24,9 +24,12 @@ import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.PKIProfiles.PKIProfile;
 import org.apache.hadoop.hdds.security.x509.keys.SecurityUtil;
 import org.apache.hadoop.util.Time;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
@@ -135,6 +138,14 @@ public class DefaultApprover extends BaseApprover {
             validFrom,
             validTill,
             x500Name, keyInfo);
+
+    Extensions exts = SecurityUtil.getPkcs9Extensions(certificationRequest);
+    for (ASN1ObjectIdentifier extId : getProfile().getSupportedExtensions()) {
+      Extension ext = exts.getExtension(extId);
+      if (ext != null) {
+        certificateGenerator.addExtension(ext);
+      }
+    }
 
     ContentSigner sigGen = new BcRSAContentSignerBuilder(sigAlgId, digAlgId)
         .build(asymmetricKP);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DNCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DNCertificateClient.java
@@ -48,6 +48,7 @@ public class DNCertificateClient extends DefaultCertificateClient {
   /**
    * Returns a CSR builder that can be used to creates a Certificate signing
    * request.
+   * The default flag is added to allow basic SSL handshake.
    *
    * @return CertificateSignRequest.Builder
    */
@@ -55,8 +56,8 @@ public class DNCertificateClient extends DefaultCertificateClient {
   public CertificateSignRequest.Builder getCSRBuilder()
       throws CertificateException {
     return super.getCSRBuilder()
-        .setDigitalEncryption(false)
-        .setDigitalSignature(false);
+        .setDigitalEncryption(true)
+        .setDigitalSignature(true);
   }
 
   public Logger getLogger() {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificates/utils/SelfSignedCertificate.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificates/utils/SelfSignedCertificate.java
@@ -26,7 +26,9 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
@@ -37,10 +39,18 @@ import org.apache.hadoop.util.Time;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.logging.log4j.util.Strings;
+import org.bouncycastle.asn1.ASN1EncodableVector;
+import org.bouncycastle.asn1.ASN1Object;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.DERSequence;
+import org.bouncycastle.asn1.DERTaggedObject;
+import org.bouncycastle.asn1.DERUTF8String;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.BasicConstraints;
 import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.cert.CertIOException;
@@ -64,28 +74,23 @@ public final class SelfSignedCertificate {
   private LocalDate endDate;
   private KeyPair key;
   private SecurityConfig config;
+  private List<GeneralName> altNames;
 
   /**
    * Private Ctor invoked only via Builder Interface.
    *
-   * @param subject - Subject
-   * @param scmID - SCM ID
-   * @param clusterID - Cluster ID
-   * @param beginDate - NotBefore
-   * @param endDate - Not After
-   * @param configuration - SCM Config
-   * @param keyPair - KeyPair
+   * @param builder - builder
    */
-  private SelfSignedCertificate(String subject, String scmID, String clusterID,
-      LocalDate beginDate, LocalDate endDate, SecurityConfig configuration,
-      KeyPair keyPair) {
-    this.subject = subject;
-    this.clusterID = clusterID;
-    this.scmID = scmID;
-    this.beginDate = beginDate;
-    this.endDate = endDate;
-    config = configuration;
-    this.key = keyPair;
+
+  private SelfSignedCertificate(Builder builder) {
+    this.subject = builder.subject;
+    this.clusterID = builder.clusterID;
+    this.scmID = builder.scmID;
+    this.beginDate = builder.beginDate;
+    this.endDate = builder.endDate;
+    this.config = builder.config;
+    this.key = builder.key;
+    this.altNames = builder.altNames;
   }
 
   @VisibleForTesting
@@ -142,6 +147,11 @@ public final class SelfSignedCertificate {
       KeyUsage keyUsage = new KeyUsage(keyUsageFlag);
       builder.addExtension(Extension.keyUsage, false,
           new DEROctetString(keyUsage));
+      if (altNames != null && altNames.size() >= 1) {
+        builder.addExtension(new Extension(Extension.subjectAlternativeName,
+            false, new GeneralNames(altNames.toArray(
+                new GeneralName[altNames.size()])).getEncoded()));
+      }
     }
     return builder.build(contentSigner);
   }
@@ -158,6 +168,7 @@ public final class SelfSignedCertificate {
     private KeyPair key;
     private SecurityConfig config;
     private boolean isCA;
+    private List<GeneralName> altNames;
 
     public Builder setConfiguration(ConfigurationSource configuration) {
       this.config = new SecurityConfig(configuration);
@@ -199,6 +210,62 @@ public final class SelfSignedCertificate {
       return this;
     }
 
+    // Support SAN extension with DNS and RFC822 Name
+    // other name type will be added as needed.
+    public Builder addDnsName(String dnsName) {
+      Preconditions.checkNotNull(dnsName, "dnsName cannot be null");
+      this.addAltName(GeneralName.dNSName, dnsName);
+      return this;
+    }
+
+    // IP address is subject to change which is optional for now.
+    public Builder addIpAddress(String ip) {
+      Preconditions.checkNotNull(ip, "Ip address cannot be null");
+      this.addAltName(GeneralName.iPAddress, ip);
+      return this;
+    }
+
+    public Builder addServiceName(
+        String serviceName) {
+      Preconditions.checkNotNull(
+          serviceName, "Service Name cannot be null");
+
+      this.addAltName(GeneralName.otherName, serviceName);
+      return this;
+    }
+
+    private Builder addAltName(int tag, String name) {
+      if (altNames == null) {
+        altNames = new ArrayList<>();
+      }
+      if (tag == GeneralName.otherName) {
+        ASN1Object ono = addOtherNameAsn1Object(name);
+
+        altNames.add(new GeneralName(tag, ono));
+      } else {
+        altNames.add(new GeneralName(tag, name));
+      }
+      return this;
+    }
+
+    /**
+     * addOtherNameAsn1Object requires special handling since
+     * Bouncy Castle does not support othername as string.
+     * @param name
+     * @return
+     */
+    private ASN1Object addOtherNameAsn1Object(String name) {
+      // Below oid is copied from this URL:
+      // https://docs.microsoft.com/en-us/windows/win32/adschema/a-middlename
+      final String otherNameOID = "2.16.840.1.113730.3.1.34";
+      ASN1EncodableVector otherName = new ASN1EncodableVector();
+      otherName.add(new ASN1ObjectIdentifier(otherNameOID));
+      otherName.add(new DERTaggedObject(
+          true, GeneralName.otherName, new DERUTF8String(name)));
+      return new DERTaggedObject(
+          false, 0, new DERSequence(otherName));
+    }
+
     public X509CertificateHolder build()
         throws SCMSecurityException, IOException {
       Preconditions.checkNotNull(key, "Key cannot be null");
@@ -225,9 +292,7 @@ public final class SelfSignedCertificate {
       }
 
       SelfSignedCertificate rootCertificate =
-          new SelfSignedCertificate(this.subject,
-              this.scmID, this.clusterID, this.beginDate, this.endDate,
-              this.config, key);
+          new SelfSignedCertificate(this);
       try {
         return rootCertificate.generateCertificate(isCA);
       } catch (OperatorCreationException | CertIOException e) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1349,8 +1349,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         .setConfiguration(config)
         .setScmID(omStore.getScmId())
         .setClusterID(omStore.getClusterID())
-        .setSubject(subject)
-        .addIpAddress(ip);
+        .setSubject(subject);
 
     OMHANodeDetails haOMHANodeDetails = OMHANodeDetails.loadOMHAConfig(config);
     String serviceName =


### PR DESCRIPTION
… for GRPC TLS.

## What changes were proposed in this pull request?

Adding SAN extension for SCM issued certificate and add DN certificate with sign/encrypt flag to meet requirement of SSL handshake with GRPC/Netty. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3997

## How was this patch tested?
Test with real cluster before patch HDDS-3996 and HDDS-3997. Certificate does not have the required extension and flag, which fail the SSL handshake for Ratis operations like addGroup, leader election when ozone.grpc.tls.enabled is true. 

After the patch, verified the RATIS-Three pipeline can be created successfuly without SSL error.

