### PR TITLE
HDDS-4019. Show the storageDir while need init om or scm

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -241,7 +241,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     scmStorageConfig = new SCMStorageConfig(conf);
     if (scmStorageConfig.getState() != StorageState.INITIALIZED) {
       LOG.error("Please make sure you have run \'ozone scm --init\' " +
-          "command to generate all the required metadata.");
+          "command to generate all the required metadata to " +
+          scmStorageConfig.getStorageDir() + ".");
       throw new SCMException("SCM not initialized due to storage config " +
           "failure.", ResultCodes.SCM_NOT_INITIALIZED);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -367,9 +367,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         OZONE_OM_USER_MAX_VOLUME + " value should be greater than zero");
 
     if (omStorage.getState() != StorageState.INITIALIZED) {
-      throw new OMException("OM not initialized, current OM storage state: " +
-          omStorage.getState().name() + ". Please ensure 'ozone om --init' "
-          + "command is executed once before starting the OM service.",
+      throw new OMException("OM not initialized, current OM storage state: "
+          + omStorage.getState().name() + ". Please ensure 'ozone om --init' "
+          + "command is executed to generate all the required metadata to "
+          + omStorage.getStorageDir()
+          + " once before starting the OM service.",
           ResultCodes.OM_NOT_INITIALIZED);
     }
     omMetaDir = OMStorage.getOmDbDir(configuration);


### PR DESCRIPTION
## What changes were proposed in this pull request?

When you accident to use a wrong ozone-site.xml or wrong configure key ozone.metadata.dirs to a new dir, the scm or om cannot start and shown that 'ozone om --init' or 'ozone scm --init' is needed, but you don't know the root cause is you are using a wrong config file or gave a wrong value of ozone.metadata.dirs.

So we can show the current storageDir to user, so that user can aware the real problem.

## What is the link to the Apache JIRA

HDDS-4019

## How was this patch tested?
execute the following command, see the output

ozone scm
ozone om

