### PR TITLE
HDDS-4041. Ozone /conf endpoint triggers kerberos replay error when S…

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/spnego/web.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/spnego/web.robot
@@ -30,6 +30,11 @@ ${OM_SERVICE_LIST_URL}       http://om:9874/serviceList
 ${SCM_URL}       http://scm:9876
 ${RECON_URL}       http://recon:9888
 
+${SCM_CONF_URL}     http://scm:9876/conf
+${SCM_JMX_URL}      http://scm:9876/jmx
+${SCM_STACKS_URL}   http://scm:9876/stacks
+
+
 *** Keywords ***
 Verify SPNEGO enabled URL
     [arguments]                      ${url}
@@ -59,6 +64,15 @@ Test OM Service List
 
 Test SCM portal
     Verify SPNEGO enabled URL       ${SCM_URL}
+
+Test SCM conf
+    Verify SPNEGO enabled URL       ${SCM_CONF_URL}
+
+Test SCM jmx
+    Verify SPNEGO enabled URL       ${SCM_JMX_URL}
+
+Test SCM stacks
+    Verify SPNEGO enabled URL       ${SCM_STACKS_URL}
 
 Test Recon portal
     Verify SPNEGO enabled URL       ${RECON_URL}


### PR DESCRIPTION
…PNEGO is enabled.

## What changes were proposed in this pull request?

Remove filter attached to the default /conf endpoint to avoid kerberos replay error when kerberos authentication filter are attached twice to the same path /conf. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4041

## How was this patch tested?

Manual testing with SPNEGO enabled /conf endpoint and verify no replay error. 
Also added additional acceptance tests. 