### PR TITLE
HDDS-3827. Intermittent failure in TestKeyManagerUnit#listMultipartUploads

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
@@ -144,7 +144,8 @@ public class TestKeyManagerUnit {
     Assert.assertNotNull(uploads.get(1));
     Instant creationTime = uploads.get(1).getCreationTime();
     Assert.assertNotNull(creationTime);
-    Assert.assertFalse("Creation date is too old: " + creationTime + " < " + startDate,
+    Assert.assertFalse("Creation date is too old: "
+            + creationTime + " < " + startDate,
         creationTime.isBefore(startDate));
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
@@ -113,8 +113,6 @@ public class TestKeyManagerUnit {
 
     Assert.assertEquals(0,
         omMultipartUploadListParts.getPartInfoList().size());
-
-    this.startDate = Instant.now();
   }
 
   @Test
@@ -144,9 +142,10 @@ public class TestKeyManagerUnit {
     Assert.assertEquals("dir/key2", uploads.get(1).getKeyName());
 
     Assert.assertNotNull(uploads.get(1));
-    Assert.assertNotNull(uploads.get(1).getCreationTime());
-    Assert.assertTrue("Creation date is too old",
-        uploads.get(1).getCreationTime().compareTo(startDate) > 0);
+    Instant creationTime = uploads.get(1).getCreationTime();
+    Assert.assertNotNull(creationTime);
+    Assert.assertFalse("Creation date is too old: " + creationTime + " < " + startDate,
+        creationTime.isBefore(startDate));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
@@ -19,6 +19,7 @@
 
 package org.apache.hadoop.ozone.om;
 
+import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -30,6 +31,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import com.google.common.base.Optional;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.BlockID;
@@ -65,6 +67,7 @@ import org.apache.hadoop.ozone.security.OzoneBlockTokenSecretManager;
 import org.apache.hadoop.test.GenericTestUtils;
 
 import org.apache.hadoop.util.Time;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -80,12 +83,14 @@ public class TestKeyManagerUnit {
   private KeyManagerImpl keyManager;
 
   private Instant startDate;
+  private File testDir;
 
   @Before
   public void setup() throws IOException {
     configuration = new OzoneConfiguration();
+    testDir = GenericTestUtils.getRandomizedTestDir();
     configuration.set(HddsConfigKeys.OZONE_METADATA_DIRS,
-        GenericTestUtils.getRandomizedTestDir().toString());
+        testDir.toString());
     metadataManager = new OmMetadataManagerImpl(configuration);
     keyManager = new KeyManagerImpl(
         Mockito.mock(ScmBlockLocationProtocol.class),
@@ -96,6 +101,12 @@ public class TestKeyManagerUnit {
     );
 
     startDate = Instant.now();
+  }
+
+  @After
+  public void cleanup() throws Exception {
+    metadataManager.stop();
+    FileUtils.deleteDirectory(testDir);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Fix intermittent failure in `TestKeyManagerUnit#listMultipartUploads`.  If the test is executed quickly, the timestamps may be the same, so check for "not before" instead of "after".
2. Cleanup test directory.  While repeatedly executing the test I found that 1.1MB of data was left over for each iteration.

https://issues.apache.org/jira/browse/HDDS-3827

## How was this patch tested?

Regular: https://github.com/adoroszlai/hadoop-ozone/runs/898216776
100x single test: https://github.com/adoroszlai/hadoop-ozone/runs/898217969