### PR TITLE
HDDS-4062. Non rack aware pipelines should not be created if multiple racks are alive

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -125,6 +125,7 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
     // get nodes in HEALTHY state
     List<DatanodeDetails> healthyNodes =
         nodeManager.getNodes(HddsProtos.NodeState.HEALTHY);
+    boolean multipleRacks = multipleRacksAvailable(healthyNodes);
     if (excludedNodes != null) {
       healthyNodes.removeAll(excludedNodes);
     }
@@ -170,7 +171,6 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
     }
 
     if (!checkAllNodesAreEqual(nodeManager.getClusterNetworkTopologyMap())) {
-      boolean multipleRacks = multipleRacksAvailable(healthyNodes);
       boolean multipleRacksAfterFilter = multipleRacksAvailable(healthyList);
       if (multipleRacks && !multipleRacksAfterFilter) {
         LOG.debug(MULTIPLE_RACK_PIPELINE_MSG);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -56,6 +56,11 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
   private final int heavyNodeCriteria;
   private static final int REQUIRED_RACKS = 2;
 
+  public static final String MULTIPLE_RACK_PIPELINE_MSG =
+      "The cluster has multiple racks, but all nodes with available " +
+      "pipeline capacity are on a single rack. There are insufficient " +
+      "cross rack nodes available to create a pipeline";
+
   /**
    * Constructs a pipeline placement with considering network topology,
    * load balancing and rack awareness.
@@ -168,11 +173,8 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
       boolean multipleRacks = multipleRacksAvailable(healthyNodes);
       boolean multipleRacksAfterFilter = multipleRacksAvailable(healthyList);
       if (multipleRacks && !multipleRacksAfterFilter) {
-        msg = "The cluster has multiple racks, but all nodes with available " +
-            "pipeline capacity are on a single rack. There are insufficient " +
-            "cross rack nodes available to create a pipeline";
-        LOG.debug(msg);
-        throw new SCMException(msg,
+        LOG.debug(MULTIPLE_RACK_PIPELINE_MSG);
+        throw new SCMException(MULTIPLE_RACK_PIPELINE_MSG,
             SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
       }
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -390,6 +390,19 @@ public class MockNodeManager implements NodeManager {
     }
   }
 
+  public void setNodeState(DatanodeDetails dn, HddsProtos.NodeState state) {
+    healthyNodes.remove(dn);
+    staleNodes.remove(dn);
+    deadNodes.remove(dn);
+    if (state == HEALTHY) {
+      healthyNodes.add(dn);
+    } else if (state == STALE) {
+      staleNodes.add(dn);
+    } else {
+      deadNodes.add(dn);
+    }
+  }
+
   /**
    * Closes this stream and releases any system resources associated with it. If
    * the stream is already closed then invoking this method has no effect.


### PR DESCRIPTION
## What changes were proposed in this pull request?

If we have a scenario where one rack has more nodes that others, it is possible for all hosts in the cluster to have reached their pipeline limit, while 3 nodes on the larger rack have not.

The current fallback logic will then allow a pipeline to be created which uses only the 3 nodes on the same rack, violating the rack placement policy.

There may be other ways this could happen with cluster load too, were the pipeline capacity has reached its limit on some nodes but not others.

The proposal here, is that if the cluster has multiple racks AND there are healthy nodes covering at least 2 racks, where healthy is defined as a node which is registered and not stale or dead, then we should not allow "fallback" (pipelines which span only 1 rack) pipelines to be created.

This means if you have a badly configured cluster - eg Rack 1 = 10 nodes; Rack 2 = 1 node, the pipeline limit will be constrained by the capacity of that 1 node on rack 2. Even a setup like Rack 1 = 10 nodes, Rack 2 = 5 would be constrained by this.

This constraint is better than creating non rack aware pipelines, and the rule above will handle the case when the cluster degrades to 1 rack, as the healthy node definition will notice only 1 rack is alive.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4062

## How was this patch tested?

New unit test added to reproduce the issue without the patch and ensure the patch fixes it.
