### PR TITLE
HDDS-4059: SCMStateMachine::applyTransaction() should not invoke TransactionContext.getClientRequest()

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -54,7 +54,7 @@ public class SCMStateMachine extends BaseStateMachine {
         new CompletableFuture<>();
     try {
       final SCMRatisRequest request = SCMRatisRequest.decode(
-          trx.getClientRequest().getMessage());
+          Message.valueOf(trx.getStateMachineLogEntry().getLogData()));
       applyTransactionFuture.complete(process(request));
     } catch (Exception ex) {
       applyTransactionFuture.completeExceptionally(ex);


### PR DESCRIPTION
## What changes were proposed in this pull request?

`applyTransaction()` should not call `trx.getClientRequest()`. Since client request will not be replicated from leader to follower, follower will not be able to update its state machine. 

We should call `trx.getStateMachineLogEntry()`, since content of client request will be injected to `StateMachineEntryProto` at leader, and extracted from log entry at follower.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4059

## How was this patch tested?

CI
