### PR TITLE
HDDS-4016. Change AbortMultipartUpload's audit log type to ABORT_MULTIPART_UPLOAD

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2688,11 +2688,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     try {
       keyManager.abortMultipartUpload(omKeyArgs);
       AUDIT.logWriteSuccess(buildAuditMessageForSuccess(OMAction
-          .COMPLETE_MULTIPART_UPLOAD, auditMap));
+          .ABORT_MULTIPART_UPLOAD, auditMap));
     } catch (IOException ex) {
       metrics.incNumAbortMultipartUploadFails();
       AUDIT.logWriteFailure(buildAuditMessageForFailure(OMAction
-          .COMPLETE_MULTIPART_UPLOAD, auditMap, ex));
+          .ABORT_MULTIPART_UPLOAD, auditMap, ex));
       throw ex;
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, the audit log of AbortMultipartUpload is COMPLETE_MULTIPART_UPLOAD, which cannot be expressed clearly. We need to change it to ABORT_MULTIPART_UPLOAD.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4016

## How was this patch tested?

[existing UT](https://github.com/captainzmc/hadoop-ozone/runs/901459583)
