### PR TITLE
HDDS-4009. Recon Overview page: The volume, bucket and key counts are not accurate

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBDefinition.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBDefinition.java
@@ -21,6 +21,10 @@ package org.apache.hadoop.hdds.utils.db;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
+
 /**
  * Simple interface to provide information to create a DBStore..
  */
@@ -43,4 +47,15 @@ public interface DBDefinition {
    */
   DBColumnFamilyDefinition[] getColumnFamilies();
 
+  default Optional<Class> getKeyType(String table) {
+    return Arrays.stream(getColumnFamilies()).filter(cf -> cf.getName().equals(
+        table)).map((Function<DBColumnFamilyDefinition, Class>)
+        DBColumnFamilyDefinition::getKeyType).findAny();
+  }
+
+  default Optional<Class> getValueType(String table) {
+    return Arrays.stream(getColumnFamilies()).filter(cf -> cf.getName().equals(
+        table)).map((Function<DBColumnFamilyDefinition, Class>)
+        DBColumnFamilyDefinition::getValueType).findAny();
+  }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBDefinition.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBDefinition.java
@@ -47,12 +47,24 @@ public interface DBDefinition {
    */
   DBColumnFamilyDefinition[] getColumnFamilies();
 
+  /**
+   * Get the key type class for the given table.
+   * @param table table name
+   * @return the class of key type of the given table wrapped in an
+   * {@link Optional}
+   */
   default Optional<Class> getKeyType(String table) {
     return Arrays.stream(getColumnFamilies()).filter(cf -> cf.getName().equals(
         table)).map((Function<DBColumnFamilyDefinition, Class>)
         DBColumnFamilyDefinition::getKeyType).findAny();
   }
 
+  /**
+   * Get the value type class for the given table.
+   * @param table table name
+   * @return the class of value type of the given table wrapped in an
+   * {@link Optional}
+   */
   default Optional<Class> getValueType(String table) {
     return Arrays.stream(getColumnFamilies()).filter(cf -> cf.getName().equals(
         table)).map((Function<DBColumnFamilyDefinition, Class>)

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -157,6 +157,19 @@ class RDBTable implements Table<byte[], byte[]> {
     }
   }
 
+  /**
+   * Skip checking cache and get the value mapped to the given key in byte
+   * array or returns null if the key is not found.
+   *
+   * @param bytes metadata key
+   * @return value in byte array or null if the key is not found.
+   * @throws IOException on Failure
+   */
+  @Override
+  public byte[] getSkipCache(byte[] bytes) throws IOException {
+    return get(bytes);
+  }
+
   @Override
   public byte[] getIfExist(byte[] key) throws IOException {
     try {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -83,6 +83,19 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
 
 
   /**
+   * Skip checking cache and get the value mapped to the given key in byte
+   * array or returns null if the key is not found.
+   *
+   * @param key metadata key
+   * @return value in byte array or null if the key is not found.
+   * @throws IOException on Failure
+   */
+  default VALUE getSkipCache(KEY key) throws IOException {
+    throw new NotImplementedException("getSkipCache is not implemented");
+  }
+
+
+  /**
    * Returns the value mapped to the given key in byte array or returns null
    * if the key is not found.
    *

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -178,6 +178,19 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   /**
+   * Skip checking cache and get the value mapped to the given key in byte
+   * array or returns null if the key is not found.
+   *
+   * @param key metadata key
+   * @return value in byte array or null if the key is not found.
+   * @throws IOException on Failure
+   */
+  @Override
+  public VALUE getSkipCache(KEY key) throws IOException {
+    return getFromTable(key);
+  }
+
+  /**
    * This method returns the value if it exists in cache, if it 
    * does not, get the value from the underlying rockdb table. If it 
    * exists in cache, it returns the same reference of the cached value.

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/StatsSchemaDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/StatsSchemaDefinition.java
@@ -66,13 +66,4 @@ public class StatsSchemaDefinition implements ReconSchemaDefinition {
             .primaryKey("key"))
         .execute();
   }
-
-  /**
-   * Returns the DSL context.
-   *
-   * @return dslContext
-   */
-  public DSLContext getDSLContext() {
-    return dslContext;
-  }
 }

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/StatsSchemaDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/StatsSchemaDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -22,6 +22,7 @@ import static org.hadoop.ozone.recon.codegen.SqlDbUtils.TABLE_EXISTS_CHECK;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import org.jooq.DSLContext;
 import org.jooq.impl.DSL;
 import org.jooq.impl.SQLDataType;
 
@@ -36,6 +37,7 @@ import java.sql.SQLException;
 public class StatsSchemaDefinition implements ReconSchemaDefinition {
 
   public static final String GLOBAL_STATS_TABLE_NAME = "GLOBAL_STATS";
+  private DSLContext dslContext;
   private final DataSource dataSource;
 
   @Inject
@@ -46,22 +48,31 @@ public class StatsSchemaDefinition implements ReconSchemaDefinition {
   @Override
   public void initializeSchema() throws SQLException {
     Connection conn = dataSource.getConnection();
+    dslContext = DSL.using(conn);
     if (!TABLE_EXISTS_CHECK.test(conn, GLOBAL_STATS_TABLE_NAME)) {
-      createGlobalStatsTable(conn);
+      createGlobalStatsTable();
     }
   }
 
   /**
    * Create the Ozone Global Stats table.
-   * @param conn connection
    */
-  private void createGlobalStatsTable(Connection conn) {
-    DSL.using(conn).createTableIfNotExists(GLOBAL_STATS_TABLE_NAME)
+  private void createGlobalStatsTable() {
+    dslContext.createTableIfNotExists(GLOBAL_STATS_TABLE_NAME)
         .column("key", SQLDataType.VARCHAR(255))
         .column("value", SQLDataType.BIGINT)
         .column("last_updated_timestamp", SQLDataType.TIMESTAMP)
         .constraint(DSL.constraint("pk_key")
             .primaryKey("key"))
         .execute();
+  }
+
+  /**
+   * Returns the DSL context.
+   *
+   * @return dslContext
+   */
+  public DSLContext getDSLContext() {
+    return dslContext;
   }
 }

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/UtilizationSchemaDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/UtilizationSchemaDefinition.java
@@ -63,14 +63,14 @@ public class UtilizationSchemaDefinition implements ReconSchemaDefinition {
     Connection conn = dataSource.getConnection();
     dslContext = DSL.using(conn);
     if (!TABLE_EXISTS_CHECK.test(conn, FILE_COUNT_BY_SIZE_TABLE_NAME)) {
-      createFileSizeCountTable(conn);
+      createFileSizeCountTable();
     }
     if (!TABLE_EXISTS_CHECK.test(conn, CLUSTER_GROWTH_DAILY_TABLE_NAME)) {
-      createClusterGrowthTable(conn);
+      createClusterGrowthTable();
     }
   }
 
-  private void createClusterGrowthTable(Connection conn) {
+  private void createClusterGrowthTable() {
     dslContext.createTableIfNotExists(CLUSTER_GROWTH_DAILY_TABLE_NAME)
         .column("timestamp", SQLDataType.TIMESTAMP)
         .column("datanode_id", SQLDataType.INTEGER)
@@ -85,7 +85,7 @@ public class UtilizationSchemaDefinition implements ReconSchemaDefinition {
         .execute();
   }
 
-  private void createFileSizeCountTable(Connection conn) {
+  private void createFileSizeCountTable() {
     dslContext.createTableIfNotExists(FILE_COUNT_BY_SIZE_TABLE_NAME)
         .column("volume", SQLDataType.VARCHAR(64))
         .column("bucket", SQLDataType.VARCHAR(64))
@@ -96,6 +96,11 @@ public class UtilizationSchemaDefinition implements ReconSchemaDefinition {
         .execute();
   }
 
+  /**
+   * Returns the DSL context.
+   *
+   * @return dslContext
+   */
   public DSLContext getDSLContext() {
     return dslContext;
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
@@ -32,13 +32,11 @@ public final class ReconConstants {
 
   public static final String RECON_CONTAINER_KEY_DB = "recon-container-key.db";
 
-  public static final String CONTAINER_COUNT_KEY = "totalCount";
+  public static final String CONTAINER_COUNT_KEY = "containerCount";
 
-  public static final String RECON_OM_SNAPSHOT_DB =
-      "om.snapshot.db";
+  public static final String RECON_OM_SNAPSHOT_DB = "om.snapshot.db";
 
-  public static final String CONTAINER_KEY_TABLE =
-      "containerKeyTable";
+  public static final String CONTAINER_KEY_TABLE = "containerKeyTable";
 
   public static final String CONTAINER_KEY_COUNT_TABLE =
       "containerKeyCountTable";

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconControllerModule.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconControllerModule.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.ozone.recon.spi.impl.ReconContainerDBProvider;
 import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.tasks.ContainerKeyMapperTask;
 import org.apache.hadoop.ozone.recon.tasks.FileSizeCountTask;
+import org.apache.hadoop.ozone.recon.tasks.TableCountTask;
 import org.apache.hadoop.ozone.recon.tasks.ReconOmTask;
 import org.apache.hadoop.ozone.recon.tasks.ReconTaskController;
 import org.apache.hadoop.ozone.recon.tasks.ReconTaskControllerImpl;
@@ -116,6 +117,7 @@ public class ReconControllerModule extends AbstractModule {
           Multibinder.newSetBinder(binder(), ReconOmTask.class);
       taskBinder.addBinding().to(ContainerKeyMapperTask.class);
       taskBinder.addBinding().to(FileSizeCountTask.class);
+      taskBinder.addBinding().to(TableCountTask.class);
     }
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ClusterStateEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ClusterStateEndpoint.java
@@ -24,10 +24,12 @@ import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.ozone.recon.api.types.ClusterStateResponse;
 import org.apache.hadoop.ozone.recon.api.types.DatanodeStorageReport;
-import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.scm.ReconContainerManager;
 import org.apache.hadoop.ozone.recon.scm.ReconNodeManager;
 import org.apache.hadoop.ozone.recon.scm.ReconPipelineManager;
+import org.apache.hadoop.ozone.recon.tasks.TableCountTask;
+import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
+import org.hadoop.ozone.recon.schema.tables.pojos.GlobalStats;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +40,10 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
+
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
 
 /**
  * Endpoint to fetch current state of ozone cluster.
@@ -52,17 +58,17 @@ public class ClusterStateEndpoint {
   private ReconNodeManager nodeManager;
   private ReconPipelineManager pipelineManager;
   private ReconContainerManager containerManager;
-  private ReconOMMetadataManager omMetadataManager;
+  private GlobalStatsDao globalStatsDao;
 
   @Inject
   ClusterStateEndpoint(OzoneStorageContainerManager reconSCM,
-                       ReconOMMetadataManager omMetadataManager) {
+                       GlobalStatsDao globalStatsDao) {
     this.nodeManager =
         (ReconNodeManager) reconSCM.getScmNodeManager();
     this.pipelineManager = (ReconPipelineManager) reconSCM.getPipelineManager();
     this.containerManager =
         (ReconContainerManager) reconSCM.getContainerManager();
-    this.omMetadataManager = omMetadataManager;
+    this.globalStatsDao = globalStatsDao;
   }
 
   /**
@@ -80,25 +86,20 @@ public class ClusterStateEndpoint {
         new DatanodeStorageReport(stats.getCapacity().get(),
             stats.getScmUsed().get(), stats.getRemaining().get());
     ClusterStateResponse.Builder builder = ClusterStateResponse.newBuilder();
-    if (omMetadataManager.isOmTablesInitialized()) {
-      try {
-        builder.setVolumes(
-            omMetadataManager.getVolumeTable().getEstimatedKeyCount());
-      } catch (Exception ex) {
-        LOG.error("Unable to get Volumes count in ClusterStateResponse.", ex);
-      }
-      try {
-        builder.setBuckets(
-            omMetadataManager.getBucketTable().getEstimatedKeyCount());
-      } catch (Exception ex) {
-        LOG.error("Unable to get Buckets count in ClusterStateResponse.", ex);
-      }
-      try {
-        builder.setKeys(
-            omMetadataManager.getKeyTable().getEstimatedKeyCount());
-      } catch (Exception ex) {
-        LOG.error("Unable to get Keys count in ClusterStateResponse.", ex);
-      }
+    GlobalStats volumeRecord = globalStatsDao.findById(
+        TableCountTask.getRowKeyFromTable(VOLUME_TABLE));
+    GlobalStats bucketRecord = globalStatsDao.findById(
+        TableCountTask.getRowKeyFromTable(BUCKET_TABLE));
+    GlobalStats keyRecord = globalStatsDao.findById(
+        TableCountTask.getRowKeyFromTable(KEY_TABLE));
+    if (volumeRecord != null) {
+      builder.setVolumes(volumeRecord.getValue());
+    }
+    if (bucketRecord != null) {
+      builder.setBuckets(bucketRecord.getValue());
+    }
+    if (keyRecord != null) {
+      builder.setKeys(keyRecord.getValue());
     }
     ClusterStateResponse response = builder
         .setStorageReport(storageReport)

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -157,7 +157,7 @@ public class ContainerEndpoint {
         // Directly calling get() on the Key table instead of iterating since
         // only full keys are supported now. When we change to using a prefix
         // of the key, this needs to change to prefix seek.
-        OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable().get(
+        OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable().getSkipCache(
             containerKeyPrefix.getKeyPrefix());
         if (null != omKeyInfo) {
           // Filter keys by version.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -243,8 +243,8 @@ public class FileSizeCountTask implements ReconOmTask {
                                     Map<FileSizeCountKey, Long>
                                         fileSizeCountMap) {
     if (omKeyInfo == null) {
-      LOG.warn("Unexpected error while handling DELETE key event. Key not " +
-          "found in Recon OM DB : {}", key);
+      LOG.warn("Deleting a key not found while handling DELETE key event. Key" +
+          " not found in Recon OM DB : {}", key);
     } else {
       FileSizeCountKey countKey = getFileSizeCountKey(omKeyInfo);
       Long count = fileSizeCountMap.containsKey(countKey) ?

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdateEvent.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdateEvent.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 
 /**
  * A class used to encapsulate a single OM DB update event.
- * Currently only PUT and DELETE are supported.
+ * Currently PUT, DELETE and UPDATE are supported.
  * @param <KEY> Type of Key.
  * @param <VALUE> Type of Value.
  */

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
@@ -18,9 +18,6 @@
 
 package org.apache.hadoop.ozone.recon.tasks;
 
-import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
-import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
-import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
 import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.DELETE;
 import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.PUT;
 import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.UPDATE;
@@ -29,11 +26,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
+import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
-import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
-import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
+import org.apache.hadoop.ozone.om.codec.OMDBDefinition;
 import org.apache.hadoop.hdds.utils.db.CodecRegistry;
 import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.rocksdb.RocksDBException;
@@ -53,16 +50,17 @@ public class OMDBUpdatesHandler extends WriteBatch.Handler {
   private CodecRegistry codecRegistry;
   private OMMetadataManager omMetadataManager;
   private List<OMDBUpdateEvent> omdbUpdateEvents = new ArrayList<>();
+  private OMDBDefinition omdbDefinition;
 
   public OMDBUpdatesHandler(OMMetadataManager metadataManager) {
     omMetadataManager = metadataManager;
     tablesNames = metadataManager.getStore().getTableNames();
     codecRegistry = metadataManager.getStore().getCodecRegistry();
+    omdbDefinition = new OMDBDefinition();
   }
 
   @Override
-  public void put(int cfIndex, byte[] keyBytes, byte[] valueBytes) throws
-      RocksDBException {
+  public void put(int cfIndex, byte[] keyBytes, byte[] valueBytes) {
     try {
       processEvent(cfIndex, keyBytes, valueBytes,
           OMDBUpdateEvent.OMDBUpdateAction.PUT);
@@ -72,7 +70,7 @@ public class OMDBUpdatesHandler extends WriteBatch.Handler {
   }
 
   @Override
-  public void delete(int cfIndex, byte[] keyBytes) throws RocksDBException {
+  public void delete(int cfIndex, byte[] keyBytes) {
     try {
       processEvent(cfIndex, keyBytes, null,
           OMDBUpdateEvent.OMDBUpdateAction.DELETE);
@@ -93,41 +91,44 @@ public class OMDBUpdatesHandler extends WriteBatch.Handler {
       valueBytes, OMDBUpdateEvent.OMDBUpdateAction action)
       throws IOException {
     String tableName = tablesNames.get(cfIndex);
-    Class<String> keyType = getKeyType();
-    Class valueType = getValueType(tableName);
-    if (valueType != null) {
+    Optional<Class> keyType = getKeyType(tableName);
+    Optional<Class> valueType = getValueType(tableName);
+    if (keyType.isPresent() && valueType.isPresent()) {
       OMDBUpdateEvent.OMUpdateEventBuilder builder =
           new OMDBUpdateEvent.OMUpdateEventBuilder<>();
       builder.setTable(tableName);
       builder.setAction(action);
-
-      String key = codecRegistry.asObject(keyBytes, keyType);
+      String key = (String) codecRegistry.asObject(keyBytes, keyType.get());
       builder.setKey(key);
 
+      // Put new
+      // Put existing --> Update
+      // Delete existing
+      // Delete non-existing
+      Table table = omMetadataManager.getTable(tableName);
+      // Recon does not add entries to cache and it is safer to always use
+      // getSkipCache in Recon.
+      Object oldValue = table.getSkipCache(key);
       if (action == PUT) {
-        Object value = codecRegistry.asObject(valueBytes, valueType);
+        Object value = codecRegistry.asObject(valueBytes, valueType.get());
         builder.setValue(value);
-        // If a PUT key operation happens on an existing Key, it is tagged
+        // If a PUT operation happens on an existing Key, it is tagged
         // as an "UPDATE" event.
-        if (tableName.equalsIgnoreCase(KEY_TABLE)) {
-          if (omMetadataManager.getKeyTable().isExist(key)) {
-            OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable().get(key);
-            builder.setOldValue(omKeyInfo);
-            builder.setAction(UPDATE);
-          }
+        if (oldValue != null) {
+          builder.setOldValue(oldValue);
+          builder.setAction(UPDATE);
         }
       } else if (action.equals(DELETE)) {
-        // When you delete a Key, we add the old OmKeyInfo to the event so that
+        // When you delete a Key, we add the old value to the event so that
         // a downstream task can use it.
-        if (tableName.equalsIgnoreCase(KEY_TABLE)) {
-          OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable().get(key);
-          builder.setValue(omKeyInfo);
-        }
+        builder.setValue(oldValue);
       }
 
       OMDBUpdateEvent event = builder.build();
-      LOG.debug("Generated OM update Event for table : " + event.getTable()
-          + ", Key = " + event.getKey() + ", action = " + event.getAction());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(String.format("Generated OM update Event for table : %s, " +
+            "action = %s", tableName, action));
+      }
       if (omdbUpdateEvents.contains(event)) {
         // If the same event is part of this batch, the last one only holds.
         // For example, if there are 2 PUT key1 events, then the first one
@@ -135,6 +136,13 @@ public class OMDBUpdatesHandler extends WriteBatch.Handler {
         omdbUpdateEvents.remove(event);
       }
       omdbUpdateEvents.add(event);
+    } else {
+      // key type or value type cannot be determined for this table.
+      // log a warn message and ignore the update.
+      if (LOG.isWarnEnabled()) {
+        LOG.warn(String.format("KeyType or ValueType could not be determined" +
+            " for table %s. Ignoring the event.", tableName));
+      }
     }
   }
 
@@ -262,12 +270,13 @@ public class OMDBUpdatesHandler extends WriteBatch.Handler {
   }
 
   /**
-   * Return Key type class for a given table name.
-   * @param name table name.
-   * @return String.class by default.
+   * Return Key type class for the given table.
+   *
+   * @return keyType class.
    */
-  private Class<String> getKeyType() {
-    return String.class;
+  @VisibleForTesting
+  Optional<Class> getKeyType(String name) {
+    return omdbDefinition.getKeyType(name);
   }
 
   /**
@@ -276,13 +285,8 @@ public class OMDBUpdatesHandler extends WriteBatch.Handler {
    * @return Value type based on table name.
    */
   @VisibleForTesting
-  protected Class getValueType(String name) {
-    switch (name) {
-    case KEY_TABLE : return OmKeyInfo.class;
-    case VOLUME_TABLE : return OmVolumeArgs.class;
-    case BUCKET_TABLE : return OmBucketInfo.class;
-    default: return null;
-    }
+  Optional<Class> getValueType(String name) {
+    return omdbDefinition.getValueType(name);
   }
 
   /**
@@ -292,5 +296,4 @@ public class OMDBUpdatesHandler extends WriteBatch.Handler {
   public List<OMDBUpdateEvent> getEvents() {
     return omdbUpdateEvents;
   }
-
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.codec.OMDBDefinition;
 import org.apache.hadoop.hdds.utils.db.CodecRegistry;
-import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.WriteBatch;
 import org.slf4j.Logger;
@@ -91,8 +90,8 @@ public class OMDBUpdatesHandler extends WriteBatch.Handler {
       valueBytes, OMDBUpdateEvent.OMDBUpdateAction action)
       throws IOException {
     String tableName = tablesNames.get(cfIndex);
-    Optional<Class> keyType = getKeyType(tableName);
-    Optional<Class> valueType = getValueType(tableName);
+    Optional<Class> keyType = omdbDefinition.getKeyType(tableName);
+    Optional<Class> valueType = omdbDefinition.getValueType(tableName);
     if (keyType.isPresent() && valueType.isPresent()) {
       OMDBUpdateEvent.OMUpdateEventBuilder builder =
           new OMDBUpdateEvent.OMUpdateEventBuilder<>();
@@ -267,26 +266,6 @@ public class OMDBUpdatesHandler extends WriteBatch.Handler {
      * There are no use cases yet for this method in Recon. These will be
      * implemented as and when need arises.
      */
-  }
-
-  /**
-   * Return Key type class for the given table.
-   *
-   * @return keyType class.
-   */
-  @VisibleForTesting
-  Optional<Class> getKeyType(String name) {
-    return omdbDefinition.getKeyType(name);
-  }
-
-  /**
-   * Return Value type class for a given table.
-   * @param name table name
-   * @return Value type based on table name.
-   */
-  @VisibleForTesting
-  Optional<Class> getValueType(String name) {
-    return omdbDefinition.getValueType(name);
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/TableCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/TableCountTask.java
@@ -49,7 +49,6 @@ public class TableCountTask implements ReconOmTask {
 
   private GlobalStatsDao globalStatsDao;
   private Configuration sqlConfiguration;
-  private HashMap<String, Long> objectCountMap;
   private ReconOMMetadataManager reconOMMetadataManager;
 
   @Inject
@@ -116,7 +115,7 @@ public class TableCountTask implements ReconOmTask {
   public Pair<String, Boolean> process(OMUpdateEventBatch events) {
     Iterator<OMDBUpdateEvent> eventIterator = events.getIterator();
 
-    initializeCountMap();
+    HashMap<String, Long> objectCountMap = initializeCountMap();
 
     while (eventIterator.hasNext()) {
       OMDBUpdateEvent<String, Object> omdbUpdateEvent = eventIterator.next();
@@ -157,13 +156,14 @@ public class TableCountTask implements ReconOmTask {
     return new ImmutablePair<>(getTaskName(), true);
   }
 
-  private void initializeCountMap() {
+  private HashMap<String, Long> initializeCountMap() {
     Collection<String> tables = getTaskTables();
-    objectCountMap = new HashMap<>(tables.size());
+    HashMap<String, Long> objectCountMap = new HashMap<>(tables.size());
     for (String tableName: tables) {
       String key = getRowKeyFromTable(tableName);
       objectCountMap.put(key, getCountForKey(key));
     }
+    return objectCountMap;
   }
 
   public static String getRowKeyFromTable(String tableName) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/TableCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/TableCountTask.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.tasks;
+
+import com.google.inject.Inject;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.recon.ReconUtils;
+import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
+import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
+import org.hadoop.ozone.recon.schema.tables.pojos.GlobalStats;
+import org.jooq.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map.Entry;
+
+/**
+ * Class to iterate over the OM DB and store the total counts of volumes,
+ * buckets, keys, open keys, deleted keys, etc.
+ */
+public class TableCountTask implements ReconOmTask {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TableCountTask.class);
+
+  private GlobalStatsDao globalStatsDao;
+  private Configuration sqlConfiguration;
+  private HashMap<String, Long> objectCountMap;
+  private ReconOMMetadataManager reconOMMetadataManager;
+
+  @Inject
+  public TableCountTask(GlobalStatsDao globalStatsDao,
+                        Configuration sqlConfiguration,
+                        ReconOMMetadataManager reconOMMetadataManager) {
+    this.globalStatsDao = globalStatsDao;
+    this.sqlConfiguration = sqlConfiguration;
+    this.reconOMMetadataManager = reconOMMetadataManager;
+  }
+
+  /**
+   * Iterate the rows of each table in OM snapshot DB and calculate the
+   * counts for each table.
+   *
+   * @param omMetadataManager OM Metadata instance.
+   * @return Pair
+   */
+  @Override
+  public Pair<String, Boolean> reprocess(OMMetadataManager omMetadataManager) {
+    for (String tableName : getTaskTables()) {
+      Table table = omMetadataManager.getTable(tableName);
+      try (TableIterator keyIter = table.iterator()) {
+        long count = getCount(keyIter);
+        ReconUtils.upsertGlobalStatsTable(sqlConfiguration, globalStatsDao,
+            getRowKeyFromTable(tableName),
+            count);
+      } catch (IOException ioEx) {
+        LOG.error("Unable to populate Table Count in Recon DB.", ioEx);
+        return new ImmutablePair<>(getTaskName(), false);
+      }
+    }
+    LOG.info("Completed a 'reprocess' run of TableCountTask.");
+    return new ImmutablePair<>(getTaskName(), true);
+  }
+
+  private long getCount(Iterator iterator) {
+    long count = 0L;
+    while (iterator.hasNext()) {
+      count++;
+      iterator.next();
+    }
+    return count;
+  }
+
+  @Override
+  public String getTaskName() {
+    return "TableCountTask";
+  }
+
+  @Override
+  public Collection<String> getTaskTables() {
+    return new ArrayList<>(reconOMMetadataManager.listTableNames());
+  }
+
+  /**
+   * Read the update events and update the count of respective object
+   * (volume, bucket, key etc.) based on the action (put or delete).
+   *
+   * @param events Update events - PUT, DELETE and UPDATE.
+   * @return Pair
+   */
+  @Override
+  public Pair<String, Boolean> process(OMUpdateEventBatch events) {
+    Iterator<OMDBUpdateEvent> eventIterator = events.getIterator();
+
+    initializeCountMap();
+
+    while (eventIterator.hasNext()) {
+      OMDBUpdateEvent<String, Object> omdbUpdateEvent = eventIterator.next();
+      String rowKey = getRowKeyFromTable(omdbUpdateEvent.getTable());
+      try{
+        switch (omdbUpdateEvent.getAction()) {
+        case PUT:
+          objectCountMap.computeIfPresent(rowKey, (k, count) -> count + 1L);
+          break;
+
+        case DELETE:
+          // if value is null, it means that the volume / bucket / key
+          // is already deleted and does not exist in the OM database anymore.
+          if (omdbUpdateEvent.getValue() != null) {
+            String key = getRowKeyFromTable(omdbUpdateEvent.getTable());
+            objectCountMap.computeIfPresent(key,
+                (k, count) -> count > 0 ? count - 1L : 0L);
+          }
+          break;
+
+        default: LOG.trace("Skipping DB update event : Table: {}, Action: {}",
+            omdbUpdateEvent.getTable(), omdbUpdateEvent.getAction());
+        }
+      } catch (Exception e) {
+        LOG.error("Unexpected exception while processing the table {}, " +
+                "Action: {}", omdbUpdateEvent.getTable(),
+            omdbUpdateEvent.getAction(), e);
+        return new ImmutablePair<>(getTaskName(), false);
+      }
+    }
+    for (Entry<String, Long> entry: objectCountMap.entrySet()) {
+      ReconUtils.upsertGlobalStatsTable(sqlConfiguration, globalStatsDao,
+          entry.getKey(),
+          entry.getValue());
+    }
+
+    LOG.info("Completed a 'process' run of TableCountTask.");
+    return new ImmutablePair<>(getTaskName(), true);
+  }
+
+  private void initializeCountMap() {
+    Collection<String> tables = getTaskTables();
+    objectCountMap = new HashMap<>(tables.size());
+    for (String tableName: tables) {
+      String key = getRowKeyFromTable(tableName);
+      objectCountMap.put(key, getCountForKey(key));
+    }
+  }
+
+  public static String getRowKeyFromTable(String tableName) {
+    return tableName + "Count";
+  }
+
+  /**
+   * Get the count stored for the given key from Global Stats table.
+   * Return 0 if record not found.
+   *
+   * @param key Key in the global stats table
+   * @return count
+   */
+  private long getCountForKey(String key) {
+    GlobalStats record = globalStatsDao.fetchOneByKey(key);
+
+    return (record == null) ? 0L : record.getValue();
+  }
+}

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/overview/overview.tsx
@@ -180,7 +180,7 @@ export class Overview extends React.Component<Record<string, object>, IOverviewS
             <OverviewCard loading={loading} title='Buckets' data={buckets.toString()} icon='folder-open'/>
           </Col>
           <Col xs={24} sm={18} md={12} lg={12} xl={6}>
-            <OverviewCard loading={loading} title='Keys (Estimated)' data={keys.toString()} icon='file-text'/>
+            <OverviewCard loading={loading} title='Keys' data={keys.toString()} icon='file-text'/>
           </Col>
         </Row>
       </div>

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -59,10 +59,15 @@ import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.tasks.FileSizeCountTask;
+import org.apache.hadoop.ozone.recon.tasks.TableCountTask;
 import org.apache.hadoop.test.LambdaTestUtils;
+import org.hadoop.ozone.recon.schema.StatsSchemaDefinition;
 import org.hadoop.ozone.recon.schema.UtilizationSchemaDefinition;
 import org.hadoop.ozone.recon.schema.tables.daos.FileCountBySizeDao;
+import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
 import org.hadoop.ozone.recon.schema.tables.pojos.FileCountBySize;
+import org.jooq.Configuration;
+import org.jooq.DSLContext;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -74,6 +79,7 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getRandom
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDataToOm;
+import static org.hadoop.ozone.recon.schema.tables.GlobalStatsTable.GLOBAL_STATS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
@@ -97,7 +103,9 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
   private UtilizationEndpoint utilizationEndpoint;
   private ReconOMMetadataManager reconOMMetadataManager;
   private FileSizeCountTask fileSizeCountTask;
+  private TableCountTask tableCountTask;
   private ReconStorageContainerManagerFacade reconScm;
+  private StatsSchemaDefinition statsSchemaDefinition;
   private boolean isSetupDone = false;
   private String pipelineId;
   private DatanodeDetails datanodeDetails;
@@ -166,17 +174,23 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
 
     nodeEndpoint = reconTestInjector.getInstance(NodeEndpoint.class);
     pipelineEndpoint = reconTestInjector.getInstance(PipelineEndpoint.class);
-    clusterStateEndpoint =
-        reconTestInjector.getInstance(ClusterStateEndpoint.class);
     fileCountBySizeDao = getDao(FileCountBySizeDao.class);
+    GlobalStatsDao globalStatsDao = getDao(GlobalStatsDao.class);
     UtilizationSchemaDefinition utilizationSchemaDefinition =
         getSchemaDefinition(UtilizationSchemaDefinition.class);
+    statsSchemaDefinition = getSchemaDefinition(StatsSchemaDefinition.class);
+    Configuration sqlConfiguration =
+        reconTestInjector.getInstance(Configuration.class);
     utilizationEndpoint = new UtilizationEndpoint(
         fileCountBySizeDao, utilizationSchemaDefinition);
     fileSizeCountTask =
         new FileSizeCountTask(fileCountBySizeDao, utilizationSchemaDefinition);
+    tableCountTask = new TableCountTask(
+        globalStatsDao, sqlConfiguration, reconOMMetadataManager);
     reconScm = (ReconStorageContainerManagerFacade)
         reconTestInjector.getInstance(OzoneStorageContainerManager.class);
+    clusterStateEndpoint =
+        new ClusterStateEndpoint(reconScm, globalStatsDao);
   }
 
   @Before
@@ -305,6 +319,10 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
 
     // key = key_three
     writeDataToOm(reconOMMetadataManager, "key_three");
+
+    DSLContext dslContext = statsSchemaDefinition.getDSLContext();
+    // Truncate global stats table before running each test
+    dslContext.truncate(GLOBAL_STATS);
   }
 
   private void testDatanodeResponse(DatanodeMetadata datanodeMetadata)
@@ -415,9 +433,9 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
         (ClusterStateResponse) response.getEntity();
 
     Assert.assertEquals(1, clusterStateResponse.getPipelines());
-    Assert.assertEquals(2, clusterStateResponse.getVolumes());
-    Assert.assertEquals(2, clusterStateResponse.getBuckets());
-    Assert.assertEquals(3, clusterStateResponse.getKeys());
+    Assert.assertEquals(0, clusterStateResponse.getVolumes());
+    Assert.assertEquals(0, clusterStateResponse.getBuckets());
+    Assert.assertEquals(0, clusterStateResponse.getKeys());
     Assert.assertEquals(2, clusterStateResponse.getTotalDatanodes());
     Assert.assertEquals(2, clusterStateResponse.getHealthyDatanodes());
 
@@ -427,6 +445,16 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
           (ClusterStateResponse) response1.getEntity();
       return (clusterStateResponse1.getContainers() == 1);
     });
+
+    // check volume, bucket and key count after running table count task
+    Pair<String, Boolean> result =
+        tableCountTask.reprocess(reconOMMetadataManager);
+    assertTrue(result.getRight());
+    response = clusterStateEndpoint.getClusterState();
+    clusterStateResponse = (ClusterStateResponse) response.getEntity();
+    Assert.assertEquals(2, clusterStateResponse.getVolumes());
+    Assert.assertEquals(2, clusterStateResponse.getBuckets());
+    Assert.assertEquals(3, clusterStateResponse.getKeys());
   }
 
   @Test

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -61,7 +61,6 @@ import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImp
 import org.apache.hadoop.ozone.recon.tasks.FileSizeCountTask;
 import org.apache.hadoop.ozone.recon.tasks.TableCountTask;
 import org.apache.hadoop.test.LambdaTestUtils;
-import org.hadoop.ozone.recon.schema.StatsSchemaDefinition;
 import org.hadoop.ozone.recon.schema.UtilizationSchemaDefinition;
 import org.hadoop.ozone.recon.schema.tables.daos.FileCountBySizeDao;
 import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
@@ -105,7 +104,6 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
   private FileSizeCountTask fileSizeCountTask;
   private TableCountTask tableCountTask;
   private ReconStorageContainerManagerFacade reconScm;
-  private StatsSchemaDefinition statsSchemaDefinition;
   private boolean isSetupDone = false;
   private String pipelineId;
   private DatanodeDetails datanodeDetails;
@@ -115,6 +113,7 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
   private DatanodeDetailsProto datanodeDetailsProto;
   private Pipeline pipeline;
   private FileCountBySizeDao fileCountBySizeDao;
+  private DSLContext dslContext;
   private final String host1 = "host1.datanode";
   private final String host2 = "host2.datanode";
   private final String ip1 = "1.1.1.1";
@@ -178,7 +177,6 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     GlobalStatsDao globalStatsDao = getDao(GlobalStatsDao.class);
     UtilizationSchemaDefinition utilizationSchemaDefinition =
         getSchemaDefinition(UtilizationSchemaDefinition.class);
-    statsSchemaDefinition = getSchemaDefinition(StatsSchemaDefinition.class);
     Configuration sqlConfiguration =
         reconTestInjector.getInstance(Configuration.class);
     utilizationEndpoint = new UtilizationEndpoint(
@@ -191,6 +189,7 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
         reconTestInjector.getInstance(OzoneStorageContainerManager.class);
     clusterStateEndpoint =
         new ClusterStateEndpoint(reconScm, globalStatsDao);
+    dslContext = getDslContext();
   }
 
   @Before
@@ -320,7 +319,6 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
     // key = key_three
     writeDataToOm(reconOMMetadataManager, "key_three");
 
-    DSLContext dslContext = statsSchemaDefinition.getDSLContext();
     // Truncate global stats table before running each test
     dslContext.truncate(GLOBAL_STATS);
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.om.codec.OMDBDefinition;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
@@ -54,6 +55,8 @@ public class TestOMDBUpdatesHandler {
 
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
+
+  private OMDBDefinition omdbDefinition = new OMDBDefinition();
 
   private OzoneConfiguration createNewTestPath() throws IOException {
     OzoneConfiguration configuration = new OzoneConfiguration();
@@ -231,9 +234,9 @@ public class TestOMDBUpdatesHandler {
     OMDBUpdatesHandler omdbUpdatesHandler =
         new OMDBUpdatesHandler(metaMgr);
 
-    assertEquals(String.class, omdbUpdatesHandler.getKeyType(
+    assertEquals(String.class, omdbDefinition.getKeyType(
         metaMgr.getKeyTable().getName()).get());
-    assertEquals(OzoneTokenIdentifier.class, omdbUpdatesHandler.getKeyType(
+    assertEquals(OzoneTokenIdentifier.class, omdbDefinition.getKeyType(
         metaMgr.getDelegationTokenTable().getName()).get());
   }
 
@@ -244,11 +247,11 @@ public class TestOMDBUpdatesHandler {
     OMDBUpdatesHandler omdbUpdatesHandler =
         new OMDBUpdatesHandler(metaMgr);
 
-    assertEquals(OmKeyInfo.class, omdbUpdatesHandler.getValueType(
+    assertEquals(OmKeyInfo.class, omdbDefinition.getValueType(
         metaMgr.getKeyTable().getName()).get());
-    assertEquals(OmVolumeArgs.class, omdbUpdatesHandler.getValueType(
+    assertEquals(OmVolumeArgs.class, omdbDefinition.getValueType(
         metaMgr.getVolumeTable().getName()).get());
-    assertEquals(OmBucketInfo.class, omdbUpdatesHandler.getValueType(
+    assertEquals(OmBucketInfo.class, omdbDefinition.getValueType(
         metaMgr.getBucketTable().getName()).get());
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestTableCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestTableCountTask.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.tasks;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.utils.db.TypedTable;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.recon.persistence.AbstractReconSqlDBTest;
+import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
+import org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMUpdateEventBuilder;
+import org.hadoop.ozone.recon.schema.StatsSchemaDefinition;
+
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_TABLE;
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.OPEN_KEY_TABLE;
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
+import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
+import org.jooq.DSLContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
+import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
+import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.DELETE;
+import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.PUT;
+import static org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMDBUpdateAction.UPDATE;
+import static org.hadoop.ozone.recon.schema.tables.GlobalStatsTable.GLOBAL_STATS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit test for Object Count Task.
+ */
+public class TestTableCountTask extends AbstractReconSqlDBTest {
+
+  private GlobalStatsDao globalStatsDao;
+  private TableCountTask tableCountTask;
+  private DSLContext dslContext;
+  private boolean isSetupDone = false;
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private void initializeInjector() throws IOException {
+    ReconOMMetadataManager omMetadataManager = getTestReconOmMetadataManager(
+        initializeNewOmMetadataManager(temporaryFolder.newFolder()),
+        temporaryFolder.newFolder());
+    globalStatsDao = getDao(GlobalStatsDao.class);
+    StatsSchemaDefinition statsSchemaDefinition =
+        getSchemaDefinition(StatsSchemaDefinition.class);
+    tableCountTask = new TableCountTask(globalStatsDao, getConfiguration(),
+            omMetadataManager);
+    dslContext = statsSchemaDefinition.getDSLContext();
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    // The following setup runs only once
+    if (!isSetupDone) {
+      initializeInjector();
+      isSetupDone = true;
+    }
+    // Truncate table before running each test
+    dslContext.truncate(GLOBAL_STATS);
+  }
+
+  @Test
+  public void testReprocess() {
+    OMMetadataManager omMetadataManager = mock(OmMetadataManagerImpl.class);
+    // Mock 5 rows in each table and test the count
+    for (String tableName: tableCountTask.getTaskTables()) {
+      TypedTable<String, Object> table = mock(TypedTable.class);
+      TypedTable.TypedTableIterator mockIter = mock(TypedTable
+          .TypedTableIterator.class);
+      when(table.iterator()).thenReturn(mockIter);
+      when(omMetadataManager.getTable(tableName)).thenReturn(table);
+      when(mockIter.hasNext())
+          .thenReturn(true)
+          .thenReturn(true)
+          .thenReturn(true)
+          .thenReturn(true)
+          .thenReturn(true)
+          .thenReturn(false);
+    }
+
+    Pair<String, Boolean> result = tableCountTask.reprocess(omMetadataManager);
+    assertTrue(result.getRight());
+
+    assertEquals(5L, getCountForTable(KEY_TABLE));
+    assertEquals(5L, getCountForTable(VOLUME_TABLE));
+    assertEquals(5L, getCountForTable(BUCKET_TABLE));
+    assertEquals(5L, getCountForTable(OPEN_KEY_TABLE));
+    assertEquals(5L, getCountForTable(DELETED_TABLE));
+  }
+
+  @Test
+  public void testProcess() {
+    ArrayList<OMDBUpdateEvent> events = new ArrayList<>();
+    // Create 5 put, 1 delete and 1 update event for each table
+    for (String tableName: tableCountTask.getTaskTables()) {
+      for (int i=0; i<5; i++) {
+        events.add(getOMUpdateEvent("item" + i, null, tableName, PUT));
+      }
+      // for delete event, if value is set to null, the counter will not be
+      // decremented. This is because the value will be null if item does not
+      // exist in the database and there is no need to delete.
+      events.add(getOMUpdateEvent("item0", mock(OmKeyInfo.class), tableName,
+          DELETE));
+      events.add(getOMUpdateEvent("item1", null, tableName, UPDATE));
+    }
+    OMUpdateEventBatch omUpdateEventBatch = new OMUpdateEventBatch(events);
+    tableCountTask.process(omUpdateEventBatch);
+
+    // Verify 4 items in each table. (5 puts - 1 delete + 0 update)
+    assertEquals(4L, getCountForTable(KEY_TABLE));
+    assertEquals(4L, getCountForTable(VOLUME_TABLE));
+    assertEquals(4L, getCountForTable(BUCKET_TABLE));
+    assertEquals(4L, getCountForTable(OPEN_KEY_TABLE));
+    assertEquals(4L, getCountForTable(DELETED_TABLE));
+
+    // add a new key and simulate delete on non-existing item (value: null)
+    ArrayList<OMDBUpdateEvent> newEvents = new ArrayList<>();
+    for (String tableName: tableCountTask.getTaskTables()) {
+      newEvents.add(getOMUpdateEvent("item5", null, tableName, PUT));
+      // This delete event should be a noop since value is null
+      newEvents.add(getOMUpdateEvent("item0", null, tableName, DELETE));
+    }
+
+    omUpdateEventBatch = new OMUpdateEventBatch(newEvents);
+    tableCountTask.process(omUpdateEventBatch);
+
+    // Verify 5 items in each table. (1 new put + 0 delete)
+    assertEquals(5L, getCountForTable(KEY_TABLE));
+    assertEquals(5L, getCountForTable(VOLUME_TABLE));
+    assertEquals(5L, getCountForTable(BUCKET_TABLE));
+    assertEquals(5L, getCountForTable(OPEN_KEY_TABLE));
+    assertEquals(5L, getCountForTable(DELETED_TABLE));
+  }
+
+  private OMDBUpdateEvent getOMUpdateEvent(String name, Object value,
+                                           String table,
+                           OMDBUpdateEvent.OMDBUpdateAction action) {
+    return new OMUpdateEventBuilder()
+        .setAction(action)
+        .setKey(name)
+        .setValue(value)
+        .setTable(table)
+        .build();
+  }
+
+  private long getCountForTable(String tableName) {
+    String key = TableCountTask.getRowKeyFromTable(tableName);
+    return globalStatsDao.findById(key).getValue();
+  }
+}

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestTableCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestTableCountTask.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.recon.persistence.AbstractReconSqlDBTest;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.tasks.OMDBUpdateEvent.OMUpdateEventBuilder;
-import org.hadoop.ozone.recon.schema.StatsSchemaDefinition;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_TABLE;
@@ -72,11 +71,9 @@ public class TestTableCountTask extends AbstractReconSqlDBTest {
         initializeNewOmMetadataManager(temporaryFolder.newFolder()),
         temporaryFolder.newFolder());
     globalStatsDao = getDao(GlobalStatsDao.class);
-    StatsSchemaDefinition statsSchemaDefinition =
-        getSchemaDefinition(StatsSchemaDefinition.class);
     tableCountTask = new TableCountTask(globalStatsDao, getConfiguration(),
             omMetadataManager);
-    dslContext = statsSchemaDefinition.getDSLContext();
+    dslContext = getDslContext();
   }
 
   @Before


### PR DESCRIPTION
## What changes were proposed in this pull request?

 - Add a new task in Recon to keep track of the count of all the OM DB tables
 - Add / update unit tests
 - Add a new method "getSkipCache" in Table interface to get value from the table by skipping the cache. This is required for Recon, since recon never adds entries to cache of any table.
 - Update ClusterStateEndpoint to get the counts of volume, bucket, and key from global stats table and not rely on "rocksdb.estimate-num-keys"

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4009

## How was this patch tested?

Manually tested in a real cluster and also added unit tests.
