### PR TITLE
HDDS-4030. Remember the selected columns and make the X-axis scrollable in recon datanodes UI

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.less
@@ -35,5 +35,6 @@
     margin-right: 5px;
     display: inline-block;
     min-width: 200px;
+    z-index: 99;
   }
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -107,16 +107,8 @@ const COLUMNS = [
     filters: DatanodeStatusList.map(status => ({text: status, value: status})),
     onFilter: (value: DatanodeStatus, record: IDatanode) => record.state === value,
     render: (text: DatanodeStatus) => renderDatanodeStatus(text),
-    sorter: (a: IDatanode, b: IDatanode) => a.state.localeCompare(b.state)
-  },
-  {
-    title: 'Uuid',
-    dataIndex: 'uuid',
-    key: 'uuid',
-    isVisible: true,
-    isSearchable: true,
-    sorter: (a: IDatanode, b: IDatanode) => a.uuid.localeCompare(b.uuid),
-    defaultSortOrder: 'ascend' as const
+    sorter: (a: IDatanode, b: IDatanode) => a.state.localeCompare(b.state),
+    fixed: 'left'
   },
   {
     title: 'Hostname',
@@ -125,6 +117,16 @@ const COLUMNS = [
     isVisible: true,
     isSearchable: true,
     sorter: (a: IDatanode, b: IDatanode) => a.hostname.localeCompare(b.hostname),
+    defaultSortOrder: 'ascend' as const,
+    fixed: 'left'
+  },
+  {
+    title: 'Uuid',
+    dataIndex: 'uuid',
+    key: 'uuid',
+    isVisible: true,
+    isSearchable: true,
+    sorter: (a: IDatanode, b: IDatanode) => a.uuid.localeCompare(b.uuid),
     defaultSortOrder: 'ascend' as const
   },
   {
@@ -266,10 +268,19 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
     });
   };
 
+  _getSelectedColumns = (selected: IOption[]) => {
+    const selectedColumns = selected.length > 0 ? selected : COLUMNS.filter(column => column.isVisible).map(column => ({
+      label: column.key,
+      value: column.key
+    }));
+    return selectedColumns;
+  };
+
   _loadData = () => {
-    this.setState({
-      loading: true
-    });
+    this.setState(prevState => ({
+      loading: true,
+      selectedColumns: this._getSelectedColumns(prevState.selectedColumns)
+    }));
     axios.get('/api/v1/datanodes').then(response => {
       const datanodesResponse: IDatanodesResponse = response.data;
       const totalCount = datanodesResponse.totalCount;
@@ -292,18 +303,12 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
           buildDate: datanode.buildDate
         };
       });
-      const selectedColumns: IOption[] = COLUMNS.filter(column => column.isVisible).map(column => ({
-        label: column.key,
-        value: column.key
-      }));
 
       this.setState({
         loading: false,
         dataSource,
         totalCount,
         lastUpdated: Number(moment())
-      }, () => {
-        this._handleColumnChange(selectedColumns, {action: 'select-option'});
       });
     }).catch(error => {
       this.setState({
@@ -381,6 +386,7 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
             loading={loading}
             pagination={paginationConfig}
             rowKey='hostname'
+            scroll={{x: true, y: false, scrollToFirstRowOnChange: true}}
           />
         </div>
       </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, the Datanodes tab can't remember the selected columns, when the page is auto reloaded, the columns will be reset to the default columns.

Meanwhile, when several columns are selected, we can't see some columns in the right side.

Also, I changed the order of two columns, putting Hostname before itself UUID, so I can pin the State and Hostname on the left of the table.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4030

## How was this patch tested?

Test with `pnpm run dev` and lint the code with `yarn run lint:fix`.

The effective as below picture.
<img width="1469" alt="datanodes" src="https://user-images.githubusercontent.com/3263540/88473767-42501080-cf53-11ea-9fd0-a15ef991f1de.png">
