### PR TITLE
HDDS-4038. Eliminate GitHub check warnings

### DIFF
--- a/.github/workflows/comments.yaml
+++ b/.github/workflows/comments.yaml
@@ -25,7 +25,7 @@ jobs:
     name: check-comment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - run: ./.github/process-comment.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -23,7 +23,7 @@ jobs:
     name: compile
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:
           path: |
@@ -39,14 +39,14 @@ jobs:
     name: rat
     runs-on: ubuntu-18.04
     steps:
-        - uses: actions/checkout@master
+        - uses: actions/checkout@v2
         - uses: ./.github/buildenv
           with:
              args: ./hadoop-ozone/dev-support/checks/rat.sh
         - name: Summary of failures
           run: cat target/${{ github.job }}/summary.txt
           if: always()
-        - uses: actions/upload-artifact@master
+        - uses: actions/upload-artifact@v2
           if: always()
           with:
             name: rat
@@ -56,12 +56,12 @@ jobs:
     name: author
     runs-on: ubuntu-18.04
     steps:
-        - uses: actions/checkout@master
+        - uses: actions/checkout@v2
         - run: hadoop-ozone/dev-support/checks/author.sh
         - name: Summary of failures
           run: cat target/${{ github.job }}/summary.txt
           if: always()
-        - uses: actions/upload-artifact@master
+        - uses: actions/upload-artifact@v2
           if: always()
           with:
             name: author
@@ -71,14 +71,14 @@ jobs:
     name: unit
     runs-on: ubuntu-18.04
     steps:
-        - uses: actions/checkout@master
+        - uses: actions/checkout@v2
         - uses: ./.github/buildenv
           with:
              args: ./hadoop-ozone/dev-support/checks/unit.sh
         - name: Summary of failures
           run: cat target/${{ github.job }}/summary.txt
           if: always()
-        - uses: actions/upload-artifact@master
+        - uses: actions/upload-artifact@v2
           if: always()
           with:
             name: unit
@@ -88,14 +88,14 @@ jobs:
     name: checkstyle
     runs-on: ubuntu-18.04
     steps:
-        - uses: actions/checkout@master
+        - uses: actions/checkout@v2
         - uses: ./.github/buildenv
           with:
              args: ./hadoop-ozone/dev-support/checks/checkstyle.sh
         - name: Summary of failures
           run: cat target/${{ github.job }}/summary.txt
           if: always()
-        - uses: actions/upload-artifact@master
+        - uses: actions/upload-artifact@v2
           if: always()
           with:
             name: checkstyle
@@ -105,14 +105,14 @@ jobs:
     name: findbugs
     runs-on: ubuntu-18.04
     steps:
-        - uses: actions/checkout@master
+        - uses: actions/checkout@v2
         - uses: ./.github/buildenv
           with:
              args: ./hadoop-ozone/dev-support/checks/findbugs.sh
         - name: Summary of failures
           run: cat target/${{ github.job }}/summary.txt
           if: always()
-        - uses: actions/upload-artifact@master
+        - uses: actions/upload-artifact@v2
           if: always()
           with:
             name: findbugs
@@ -166,7 +166,7 @@ jobs:
           OZONE_ACCEPTANCE_SUITE: ${{ matrix.suite }}
           OZONE_WITH_COVERAGE: true
           OZONE_VOLUME_OWNER: 1000
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v2
         if: always()
         with:
           name: acceptance-${{ matrix.suite }}
@@ -189,7 +189,7 @@ jobs:
       fail-fast: false
     steps:
         - run: sudo mkdir mnt && sudo mount --bind /mnt `pwd`/mnt && sudo chmod 777 mnt
-        - uses: actions/checkout@master
+        - uses: actions/checkout@v2
           with:
             path: mnt/ozone
         - uses: ./mnt/ozone/.github/buildenv
@@ -198,7 +198,7 @@ jobs:
         - name: Summary of failures
           run: cat mnt/ozone/target/${{ github.job }}/summary.txt
           if: always()
-        - uses: actions/upload-artifact@master
+        - uses: actions/upload-artifact@v2
           if: always()
           with:
             name: it-${{ matrix.profile }}
@@ -233,7 +233,7 @@ jobs:
            file: ./target/coverage/all.xml
            name: codecov-umbrella
            fail_ci_if_error: true
-       - uses: actions/upload-artifact@master
+       - uses: actions/upload-artifact@v2
          with:
            name: coverage
            path: target/coverage


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use `@v2` instead of `@master` for GitHub Actions to eliminate the warnings:

> The "master" branch is no longer the default branch name for actions/checkout
> The "master" branch is no longer the default branch name for actions/upload-artifact

https://issues.apache.org/jira/browse/HDDS-4038

## How was this patch tested?

No "annotations" in
https://github.com/adoroszlai/hadoop-ozone/actions/runs/184737522

compare to current master:
https://github.com/apache/hadoop-ozone/actions/runs/185025914