### PR TITLE
HDDS-4017. Acceptance check may run against wrong commit

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -134,9 +134,13 @@ jobs:
       - name: checkout to /mnt/ozone
         run: |
           sudo chmod 777 /mnt
-          git clone https://github.com/${GITHUB_REPOSITORY}.git /mnt/ozone
+          git clone 'https://github.com/${{ github.repository }}.git' /mnt/ozone
           cd /mnt/ozone
-          git fetch origin "${GITHUB_REF}"
+          if [[ '${{ github.event_name }}' == 'pull_request' ]]; then
+            git fetch --verbose origin '${{ github.ref }}'
+          else
+            git fetch --verbose origin '${{ github.sha }}'
+          fi
           git checkout FETCH_HEAD
           git reset --hard
       - name: run a full build


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use commit SHA to checkout a specific commit on `push` and `schedule` events.  Keep using name for `pull_request` events (eg. `refs/pull/1234/merge`), because merge commit may not be available by SHA.

Use `github` context instead of environment variables.  Github substitutes these values before running the command, so we can see them in the log.  Comparison:


```
git clone https://github.com/${GITHUB_REPOSITORY}.git /mnt/ozone
cd /mnt/ozone
git fetch origin "${GITHUB_REF}"
git checkout FETCH_HEAD
```

vs.

```
git clone https://github.com/adoroszlai/hadoop-ozone.git /mnt/ozone
cd /mnt/ozone
git fetch origin "refs/heads/HDDS-4017"
git checkout FETCH_HEAD
```

https://issues.apache.org/jira/browse/HDDS-4017

## How was this patch tested?

`push` event:
https://github.com/adoroszlai/hadoop-ozone/runs/903007668#step:4:8

`pull_request` event:
https://github.com/apache/hadoop-ozone/pull/1249/checks?check_run_id=903076398#step:4:6