### PR TITLE
HDDS-4026. Dir rename failed when sets 'ozone.om.enable.filesystem.paths' to true

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -35,10 +35,16 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_SCHEME;
+import static org.junit.Assert.fail;
 
 /**
  * Class tests create with object store and getFileStatus.
@@ -118,6 +124,100 @@ public class TestOzoneFSWithObjectStoreCreate {
     Assert.assertTrue(o3fs.getFileStatus(p).isFile());
     checkAncestors(p);
 
+  }
+
+
+  @Test
+  public void testObjectStoreCreateWithO3fs() throws Exception {
+    OzoneVolume ozoneVolume =
+        cluster.getRpcClient().getObjectStore().getVolume(volumeName);
+
+    OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
+
+
+    // Use ObjectStore API to create keys. This similates how s3 create keys.
+    String parentDir = "/dir1/dir2/dir3/dir4/";
+
+
+    List<String> keys = new ArrayList<>();
+    keys.add("/dir1");
+    keys.add("/dir1/dir2");
+    keys.add("/dir1/dir2/dir3");
+    keys.add("/dir1/dir2/dir3/dir4/");
+    for (int i=1; i <= 3; i++) {
+      int length = 10;
+      String fileName = parentDir.concat("/file" + i + "/");
+      keys.add(fileName);
+      OzoneOutputStream ozoneOutputStream =
+          ozoneBucket.createKey(fileName, length);
+      byte[] b = new byte[10];
+      Arrays.fill(b, (byte)96);
+      ozoneOutputStream.write(b);
+      ozoneOutputStream.close();
+    }
+
+    // check
+    for (int i=1; i <= 3; i++) {
+      String fileName = parentDir.concat("/file" + i + "/");
+      Path p = new Path(fileName);
+      Assert.assertTrue(o3fs.getFileStatus(p).isFile());
+      checkAncestors(p);
+    }
+
+    // Delete keys with object store api delete
+    for (int i = 1; i <= 3; i++) {
+      String fileName = parentDir.concat("/file" + i + "/");
+      ozoneBucket.deleteKey(fileName);
+    }
+
+
+    // Delete parent dir via o3fs.
+    boolean result = o3fs.delete(new Path("/dir1"), true);
+    Assert.assertTrue(result);
+
+    // No Key should exist.
+    for(String key : keys) {
+      checkPath(new Path(key));
+    }
+
+
+    for (int i=1; i <= 3; i++) {
+      int length = 10;
+      String fileName = parentDir.concat("/file" + i + "/");
+      OzoneOutputStream ozoneOutputStream =
+          ozoneBucket.createKey(fileName, length);
+      byte[] b = new byte[10];
+      Arrays.fill(b, (byte)96);
+      ozoneOutputStream.write(b);
+      ozoneOutputStream.close();
+    }
+
+    o3fs.mkdirs(new Path("/dest"));
+    o3fs.rename(new Path("/dir1"), new Path("/dest"));
+
+    // No source Key should exist.
+    for(String key : keys) {
+      checkPath(new Path(key));
+    }
+
+    // check dest path.
+    for (int i=1; i <= 3; i++) {
+      String fileName = "/dest/".concat(parentDir.concat("/file" + i + "/"));
+      Path p = new Path(fileName);
+      Assert.assertTrue(o3fs.getFileStatus(p).isFile());
+      checkAncestors(p);
+    }
+
+  }
+
+  private void checkPath(Path path) {
+    try {
+      o3fs.getFileStatus(path);
+      fail("testObjectStoreCreateWithO3fs failed for Path" + path);
+    } catch (IOException ex) {
+      Assert.assertTrue(ex instanceof FileNotFoundException);
+      Assert.assertTrue(ex.getMessage().contains("No such file or directory"));
+    }
   }
 
   private void checkAncestors(Path p) throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -35,7 +35,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
@@ -97,7 +98,8 @@ public class TestOzoneFileInterfaces {
    */
   @Parameters
   public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][] {{false, true}, {true, false}});
+    return Arrays.asList(new Object[][] {{false, true, true},
+        {true, false, false}});
   }
 
   private boolean setDefaultFs;
@@ -118,10 +120,13 @@ public class TestOzoneFileInterfaces {
 
   private OMMetrics omMetrics;
 
+  private boolean enableFileSystemPaths;
+
   public TestOzoneFileInterfaces(boolean setDefaultFs,
-      boolean useAbsolutePath) {
+      boolean useAbsolutePath, boolean enabledFileSystemPaths) {
     this.setDefaultFs = setDefaultFs;
     this.useAbsolutePath = useAbsolutePath;
+    this.enableFileSystemPaths = enabledFileSystemPaths;
     GlobalStorageStatistics.INSTANCE.reset();
   }
 
@@ -131,6 +136,8 @@ public class TestOzoneFileInterfaces {
     bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
 
     OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,
+        enableFileSystemPaths);
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(3)
         .build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -87,19 +87,13 @@ public class OMKeyRenameRequest extends OMKeyRequest {
 
     KeyArgs renameKeyArgs = renameKeyRequest.getKeyArgs();
 
-    // Set modification time and normalize key if needed.
+    // Set modification time.
     KeyArgs.Builder newKeyArgs = renameKeyArgs.toBuilder()
-            .setModificationTime(Time.now())
-        .setKeyName(validateAndNormalizeKey(
-            ozoneManager.getEnableFileSystemPaths(),
-            renameKeyArgs.getKeyName()));
+            .setModificationTime(Time.now());
 
     return getOmRequest().toBuilder()
         .setRenameKeyRequest(renameKeyRequest.toBuilder()
-            .setKeyArgs(newKeyArgs)
-            .setToKeyName(validateAndNormalizeKey(
-                ozoneManager.getEnableFileSystemPaths(),
-                renameKeyRequest.getToKeyName())))
+            .setKeyArgs(newKeyArgs))
         .setUserInfo(getUserInfo()).build();
 
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rename failed for directory when ozone.om.enable.filesystem.paths is set to true.

As rename is not used by ObjectStore API, we don't need to normalize the path when ozone.om.enable.filesystem.paths is set to true.

O3FS uses `deleteObjects` for deleting directory and `deleteKey` for delete file/key. So, normalizing the path when the config is enabled should be fine, as the` deletekey` only used for deleting file. (Note: `deleteObject` does not normalize paths)

Still, a fix is required for OFS delete, as it uses `deleteKey` for deleting the directory. I will open a Jira to fix the issue.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4026

## How was this patch tested?

Added tests for rename and delete.

