### PR TITLE
HDDS-4052. Remove master/slave terminology from Ozone

### DIFF
--- a/hadoop-hdds/docs/content/start/OnPrem.md
+++ b/hadoop-hdds/docs/content/start/OnPrem.md
@@ -165,7 +165,7 @@ ozone om --init
 start-ozone.sh
 {{< /highlight >}}
 
-This assumes that you have set up the slaves file correctly and ssh
+This assumes that you have set up the `workers` file correctly and ssh
 configuration that allows ssh-ing to all data nodes. This is the same as the
 HDFS configuration, so please refer to HDFS documentation on how to set this
 up.

--- a/hadoop-hdds/docs/content/start/OnPrem.zh.md
+++ b/hadoop-hdds/docs/content/start/OnPrem.zh.md
@@ -151,4 +151,4 @@ ozone om --init
 start-ozone.sh
 {{< /highlight >}}
 
-这么做的前提是，slaves 文件已经正确编写，并且配置好了到各个 Datanode 的 ssh，这和 HDFS 的配置方式相同，具体方法请查看 HDFS 文档。
+这么做的前提是，`workers` 文件已经正确编写，并且配置好了到各个 Datanode 的 ssh，这和 HDFS 的配置方式相同，具体方法请查看 HDFS 文档。

--- a/hadoop-ozone/dist/src/shell/hdds/hadoop-daemons.sh
+++ b/hadoop-ozone/dist/src/shell/hdds/hadoop-daemons.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 
-# Run a Hadoop command on all slave hosts.
+# Run a Hadoop command on all worker hosts.
 
 function hadoop_usage
 {

--- a/hadoop-ozone/dist/src/shell/hdds/hadoop-functions.sh
+++ b/hadoop-ozone/dist/src/shell/hdds/hadoop-functions.sh
@@ -999,7 +999,7 @@ function hadoop_connect_to_hosts
   # shellcheck disable=SC2124
   local params="$@"
   local worker_file
-  local tmpslvnames
+  local tmp_worker_names
 
   #
   # ssh (or whatever) to a host
@@ -1030,10 +1030,10 @@ function hadoop_connect_to_hosts
     else
       # no spaces allowed in the pdsh arg host list
       # shellcheck disable=SC2086
-      tmpslvnames=$(echo ${HADOOP_WORKER_NAMES} | tr -s ' ' ,)
+      tmp_worker_names=$(echo ${HADOOP_WORKER_NAMES} | tr -s ' ' ,)
       PDSH_SSH_ARGS_APPEND="${HADOOP_SSH_OPTS}" pdsh \
         -f "${HADOOP_SSH_PARALLEL}" \
-        -w "${tmpslvnames}" $"${@// /\\ }" 2>&1
+        -w "${tmp_worker_names}" $"${@// /\\ }" 2>&1
     fi
   else
     if [[ -z "${HADOOP_WORKER_NAMES}" ]]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace "slave" with "worker", which is already established terminology, but there were a few leftover occurrences.

https://issues.apache.org/jira/browse/HDDS-4052

## How was this patch tested?

The only remaining occurrences are deprecation warnings:

```
$ rg --ignore-case --no-ignore slave
hadoop-ozone/dist/src/shell/hdds/hadoop-config.sh
122:hadoop_deprecate_envvar HADOOP_SLAVES HADOOP_WORKERS
123:hadoop_deprecate_envvar HADOOP_SLAVE_NAMES HADOOP_WORKER_NAMES
124:hadoop_deprecate_envvar HADOOP_SLAVE_SLEEP HADOOP_WORKER_SLEEP

hadoop-ozone/dist/src/shell/hdds/hadoop-functions.sh
1016:    elif [[ -f "${HADOOP_CONF_DIR}/slaves" ]]; then
1017:      hadoop_error "WARNING: 'slaves' file has been deprecated. Please use 'workers' file instead."
1018:      worker_file=${HADOOP_CONF_DIR}/slaves
```