### PR TITLE
HDDS-4093: update RATIS version from 1.0.0 to 1.1.0-85281b2-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>1.0.0</ratis.version>
+    <ratis.version>1.1.0-85281b2-SNAPSHOT</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
     <ratis.thirdparty.version>0.5.0</ratis.thirdparty.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

1.1.0-85281b2-SNAPSHOT is the latest version of Ratis master that supports following two features which are needed by SCM-HA
 
[RATIS-981: Step-down stale leader in case of split-brain](https://issues.apache.org/jira/projects/RATIS/issues/RATIS-981?filter=allissues)
[RATIS-1001: add currentTerm to LeaderInfoProto for supporting SCM-HA.](https://issues.apache.org/jira/projects/RATIS/issues/RATIS-1001?filter=allissues)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4093

## How was this patch tested?

CI
