### PR TITLE
HDDS-4061. Pending delete blocks are not always included in #BLOCKCOUNT metadata

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -230,10 +230,22 @@ public final class KeyValueContainerUtil {
   private static void initializeUsedBytesAndBlockCount(
       KeyValueContainerData kvContainerData) throws IOException {
 
+    MetadataKeyFilters.KeyPrefixFilter filter =
+            new MetadataKeyFilters.KeyPrefixFilter();
+
+    // Ignore all blocks except those with no prefix, or those with
+    // #deleting# prefix.
+    filter.addFilter(OzoneConsts.DELETED_KEY_PREFIX, true)
+          .addFilter(OzoneConsts.DELETE_TRANSACTION_KEY_PREFIX, true)
+          .addFilter(OzoneConsts.BLOCK_COMMIT_SEQUENCE_ID_PREFIX, true)
+          .addFilter(OzoneConsts.BLOCK_COUNT, true)
+          .addFilter(OzoneConsts.CONTAINER_BYTES_USED, true)
+          .addFilter(OzoneConsts.PENDING_DELETE_BLOCK_COUNT, true);
+
     long blockCount = 0;
     try (KeyValueBlockIterator blockIter = new KeyValueBlockIterator(
         kvContainerData.getContainerID(),
-        new File(kvContainerData.getContainerPath()))) {
+        new File(kvContainerData.getContainerPath()), filter)) {
       long usedBytes = 0;
 
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
@@ -52,7 +52,6 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.apache.hadoop.ozone.OzoneConsts.DB_BLOCK_COUNT_KEY;
-import static org.apache.hadoop.ozone.OzoneConsts.DB_CONTAINER_BYTES_USED_KEY;
 import static org.apache.hadoop.ozone.OzoneConsts.DB_PENDING_DELETE_BLOCK_COUNT_KEY;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
@@ -139,17 +139,10 @@ public class TestContainerReader {
       }
 
       if (setMetaData) {
+        // Pending delete blocks are still counted towards the block count
+        // and bytes used metadata values, so those do not change.
         metadataStore.getStore().put(DB_PENDING_DELETE_BLOCK_COUNT_KEY,
             Longs.toByteArray(count));
-        long blkCount = Longs.fromByteArray(
-            metadataStore.getStore().get(DB_BLOCK_COUNT_KEY));
-        metadataStore.getStore().put(DB_BLOCK_COUNT_KEY,
-            Longs.toByteArray(blkCount - count));
-        long bytesUsed = Longs.fromByteArray(
-            metadataStore.getStore().get(DB_CONTAINER_BYTES_USED_KEY));
-        metadataStore.getStore().put(DB_CONTAINER_BYTES_USED_KEY,
-            Longs.toByteArray(bytesUsed - (count * blockLen)));
-
       }
     }
 
@@ -210,10 +203,10 @@ public class TestContainerReader {
           keyValueContainer.getContainerData();
 
       // Verify block related metadata.
-      Assert.assertEquals(blockCount - i,
+      Assert.assertEquals(blockCount,
           keyValueContainerData.getKeyCount());
 
-      Assert.assertEquals((blockCount - i) * blockLen,
+      Assert.assertEquals(blockCount * blockLen,
           keyValueContainerData.getBytesUsed());
 
       Assert.assertEquals(i,


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Make `KeyValueContainerUtil#initializeUsedBytesAndBlockCount` include pending delete blocks (with `#deleting#` prefix) when setting the `#BLOCKCOUNT` and `#BYTESUSED` metadata values.
    - This behavior makes it consistent with the current `BlockDeletingService` implementation.

- Adjust the TestContainerReader unit tests to account for this change.

## What is the link to the Apache JIRA

HDDS-4061

## How was this patch tested?

`TestContainerReader#testContainerReader` unit tests were modified to include pending delete blocks in the `#BLOCKCOUNT` and `#BYTESUSED` metadata values. These tests were run and passed.
