### PR TITLE
HDDS-4031. Run shell tests in CI

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -35,6 +35,26 @@ jobs:
       - uses: ./.github/buildenv
         with:
           args: ./hadoop-ozone/dev-support/checks/build.sh
+  bats:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: install bats
+        run: |
+          cd /tmp
+          curl -LSs https://github.com/bats-core/bats-core/archive/v1.2.1.tar.gz | tar xzf -
+          cd bats-core-1.2.1
+          sudo ./install.sh /usr/local
+      - name: run tests
+        run: ./hadoop-ozone/dev-support/checks/${{ github.job }}.sh
+      - name: Summary of failures
+        run: cat target/${{ github.job }}/summary.txt
+        if: always()
+      - uses: actions/upload-artifact@master
+        if: always()
+        with:
+          name: ${{ github.job }}
+          path: target/${{ github.job }}
   rat:
     name: rat
     runs-on: ubuntu-18.04

--- a/hadoop-ozone/dev-support/checks/bats.sh
+++ b/hadoop-ozone/dev-support/checks/bats.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "${DIR}/../../.." || exit 1
+
+REPORT_DIR=${OUTPUT_DIR:-"${DIR}/../../../target/bats"}
+mkdir -p "${REPORT_DIR}"
+REPORT_FILE="${REPORT_DIR}/summary.txt"
+
+rm -f "${REPORT_DIR}/output.log"
+
+find * -path '*/src/test/shell/*' -name '*.bats' -print0 \
+  | xargs -0 -n1 bats --formatter tap \
+  | tee -a "${REPORT_DIR}/output.log"
+
+grep '^\(not ok\|#\)' "${REPORT_DIR}/output.log" > "${REPORT_FILE}"
+
+grep -c '^not ok' "${REPORT_FILE}" > "${REPORT_DIR}/failures"
+
+if [[ -s "${REPORT_FILE}" ]]; then
+   exit 1
+fi

--- a/hadoop-ozone/dist/src/test/shell/gc_opts.bats
+++ b/hadoop-ozone/dist/src/test/shell/gc_opts.bats
@@ -14,14 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
 #
 # Can be executed with bats (https://github.com/bats-core/bats-core)
-# bats gc_opts.bats (FROM THE CURRENT DIRECTORY)
+# bats gc_opts.bats
 #
 
-source ../../shell/hdds/hadoop-functions.sh
+load ../../shell/hdds/hadoop-functions.sh
 @test "Setting Hadoop GC parameters: add GC params for server" {
   export HADOOP_SUBCMD_SUPPORTDAEMONIZATION=true
   export HADOOP_OPTS="Test"


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Add a helper script to run bash test scripts (`*.bats`).
2. Run `bats` part of CI.

https://issues.apache.org/jira/browse/HDDS-4031

## How was this patch tested?

Created failing test at `hadoop-hdds/common/src/test/shell/failing.bats`:

```
@test "fails" {
  [[ "123" == "456" ]]
}

@test "err" {
  asdfs
}
```

and tested:

```
$ hadoop-ozone/dev-support/checks/bats.sh
...

$ echo $?
1

$ cat target/bats/summary.txt
not ok 1 fails
# (in test file hadoop-hdds/common/src/test/shell/failing.bats, line 24)
#   `@test "fails" {' failed
not ok 2 err
# (in test file hadoop-hdds/common/src/test/shell/failing.bats, line 29)
#   `asdfs' failed with status 127
# /var/folders/32/sr06nr7123s3bdfsmqsm4pqw0000gn/T/bats-run-70119/bats.70145.src: line 29: asdfs: command not found

$ cat target/bats/failures
2
```

Passing tests (currently only `gc_opts.bat`):

```
1..3
ok 1 Setting Hadoop GC parameters: add GC params for server
ok 2 Setting Hadoop GC parameters: disabled for client
ok 3 Setting Hadoop GC parameters: disabled if GC params are customized
```

https://github.com/adoroszlai/hadoop-ozone/runs/913609741#step:4:4