### PR TITLE
HDDS-4022. Ozone s3 API return 400 Bad Request for head-bucket for non existing bucket.

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/buckethead.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/buckethead.robot
@@ -31,5 +31,6 @@ ${BUCKET}             generated
 Head Bucket not existent
     ${result} =         Execute AWSS3APICli     head-bucket --bucket ${BUCKET}
     ${result} =         Execute AWSS3APICli and checkrc      head-bucket --bucket ozonenosuchbucketqqweqwe  255
-                        Should contain          ${result}    Bad Request
-                        Should contain          ${result}    400
+                        Should contain          ${result}    404
+                        Should contain          ${result}    Not Found
+

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -31,7 +31,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -253,12 +253,7 @@ public class BucketEndpoint extends EndpointBase {
       getBucket(bucketName);
     } catch (OS3Exception ex) {
       LOG.error("Exception occurred in headBucket", ex);
-      //TODO: use a subclass fo OS3Exception and catch it here.
-      if (ex.getCode().contains("NoSuchBucket")) {
-        return Response.status(Status.BAD_REQUEST).build();
-      } else {
-        throw ex;
-      }
+      throw ex;
     }
     return Response.ok().build();
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketHead.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketHead.java
@@ -26,7 +26,10 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 
+import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.junit.Assert;
+
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,7 +63,11 @@ public class TestBucketHead {
 
   @Test
   public void testHeadFail() throws Exception {
-    Response response = bucketEndpoint.head("unknownbucket");
-    Assert.assertEquals(400, response.getStatus());
+    try {
+      bucketEndpoint.head("unknownbucket");
+    } catch (OS3Exception ex) {
+      Assert.assertEquals(HTTP_NOT_FOUND, ex.getHttpCode());
+      Assert.assertEquals("NoSuchBucket", ex.getCode());
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone s3 API returns 400 Bad Request for head-bucket for non-existing bucket.

**hrt_qa$ aws s3api --ca-bundle=/usr/local/share/ca-certificates/ca.crt --endpoint https://s3g:9879/ head-bucket --bucket fsdghj

An error occurred (400) when calling the HeadBucket operation: Bad Request**

It should return 404 as per AWS documentation:
https://docs.aws.amazon.com/cli/latest/reference/s3api/head-bucket.html

A client error (404) occurred when calling the HeadBucket operation: Not Found

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4022

## How was this patch tested?

Added test.
