### PR TITLE
HDDS-4010. S3G startup fails when multiple service ids are configured.

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneServiceProvider.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneServiceProvider.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.s3;
 
+import org.apache.hadoop.hdds.conf.ConfigurationException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.OmUtils;
@@ -28,11 +29,10 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
-import java.util.Arrays;
+import java.io.IOException;
 import java.util.Collection;
 
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 
 /**
  * This class creates the OM service .
@@ -49,34 +49,24 @@ public class OzoneServiceProvider {
 
   @PostConstruct
   public void init() {
-    Collection<String> serviceIdList =
-        conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY);
-    if (serviceIdList.size() == 0) {
-      // Non-HA cluster
+    try {
+      omserviceID = OmUtils.getOzoneManagerServiceId(conf);
+    } catch (IOException ex) {
+      throw new ConfigurationException(ex.getMessage(), ex);
+    }
+
+    // Non-HA cluster.
+    if (omserviceID == null) {
       omServiceAddr = SecurityUtil.buildTokenService(OmUtils.
           getOmAddressForClients(conf));
     } else {
-      // HA cluster.
-      //For now if multiple service id's are configured we throw exception.
-      // As if multiple service id's are configured, S3Gateway will not be
-      // knowing which one to talk to. In future, if OM federation is supported
-      // we can resolve this by having another property like
-      // ozone.om.internal.service.id.
-      // TODO: Revisit this later.
-      if (serviceIdList.size() > 1) {
-        throw new IllegalArgumentException("Multiple serviceIds are " +
-            "configured. " + Arrays.toString(serviceIdList.toArray()));
-      } else {
-        String serviceId = serviceIdList.iterator().next();
-        Collection<String> omNodeIds = OmUtils.getOMNodeIds(conf, serviceId);
-        if (omNodeIds.size() == 0) {
-          throw new IllegalArgumentException(OZONE_OM_NODES_KEY
-              + "." + serviceId + " is not defined");
-        }
-        omServiceAddr = new Text(OzoneS3Util.buildServiceNameForToken(conf,
-            serviceId, omNodeIds));
-        omserviceID = serviceId;
+      Collection<String> omNodeIds = OmUtils.getOMNodeIds(conf, omserviceID);
+      if (omNodeIds.size() == 0) {
+        throw new ConfigurationException(OZONE_OM_NODES_KEY
+            + "." + omserviceID + " is not defined");
       }
+      omServiceAddr = new Text(OzoneS3Util.buildServiceNameForToken(conf,
+          omserviceID, omNodeIds));
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This Jira is to fix this TODO.

**OzoneServiceProvider.java L59:

      // HA cluster.
      //For now if multiple service id's are configured we throw exception.
      // As if multiple service id's are configured, S3Gateway will not be
      // knowing which one to talk to. In future, if OM federation is supported
      // we can resolve this by having another property like
      // ozone.om.internal.service.id.
      // TODO: Revisit this later.
      if (serviceIdList.size() > 1) {
        throw new IllegalArgumentException("Multiple serviceIds are " +
            "configured. " + Arrays.toString(serviceIdList.toArray()));**

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4010

## How was this patch tested?

HDDS-4008 added test for configuration, this Jira reuses the same.
Existing ozone-om-ha docker running s3 test suite should cover S3 tests.
