### PR TITLE
HDDS-4040. [OFS] BasicRootedOzoneFileSystem to support batchDelete

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.VolumeArgs;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
@@ -52,9 +53,12 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -81,10 +85,22 @@ import static org.junit.Assert.assertTrue;
  * Ozone file system tests that are not covered by contract tests.
  * TODO: Refactor this and TestOzoneFileSystem later to reduce code duplication.
  */
+@RunWith(Parameterized.class)
 public class TestRootedOzoneFileSystem {
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[]{true}, new Object[]{false});
+  }
+
+  public TestRootedOzoneFileSystem(boolean setDefaultFs) {
+    this.enabledFileSystemPaths = setDefaultFs;
+  }
 
   @Rule
   public Timeout globalTimeout = new Timeout(300_000);
+
+  private boolean enabledFileSystemPaths;
 
   private OzoneConfiguration conf;
   private MiniOzoneCluster cluster = null;
@@ -105,6 +121,8 @@ public class TestRootedOzoneFileSystem {
   public void init() throws Exception {
     conf = new OzoneConfiguration();
     conf.setInt(FS_TRASH_INTERVAL_KEY, 1);
+    conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,
+        enabledFileSystemPaths);
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(3)
         .build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -98,7 +98,7 @@ public class TestRootedOzoneFileSystem {
   }
 
   @Rule
-  public Timeout globalTimeout = new Timeout(600_000);
+  public Timeout globalTimeout = new Timeout(300_000);
 
   private boolean enabledFileSystemPaths;
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -98,7 +98,7 @@ public class TestRootedOzoneFileSystem {
   }
 
   @Rule
-  public Timeout globalTimeout = new Timeout(300_000);
+  public Timeout globalTimeout = new Timeout(600_000);
 
   private boolean enabledFileSystemPaths;
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -176,7 +176,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
 
   @Override
   public InputStream readFile(String key) throws IOException {
-    incrementCounter(Statistic.OBJECTS_READ);
+    incrementCounter(Statistic.OBJECTS_READ, 1);
     try {
       return bucket.readFile(key).getInputStream();
     } catch (OMException ex) {
@@ -190,14 +190,14 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
     }
   }
 
-  protected void incrementCounter(Statistic objectsRead) {
+  protected void incrementCounter(Statistic objectsRead, long count) {
     //noop: Use OzoneClientAdapterImpl which supports statistics.
   }
 
   @Override
   public OzoneFSOutputStream createFile(String key, short replication,
       boolean overWrite, boolean recursive) throws IOException {
-    incrementCounter(Statistic.OBJECTS_CREATED);
+    incrementCounter(Statistic.OBJECTS_CREATED, 1);
     try {
       OzoneOutputStream ozoneOutputStream = null;
       if (replication == ReplicationFactor.ONE.getValue()
@@ -224,7 +224,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
 
   @Override
   public void renameKey(String key, String newKeyName) throws IOException {
-    incrementCounter(Statistic.OBJECTS_RENAMED);
+    incrementCounter(Statistic.OBJECTS_RENAMED, 1);
     bucket.renameKey(key, newKeyName);
   }
 
@@ -242,7 +242,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   @Override
   public boolean createDirectory(String keyName) throws IOException {
     LOG.trace("creating dir for key:{}", keyName);
-    incrementCounter(Statistic.OBJECTS_CREATED);
+    incrementCounter(Statistic.OBJECTS_CREATED, 1);
     try {
       bucket.createDirectory(keyName);
     } catch (OMException e) {
@@ -264,7 +264,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   public boolean deleteObject(String keyName) {
     LOG.trace("issuing delete for key {}", keyName);
     try {
-      incrementCounter(Statistic.OBJECTS_DELETED);
+      incrementCounter(Statistic.OBJECTS_DELETED, 1);
       bucket.deleteKey(keyName);
       return true;
     } catch (IOException ioe) {
@@ -282,7 +282,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   @Override
   public boolean deleteObjects(List<String> keyNameList) {
     try {
-      incrementCounter(Statistic.OBJECTS_DELETED);
+      incrementCounter(Statistic.OBJECTS_DELETED, keyNameList.size());
       bucket.deleteKeys(keyNameList);
       return true;
     } catch (IOException ioe) {
@@ -295,7 +295,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
       Path qualifiedPath, String userName)
       throws IOException {
     try {
-      incrementCounter(Statistic.OBJECTS_QUERY);
+      incrementCounter(Statistic.OBJECTS_QUERY, 1);
       OzoneFileStatus status = bucket.getFileStatus(key);
       return toFileStatusAdapter(status, userName, uri, qualifiedPath);
 
@@ -311,7 +311,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
 
   @Override
   public Iterator<BasicKeyInfo> listKeys(String pathKey) {
-    incrementCounter(Statistic.OBJECTS_LIST);
+    incrementCounter(Statistic.OBJECTS_LIST, 1);
     return new IteratorAdapter(bucket.listKeys(pathKey));
   }
 
@@ -319,7 +319,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
       String startKey, long numEntries, URI uri,
       Path workingDir, String username) throws IOException {
     try {
-      incrementCounter(Statistic.OBJECTS_LIST);
+      incrementCounter(Statistic.OBJECTS_LIST, 1);
       List<OzoneFileStatus> statuses = bucket
           .listStatus(keyName, recursive, startKey, numEntries);
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -190,11 +190,6 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
     }
   }
 
-  @Deprecated
-  protected void incrementCounter(Statistic objectsRead) {
-    //noop: Use OzoneClientAdapterImpl which supports statistics.
-  }
-
   protected void incrementCounter(Statistic objectsRead, long count) {
     //noop: Use OzoneClientAdapterImpl which supports statistics.
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -190,6 +190,11 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
     }
   }
 
+  @Deprecated
+  protected void incrementCounter(Statistic objectsRead) {
+    //noop: Use OzoneClientAdapterImpl which supports statistics.
+  }
+
   protected void incrementCounter(Statistic objectsRead, long count) {
     //noop: Use OzoneClientAdapterImpl which supports statistics.
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -281,7 +281,6 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
    */
   @Override
   public boolean deleteObjects(List<String> keyNameList) {
-    LOG.trace("issuing delete for key {}", keyNameList);
     try {
       incrementCounter(Statistic.OBJECTS_DELETED);
       bucket.deleteKeys(keyNameList);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -220,13 +220,12 @@ public class BasicOzoneFileSystem extends FileSystem {
     return new OzoneFSInputStream(inputStream, statistics);
   }
 
-  @Deprecated
   protected void incrementCounter(Statistic statistic) {
-    //don't do anyting in this default implementation.
+    incrementCounter(statistic, 1);
   }
 
   protected void incrementCounter(Statistic statistic, long count) {
-    //don't do anyting in this default implementation.
+    //don't do anything in this default implementation.
   }
 
   @Override

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -479,13 +479,6 @@ public class BasicOzoneFileSystem extends FileSystem {
     }
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * OFS supports volume and bucket deletion, recursive or non-recursive.
-   * e.g. delete(new Path("/volume1"), true)
-   * But root deletion is explicitly disallowed for safety concerns.
-   */
   @Override
   public boolean delete(Path f, boolean recursive) throws IOException {
     incrementCounter(Statistic.INVOCATION_DELETE);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -208,7 +208,7 @@ public class BasicOzoneFileSystem extends FileSystem {
 
   @Override
   public FSDataInputStream open(Path f, int bufferSize) throws IOException {
-    incrementCounter(Statistic.INVOCATION_OPEN);
+    incrementCounter(Statistic.INVOCATION_OPEN, 1);
     statistics.incrementReadOps(1);
     LOG.trace("open() path:{}", f);
     final String key = pathToKey(f);
@@ -220,7 +220,12 @@ public class BasicOzoneFileSystem extends FileSystem {
     return new OzoneFSInputStream(inputStream, statistics);
   }
 
+  @Deprecated
   protected void incrementCounter(Statistic statistic) {
+    //don't do anyting in this default implementation.
+  }
+
+  protected void incrementCounter(Statistic statistic, long count) {
     //don't do anyting in this default implementation.
   }
 
@@ -230,7 +235,7 @@ public class BasicOzoneFileSystem extends FileSystem {
       short replication, long blockSize,
       Progressable progress) throws IOException {
     LOG.trace("create() path:{}", f);
-    incrementCounter(Statistic.INVOCATION_CREATE);
+    incrementCounter(Statistic.INVOCATION_CREATE, 1);
     statistics.incrementWriteOps(1);
     final String key = pathToKey(f);
     return createOutputStream(key, replication, overwrite, true);
@@ -244,7 +249,7 @@ public class BasicOzoneFileSystem extends FileSystem {
       short replication,
       long blockSize,
       Progressable progress) throws IOException {
-    incrementCounter(Statistic.INVOCATION_CREATE_NON_RECURSIVE);
+    incrementCounter(Statistic.INVOCATION_CREATE_NON_RECURSIVE, 1);
     statistics.incrementWriteOps(1);
     final String key = pathToKey(path);
     return createOutputStream(key,
@@ -302,7 +307,7 @@ public class BasicOzoneFileSystem extends FileSystem {
    */
   @Override
   public boolean rename(Path src, Path dst) throws IOException {
-    incrementCounter(Statistic.INVOCATION_RENAME);
+    incrementCounter(Statistic.INVOCATION_RENAME, 1);
     statistics.incrementWriteOps(1);
     super.checkPath(src);
     super.checkPath(dst);
@@ -481,7 +486,7 @@ public class BasicOzoneFileSystem extends FileSystem {
 
   @Override
   public boolean delete(Path f, boolean recursive) throws IOException {
-    incrementCounter(Statistic.INVOCATION_DELETE);
+    incrementCounter(Statistic.INVOCATION_DELETE, 1);
     statistics.incrementWriteOps(1);
     LOG.debug("Delete path {} - recursive {}", f, recursive);
     FileStatus status;
@@ -561,7 +566,7 @@ public class BasicOzoneFileSystem extends FileSystem {
 
   @Override
   public FileStatus[] listStatus(Path f) throws IOException {
-    incrementCounter(Statistic.INVOCATION_LIST_STATUS);
+    incrementCounter(Statistic.INVOCATION_LIST_STATUS, 1);
     statistics.incrementReadOps(1);
     LOG.trace("listStatus() path:{}", f);
     int numEntries = LISTING_PAGE_SIZE;
@@ -698,7 +703,7 @@ public class BasicOzoneFileSystem extends FileSystem {
 
   @Override
   public FileStatus getFileStatus(Path f) throws IOException {
-    incrementCounter(Statistic.INVOCATION_GET_FILE_STATUS);
+    incrementCounter(Statistic.INVOCATION_GET_FILE_STATUS, 1);
     statistics.incrementReadOps(1);
     LOG.trace("getFileStatus() path:{}", f);
     Path qualifiedPath = f.makeQualified(uri, workingDir);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -489,7 +489,6 @@ public class BasicRootedOzoneClientAdapterImpl
    */
   @Override
   public boolean deleteObjects(List<String> keyNameList) {
-    LOG.trace("issuing delete for keys: {}", keyNameList);
     if (keyNameList.size() == 0) {
       return true;
     }
@@ -520,8 +519,6 @@ public class BasicRootedOzoneClientAdapterImpl
    * @return true if operation succeeded, false on IOException.
    */
   boolean deleteObjects(OzoneBucket bucket, List<String> keyNameList) {
-    LOG.trace("issuing delete in volume: {}, bucket: {} for keys: {}",
-        bucket.getVolumeName(), bucket.getName(), keyNameList);
     List<String> keyList = keyNameList.stream()
         .map(p -> new OFSPath(p).getKeyName())
         .collect(Collectors.toList());

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -485,13 +485,13 @@ public class BasicRootedOzoneClientAdapterImpl
    * e.g. ofs://om/vol1/buck1/k1
    *
    * @param keyNameList key name list to be deleted
-   * @return true if the key is deleted, false otherwise
+   * @return true if the key deletion is successful, false otherwise
    */
   @Override
   public boolean deleteObjects(List<String> keyNameList) {
     LOG.trace("issuing delete for keys: {}", keyNameList);
     if (keyNameList.size() == 0) {
-      return false;
+      return true;
     }
     // Sanity check. Support only deleting a list of keys in the same bucket
     if (!areInSameBucket(keyNameList)) {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -468,17 +468,15 @@ public class BasicRootedOzoneClientAdapterImpl
    * and same bucket.
    */
   private boolean areInSameBucket(List<String> keyNameList) {
-    if (keyNameList.size() == 0) {
+    if (keyNameList.isEmpty()) {
       return true;
     }
     String firstKeyPath = keyNameList.get(0);
     final String volAndBucket = new OFSPath(firstKeyPath).getNonKeyPath();
-    // If any key path's volume and bucket from the second element and on
-    // in the list doesn't match the first element's, hasDifferentVolAndBucket
-    // would be true
-    boolean hasDifferentVolAndBucket = keyNameList.stream().skip(1)
-        .anyMatch(p -> !(new OFSPath(p).getNonKeyPath().equals(volAndBucket)));
-    return !hasDifferentVolAndBucket;
+    // return true only if all key paths' volume and bucket in the list match
+    // the first element's
+    return keyNameList.stream().skip(1).allMatch(p ->
+        new OFSPath(p).getNonKeyPath().equals(volAndBucket));
   }
 
   /**

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -302,6 +302,11 @@ public class BasicRootedOzoneClientAdapterImpl
     }
   }
 
+  @Deprecated
+  protected void incrementCounter(Statistic objectsRead) {
+    //noop: Use OzoneClientAdapterImpl which supports statistics.
+  }
+
   protected void incrementCounter(Statistic objectsRead, long count) {
     //noop: Use OzoneClientAdapterImpl which supports statistics.
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -285,7 +285,7 @@ public class BasicRootedOzoneClientAdapterImpl
 
   @Override
   public InputStream readFile(String pathStr) throws IOException {
-    incrementCounter(Statistic.OBJECTS_READ);
+    incrementCounter(Statistic.OBJECTS_READ, 1);
     OFSPath ofsPath = new OFSPath(pathStr);
     String key = ofsPath.getKeyName();
     try {
@@ -302,14 +302,14 @@ public class BasicRootedOzoneClientAdapterImpl
     }
   }
 
-  protected void incrementCounter(Statistic objectsRead) {
+  protected void incrementCounter(Statistic objectsRead, long count) {
     //noop: Use OzoneClientAdapterImpl which supports statistics.
   }
 
   @Override
   public OzoneFSOutputStream createFile(String pathStr, short replication,
       boolean overWrite, boolean recursive) throws IOException {
-    incrementCounter(Statistic.OBJECTS_CREATED);
+    incrementCounter(Statistic.OBJECTS_CREATED, 1);
     OFSPath ofsPath = new OFSPath(pathStr);
     if (ofsPath.isRoot() || ofsPath.isVolume() || ofsPath.isBucket()) {
       throw new IOException("Cannot create file under root or volume.");
@@ -359,7 +359,7 @@ public class BasicRootedOzoneClientAdapterImpl
    */
   @Override
   public void rename(String path, String newPath) throws IOException {
-    incrementCounter(Statistic.OBJECTS_RENAMED);
+    incrementCounter(Statistic.OBJECTS_RENAMED, 1);
     OFSPath ofsPath = new OFSPath(path);
     OFSPath ofsNewPath = new OFSPath(newPath);
 
@@ -385,7 +385,7 @@ public class BasicRootedOzoneClientAdapterImpl
    */
   void rename(OzoneBucket bucket, String path, String newPath)
       throws IOException {
-    incrementCounter(Statistic.OBJECTS_RENAMED);
+    incrementCounter(Statistic.OBJECTS_RENAMED, 1);
     OFSPath ofsPath = new OFSPath(path);
     OFSPath ofsNewPath = new OFSPath(newPath);
     // No same-bucket policy check here since this call path is controlled
@@ -403,7 +403,7 @@ public class BasicRootedOzoneClientAdapterImpl
   @Override
   public boolean createDirectory(String pathStr) throws IOException {
     LOG.trace("creating dir for path: {}", pathStr);
-    incrementCounter(Statistic.OBJECTS_CREATED);
+    incrementCounter(Statistic.OBJECTS_CREATED, 1);
     OFSPath ofsPath = new OFSPath(pathStr);
     if (ofsPath.getVolumeName().isEmpty()) {
       // Volume name unspecified, invalid param, return failure
@@ -442,7 +442,7 @@ public class BasicRootedOzoneClientAdapterImpl
   @Override
   public boolean deleteObject(String path) {
     LOG.trace("issuing delete for path to key: {}", path);
-    incrementCounter(Statistic.OBJECTS_DELETED);
+    incrementCounter(Statistic.OBJECTS_DELETED, 1);
     OFSPath ofsPath = new OFSPath(path);
     String keyName = ofsPath.getKeyName();
     if (keyName.length() == 0) {
@@ -523,7 +523,7 @@ public class BasicRootedOzoneClientAdapterImpl
         .map(p -> new OFSPath(p).getKeyName())
         .collect(Collectors.toList());
     try {
-      incrementCounter(Statistic.OBJECTS_DELETED);
+      incrementCounter(Statistic.OBJECTS_DELETED, keyNameList.size());
       bucket.deleteKeys(keyList);
       return true;
     } catch (IOException ioe) {
@@ -534,7 +534,7 @@ public class BasicRootedOzoneClientAdapterImpl
 
   public FileStatusAdapter getFileStatus(String path, URI uri,
       Path qualifiedPath, String userName) throws IOException {
-    incrementCounter(Statistic.OBJECTS_QUERY);
+    incrementCounter(Statistic.OBJECTS_QUERY, 1);
     OFSPath ofsPath = new OFSPath(path);
     String key = ofsPath.getKeyName();
     if (ofsPath.isRoot()) {
@@ -618,7 +618,7 @@ public class BasicRootedOzoneClientAdapterImpl
 
   @Override
   public Iterator<BasicKeyInfo> listKeys(String pathStr) {
-    incrementCounter(Statistic.OBJECTS_LIST);
+    incrementCounter(Statistic.OBJECTS_LIST, 1);
     OFSPath ofsPath = new OFSPath(pathStr);
     String key = ofsPath.getKeyName();
     OzoneBucket bucket;
@@ -707,7 +707,7 @@ public class BasicRootedOzoneClientAdapterImpl
       String startPath, long numEntries, URI uri,
       Path workingDir, String username) throws IOException {
 
-    incrementCounter(Statistic.OBJECTS_LIST);
+    incrementCounter(Statistic.OBJECTS_LIST, 1);
     // Remove authority from startPath if it exists
     if (startPath.startsWith(uri.toString())) {
       try {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -302,13 +302,8 @@ public class BasicRootedOzoneClientAdapterImpl
     }
   }
 
-  @Deprecated
-  protected void incrementCounter(Statistic objectsRead) {
-    //noop: Use OzoneClientAdapterImpl which supports statistics.
-  }
-
   protected void incrementCounter(Statistic objectsRead, long count) {
-    //noop: Use OzoneClientAdapterImpl which supports statistics.
+    //noop: Use RootedOzoneClientAdapterImpl which supports statistics.
   }
 
   @Override

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -186,7 +186,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
   @Override
   public FSDataInputStream open(Path path, int bufferSize) throws IOException {
-    incrementCounter(Statistic.INVOCATION_OPEN);
+    incrementCounter(Statistic.INVOCATION_OPEN, 1);
     statistics.incrementReadOps(1);
     LOG.trace("open() path: {}", path);
     final String key = pathToKey(path);
@@ -194,7 +194,12 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
         new OzoneFSInputStream(adapter.readFile(key), statistics));
   }
 
+  @Deprecated
   protected void incrementCounter(Statistic statistic) {
+    //don't do anything in this default implementation.
+  }
+
+  protected void incrementCounter(Statistic statistic, long count) {
     //don't do anything in this default implementation.
   }
 
@@ -204,7 +209,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       short replication, long blockSize,
       Progressable progress) throws IOException {
     LOG.trace("create() path:{}", f);
-    incrementCounter(Statistic.INVOCATION_CREATE);
+    incrementCounter(Statistic.INVOCATION_CREATE, 1);
     statistics.incrementWriteOps(1);
     final String key = pathToKey(f);
     return createOutputStream(key, replication, overwrite, true);
@@ -218,7 +223,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       short replication,
       long blockSize,
       Progressable progress) throws IOException {
-    incrementCounter(Statistic.INVOCATION_CREATE_NON_RECURSIVE);
+    incrementCounter(Statistic.INVOCATION_CREATE_NON_RECURSIVE, 1);
     statistics.incrementWriteOps(1);
     final String key = pathToKey(path);
     return createOutputStream(key,
@@ -282,7 +287,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
    */
   @Override
   public boolean rename(Path src, Path dst) throws IOException {
-    incrementCounter(Statistic.INVOCATION_RENAME);
+    incrementCounter(Statistic.INVOCATION_RENAME, 1);
     statistics.incrementWriteOps(1);
     if (src.equals(dst)) {
       return true;
@@ -467,7 +472,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
    */
   @Override
   public boolean delete(Path f, boolean recursive) throws IOException {
-    incrementCounter(Statistic.INVOCATION_DELETE);
+    incrementCounter(Statistic.INVOCATION_DELETE, 1);
     statistics.incrementWriteOps(1);
     LOG.debug("Delete path {} - recursive {}", f, recursive);
     FileStatus status;
@@ -607,7 +612,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
   @Override
   public FileStatus[] listStatus(Path f) throws IOException {
-    incrementCounter(Statistic.INVOCATION_LIST_STATUS);
+    incrementCounter(Statistic.INVOCATION_LIST_STATUS, 1);
     statistics.incrementReadOps(1);
     LOG.trace("listStatus() path:{}", f);
     int numEntries = LISTING_PAGE_SIZE;
@@ -721,7 +726,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
   @Override
   public FileStatus getFileStatus(Path f) throws IOException {
-    incrementCounter(Statistic.INVOCATION_GET_FILE_STATUS);
+    incrementCounter(Statistic.INVOCATION_GET_FILE_STATUS, 1);
     statistics.incrementReadOps(1);
     LOG.trace("getFileStatus() path:{}", f);
     Path qualifiedPath = f.makeQualified(uri, workingDir);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -194,9 +194,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
         new OzoneFSInputStream(adapter.readFile(key), statistics));
   }
 
-  @Deprecated
   protected void incrementCounter(Statistic statistic) {
-    //don't do anything in this default implementation.
+    incrementCounter(statistic, 1);
   }
 
   protected void incrementCounter(Statistic statistic, long count) {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapterImpl.java
@@ -53,9 +53,9 @@ public class OzoneClientAdapterImpl extends BasicOzoneClientAdapterImpl {
   }
 
   @Override
-  protected void incrementCounter(Statistic objectsRead) {
+  protected void incrementCounter(Statistic objectsRead, long count) {
     if (storageStatistics != null) {
-      storageStatistics.incrementCounter(objectsRead, 1);
+      storageStatistics.incrementCounter(objectsRead, count);
     }
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapterImpl.java
@@ -53,6 +53,13 @@ public class OzoneClientAdapterImpl extends BasicOzoneClientAdapterImpl {
   }
 
   @Override
+  protected void incrementCounter(Statistic objectsRead) {
+    if (storageStatistics != null) {
+      storageStatistics.incrementCounter(objectsRead, 1);
+    }
+  }
+
+  @Override
   protected void incrementCounter(Statistic objectsRead, long count) {
     if (storageStatistics != null) {
       storageStatistics.incrementCounter(objectsRead, count);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapterImpl.java
@@ -53,13 +53,6 @@ public class OzoneClientAdapterImpl extends BasicOzoneClientAdapterImpl {
   }
 
   @Override
-  protected void incrementCounter(Statistic objectsRead) {
-    if (storageStatistics != null) {
-      storageStatistics.incrementCounter(objectsRead, 1);
-    }
-  }
-
-  @Override
   protected void incrementCounter(Statistic objectsRead, long count) {
     if (storageStatistics != null) {
       storageStatistics.incrementCounter(objectsRead, count);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneClientAdapterImpl.java
@@ -53,9 +53,9 @@ public class RootedOzoneClientAdapterImpl
   }
 
   @Override
-  protected void incrementCounter(Statistic objectsRead) {
+  protected void incrementCounter(Statistic objectsRead, long count) {
     if (storageStatistics != null) {
-      storageStatistics.incrementCounter(objectsRead, 1);
+      storageStatistics.incrementCounter(objectsRead, count);
     }
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneClientAdapterImpl.java
@@ -53,6 +53,13 @@ public class RootedOzoneClientAdapterImpl
   }
 
   @Override
+  protected void incrementCounter(Statistic objectsRead) {
+    if (storageStatistics != null) {
+      storageStatistics.incrementCounter(objectsRead, 1);
+    }
+  }
+
+  @Override
   protected void incrementCounter(Statistic objectsRead, long count) {
     if (storageStatistics != null) {
       storageStatistics.incrementCounter(objectsRead, count);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneClientAdapterImpl.java
@@ -53,13 +53,6 @@ public class RootedOzoneClientAdapterImpl
   }
 
   @Override
-  protected void incrementCounter(Statistic objectsRead) {
-    if (storageStatistics != null) {
-      storageStatistics.incrementCounter(objectsRead, 1);
-    }
-  }
-
-  @Override
   protected void incrementCounter(Statistic objectsRead, long count) {
     if (storageStatistics != null) {
       storageStatistics.incrementCounter(objectsRead, count);

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -88,6 +88,13 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
   }
 
   @Override
+  protected void incrementCounter(Statistic statistic, long count) {
+    if (storageStatistics != null) {
+      storageStatistics.incrementCounter(statistic, count);
+    }
+  }
+
+  @Override
   protected OzoneClientAdapter createAdapter(ConfigurationSource conf,
       String bucketStr, String volumeStr, String omHost, int omPort)
       throws IOException {

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -81,13 +81,6 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
   }
 
   @Override
-  protected void incrementCounter(Statistic statistic) {
-    if (storageStatistics != null) {
-      storageStatistics.incrementCounter(statistic, 1);
-    }
-  }
-
-  @Override
   protected void incrementCounter(Statistic statistic, long count) {
     if (storageStatistics != null) {
       storageStatistics.incrementCounter(statistic, count);

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -80,13 +80,6 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
   }
 
   @Override
-  protected void incrementCounter(Statistic statistic) {
-    if (storageStatistics != null) {
-      storageStatistics.incrementCounter(statistic, 1);
-    }
-  }
-
-  @Override
   protected void incrementCounter(Statistic statistic, long count) {
     if (storageStatistics != null) {
       storageStatistics.incrementCounter(statistic, count);

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -87,6 +87,13 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
   }
 
   @Override
+  protected void incrementCounter(Statistic statistic, long count) {
+    if (storageStatistics != null) {
+      storageStatistics.incrementCounter(statistic, count);
+    }
+  }
+
+  @Override
   protected OzoneClientAdapter createAdapter(ConfigurationSource conf,
       String omHost, int omPort) throws IOException {
     return new RootedOzoneClientAdapterImpl(omHost, omPort, conf,

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -88,6 +88,13 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
   }
 
   @Override
+  protected void incrementCounter(Statistic statistic, long count) {
+    if (storageStatistics != null) {
+      storageStatistics.incrementCounter(statistic, count);
+    }
+  }
+
+  @Override
   protected OzoneClientAdapter createAdapter(ConfigurationSource conf,
       String bucketStr, String volumeStr, String omHost, int omPort)
       throws IOException {

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/OzoneFileSystem.java
@@ -81,13 +81,6 @@ public class OzoneFileSystem extends BasicOzoneFileSystem
   }
 
   @Override
-  protected void incrementCounter(Statistic statistic) {
-    if (storageStatistics != null) {
-      storageStatistics.incrementCounter(statistic, 1);
-    }
-  }
-
-  @Override
   protected void incrementCounter(Statistic statistic, long count) {
     if (storageStatistics != null) {
       storageStatistics.incrementCounter(statistic, count);

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -80,13 +80,6 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
   }
 
   @Override
-  protected void incrementCounter(Statistic statistic) {
-    if (storageStatistics != null) {
-      storageStatistics.incrementCounter(statistic, 1);
-    }
-  }
-
-  @Override
   protected void incrementCounter(Statistic statistic, long count) {
     if (storageStatistics != null) {
       storageStatistics.incrementCounter(statistic, count);

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -87,6 +87,13 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
   }
 
   @Override
+  protected void incrementCounter(Statistic statistic, long count) {
+    if (storageStatistics != null) {
+      storageStatistics.incrementCounter(statistic, count);
+    }
+  }
+
+  @Override
   protected OzoneClientAdapter createAdapter(ConfigurationSource conf,
       String omHost, int omPort) throws IOException {
     return new RootedOzoneClientAdapterImpl(omHost, omPort, conf,

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <native-maven-plugin.version>1.0-alpha-8</native-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
     <checkstyle.version>8.19</checkstyle.version>
-    <surefire.fork.timeout>1000</surefire.fork.timeout>
+    <surefire.fork.timeout>1200</surefire.fork.timeout>
     <aws-java-sdk.version>1.11.615</aws-java-sdk.version>
     <hsqldb.version>2.3.4</hsqldb.version>
     <frontend-maven-plugin.version>1.10.0</frontend-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <native-maven-plugin.version>1.0-alpha-8</native-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
     <checkstyle.version>8.19</checkstyle.version>
-    <surefire.fork.timeout>900</surefire.fork.timeout>
+    <surefire.fork.timeout>1000</surefire.fork.timeout>
     <aws-java-sdk.version>1.11.615</aws-java-sdk.version>
     <hsqldb.version>2.3.4</hsqldb.version>
     <frontend-maven-plugin.version>1.10.0</frontend-maven-plugin.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This Jira is to use deleteObjects in OFS delete now that HDDS-3286 is committed.

Currently when ozone.om.enable.filesystem.paths is enabled it normalizes the path, so using deleteKey for delete directory will fail.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4040

## How was this patch tested?

Added `testFileDelete` - mostly copied from o3fs test.