### PR TITLE
HDDS-4048. Show more information while SCM version info mismatch

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Storage.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Storage.java
@@ -168,7 +168,7 @@ public abstract class Storage {
    *
    * @return the version file path
    */
-  private File getVersionFile() {
+  public File getVersionFile() {
     return new File(getCurrentDir(), STORAGE_FILE_VERSION);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -407,6 +407,18 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       ScmInfo scmInfo = getScmInfo(configuration);
       if (!(scmInfo.getClusterId().equals(omStorage.getClusterID()) && scmInfo
           .getScmId().equals(omStorage.getScmId()))) {
+        InetSocketAddress scmBlockAddress =
+            getScmAddressForBlockClients(conf);
+        if (!scmInfo.getClusterId().equals(omStorage.getClusterID())) {
+          LOG.error("clusterId from {} is {}, but is {} in {}",
+              scmBlockAddress, scmInfo.getClusterId(),
+              omStorage.getClusterID(), omStorage.getVersionFile());
+        }
+        if (!scmInfo.getScmId().equals(omStorage.getScmId())) {
+          LOG.error("scmId from {} is {}, but is {} in {}",
+              scmBlockAddress, scmInfo.getScmId(),
+              omStorage.getScmId(), omStorage.getVersionFile());
+        }
         throw new OMException("SCM version info mismatch.",
             ResultCodes.SCM_VERSION_MISMATCH_ERROR);
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -407,18 +407,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       ScmInfo scmInfo = getScmInfo(configuration);
       if (!(scmInfo.getClusterId().equals(omStorage.getClusterID()) && scmInfo
           .getScmId().equals(omStorage.getScmId()))) {
-        InetSocketAddress scmBlockAddress =
-            getScmAddressForBlockClients(conf);
-        if (!scmInfo.getClusterId().equals(omStorage.getClusterID())) {
-          LOG.error("clusterId from {} is {}, but is {} in {}",
-              scmBlockAddress, scmInfo.getClusterId(),
-              omStorage.getClusterID(), omStorage.getVersionFile());
-        }
-        if (!scmInfo.getScmId().equals(omStorage.getScmId())) {
-          LOG.error("scmId from {} is {}, but is {} in {}",
-              scmBlockAddress, scmInfo.getScmId(),
-              omStorage.getScmId(), omStorage.getVersionFile());
-        }
+        logVersionMismatch(conf, scmInfo);
         throw new OMException("SCM version info mismatch.",
             ResultCodes.SCM_VERSION_MISMATCH_ERROR);
       }
@@ -490,6 +479,21 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     ShutdownHookManager.get().addShutdownHook(shutdownHook,
         SHUTDOWN_HOOK_PRIORITY);
     omState = State.INITIALIZED;
+  }
+
+  private void logVersionMismatch(OzoneConfiguration conf, ScmInfo scmInfo) {
+    InetSocketAddress scmBlockAddress =
+        getScmAddressForBlockClients(conf);
+    if (!scmInfo.getClusterId().equals(omStorage.getClusterID())) {
+      LOG.error("clusterId from {} is {}, but is {} in {}",
+          scmBlockAddress, scmInfo.getClusterId(),
+          omStorage.getClusterID(), omStorage.getVersionFile());
+    }
+    if (!scmInfo.getScmId().equals(omStorage.getScmId())) {
+      LOG.error("scmId from {} is {}, but is {} in {}",
+          scmBlockAddress, scmInfo.getScmId(),
+          omStorage.getScmId(), omStorage.getVersionFile());
+    }
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Now, if I accident to connect unexpected SCM since i specify the wrong ozone-site.xml file, the OM cannot startup and through exception `SCM_VERSION_MISMATCH_ERROR`, but i really don't know what happened. After this PR, you can get the following concrete and complete information about the mismatch clusterId and scmId.

Something like this following:

```
2020-07-30 23:50:46,759 ERROR om.OzoneManager (OzoneManager.java:<init>(413)) - clusterId from localhost/127.0.0.1:9863 is CID-986bb182-6cf5-43c6-8ad0-979eb7353589, but is CID-986bb182-6cf5-43c6-8ad0-979eb73535891 in /tmp/metadata/om/current/VERSION
2020-07-30 23:50:46,759 ERROR om.OzoneManager (OzoneManager.java:<init>(418)) - scmId from localhost/127.0.0.1:9863 is ff25a950-8683-43bf-95c7-6ae5bcd1d27f, but is ff25a950-8683-43bf-95c7-6ae5bcd1d271f1 in /tmp/metadata/om/current/VERSION
2020-07-30 23:50:46,761 ERROR om.OzoneManagerStarter (OzoneManagerStarter.java:call(69)) - OM start failed with exception
SCM_VERSION_MISMATCH_ERROR org.apache.hadoop.ozone.om.exceptions.OMException: SCM version info mismatch.
	at org.apache.hadoop.ozone.om.OzoneManager.<init>(OzoneManager.java:422)
	at org.apache.hadoop.ozone.om.OzoneManager.createOm(OzoneManager.java:910)
	at org.apache.hadoop.ozone.om.OzoneManagerStarter$OMStarterHelper.start(OzoneManagerStarter.java:124)
	at org.apache.hadoop.ozone.om.OzoneManagerStarter.startOm(OzoneManagerStarter.java:79)
	at org.apache.hadoop.ozone.om.OzoneManagerStarter.call(OzoneManagerStarter.java:67)
	at org.apache.hadoop.ozone.om.OzoneManagerStarter.call(OzoneManagerStarter.java:38)
	at picocli.CommandLine.execute(CommandLine.java:1173)
	at picocli.CommandLine.access$800(CommandLine.java:141)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:1367)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:1335)
	at picocli.CommandLine$AbstractParseResultHandler.handleParseResult(CommandLine.java:1243)
	at picocli.CommandLine.parseWithHandlers(CommandLine.java:1526)
	at picocli.CommandLine.parseWithHandler(CommandLine.java:1465)
	at org.apache.hadoop.hdds.cli.GenericCli.execute(GenericCli.java:75)
	at org.apache.hadoop.hdds.cli.GenericCli.run(GenericCli.java:66)
	at org.apache.hadoop.ozone.om.OzoneManagerStarter.main(OzoneManagerStarter.java:51)
2020-07-30 23:50:46,763 INFO  om.OzoneManagerStarter (StringUtils.java:lambda$startupShutdownMessage$0(124)) - SHUTDOWN_MSG:
```

## What is the link to the Apache JIRA

HDDS-4048

## How was this patch tested?

Modify the `scmUuid` and `clusterID` of `VERSION` file, and run OM. 