### PR TITLE
HDDS-3882. Update modification time when updating volume/bucket/key ACLs

### DIFF
--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -635,6 +635,7 @@ message GetAclResponse {
 message AddAclRequest {
   required OzoneObj obj = 1;
   required OzoneAclInfo acl = 2;
+  optional uint64 modificationTime = 3;
 }
 
 message AddAclResponse {
@@ -644,6 +645,7 @@ message AddAclResponse {
 message RemoveAclRequest {
   required OzoneObj obj = 1;
   required OzoneAclInfo acl = 2;
+  optional uint64 modificationTime = 3;
 }
 
 message RemoveAclResponse {
@@ -653,6 +655,7 @@ message RemoveAclResponse {
 message SetAclRequest {
   required OzoneObj obj = 1;
   repeated OzoneAclInfo acl = 2;
+  optional uint64 modificationTime = 3;
 }
 
 message SetAclResponse {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
@@ -110,7 +110,7 @@ public abstract class OMBucketAclRequest extends OMClientRequest {
           ozoneManager.isRatisEnabled());
 
       // Update the modification time when updating ACLs of Bucket.
-      long modificationTime = 0;
+      long modificationTime = omBucketInfo.getModificationTime();
       if (getOmRequest().getAddAclRequest().hasObj()) {
         modificationTime = getOmRequest().getAddAclRequest()
             .getModificationTime();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
@@ -109,6 +109,21 @@ public abstract class OMBucketAclRequest extends OMClientRequest {
       omBucketInfo.setUpdateID(transactionLogIndex,
           ozoneManager.isRatisEnabled());
 
+      // Update the modification time when updating ACLs of Bucket.
+      long modificationTime = 0;
+      if (getOmRequest().getAddAclRequest().hasObj()) {
+        modificationTime = getOmRequest().getAddAclRequest()
+            .getModificationTime();
+      } else if (getOmRequest().getSetAclRequest().hasObj()) {
+        modificationTime = getOmRequest().getSetAclRequest()
+            .getModificationTime();
+      } else if (getOmRequest().getRemoveAclRequest().hasObj()) {
+        modificationTime = getOmRequest().getRemoveAclRequest()
+            .getModificationTime();
+      }
+      omBucketInfo = omBucketInfo.toBuilder()
+          .setModificationTime(modificationTime).build();
+
       if (operationResult) {
         // update cache.
         omMetadataManager.getBucketTable().addCacheEntry(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
@@ -109,22 +109,22 @@ public abstract class OMBucketAclRequest extends OMClientRequest {
       omBucketInfo.setUpdateID(transactionLogIndex,
           ozoneManager.isRatisEnabled());
 
-      // Update the modification time when updating ACLs of Bucket.
-      long modificationTime = omBucketInfo.getModificationTime();
-      if (getOmRequest().getAddAclRequest().hasObj()) {
-        modificationTime = getOmRequest().getAddAclRequest()
-            .getModificationTime();
-      } else if (getOmRequest().getSetAclRequest().hasObj()) {
-        modificationTime = getOmRequest().getSetAclRequest()
-            .getModificationTime();
-      } else if (getOmRequest().getRemoveAclRequest().hasObj()) {
-        modificationTime = getOmRequest().getRemoveAclRequest()
-            .getModificationTime();
-      }
-      omBucketInfo = omBucketInfo.toBuilder()
-          .setModificationTime(modificationTime).build();
-
       if (operationResult) {
+        // Update the modification time when updating ACLs of Bucket.
+        long modificationTime = omBucketInfo.getModificationTime();
+        if (getOmRequest().getAddAclRequest().hasObj()) {
+          modificationTime = getOmRequest().getAddAclRequest()
+              .getModificationTime();
+        } else if (getOmRequest().getSetAclRequest().hasObj()) {
+          modificationTime = getOmRequest().getSetAclRequest()
+              .getModificationTime();
+        } else if (getOmRequest().getRemoveAclRequest().hasObj()) {
+          modificationTime = getOmRequest().getRemoveAclRequest()
+              .getModificationTime();
+        }
+        omBucketInfo = omBucketInfo.toBuilder()
+            .setModificationTime(modificationTime).build();
+
         // update cache.
         omMetadataManager.getBucketTable().addCacheEntry(
             new CacheKey<>(dbBucketKey),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAddAclRequest.java
@@ -23,8 +23,10 @@ import java.util.List;
 
 import com.google.common.collect.Lists;
 import org.apache.hadoop.ozone.om.OMMetrics;
+import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.util.BooleanBiFunction;
+import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +58,19 @@ public class OMBucketAddAclRequest extends OMBucketAclRequest {
     bucketAddAclOp = (ozoneAcls, omBucketInfo) -> {
       return omBucketInfo.addAcl(ozoneAcls.get(0));
     };
+  }
+
+  @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    long modificationTime = Time.now();
+    OzoneManagerProtocolProtos.AddAclRequest addAclRequest =
+        getOmRequest().getAddAclRequest().toBuilder()
+            .setModificationTime(modificationTime).build();
+
+    return getOmRequest().toBuilder()
+        .setAddAclRequest(addAclRequest.toBuilder())
+        .setUserInfo(getUserInfo())
+        .build();
   }
 
   public OMBucketAddAclRequest(OMRequest omRequest) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAddAclRequest.java
@@ -63,12 +63,12 @@ public class OMBucketAddAclRequest extends OMBucketAclRequest {
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     long modificationTime = Time.now();
-    OzoneManagerProtocolProtos.AddAclRequest addAclRequest =
+    OzoneManagerProtocolProtos.AddAclRequest.Builder addAclRequestBuilder =
         getOmRequest().getAddAclRequest().toBuilder()
-            .setModificationTime(modificationTime).build();
+            .setModificationTime(modificationTime);
 
     return getOmRequest().toBuilder()
-        .setAddAclRequest(addAclRequest.toBuilder())
+        .setAddAclRequest(addAclRequestBuilder)
         .setUserInfo(getUserInfo())
         .build();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketRemoveAclRequest.java
@@ -60,12 +60,12 @@ public class OMBucketRemoveAclRequest extends OMBucketAclRequest {
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     long modificationTime = Time.now();
-    OzoneManagerProtocolProtos.RemoveAclRequest removeAclRequest =
-        getOmRequest().getRemoveAclRequest().toBuilder()
-            .setModificationTime(modificationTime).build();
+    OzoneManagerProtocolProtos.RemoveAclRequest.Builder removeAclRequestBuilder
+        = getOmRequest().getRemoveAclRequest().toBuilder()
+            .setModificationTime(modificationTime);
 
     return getOmRequest().toBuilder()
-        .setRemoveAclRequest(removeAclRequest.toBuilder())
+        .setRemoveAclRequest(removeAclRequestBuilder)
         .setUserInfo(getUserInfo())
         .build();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketRemoveAclRequest.java
@@ -21,7 +21,9 @@ package org.apache.hadoop.ozone.om.request.bucket.acl;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
+import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +55,19 @@ public class OMBucketRemoveAclRequest extends OMBucketAclRequest {
     bucketAddAclOp = (ozoneAcls, omBucketInfo) -> {
       return omBucketInfo.removeAcl(ozoneAcls.get(0));
     };
+  }
+
+  @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    long modificationTime = Time.now();
+    OzoneManagerProtocolProtos.RemoveAclRequest removeAclRequest =
+        getOmRequest().getRemoveAclRequest().toBuilder()
+            .setModificationTime(modificationTime).build();
+
+    return getOmRequest().toBuilder()
+        .setRemoveAclRequest(removeAclRequest.toBuilder())
+        .setUserInfo(getUserInfo())
+        .build();
   }
 
   public OMBucketRemoveAclRequest(OMRequest omRequest) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketSetAclRequest.java
@@ -22,7 +22,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
+import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +55,19 @@ public class OMBucketSetAclRequest extends OMBucketAclRequest {
     bucketAddAclOp = (ozoneAcls, omBucketInfo) -> {
       return omBucketInfo.setAcls(ozoneAcls);
     };
+  }
+
+  @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    long modificationTime = Time.now();
+    OzoneManagerProtocolProtos.SetAclRequest setAclRequest =
+        getOmRequest().getSetAclRequest().toBuilder()
+            .setModificationTime(modificationTime).build();
+
+    return getOmRequest().toBuilder()
+        .setSetAclRequest(setAclRequest.toBuilder())
+        .setUserInfo(getUserInfo())
+        .build();
   }
 
   public OMBucketSetAclRequest(OMRequest omRequest) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketSetAclRequest.java
@@ -60,12 +60,12 @@ public class OMBucketSetAclRequest extends OMBucketAclRequest {
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     long modificationTime = Time.now();
-    OzoneManagerProtocolProtos.SetAclRequest setAclRequest =
+    OzoneManagerProtocolProtos.SetAclRequest.Builder setAclRequestBuilder =
         getOmRequest().getSetAclRequest().toBuilder()
-            .setModificationTime(modificationTime).build();
+            .setModificationTime(modificationTime);
 
     return getOmRequest().toBuilder()
-        .setSetAclRequest(setAclRequest.toBuilder())
+        .setSetAclRequest(setAclRequestBuilder)
         .setUserInfo(getUserInfo())
         .build();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
@@ -95,6 +95,21 @@ public abstract class OMKeyAclRequest extends OMClientRequest {
       operationResult = apply(omKeyInfo, trxnLogIndex);
       omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());
 
+      // Update the modification time when updating ACLs of Key.
+      long modificationTime = omKeyInfo.getModificationTime();
+      if (getOmRequest().getAddAclRequest().hasObj() && operationResult) {
+        modificationTime = getOmRequest().getAddAclRequest()
+            .getModificationTime();
+      } else if (getOmRequest().getSetAclRequest().hasObj()){
+        modificationTime = getOmRequest().getSetAclRequest()
+            .getModificationTime();
+      } else if (getOmRequest().getRemoveAclRequest().hasObj()
+          && operationResult) {
+        modificationTime = getOmRequest().getRemoveAclRequest()
+            .getModificationTime();
+      }
+      omKeyInfo.setModificationTime(modificationTime);
+
       // update cache.
       omMetadataManager.getKeyTable().addCacheEntry(
           new CacheKey<>(dbKey),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
@@ -48,12 +48,12 @@ public class OMKeyAddAclRequest extends OMKeyAclRequest {
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     long modificationTime = Time.now();
-    OzoneManagerProtocolProtos.AddAclRequest addAclRequest =
+    OzoneManagerProtocolProtos.AddAclRequest.Builder addAclRequestBuilder =
         getOmRequest().getAddAclRequest().toBuilder()
-        .setModificationTime(modificationTime).build();
+            .setModificationTime(modificationTime);
 
     return getOmRequest().toBuilder()
-        .setAddAclRequest(addAclRequest.toBuilder())
+        .setAddAclRequest(addAclRequestBuilder)
         .setUserInfo(getUserInfo())
         .build();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequest.java
@@ -23,10 +23,12 @@ import java.util.List;
 
 import com.google.common.collect.Lists;
 import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.key.acl.OMKeyAclResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +44,19 @@ public class OMKeyAddAclRequest extends OMKeyAclRequest {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OMKeyAddAclRequest.class);
+
+  @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    long modificationTime = Time.now();
+    OzoneManagerProtocolProtos.AddAclRequest addAclRequest =
+        getOmRequest().getAddAclRequest().toBuilder()
+        .setModificationTime(modificationTime).build();
+
+    return getOmRequest().toBuilder()
+        .setAddAclRequest(addAclRequest.toBuilder())
+        .setUserInfo(getUserInfo())
+        .build();
+  }
 
   private String path;
   private List<OzoneAcl> ozoneAcls;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
@@ -23,10 +23,12 @@ import java.util.List;
 
 import com.google.common.collect.Lists;
 import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.key.acl.OMKeyAclResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +44,19 @@ public class OMKeyRemoveAclRequest extends OMKeyAclRequest {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OMKeyRemoveAclRequest.class);
+
+  @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    long modificationTime = Time.now();
+    OzoneManagerProtocolProtos.RemoveAclRequest removeAclRequest =
+        getOmRequest().getRemoveAclRequest().toBuilder()
+            .setModificationTime(modificationTime).build();
+
+    return getOmRequest().toBuilder()
+        .setRemoveAclRequest(removeAclRequest.toBuilder())
+        .setUserInfo(getUserInfo())
+        .build();
+  }
 
   private String path;
   private List<OzoneAcl> ozoneAcls;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequest.java
@@ -48,12 +48,12 @@ public class OMKeyRemoveAclRequest extends OMKeyAclRequest {
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     long modificationTime = Time.now();
-    OzoneManagerProtocolProtos.RemoveAclRequest removeAclRequest =
-        getOmRequest().getRemoveAclRequest().toBuilder()
-            .setModificationTime(modificationTime).build();
+    OzoneManagerProtocolProtos.RemoveAclRequest.Builder removeAclRequestBuilder
+        = getOmRequest().getRemoveAclRequest().toBuilder()
+            .setModificationTime(modificationTime);
 
     return getOmRequest().toBuilder()
-        .setRemoveAclRequest(removeAclRequest.toBuilder())
+        .setRemoveAclRequest(removeAclRequestBuilder)
         .setUserInfo(getUserInfo())
         .build();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
@@ -49,12 +49,12 @@ public class OMKeySetAclRequest extends OMKeyAclRequest {
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     long modificationTime = Time.now();
-    OzoneManagerProtocolProtos.SetAclRequest setAclRequest =
+    OzoneManagerProtocolProtos.SetAclRequest.Builder setAclRequestBuilder =
         getOmRequest().getSetAclRequest().toBuilder()
-            .setModificationTime(modificationTime).build();
+            .setModificationTime(modificationTime);
 
     return getOmRequest().toBuilder()
-        .setSetAclRequest(setAclRequest.toBuilder())
+        .setSetAclRequest(setAclRequestBuilder)
         .setUserInfo(getUserInfo())
         .build();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequest.java
@@ -23,11 +23,13 @@ import java.util.List;
 
 import com.google.common.collect.Lists;
 import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.key.acl.OMKeyAclResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +45,19 @@ public class OMKeySetAclRequest extends OMKeyAclRequest {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OMKeySetAclRequest.class);
+
+  @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    long modificationTime = Time.now();
+    OzoneManagerProtocolProtos.SetAclRequest setAclRequest =
+        getOmRequest().getSetAclRequest().toBuilder()
+            .setModificationTime(modificationTime).build();
+
+    return getOmRequest().toBuilder()
+        .setSetAclRequest(setAclRequest.toBuilder())
+        .setUserInfo(getUserInfo())
+        .build();
+  }
 
   private String path;
   private List<OzoneAcl> ozoneAcls;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java
@@ -84,6 +84,20 @@ public abstract class OMVolumeAclRequest extends OMVolumeRequest {
           VOLUME_LOCK, volume);
       omVolumeArgs = getVolumeInfo(omMetadataManager, volume);
 
+      // Update the modification time when updating ACLs of Volume.
+      long modificationTime = 0;
+      if (getOmRequest().getAddAclRequest().hasObj()) {
+        modificationTime = getOmRequest().getAddAclRequest()
+            .getModificationTime();
+      } else if (getOmRequest().getSetAclRequest().hasObj()){
+        modificationTime = getOmRequest().getSetAclRequest()
+            .getModificationTime();
+      } else if (getOmRequest().getRemoveAclRequest().hasObj()) {
+        modificationTime = getOmRequest().getRemoveAclRequest()
+            .getModificationTime();
+      }
+      omVolumeArgs.setModificationTime(modificationTime);
+
       // result is false upon add existing acl or remove non-existing acl
       boolean applyAcl = true;
       try {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java
@@ -85,7 +85,7 @@ public abstract class OMVolumeAclRequest extends OMVolumeRequest {
       omVolumeArgs = getVolumeInfo(omMetadataManager, volume);
 
       // Update the modification time when updating ACLs of Volume.
-      long modificationTime = 0;
+      long modificationTime = omVolumeArgs.getModificationTime();
       if (getOmRequest().getAddAclRequest().hasObj()) {
         modificationTime = getOmRequest().getAddAclRequest()
             .getModificationTime();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java
@@ -84,19 +84,6 @@ public abstract class OMVolumeAclRequest extends OMVolumeRequest {
           VOLUME_LOCK, volume);
       omVolumeArgs = getVolumeInfo(omMetadataManager, volume);
 
-      // Update the modification time when updating ACLs of Volume.
-      long modificationTime = omVolumeArgs.getModificationTime();
-      if (getOmRequest().getAddAclRequest().hasObj()) {
-        modificationTime = getOmRequest().getAddAclRequest()
-            .getModificationTime();
-      } else if (getOmRequest().getSetAclRequest().hasObj()){
-        modificationTime = getOmRequest().getSetAclRequest()
-            .getModificationTime();
-      } else if (getOmRequest().getRemoveAclRequest().hasObj()) {
-        modificationTime = getOmRequest().getRemoveAclRequest()
-            .getModificationTime();
-      }
-      omVolumeArgs.setModificationTime(modificationTime);
 
       // result is false upon add existing acl or remove non-existing acl
       boolean applyAcl = true;
@@ -108,6 +95,20 @@ public abstract class OMVolumeAclRequest extends OMVolumeRequest {
 
       // Update only when
       if (applyAcl) {
+        // Update the modification time when updating ACLs of Volume.
+        long modificationTime = omVolumeArgs.getModificationTime();
+        if (getOmRequest().getAddAclRequest().hasObj()) {
+          modificationTime = getOmRequest().getAddAclRequest()
+              .getModificationTime();
+        } else if (getOmRequest().getSetAclRequest().hasObj()){
+          modificationTime = getOmRequest().getSetAclRequest()
+              .getModificationTime();
+        } else if (getOmRequest().getRemoveAclRequest().hasObj()) {
+          modificationTime = getOmRequest().getRemoveAclRequest()
+              .getModificationTime();
+        }
+        omVolumeArgs.setModificationTime(modificationTime);
+
         omVolumeArgs.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());
 
         // update cache.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAclRequest.java
@@ -84,7 +84,6 @@ public abstract class OMVolumeAclRequest extends OMVolumeRequest {
           VOLUME_LOCK, volume);
       omVolumeArgs = getVolumeInfo(omMetadataManager, volume);
 
-
       // result is false upon add existing acl or remove non-existing acl
       boolean applyAcl = true;
       try {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAddAclRequest.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.hdds.scm.storage.CheckedBiFunction;
 import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -28,6 +29,7 @@ import org.apache.hadoop.ozone.om.response.volume.OMVolumeAclOpResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +48,19 @@ public class OMVolumeAddAclRequest extends OMVolumeAclRequest {
 
   static {
     volumeAddAclOp = (acls, volArgs) -> volArgs.addAcl(acls.get(0));
+  }
+
+  @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    long modificationTime = Time.now();
+    OzoneManagerProtocolProtos.AddAclRequest addAclRequest =
+        getOmRequest().getAddAclRequest().toBuilder()
+        .setModificationTime(modificationTime).build();
+
+    return getOmRequest().toBuilder()
+        .setAddAclRequest(addAclRequest.toBuilder())
+        .setUserInfo(getUserInfo())
+        .build();
   }
 
   private List<OzoneAcl> ozoneAcls;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeAddAclRequest.java
@@ -53,12 +53,12 @@ public class OMVolumeAddAclRequest extends OMVolumeAclRequest {
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     long modificationTime = Time.now();
-    OzoneManagerProtocolProtos.AddAclRequest addAclRequest =
+    OzoneManagerProtocolProtos.AddAclRequest.Builder addAclRequestBuilder =
         getOmRequest().getAddAclRequest().toBuilder()
-        .setModificationTime(modificationTime).build();
+            .setModificationTime(modificationTime);
 
     return getOmRequest().toBuilder()
-        .setAddAclRequest(addAclRequest.toBuilder())
+        .setAddAclRequest(addAclRequestBuilder)
         .setUserInfo(getUserInfo())
         .build();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeRemoveAclRequest.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.hdds.scm.storage.CheckedBiFunction;
 import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -28,6 +29,7 @@ import org.apache.hadoop.ozone.om.response.volume.OMVolumeAclOpResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +48,19 @@ public class OMVolumeRemoveAclRequest extends OMVolumeAclRequest {
 
   static {
     volumeRemoveAclOp = (acls, volArgs) -> volArgs.removeAcl(acls.get(0));
+  }
+
+  @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    long modificationTime = Time.now();
+    OzoneManagerProtocolProtos.RemoveAclRequest removeAclRequest =
+        getOmRequest().getRemoveAclRequest().toBuilder()
+        .setModificationTime(modificationTime).build();
+
+    return getOmRequest().toBuilder()
+        .setRemoveAclRequest(removeAclRequest.toBuilder())
+        .setUserInfo(getUserInfo())
+        .build();
   }
 
   private List<OzoneAcl> ozoneAcls;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeRemoveAclRequest.java
@@ -53,12 +53,12 @@ public class OMVolumeRemoveAclRequest extends OMVolumeAclRequest {
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     long modificationTime = Time.now();
-    OzoneManagerProtocolProtos.RemoveAclRequest removeAclRequest =
-        getOmRequest().getRemoveAclRequest().toBuilder()
-        .setModificationTime(modificationTime).build();
+    OzoneManagerProtocolProtos.RemoveAclRequest.Builder removeAclRequestBuilder
+        = getOmRequest().getRemoveAclRequest().toBuilder()
+            .setModificationTime(modificationTime);
 
     return getOmRequest().toBuilder()
-        .setRemoveAclRequest(removeAclRequest.toBuilder())
+        .setRemoveAclRequest(removeAclRequestBuilder)
         .setUserInfo(getUserInfo())
         .build();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeSetAclRequest.java
@@ -53,12 +53,12 @@ public class OMVolumeSetAclRequest extends OMVolumeAclRequest {
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     long modificationTime = Time.now();
-    OzoneManagerProtocolProtos.SetAclRequest setAclRequest =
+    OzoneManagerProtocolProtos.SetAclRequest.Builder setAclRequestBuilder =
         getOmRequest().getSetAclRequest().toBuilder()
-        .setModificationTime(modificationTime).build();
+            .setModificationTime(modificationTime);
 
     return getOmRequest().toBuilder()
-        .setSetAclRequest(setAclRequest.toBuilder())
+        .setSetAclRequest(setAclRequestBuilder)
         .setUserInfo(getUserInfo())
         .build();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/acl/OMVolumeSetAclRequest.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.request.volume.acl;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.scm.storage.CheckedBiFunction;
 import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -27,6 +28,7 @@ import org.apache.hadoop.ozone.om.response.volume.OMVolumeAclOpResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +48,19 @@ public class OMVolumeSetAclRequest extends OMVolumeAclRequest {
 
   static {
     volumeSetAclOp = (acls, volArgs) -> volArgs.setAcls(acls);
+  }
+
+  @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    long modificationTime = Time.now();
+    OzoneManagerProtocolProtos.SetAclRequest setAclRequest =
+        getOmRequest().getSetAclRequest().toBuilder()
+        .setModificationTime(modificationTime).build();
+
+    return getOmRequest().toBuilder()
+        .setSetAclRequest(setAclRequest.toBuilder())
+        .setUserInfo(getUserInfo())
+        .build();
   }
 
   private List<OzoneAcl> ozoneAcls;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -519,6 +519,66 @@ public final class TestOMRequestUtils {
         .setSetAclRequest(setAclRequestBuilder.build()).build();
   }
 
+  // Create OMRequest for testing adding acl of bucket.
+  public static OMRequest createBucketAddAclRequest(String volumeName,
+      String bucketName, OzoneAcl acl) {
+    AddAclRequest.Builder addAclRequestBuilder = AddAclRequest.newBuilder();
+    addAclRequestBuilder.setObj(OzoneObj.toProtobuf(new OzoneObjInfo.Builder()
+        .setVolumeName(volumeName).setBucketName(bucketName)
+        .setResType(ResourceType.BUCKET)
+        .setStoreType(StoreType.OZONE)
+        .build()));
+
+    if (acl != null) {
+      addAclRequestBuilder.setAcl(OzoneAcl.toProtobuf(acl));
+    }
+
+    return OMRequest.newBuilder().setClientId(UUID.randomUUID().toString())
+        .setCmdType(OzoneManagerProtocolProtos.Type.AddAcl)
+        .setAddAclRequest(addAclRequestBuilder.build()).build();
+  }
+
+  // Create OMRequest for testing removing acl of bucket.
+  public static OMRequest createBucketRemoveAclRequest(String volumeName,
+      String bucketName, OzoneAcl acl) {
+    RemoveAclRequest.Builder removeAclRequestBuilder =
+        RemoveAclRequest.newBuilder();
+    removeAclRequestBuilder.setObj(OzoneObj.toProtobuf(
+        new OzoneObjInfo.Builder()
+            .setVolumeName(volumeName).setBucketName(bucketName)
+            .setResType(ResourceType.BUCKET)
+            .setStoreType(StoreType.OZONE)
+            .build()));
+
+    if (acl != null) {
+      removeAclRequestBuilder.setAcl(OzoneAcl.toProtobuf(acl));
+    }
+
+    return OMRequest.newBuilder().setClientId(UUID.randomUUID().toString())
+        .setCmdType(OzoneManagerProtocolProtos.Type.RemoveAcl)
+        .setRemoveAclRequest(removeAclRequestBuilder.build()).build();
+  }
+
+  // Create OMRequest for testing setting acls of bucket.
+  public static OMRequest createBucketSetAclRequest(String volumeName,
+      String bucketName, List<OzoneAcl> acls) {
+    SetAclRequest.Builder setAclRequestBuilder = SetAclRequest.newBuilder();
+    setAclRequestBuilder.setObj(OzoneObj.toProtobuf(new OzoneObjInfo.Builder()
+        .setVolumeName(volumeName).setBucketName(bucketName)
+        .setResType(ResourceType.BUCKET)
+        .setStoreType(StoreType.OZONE)
+        .build()));
+
+    if (acls != null) {
+      acls.forEach(
+          acl -> setAclRequestBuilder.addAcl(OzoneAcl.toProtobuf(acl)));
+    }
+
+    return OMRequest.newBuilder().setClientId(UUID.randomUUID().toString())
+        .setCmdType(OzoneManagerProtocolProtos.Type.SetAcl)
+        .setSetAclRequest(setAclRequestBuilder.build()).build();
+  }
+
   /**
    * Deletes key from Key table and adds it to DeletedKeys table.
    * @return the deletedKey name

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketAddAclRequest.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.bucket.acl;
+
+import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
+import org.apache.hadoop.ozone.om.request.bucket.TestBucketRequest;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Tests bucket addAcl request.
+ */
+public class TestOMBucketAddAclRequest extends TestBucketRequest {
+  @Test
+  public void testPreExecute() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    OzoneAcl acl = OzoneAcl.parseAcl("user:testUser:rw");
+
+    OMRequest originalRequest = TestOMRequestUtils
+        .createBucketAddAclRequest(volumeName, bucketName, acl);
+    long originModTime = originalRequest.getAddAclRequest()
+        .getModificationTime();
+
+    OMBucketAddAclRequest omBucketAddAclRequest =
+        new OMBucketAddAclRequest(originalRequest);
+    OMRequest preExecuteRequest = omBucketAddAclRequest
+        .preExecute(ozoneManager);
+    Assert.assertNotEquals(originalRequest, preExecuteRequest);
+
+    long newModTime = preExecuteRequest.getAddAclRequest()
+        .getModificationTime();
+    // When preExecute() of adding acl,
+    // the new modification time is greater than origin one.
+    Assert.assertTrue(newModTime > originModTime);
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheSuccess() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String ownerName = "testUser";
+
+    TestOMRequestUtils.addUserToDB(volumeName, ownerName, omMetadataManager);
+    TestOMRequestUtils.addVolumeToDB(volumeName, ownerName, omMetadataManager);
+    TestOMRequestUtils.addBucketToDB(volumeName, bucketName, omMetadataManager);
+
+    OzoneAcl acl = OzoneAcl.parseAcl("user:newUser:rw");
+
+    OMRequest originalRequest = TestOMRequestUtils.
+        createBucketAddAclRequest(volumeName, bucketName, acl);
+    OMBucketAddAclRequest omBucketAddAclRequest =
+        new OMBucketAddAclRequest(originalRequest);
+
+    OMClientResponse omClientResponse = omBucketAddAclRequest
+        .validateAndUpdateCache(ozoneManager, 1,
+            ozoneManagerDoubleBufferHelper);
+    OMResponse omResponse = omClientResponse.getOMResponse();
+    Assert.assertNotNull(omResponse.getAddAclResponse());
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omResponse.getStatus());
+
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    List<OzoneAcl> bucketAcls = omMetadataManager.getBucketTable()
+        .get(bucketKey).getAcls();
+
+    // Acl is added.
+    Assert.assertEquals(1, bucketAcls.size());
+    Assert.assertEquals(acl, bucketAcls.get(0));
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheWithBucketNotFound() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    OzoneAcl acl = OzoneAcl.parseAcl("user:newUser:rw");
+
+    OMRequest originalRequest = TestOMRequestUtils
+        .createBucketAddAclRequest(volumeName, bucketName, acl);
+    OMBucketAddAclRequest omBucketAddAclRequest =
+        new OMBucketAddAclRequest(originalRequest);
+    omBucketAddAclRequest.preExecute(ozoneManager);
+
+    OMClientResponse omClientResponse = omBucketAddAclRequest
+        .validateAndUpdateCache(ozoneManager, 1,
+            ozoneManagerDoubleBufferHelper);
+    OMResponse omResponse = omClientResponse.getOMResponse();
+    Assert.assertNotNull(omResponse.getAddAclResponse());
+    // The bucket is not created.
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
+        omResponse.getStatus());
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketAddAclRequest.java
@@ -67,8 +67,8 @@ public class TestOMBucketAddAclRequest extends TestBucketRequest {
     String ownerName = "testUser";
 
     TestOMRequestUtils.addUserToDB(volumeName, ownerName, omMetadataManager);
-    TestOMRequestUtils.addVolumeToDB(volumeName, ownerName, omMetadataManager);
-    TestOMRequestUtils.addBucketToDB(volumeName, bucketName, omMetadataManager);
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
 
     OzoneAcl acl = OzoneAcl.parseAcl("user:newUser:rw");
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketAddAclRequest.java
@@ -76,6 +76,7 @@ public class TestOMBucketAddAclRequest extends TestBucketRequest {
         createBucketAddAclRequest(volumeName, bucketName, acl);
     OMBucketAddAclRequest omBucketAddAclRequest =
         new OMBucketAddAclRequest(originalRequest);
+    omBucketAddAclRequest.preExecute(ozoneManager);
 
     OMClientResponse omClientResponse = omBucketAddAclRequest
         .validateAndUpdateCache(ozoneManager, 1,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketRemoveAclRequest.java
@@ -66,8 +66,8 @@ public class TestOMBucketRemoveAclRequest extends TestBucketRequest {
     String ownerName = "testUser";
 
     TestOMRequestUtils.addUserToDB(volumeName, ownerName, omMetadataManager);
-    TestOMRequestUtils.addVolumeToDB(volumeName, ownerName, omMetadataManager);
-    TestOMRequestUtils.addBucketToDB(volumeName, bucketName, omMetadataManager);
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
 
     OzoneAcl acl = OzoneAcl.parseAcl("user:newUser:rw");
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketRemoveAclRequest.java
@@ -1,0 +1,137 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.bucket.acl;
+
+import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
+import org.apache.hadoop.ozone.om.request.bucket.TestBucketRequest;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Tests bucket removeAcl request.
+ */
+public class TestOMBucketRemoveAclRequest extends TestBucketRequest {
+  @Test
+  public void testPreExecute() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    OzoneAcl acl = OzoneAcl.parseAcl("user:testUser:rw");
+
+    OMRequest originalRequest = TestOMRequestUtils
+        .createBucketRemoveAclRequest(volumeName, bucketName, acl);
+    long originModTime = originalRequest.getRemoveAclRequest()
+        .getModificationTime();
+
+    OMBucketRemoveAclRequest omBucketRemoveAclRequest =
+        new OMBucketRemoveAclRequest(originalRequest);
+    OMRequest preExecuteRequest = omBucketRemoveAclRequest
+        .preExecute(ozoneManager);
+    Assert.assertNotEquals(originalRequest, preExecuteRequest);
+
+    long newModTime = preExecuteRequest.getRemoveAclRequest()
+        .getModificationTime();
+    // When preExecute() of removing acl,
+    // the new modification time is greater than origin one.
+    Assert.assertTrue(newModTime > originModTime);
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheSuccess() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String ownerName = "testUser";
+
+    TestOMRequestUtils.addUserToDB(volumeName, ownerName, omMetadataManager);
+    TestOMRequestUtils.addVolumeToDB(volumeName, ownerName, omMetadataManager);
+    TestOMRequestUtils.addBucketToDB(volumeName, bucketName, omMetadataManager);
+
+    OzoneAcl acl = OzoneAcl.parseAcl("user:newUser:rw");
+
+    // Add acl
+    OMRequest addAclRequest = TestOMRequestUtils
+        .createBucketAddAclRequest(volumeName, bucketName, acl);
+    OMBucketAddAclRequest omBucketAddAclRequest =
+        new OMBucketAddAclRequest(addAclRequest);
+    omBucketAddAclRequest.preExecute(ozoneManager);
+    OMClientResponse omClientAddAclResponse = omBucketAddAclRequest
+        .validateAndUpdateCache(ozoneManager, 1,
+            ozoneManagerDoubleBufferHelper);
+    OMResponse omAddAclResponse = omClientAddAclResponse.getOMResponse();
+    Assert.assertNotNull(omAddAclResponse.getAddAclResponse());
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omAddAclResponse.getStatus());
+
+    // Verify result of adding acl.
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    List<OzoneAcl> bucketAcls = omMetadataManager.getBucketTable()
+        .get(bucketKey).getAcls();
+    Assert.assertEquals(1, bucketAcls.size());
+    Assert.assertEquals(acl, bucketAcls.get(0));
+
+    // Remove acl.
+    OMRequest removeAclRequest = TestOMRequestUtils
+        .createBucketRemoveAclRequest(volumeName, bucketName, acl);
+    OMBucketRemoveAclRequest omBucketRemoveAclRequest =
+        new OMBucketRemoveAclRequest(removeAclRequest);
+    omBucketRemoveAclRequest.preExecute(ozoneManager);
+    OMClientResponse omClientRemoveAclResponse = omBucketRemoveAclRequest
+        .validateAndUpdateCache(ozoneManager, 2,
+            ozoneManagerDoubleBufferHelper);
+    OMResponse omRemoveAclResponse = omClientRemoveAclResponse.getOMResponse();
+    Assert.assertNotNull(omRemoveAclResponse.getRemoveAclResponse());
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omRemoveAclResponse.getStatus());
+
+    // Verify result of removing acl.
+    List<OzoneAcl> newAcls = omMetadataManager.getBucketTable()
+        .get(bucketKey).getAcls();
+    Assert.assertEquals(0, newAcls.size());
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheWithBucketNotFound() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    OzoneAcl acl = OzoneAcl.parseAcl("user:newUser:rw");
+
+    OMRequest originalRequest = TestOMRequestUtils
+        .createBucketRemoveAclRequest(volumeName, bucketName, acl);
+    OMBucketRemoveAclRequest omBucketRemoveAclRequest =
+        new OMBucketRemoveAclRequest(originalRequest);
+    omBucketRemoveAclRequest.preExecute(ozoneManager);
+
+    OMClientResponse omClientResponse = omBucketRemoveAclRequest
+        .validateAndUpdateCache(ozoneManager, 1,
+            ozoneManagerDoubleBufferHelper);
+    OMResponse omResponse = omClientResponse.getOMResponse();
+
+    Assert.assertNotNull(omResponse.getRemoveAclResponse());
+    // The bucket is not created.
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
+        omResponse.getStatus());
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketSetAclRequest.java
@@ -68,8 +68,8 @@ public class TestOMBucketSetAclRequest extends TestBucketRequest {
     String ownerName = "owner";
 
     TestOMRequestUtils.addUserToDB(volumeName, ownerName, omMetadataManager);
-    TestOMRequestUtils.addVolumeToDB(volumeName, ownerName, omMetadataManager);
-    TestOMRequestUtils.addBucketToDB(volumeName, bucketName, omMetadataManager);
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
 
     OzoneAcl userAcl = OzoneAcl.parseAcl("user:newUser:rw");
     OzoneAcl groupAcl = OzoneAcl.parseAcl("group:newGroup:rw");

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketSetAclRequest.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.bucket.acl;
+
+import com.google.common.collect.Lists;
+import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
+import org.apache.hadoop.ozone.om.request.bucket.TestBucketRequest;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Tests bucket setAcl request.
+ */
+public class TestOMBucketSetAclRequest extends TestBucketRequest {
+  @Test
+  public void testPreExecute() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    OzoneAcl acl = OzoneAcl.parseAcl("user:testUser:rw");
+
+    OMRequest originalRequest = TestOMRequestUtils
+        .createBucketSetAclRequest(volumeName, bucketName,
+            Lists.newArrayList(acl));
+    long originModTime = originalRequest.getSetAclRequest()
+        .getModificationTime();
+
+    OMBucketSetAclRequest omBucketSetAclRequest =
+        new OMBucketSetAclRequest(originalRequest);
+    OMRequest preExecuteRequest = omBucketSetAclRequest
+        .preExecute(ozoneManager);
+    Assert.assertNotEquals(originalRequest, preExecuteRequest);
+
+    long newModTime = preExecuteRequest.getSetAclRequest()
+        .getModificationTime();
+    // When preExecute() of setting acl,
+    // the new modification time is greater than origin one.
+    Assert.assertTrue(newModTime > originModTime);
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheSuccess() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String ownerName = "owner";
+
+    TestOMRequestUtils.addUserToDB(volumeName, ownerName, omMetadataManager);
+    TestOMRequestUtils.addVolumeToDB(volumeName, ownerName, omMetadataManager);
+    TestOMRequestUtils.addBucketToDB(volumeName, bucketName, omMetadataManager);
+
+    OzoneAcl userAcl = OzoneAcl.parseAcl("user:newUser:rw");
+    OzoneAcl groupAcl = OzoneAcl.parseAcl("group:newGroup:rw");
+    List<OzoneAcl> acls = Lists.newArrayList(userAcl, groupAcl);
+
+    OMRequest originalRequest = TestOMRequestUtils
+        .createBucketSetAclRequest(volumeName, bucketName, acls);
+    OMBucketSetAclRequest omBucketSetAclRequest =
+        new OMBucketSetAclRequest(originalRequest);
+    omBucketSetAclRequest.preExecute(ozoneManager);
+
+    OMClientResponse omClientResponse = omBucketSetAclRequest
+        .validateAndUpdateCache(ozoneManager, 1,
+            ozoneManagerDoubleBufferHelper);
+    OMResponse omResponse = omClientResponse.getOMResponse();
+    Assert.assertNotNull(omResponse.getSetAclResponse());
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omResponse.getStatus());
+
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    List<OzoneAcl> bucketAclList = omMetadataManager.getBucketTable()
+        .get(bucketKey).getAcls();
+
+    // Acls are added to acl list.
+    Assert.assertEquals(acls.size(), bucketAclList.size());
+    Assert.assertEquals(userAcl, bucketAclList.get(0));
+    Assert.assertEquals(groupAcl, bucketAclList.get(1));
+
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheWithBucketNotFound() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    OzoneAcl acl = OzoneAcl.parseAcl("user:newUser:rw");
+
+    OMRequest originalRequest = TestOMRequestUtils
+        .createBucketSetAclRequest(volumeName, bucketName,
+            Lists.newArrayList(acl));
+    OMBucketSetAclRequest omBucketSetAclRequest =
+        new OMBucketSetAclRequest(originalRequest);
+    omBucketSetAclRequest.preExecute(ozoneManager);
+
+    OMClientResponse omClientResponse = omBucketSetAclRequest
+        .validateAndUpdateCache(ozoneManager, 1,
+            ozoneManagerDoubleBufferHelper);
+    OMResponse omResponse = omClientResponse.getOMResponse();
+    Assert.assertNotNull(omResponse.getSetAclResponse());
+    // The bucket is not created.
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
+        omResponse.getStatus());
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/package-info.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Package contains test classes for bucket acl requests.
+ */
+package org.apache.hadoop.ozone.om.request.bucket.acl;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequest.java
@@ -17,14 +17,20 @@
  */
 package org.apache.hadoop.ozone.om.request.key;
 
+import java.util.List;
 import java.util.UUID;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.hadoop.ozone.om.request.key.acl.OMKeyAddAclRequest;
+import org.apache.hadoop.ozone.om.request.key.acl.OMKeyRemoveAclRequest;
+import org.apache.hadoop.ozone.om.request.key.acl.OMKeySetAclRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AddAclRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RemoveAclRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetAclRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.junit.Assert;
@@ -36,7 +42,7 @@ import org.junit.Test;
 public class TestOMKeyAclRequest extends TestOMKeyRequest {
 
   @Test
-  public void testAclRequest() throws Exception {
+  public void testKeyAddAclRequest() throws Exception {
     // Manually add volume, bucket and key to DB
     TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager);
@@ -50,7 +56,15 @@ public class TestOMKeyAclRequest extends TestOMKeyRequest {
     OMRequest originalRequest = createAddAclkeyRequest(acl);
     OMKeyAddAclRequest omKeyAddAclRequest = new OMKeyAddAclRequest(
         originalRequest);
-    omKeyAddAclRequest.preExecute(ozoneManager);
+    OMRequest preExecuteRequest = omKeyAddAclRequest.preExecute(ozoneManager);
+
+    // When preExecute() of adding acl,
+    // the new modification time is greater than origin one.
+    long originModTime = originalRequest.getAddAclRequest()
+        .getModificationTime();
+    long newModTime = preExecuteRequest.getAddAclRequest()
+        .getModificationTime();
+    Assert.assertTrue(newModTime > originModTime);
 
     // Execute original request
     OMClientResponse omClientResponse = omKeyAddAclRequest
@@ -59,6 +73,105 @@ public class TestOMKeyAclRequest extends TestOMKeyRequest {
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());
 
+  }
+
+  @Test
+  public void testKeyRemoveAclRequest() throws Exception {
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
+    TestOMRequestUtils.addKeyToTable(false, false, volumeName, bucketName,
+        keyName, clientID, replicationType, replicationFactor, 1L,
+        omMetadataManager);
+
+    OzoneAcl acl = OzoneAcl.parseAcl("user:bilbo:rwdlncxy[ACCESS]");
+
+    // Add acl.
+    OMRequest addAclRequest = createAddAclkeyRequest(acl);
+    OMKeyAddAclRequest omKeyAddAclRequest =
+        new OMKeyAddAclRequest(addAclRequest);
+    omKeyAddAclRequest.preExecute(ozoneManager);
+    OMClientResponse omClientAddAclResponse = omKeyAddAclRequest
+        .validateAndUpdateCache(ozoneManager, 1,
+            ozoneManagerDoubleBufferHelper);
+    OMResponse omAddAclResponse = omClientAddAclResponse.getOMResponse();
+    Assert.assertNotNull(omAddAclResponse.getAddAclResponse());
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omAddAclResponse.getStatus());
+
+    // Verify result of adding acl.
+    String ozoneKey = omMetadataManager
+        .getOzoneKey(volumeName, bucketName, keyName);
+    List<OzoneAcl> keyAcls = omMetadataManager.getKeyTable().get(ozoneKey)
+        .getAcls();
+    Assert.assertEquals(1, keyAcls.size());
+    Assert.assertEquals(acl, keyAcls.get(0));
+
+    // Remove acl.
+    OMRequest removeAclRequest = createRemoveAclKeyRequest(acl);
+    OMKeyRemoveAclRequest omKeyRemoveAclRequest =
+        new OMKeyRemoveAclRequest(removeAclRequest);
+    OMRequest preExecuteRequest = omKeyRemoveAclRequest
+        .preExecute(ozoneManager);
+
+    // When preExecute() of removing acl,
+    // the new modification time is greater than origin one.
+    long originModTime = removeAclRequest.getRemoveAclRequest()
+        .getModificationTime();
+    long newModTime = preExecuteRequest.getRemoveAclRequest()
+        .getModificationTime();
+    Assert.assertTrue(newModTime > originModTime);
+
+    OMClientResponse omClientRemoveAclResponse = omKeyRemoveAclRequest
+        .validateAndUpdateCache(ozoneManager, 2,
+            ozoneManagerDoubleBufferHelper);
+    OMResponse omRemoveAclResponse = omClientRemoveAclResponse.getOMResponse();
+    Assert.assertNotNull(omRemoveAclResponse.getRemoveAclResponse());
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omRemoveAclResponse.getStatus());
+
+    // Verify result of removing acl.
+    List<OzoneAcl> newAcls = omMetadataManager.getKeyTable().get(ozoneKey)
+        .getAcls();
+    Assert.assertEquals(0, newAcls.size());
+  }
+
+  @Test
+  public void testKeySetAclRequest() throws Exception {
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
+    TestOMRequestUtils.addKeyToTable(false, false, volumeName, bucketName,
+        keyName, clientID, replicationType, replicationFactor, 1L,
+        omMetadataManager);
+
+    OzoneAcl acl = OzoneAcl.parseAcl("user:bilbo:rwdlncxy[ACCESS]");
+
+    OMRequest setAclRequest = createSetAclKeyRequest(acl);
+    OMKeySetAclRequest omKeySetAclRequest =
+        new OMKeySetAclRequest(setAclRequest);
+    OMRequest preExecuteRequest = omKeySetAclRequest.preExecute(ozoneManager);
+
+    // When preExecute() of setting acl,
+    // the new modification time is greater than origin one.
+    long originModTime = setAclRequest.getSetAclRequest()
+        .getModificationTime();
+    long newModTime = preExecuteRequest.getSetAclRequest()
+        .getModificationTime();
+    Assert.assertTrue(newModTime > originModTime);
+
+    OMClientResponse omClientResponse = omKeySetAclRequest
+        .validateAndUpdateCache(ozoneManager, 1,
+            ozoneManagerDoubleBufferHelper);
+    OMResponse omSetAclResponse = omClientResponse.getOMResponse();
+    Assert.assertNotNull(omSetAclResponse.getSetAclResponse());
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omSetAclResponse.getStatus());
+
+    // Verify result of setting acl.
+    String ozoneKey = omMetadataManager
+        .getOzoneKey(volumeName, bucketName, keyName);
+    List<OzoneAcl> newAcls = omMetadataManager.getKeyTable().get(ozoneKey)
+        .getAcls();
+    Assert.assertEquals(newAcls.get(0), acl);
   }
 
   /**
@@ -80,6 +193,44 @@ public class TestOMKeyAclRequest extends TestOMKeyRequest {
     return OMRequest.newBuilder().setClientId(UUID.randomUUID().toString())
         .setCmdType(OzoneManagerProtocolProtos.Type.AddAcl)
         .setAddAclRequest(addAclRequest)
+        .build();
+  }
+
+  private OMRequest createRemoveAclKeyRequest(OzoneAcl acl) {
+    OzoneObj obj = OzoneObjInfo.Builder.newBuilder()
+        .setBucketName(bucketName)
+        .setVolumeName(volumeName)
+        .setKeyName(keyName)
+        .setResType(OzoneObj.ResourceType.KEY)
+        .setStoreType(OzoneObj.StoreType.OZONE)
+        .build();
+    RemoveAclRequest removeAclRequest = RemoveAclRequest.newBuilder()
+        .setObj(OzoneObj.toProtobuf(obj))
+        .setAcl(OzoneAcl.toProtobuf(acl))
+        .build();
+
+    return OMRequest.newBuilder().setClientId(UUID.randomUUID().toString())
+        .setCmdType(OzoneManagerProtocolProtos.Type.RemoveAcl)
+        .setRemoveAclRequest(removeAclRequest)
+        .build();
+  }
+
+  private OMRequest createSetAclKeyRequest(OzoneAcl acl) {
+    OzoneObj obj = OzoneObjInfo.Builder.newBuilder()
+        .setBucketName(bucketName)
+        .setVolumeName(volumeName)
+        .setKeyName(keyName)
+        .setResType(OzoneObj.ResourceType.KEY)
+        .setStoreType(OzoneObj.StoreType.OZONE)
+        .build();
+    SetAclRequest setAclRequest = SetAclRequest.newBuilder()
+        .setObj(OzoneObj.toProtobuf(obj))
+        .addAcl(OzoneAcl.toProtobuf(acl))
+        .build();
+
+    return OMRequest.newBuilder().setClientId(UUID.randomUUID().toString())
+        .setCmdType(OzoneManagerProtocolProtos.Type.SetAcl)
+        .setSetAclRequest(setAclRequest)
         .build();
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeAddAclRequest.java
@@ -44,6 +44,8 @@ public class TestOMVolumeAddAclRequest extends TestOMVolumeRequest {
     OzoneAcl acl = OzoneAcl.parseAcl("user:bilbo:rw");
     OMRequest originalRequest =
         TestOMRequestUtils.createVolumeAddAclRequest(volumeName, acl);
+    long originModTime = originalRequest.getAddAclRequest()
+        .getModificationTime();
 
     OMVolumeAddAclRequest omVolumeAddAclRequest =
         new OMVolumeAddAclRequest(originalRequest);
@@ -51,6 +53,11 @@ public class TestOMVolumeAddAclRequest extends TestOMVolumeRequest {
     OMRequest modifiedRequest = omVolumeAddAclRequest.preExecute(
         ozoneManager);
     Assert.assertNotEquals(modifiedRequest, originalRequest);
+
+    long newModTime = modifiedRequest.getAddAclRequest().getModificationTime();
+    // When preExecute() of adding acl,
+    // the new modification time is greater than origin one.
+    Assert.assertTrue(newModTime > originModTime);
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeRemoveAclRequest.java
@@ -43,6 +43,8 @@ public class TestOMVolumeRemoveAclRequest extends TestOMVolumeRequest {
     OzoneAcl acl = OzoneAcl.parseAcl("user:bilbo:rw");
     OMRequest originalRequest =
         TestOMRequestUtils.createVolumeRemoveAclRequest(volumeName, acl);
+    long originModTime = originalRequest.getRemoveAclRequest()
+        .getModificationTime();
 
     OMVolumeRemoveAclRequest omVolumeRemoveAclRequest =
         new OMVolumeRemoveAclRequest(originalRequest);
@@ -50,6 +52,12 @@ public class TestOMVolumeRemoveAclRequest extends TestOMVolumeRequest {
     OMRequest modifiedRequest = omVolumeRemoveAclRequest.preExecute(
         ozoneManager);
     Assert.assertNotEquals(modifiedRequest, originalRequest);
+
+    long newModTime = modifiedRequest.getRemoveAclRequest()
+        .getModificationTime();
+    // When preExecute() of removing acl,
+    // the new modification time is greater than origin one.
+    Assert.assertTrue(newModTime > originModTime);
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/acl/TestOMVolumeSetAclRequest.java
@@ -49,6 +49,8 @@ public class TestOMVolumeSetAclRequest extends TestOMVolumeRequest {
     OMRequest originalRequest =
         TestOMRequestUtils.createVolumeSetAclRequest(volumeName,
             Lists.newArrayList(acl));
+    long originModTime = originalRequest.getSetAclRequest()
+        .getModificationTime();
 
     OMVolumeSetAclRequest omVolumeSetAclRequest =
         new OMVolumeSetAclRequest(originalRequest);
@@ -56,6 +58,11 @@ public class TestOMVolumeSetAclRequest extends TestOMVolumeRequest {
     OMRequest modifiedRequest = omVolumeSetAclRequest.preExecute(
         ozoneManager);
     Assert.assertNotEquals(modifiedRequest, originalRequest);
+
+    long newModTime = modifiedRequest.getSetAclRequest().getModificationTime();
+    // When preExecute() of setting acl,
+    // the new modification time is greater than origin one.
+    Assert.assertTrue(newModTime > originModTime);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
For renewing modification time when updating Acls of `Volume`/ `Bucket`/ `Key`, there are three parts to be modified in this patch.

**I. Volume Part**
  - addacl: Add one or more new ACLs.
  - removeacl: Remove one or more existing ACLs.
  - setacl: Set one or more ACLs, replacing the existing ones.
    
**II. Bucket Part**
  - addacl
  - removeacl
  - setacl

**III. Key Part**
  - addacl
  - removeacl
  - setacl

#### Proposed fix.
Let `preExecute()` be overrided by `OMAddAclRequest`/ `OMSetAclRequest`/ `OMRemoveAclRequest` of `Volume`/ `Bucket`/`Key`, and evalute modification time in `preExecute()`.

After `preExecute()`, renew modification time after true `acl apply operation` in `validateAndUpdateCache()` of `OMVolumeAclRequest`/ `OMBucketAclRequest`/ `OMKeyAclRequest`.

**[note]**
In `OMVolumeAclRequest` and `OMBucketAclRequest`, the cache of table is updated only when true `acl apply operation` happening, so the code snippet of renewing modification time is added in this block.

But in `OMKeyAclRequest`, the original flow didn't consider boolean of `acl apply operation` when updating the cache of table, so the if-condition includes boolean of `acl apply operation`.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3882

## How was this patch tested?
- Modify/Add unit tests.
  Volume Part : Just modify the `testPreExecute()` to verify modification time is renewed.
      
  Bucket Part : Add new unit tests to verify `OMBucketAddAclRequest`/ `OMBucketRemoveAclRequest`/ `OMBucketSetAclRequest` including `testPreExecute()` and `testValidateAndUpdateCache`.
  (Feel free to correct me if anyone think this part should be addressed in separated Jira or any thoughts :) )
  
  Key Part : Modify original `TestOMKeyAclRequest.java` to `testKeyRemoveAclRequest()` and `testKeySetAclRequest()`.
  (Again, Feel free to correct me if anyone think this part should be addressed in separated Jira or any thoughts, thanks)
 

- [Github action passed except codecov](https://github.com/cxorm/hadoop-ozone/runs/957353259)