### PR TITLE
HDDS-4045. Add more ignore rules to the RAT ignore list

### DIFF
--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -252,7 +252,15 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <configuration>
           <excludes>
             <exclude>**/hs_err*.log</exclude>
+            <exclude>**/.attach_*</exclude>
+            <exclude>**/**.rej</exclude>
+            <exclude>**/.factorypath</exclude>
+            <exclude>public</exclude>
+            <exclude>**/*.iml</exclude>
             <exclude>**/target/**</exclude>
+            <exclude>output.xml</exclude>
+            <exclude>log.html</exclude>
+            <exclude>report.html</exclude>
             <exclude>.gitattributes</exclude>
             <exclude>.idea/**</exclude>
             <exclude>src/main/resources/webapps/static/angular-1.7.9.min.js</exclude>

--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -258,9 +258,9 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
             <exclude>public</exclude>
             <exclude>**/*.iml</exclude>
             <exclude>**/target/**</exclude>
-            <exclude>output.xml</exclude>
-            <exclude>log.html</exclude>
-            <exclude>report.html</exclude>
+            <exclude>**/output.xml</exclude>
+            <exclude>**/log.html</exclude>
+            <exclude>**/report.html</exclude>
             <exclude>.gitattributes</exclude>
             <exclude>.idea/**</exclude>
             <exclude>src/main/resources/webapps/static/angular-1.7.9.min.js</exclude>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -259,6 +259,14 @@
             <exclude>**/hs_err*.log</exclude>
             <exclude>**/target/**</exclude>
             <exclude>.gitattributes</exclude>
+            <exclude>**/.attach_*</exclude>
+            <exclude>**/**.rej</exclude>
+            <exclude>**/.factorypath</exclude>
+            <exclude>public</exclude>
+            <exclude>**/*.iml</exclude>
+            <exclude>**/output.xml</exclude>
+            <exclude>**/log.html</exclude>
+            <exclude>**/report.html</exclude>
             <exclude>.idea/**</exclude>
             <exclude>**/.ssh/id_rsa*</exclude>
             <exclude>dev-support/*tests</exclude>


### PR DESCRIPTION
## What changes were proposed in this pull request?

We have separated rat ignore list for Hdds and Ozone projects but some files (which are ignored by .gitignore) not added to there. It's not a problem on github as rat is executed on a clean repo, but locally it can make the execution easier (exclude files which are already ignored).

Rats can read ignore list from VCS ignore file, unfortunately only from directory of the current project not from the root of the git repository.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4045

## How was this patch tested?

```
./hadoop-ozone/dev-support/checks/rat.sh
```