### PR TITLE
HDDS-4004. Remove optional jersey-json dependency

### DIFF
--- a/hadoop-hdds/hadoop-dependency-server/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-server/pom.xml
@@ -67,6 +67,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
           <groupId>org.codehaus.jackson</groupId>
           <artifactId>jackson-xc</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-json</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

jersey-json is inherited from hadoop-common but it's not used by Ozone (and not used by the active code-path of hadoop-common).

As it's an older jersey-json seems to be better to remove it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4004

## How was this patch tested?

Full CI.

https://github.com/elek/hadoop-ozone/actions/runs/178257980

And checked if jersey-json is disappeared:

```
cd hadoop-ozone/dist/target/ozone-0.6.0-SNAPSHOT/share/ozone/lib
ls *json*
jersey-media-json-jackson-2.27.jar  json-smart-2.3.jar
```