### PR TITLE
HDDS-4058. Wrong use of AtomicBoolean in HddsDatanodeService

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -99,7 +99,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
   private HddsDatanodeHttpServer httpServer;
   private boolean printBanner;
   private String[] args;
-  private volatile AtomicBoolean isStopped = new AtomicBoolean(false);
+  private final AtomicBoolean isStopped = new AtomicBoolean(false);
   private final Map<String, RatisDropwizardExports> ratisMetricsMap =
       new ConcurrentHashMap<>();
   private DNMXBeanImpl serviceRuntimeInfo =
@@ -531,8 +531,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
 
   @Override
   public void stop() {
-    if (!isStopped.get()) {
-      isStopped.set(true);
+    if (!isStopped.getAndSet(true)) {
       if (plugins != null) {
         for (ServicePlugin plugin : plugins) {
           try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

* `AtomicBoolean isStopped` should be `final`, not `volatile`, since the reference is not being changed
* `stop()` should use atomic `getAndSet()` instead of `get()` followed by `set()`

https://issues.apache.org/jira/browse/HDDS-4058

## How was this patch tested?

Not really tested, trivial code change.

CI passed:
https://github.com/adoroszlai/hadoop-ozone/runs/939478014