### PR TITLE
HDDS-1889 Add support for verifying multiline log entry

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -183,6 +183,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-interface-client</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
@@ -143,7 +143,31 @@ public class TestOzoneAuditLogger {
     verifyNoLog();
   }
 
-  private void verifyLog(String expected) throws IOException {
+  /**
+   * Test to verify if multiline entries can be checked.
+   */
+
+  @Test
+  public void messageIncludesMultilineException() throws IOException {
+    String exceptionMessage = "Dummuy exception message";
+    TestException testException = new TestException(exceptionMessage);
+    AuditMessage exceptionAuditMessage =
+        new AuditMessage.Builder()
+            .setUser(USER)
+            .atIp(IP_ADDRESS)
+            .forOperation(DummyAction.CREATE_VOLUME)
+            .withParams(PARAMS)
+            .withResult(FAILURE)
+            .withException(testException).build();
+    AUDIT.logWriteFailure(exceptionAuditMessage);
+    verifyLog(exceptionMessage,
+          "org.apache.hadoop.ozone.audit."
+              + "TestOzoneAuditLogger."
+              + "messageIncludesMultilineException");
+
+  }
+
+  private void verifyLog(String... expectedStrings) throws IOException {
     File file = new File("audit.log");
     List<String> lines = FileUtils.readLines(file, (String)null);
     final int retry = 5;
@@ -158,14 +182,22 @@ public class TestOzoneAuditLogger {
       }
       i++;
     }
-
-    // When log entry is expected, the log file will contain one line and
-    // that must be equal to the expected string
-    assertTrue(lines.size() != 0);
-    assertTrue(expected.equalsIgnoreCase(lines.get(0)));
+    //check if every expected string can be found in the log entry
+    for(String expected : expectedStrings) {
+      assertTrue(contains(lines, expected));
+    }
     //empty the file
     lines.clear();
     FileUtils.writeLines(file, lines, false);
+  }
+
+  private boolean contains(List<String> lines, String searched){
+    for(String line : lines){
+      if(line.toLowerCase().contains(searched.toLowerCase())){
+        return true;
+      }
+    }
+    return false;
   }
 
   private void verifyNoLog() throws IOException {
@@ -173,5 +205,11 @@ public class TestOzoneAuditLogger {
     List<String> lines = FileUtils.readLines(file, (String)null);
     // When no log entry is expected, the log file must be empty
     assertEquals(0, lines.size());
+  }
+
+  private class TestException extends Exception{
+    TestException(String message) {
+      super(message);
+    }
   }
 }

--- a/hadoop-hdds/docs/content/interface/S3.md
+++ b/hadoop-hdds/docs/content/interface/S3.md
@@ -24,7 +24,7 @@ summary: Ozone supports Amazon's Simple Storage Service (S3) protocol. In fact, 
 
 Ozone provides S3 compatible REST interface to use the object store data with any S3 compatible tools.
 
-S3 buckets are stored under the `/s3v` volume. The default name `s3v` can be changed by setting the `ozone.s3g.volume.name` config property in `ozone-site.xml`.
+S3 buckets are stored under the `/s3v` volume.
 
 ## Getting started
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -407,6 +407,7 @@ public final class OzoneManagerRatisServer {
         StorageUnit.BYTES);
     RaftServerConfigKeys.Log.setSegmentSizeMax(properties,
         SizeInBytes.valueOf(raftSegmentSize));
