### PR TITLE
HDDS-4066. add core-site support debug ozone in IntelliJ using ofs.

### DIFF
--- a/hadoop-ozone/dev-support/intellij/core-site.xml
+++ b/hadoop-ozone/dev-support/intellij/core-site.xml
@@ -1,0 +1,27 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<configuration>
+<property>
+  <name>fs.ofs.impl</name>
+  <value>org.apache.hadoop.fs.ozone.RootedOzoneFileSystem</value>
+</property>
+<property>
+  <name>fs.defaultFS</name>
+  <value>ofs://localhost/</value>
+</property>
+</configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently Ozone supports debug to start in IntelliJ. [See Elek's video on how to use it](https://www.youtube.com/watch?v=PJGqlPNnJdU). In addition to the video described starting OzoneShell in IntelliJ. We can also use commands to trigger breakpoint debugging in an external shell.
First we need export HADOOP_CONF_DIR=$OZONE_HIME/hadoop-ozone/dev-support/intellij
Now Intellij has ozone-site.xml. Add core-site.xml here. Can support debugging using "ozone sh" and "ozone fs".

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4066

## How was this patch tested?

Don't have to add UT
