### PR TITLE
HDDS-3232. Include the byteman scripts in the distribution tar file

### DIFF
--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -122,6 +122,9 @@ run cp  -r "${ROOT}/hadoop-ozone/fault-injection-test/network-tests/src/test/blo
 # Optional documentation, could be missing
 cp -r "${ROOT}/hadoop-hdds/docs/target/classes/docs" ./
 
+#copy byteman helpers
+run cp -r "${ROOT}/dev-support/byteman" "share/ozone/"
+
 #Copy docker compose files
 #compose files are preprocessed: properties (eg. project.version) are replaced first by maven.
 run cp -p -R "${ROOT}/hadoop-ozone/dist/target/compose" .


### PR DESCRIPTION
## What changes were proposed in this pull request?

Suggested by Attila Doroszlai at #656 : include the btm (byteman) script definitions in the tar/distribution.

Scripts can help to debug / support ozone installs but they are hidden in the share directory...

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3232

## How was this patch tested?

I created new docker image based on dist folder (btm scripts were included) and executed tests in K8s environment:

https://elek.github.io/ozone-notes/performance/19_hcfs/

btm scripts are used to get additional insight about HDFS vs Ozone performance.