### PR TITLE
HDDS-4044. Deprecate ozone.s3g.volume.name.

### DIFF
--- a/hadoop-hdds/docs/content/interface/S3.md
+++ b/hadoop-hdds/docs/content/interface/S3.md
@@ -24,7 +24,7 @@ summary: Ozone supports Amazon's Simple Storage Service (S3) protocol. In fact, 
 
 Ozone provides S3 compatible REST interface to use the object store data with any S3 compatible tools.
 
-S3 buckets are stored under the `/s3v` volume. The default name `s3v` can be changed by setting the `ozone.s3g.volume.name` config property in `ozone-site.xml`.
+S3 buckets are stored under the `/s3v` volume.
 
 ## Getting started
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-3612 introduced bucket links.
After this feature now we don't need this parameter, any volume/bucket can be exposed to S3 via using bucket links.

ozone bucket link srcvol/srcbucket destvol/destbucket

So now to expose any ozone bucket to S3G

For example, the user wants to expose a bucket named bucket1 under volume1 to S3G, they can run below command

ozone bucket link volume1/bucket1 s3v/bucket2
Now, the user can access all the keys in volume/bucket1 using s3v/bucket2 and also ingest data to the volume/bucket1 using using s3v/bucket2

This Jira is opened to remove the config from ozone-default.xml
And also log a warning message to use bucket links, when it does not have default value s3v.

With this configuration it causes trouble to users, to figure which volume is used for their buckets whenever this configuration is changed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4044

## How was this patch tested?

Added UT