+    RaftServerConfigKeys.Log.setPurgeUptoSnapshotIndex(properties, true);
 
     // Set RAFT segment pre-allocated size
     final int raftSegmentPreallocatedSize = (int) conf.getStorageSize(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -363,20 +363,10 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
   public CompletableFuture<TermIndex> notifyInstallSnapshotFromLeader(
       RaftProtos.RoleInfoProto roleInfoProto, TermIndex firstTermIndexInLog) {
 
-    String leaderNodeId = RaftPeerId.valueOf(roleInfoProto.getSelf().getId())
-        .toString();
-
-    LOG.info("Received install snapshot notificaiton form OM leader: {} with " +
+    String leaderNodeId = RaftPeerId.valueOf(roleInfoProto.getFollowerInfo()
+        .getLeaderInfo().getId().getId()).toString();
+    LOG.info("Received install snapshot notification from OM leader: {} with " +
             "term index: {}", leaderNodeId, firstTermIndexInLog);
-
-    if (!roleInfoProto.getRole().equals(RaftProtos.RaftPeerRole.LEADER)) {
-      // A non-leader Ratis server should not send this notification.
-      LOG.error("Received Install Snapshot notification from non-leader OM " +
-          "node: {}. Ignoring the notification.", leaderNodeId);
-      return completeExceptionally(new OMException("Received notification to " +
-          "install snaphost from non-leader OM node",
-          OMException.ResultCodes.RATIS_ERROR));
-    }
 
     CompletableFuture<TermIndex> future = CompletableFuture.supplyAsync(
         () -> ozoneManager.installSnapshotFromLeader(leaderNodeId),

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -302,6 +302,16 @@ public class BaseFreonGenerator {
   }
 
   /**
+   * Print out reports with the given message.
+   */
+  public void print(String msg){
+    Consumer<String> print = freonCommand.isInteractive()
+            ? System.out::println
+            : LOG::info;
+    print.accept(msg);
+  }
+
+  /**
    * Create the OM RPC client to use it for testing.
    */
   public OzoneManagerProtocolClientSideTranslatorPB createOmClient(

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
@@ -97,17 +97,24 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
 
   @Override
   public Void call() throws Exception {
+    String s;
+    if (depth <= 0) {
+      s = "Invalid depth value, depth value should be greater than zero!";
+      print(s);
+    } else if (span <= 0) {
+      s = "Invalid span value, span value should be greater than zero!";
+      print(s);
+    } else {
+      init();
+      OzoneConfiguration configuration = createOzoneConfiguration();
+      fileSystem = FileSystem.get(URI.create(rootPath), configuration);
 
-    init();
-    OzoneConfiguration configuration = createOzoneConfiguration();
-    fileSystem = FileSystem.get(URI.create(rootPath), configuration);
+      contentGenerator = new ContentGenerator(fileSizeInBytes, bufferSize);
+      timer = getMetrics().timer("file-create");
 
-    contentGenerator = new ContentGenerator(fileSizeInBytes, bufferSize);
-    timer = getMetrics().timer("file-create");
-
-    runTests(this::createDir);
+      runTests(this::createDir);
+    }
     return null;
-
   }
 
   /*
@@ -139,21 +146,14 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
      created.
    */
   private void createDir(long counter) throws Exception {
-    if (depth <= 0) {
-      LOG.info("Invalid depth value, at least one depth should be passed!");
-      return;
-    }
-    if (span <= 0) {
-      LOG.info("Invalid span value, at least one span should be passed!");
-      return;
-    }
     String dir = makeDirWithGivenNumberOfFiles(rootPath);
     if (depth > 1) {
       createSubDirRecursively(dir, 1, 1);
     }
-    System.out.println("Successfully created directories & files. Total Dirs " +
+    String message = "Successfully created directories & files. Total Dirs " +
             "Count=" + totalDirsCnt.get() + ", Total Files Count=" +
-            timer.getCount());
+            timer.getCount();
+    print(message);
   }
 
   private void createSubDirRecursively(String parent, int depthIndex,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopNestedDirGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopNestedDirGenerator.java
@@ -72,13 +72,20 @@ public class HadoopNestedDirGenerator extends BaseFreonGenerator
 
   @Override
   public Void call() throws Exception {
-
-    init();
-    OzoneConfiguration configuration = createOzoneConfiguration();
-    fileSystem = FileSystem.get(URI.create(rootPath), configuration);
-    runTests(this::createDir);
+    String s;
+    if (depth <= 0) {
+      s = "Invalid depth value, depth value should be greater than zero!";
+      print(s);
+    } else if (span < 0) {
+      s = "Invalid span value, span value should be greater or equal to zero!";
+      print(s);
+    } else {
+      init();
+      OzoneConfiguration configuration = createOzoneConfiguration();
+      fileSystem = FileSystem.get(URI.create(rootPath), configuration);
+      runTests(this::createDir);
+    }
     return null;
-
   }
 
   /*
@@ -109,5 +116,8 @@ public class HadoopNestedDirGenerator extends BaseFreonGenerator
       Path dir = new Path(rootPath.concat("/").concat(childDir));
       fileSystem.mkdirs(dir.getParent());
     }
+    String message = "\nSuccessfully created directories. " +
+            "Total Directories with level = " + depth + " and span = " + span;
+    print(message);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added multi line support for Audit messages in TestOzoneAuditLogger

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-1889


## How was this patch tested?

added messageIncludesMultilineException in TestOzoneAuditLogger

