### PR TITLE
HDDS-4025. Add test for creating encrypted key

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/security/bucket-encryption.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/bucket-encryption.robot
@@ -20,7 +20,7 @@ Library             String
 Resource            ../commonlib.robot
 Resource            ../lib/os.robot
 Resource            ../ozone-lib/shell.robot
-Test Setup          Setup Test
+Suite Setup         Setup Test
 Test Timeout        5 minutes
 
 *** Variables ***
@@ -38,3 +38,8 @@ Create Encrypted Bucket
     ${output} =      Execute    ozone sh bucket create -k ${KEY_NAME} o3://${OM_SERVICE_ID}/${VOLUME}/encrypted-bucket
                      Should Not Contain    ${output}    INVALID_REQUEST
     Bucket Exists    o3://${OM_SERVICE_ID}/${VOLUME}/encrypted-bucket
+
+Create Key in Encrypted Bucket
+    ${key} =         Set Variable    o3://${OM_SERVICE_ID}/${VOLUME}/encrypted-bucket/passwd
+    ${output} =      Execute    ozone sh key put ${key} /etc/passwd
+    Key Should Match Local File    ${key}    /etc/passwd


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add acceptance test case to create a key in encrypted bucket.  Inspired by HDDS-4007.

https://issues.apache.org/jira/browse/HDDS-4025

## How was this patch tested?

```
Create Encrypted Bucket                                               | PASS |
------------------------------------------------------------------------------
Create Key in Encrypted Bucket                                        | PASS |
```

https://github.com/adoroszlai/hadoop-ozone/runs/906155913#step:7:2556