### PR TITLE
HDDS-3998. Shorten Ozone FS Hadoop compatibility module names

### DIFF
--- a/hadoop-ozone/ozonefs-hadoop2/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop2/pom.xml
@@ -22,7 +22,7 @@
     <version>0.6.0-SNAPSHOT</version>
   </parent>
   <artifactId>hadoop-ozone-filesystem-hadoop2</artifactId>
-  <name>Apache Hadoop Ozone FileSystem Hadoop 2.x compatibility</name>
+  <name>Apache Hadoop Ozone FS Hadoop 2.x compatibility</name>
   <packaging>jar</packaging>
   <version>0.6.0-SNAPSHOT</version>
   <properties>

--- a/hadoop-ozone/ozonefs-hadoop3/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3/pom.xml
@@ -22,7 +22,7 @@
     <version>0.6.0-SNAPSHOT</version>
   </parent>
   <artifactId>hadoop-ozone-filesystem-hadoop3</artifactId>
-  <name>Apache Hadoop Ozone FileSystem Hadoop 3.x compatibility</name>
+  <name>Apache Hadoop Ozone FS Hadoop 3.x compatibility</name>
   <packaging>jar</packaging>
   <version>0.6.0-SNAPSHOT</version>
   <properties>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The display name of `hadoop-ozone-filesystem-hadoopX` modules is so long that Maven output looks ugly:

```
[INFO] Apache Hadoop Ozone Insight Tool ................... SUCCESS [  3.940 s]
[INFO] Apache Hadoop Ozone FileSystem Shaded .............. SUCCESS [02:28 min]
[INFO] Apache Hadoop Ozone FileSystem Hadoop 2.x compatibility SUCCESS [ 14.397 s]
[INFO] Apache Hadoop Ozone FileSystem Hadoop 3.x compatibility SUCCESS [ 13.095 s]
[INFO] Apache Hadoop Ozone Distribution ................... SUCCESS [ 12.380 s]
[INFO] Apache Hadoop Ozone Fault Injection Tests .......... SUCCESS [  0.725 s]
```

Abbreviate `FileSystem` as `FS` in module names `Apache Hadoop Ozone FileSystem Hadoop N.x compatibility` so that it can fit regular Maven reactor summary width.

https://issues.apache.org/jira/browse/HDDS-3998

## How was this patch tested?

```
$ mvn clean
...
[INFO] Apache Hadoop Ozone Insight Tool ................... SUCCESS [  0.012 s]
[INFO] Apache Hadoop Ozone FileSystem Shaded .............. SUCCESS [  0.009 s]
[INFO] Apache Hadoop Ozone FS Hadoop 2.x compatibility .... SUCCESS [  0.009 s]
[INFO] Apache Hadoop Ozone FS Hadoop 3.x compatibility .... SUCCESS [  0.008 s]
[INFO] Apache Hadoop Ozone Distribution ................... SUCCESS [  0.174 s]
[INFO] Apache Hadoop Ozone Fault Injection Tests .......... SUCCESS [  0.003 s]
```

https://github.com/adoroszlai/hadoop-ozone/runs/897071523#step:4:2858