### PR TITLE
HDDS-3999. OM Shutdown when Commit part tries to commit the part, after abort upload.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1943,12 +1943,12 @@ public abstract class TestOzoneRpcClientAbstract {
 
     try {
       ozoneOutputStream.close();
+      fail("testAbortUploadFailWithInProgressPartUpload failed");
     } catch (IOException ex) {
       assertTrue(ex instanceof OMException);
       assertEquals(NO_SUCH_MULTIPART_UPLOAD_ERROR,
           ((OMException) ex).getResult());
     }
-
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
@@ -96,7 +96,8 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
 
       repeatedOmKeyInfo =
           OmUtils.prepareKeyForDelete(openPartKeyInfoToBeDeleted,
-          repeatedOmKeyInfo, omMultipartKeyInfo.getUpdateID(), isRatisEnabled);
+          repeatedOmKeyInfo, openPartKeyInfoToBeDeleted.getUpdateID(),
+              isRatisEnabled);
 
       omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
           openKey, repeatedOmKeyInfo);


### PR DESCRIPTION

## What changes were proposed in this pull request?
This is caused by HDDS-3685. And the tests have not caught this because there is no test for the below scenario in our test suite.
1. Initiate MPU
2. Part Upload in progress
3. Abort Upload
4. Part upload close to commit the part.

(Please fill in changes proposed in this fix)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3999

## How was this patch tested?
Added a test and confirmed now OM does not crash.
