### PR TITLE
HDDS-4024. Avoid while loop too soon when exception happen

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -229,6 +229,7 @@ public class DatanodeStateMachine implements Closeable {
         // 1. Trigger heartbeat immediately
         // 2. Shutdown has be initiated.
         LOG.warn("Interrupt the execution.", e);
+        Thread.currentThread().interrupt();
       } catch (Exception e) {
         LOG.error("Unable to finish the execution.", e);
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -224,18 +224,24 @@ public class DatanodeStateMachine implements Closeable {
         nextHB.set(Time.monotonicNow() + heartbeatFrequency);
         context.execute(executorService, heartbeatFrequency,
             TimeUnit.MILLISECONDS);
-        now = Time.monotonicNow();
-        if (now < nextHB.get()) {
-          if(!Thread.interrupted()) {
-            Thread.sleep(nextHB.get() - now);
-          }
-        }
       } catch (InterruptedException e) {
         // Some one has sent interrupt signal, this could be because
         // 1. Trigger heartbeat immediately
         // 2. Shutdown has be initiated.
+        LOG.warn("Interrupt the execution.", e);
       } catch (Exception e) {
         LOG.error("Unable to finish the execution.", e);
+      }
+
+      now = Time.monotonicNow();
+      if (now < nextHB.get()) {
+        if(!Thread.interrupted()) {
+          try {
+            Thread.sleep(nextHB.get() - now);
+          } catch (InterruptedException e) {
+            LOG.warn("Interrupt the execution.", e);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When exception throw in `context.execute(executorService, heartbeatFrequency, TimeUnit.MILLISECONDS)`, thread will not sleep and start another while loop immediately, it will cause cpu very high and huge log size.

![image](https://user-images.githubusercontent.com/51938049/88366638-44339b80-cdbc-11ea-8e68-7c5986e09ecb.png)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4024

## How was this patch tested?

No need add test.
