### PR TITLE
HDDS-4020. ACL commands like getacl and setacl should return a response only when Native Authorizer is enabled.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/web/utils/OzoneUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/web/utils/OzoneUtils.java
@@ -30,11 +30,15 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 
 import com.google.common.base.Preconditions;
 import org.apache.ratis.util.TimeDuration;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS_DEFAULT;
 
 /**
  * Set of Utility functions used in ozone.
@@ -164,6 +168,24 @@ public final class OzoneUtils {
       TimeDuration defaultValue) {
     return getTimeDuration(conf, key, defaultValue)
         .toLong(TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Return true, when Authorizer class is configured with non-default value.
+   * @param configuration
+   * @return boolean
+   */
+  public static boolean checkExternalAuthorizer(
+      OzoneConfiguration configuration) {
+    String authorizerClass = configuration.get(OZONE_ACL_AUTHORIZER_CLASS);
+    if (authorizerClass != null &&
+        !authorizerClass.equals(OZONE_ACL_AUTHORIZER_CLASS_DEFAULT)) {
+      System.out.print(String.format("When External Authorizer %s is " +
+          "configured, Acl commands are not supported via ozone shell.",
+          authorizerClass));
+      return true;
+    }
+    return false;
   }
 
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/util/TestOzoneUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/util/TestOzoneUtils.java
@@ -1,0 +1,23 @@
+package org.apache.hadoop.ozone.util;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.web.utils.OzoneUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Class tests OzoneUtils.
+ */
+public class TestOzoneUtils {
+
+  @Test
+  public void testCheckExternalAuthorizer() {
+    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
+    Assert.assertFalse(OzoneUtils.checkExternalAuthorizer(ozoneConfiguration));
+
+    ozoneConfiguration.set(OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS,
+        "RangerAuthorizer");
+    Assert.assertTrue(OzoneUtils.checkExternalAuthorizer(ozoneConfiguration));
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/acl/AclHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/acl/AclHandler.java
@@ -17,12 +17,14 @@
  */
 package org.apache.hadoop.ozone.shell.acl;
 
+
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.shell.StoreTypeOption;
 import org.apache.hadoop.ozone.shell.Handler;
 
+import org.apache.hadoop.ozone.web.utils.OzoneUtils;
 import picocli.CommandLine;
 
 import java.io.IOException;
@@ -55,7 +57,10 @@ public abstract class AclHandler extends Handler {
   @Override
   protected void execute(OzoneClient client, OzoneAddress address)
       throws IOException {
-
+    boolean externalAuthorizer = OzoneUtils.checkExternalAuthorizer(getConf());
+    if (externalAuthorizer) {
+      return;
+    }
     execute(client, address.toOzoneObj(storeType.getValue()));
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, the getacl and setacl commands return wrong information when an external authorizer such as Ranger is enabled. There should be a check to verify if Native Authorizer is enabled before returning any response for these two commands.

If an external authorizer is enabled, it should show a nice message about managing acls in external authorizer.  

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4020

## How was this patch tested?

Added UT
