### PR TITLE
HDDS-4032. Run author check without docker

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -56,9 +56,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
-        - uses: ./.github/buildenv
-          with:
-             args: ./hadoop-ozone/dev-support/checks/author.sh
+        - run: hadoop-ozone/dev-support/checks/author.sh
         - name: Summary of failures
           run: cat target/${{ github.job }}/summary.txt
           if: always()


### PR DESCRIPTION
## What changes were proposed in this pull request?

`author.sh` can be run in CI without docker container, since it's mostly just a recursive grep.  This reduces runtime from 2 minutes to 5 seconds.  Overall CI response time is the same (since this is one of the quickest checks anyway), but it still helps, as the number of concurrent checks in the repo is limited.

https://issues.apache.org/jira/browse/HDDS-4032

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/913684427