### PR TITLE
HDDS-4094. Support byte-level write in Freon HadoopFsGenerator

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.RandomStringUtils;
 
 /**
@@ -77,7 +78,8 @@ public class ContentGenerator {
     }
   }
 
-  public byte[] getBuffer() {
+  @VisibleForTesting
+  byte[] getBuffer() {
     return buffer;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
@@ -40,7 +40,7 @@ public class ContentGenerator {
   private int bufferSize;
 
   /**
-   * Number of bytes to write in one call. Should be less than the bufferSize.
+   * Number of bytes to write in one call. Should be no larger than the bufferSize.
    */
   private final int copyBufferSize;
 
@@ -70,9 +70,9 @@ public class ContentGenerator {
           outputStream.write(buffer[i]);
         }
       } else {
-        for (int i = 0; i < nrRemaining; i += copyBufferSize) {
+        for (int i = 0; i < curSize; i += copyBufferSize) {
           outputStream.write(buffer, i,
-              Math.min(copyBufferSize, (int) (nrRemaining - i)));
+              Math.min(copyBufferSize, curSize - i));
         }
       }
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
@@ -40,7 +40,9 @@ public class ContentGenerator {
   private int bufferSize;
 
   /**
-   * Number of bytes to write in one call. Should be no larger than the bufferSize.
+   * Number of bytes to write in one call.
+   * <p>
+   * Should be no larger than the bufferSize.
    */
   private final int copyBufferSize;
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
@@ -57,9 +57,14 @@ public class HadoopFsGenerator extends BaseFreonGenerator
   private int fileSize;
 
   @Option(names = {"--buffer"},
-      description = "Size of buffer used to generated the key content.",
-      defaultValue = "4096")
+      description = "Size of buffer used store the generated key content",
+      defaultValue = "10240")
   private int bufferSize;
+
+  @Option(names = {"--copy-buffer"},
+      description = "Size of bytes written to the output in one operation",
+      defaultValue = "4096")
+  private int copyBufferSize;
 
   private ContentGenerator contentGenerator;
 
@@ -76,7 +81,8 @@ public class HadoopFsGenerator extends BaseFreonGenerator
 
     fileSystem = FileSystem.get(URI.create(rootPath), configuration);
 
-    contentGenerator = new ContentGenerator(fileSize, bufferSize);
+    contentGenerator =
+        new ContentGenerator(fileSize, bufferSize, copyBufferSize);
 
     timer = getMetrics().timer("file-create");
 

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
@@ -53,4 +53,19 @@ public class TestContentGenerator {
     generator.write(output);
     Assert.assertArrayEquals(generator.getBuffer(), output.toByteArray());
   }
+
+  @Test
+  public void writeWithDistinctSizes() throws IOException {
+    ContentGenerator generator = new ContentGenerator(20, 8, 3);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    generator.write(output);
+
+    byte[] expected = new byte[20];
+    byte[] buffer = generator.getBuffer();
+    System.arraycopy(buffer, 0, expected, 0, buffer.length);
+    System.arraycopy(buffer, 0, expected, 8, buffer.length);
+    System.arraycopy(buffer, 0, expected, 16, 4);
+    Assert.assertArrayEquals(expected, output.toByteArray());
+  }
 }

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
@@ -1,0 +1,56 @@
+package org.apache.hadoop.ozone.freon;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for the ContentGenerator class of Freon.
+ */
+public class TestContentGenerator {
+
+  @Test
+  public void writeWrite() throws IOException {
+    ContentGenerator generator = new ContentGenerator(1024, 1024);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    generator.write(output);
+    Assert.assertArrayEquals(generator.getBuffer(), output.toByteArray());
+  }
+
+  @Test
+  public void writeWithByteLevelWrite() throws IOException {
+    ContentGenerator generator = new ContentGenerator(1024, 1024, 1);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    generator.write(output);
+    Assert.assertArrayEquals(generator.getBuffer(), output.toByteArray());
+  }
+
+  @Test
+  public void writeWithSmallBuffer() throws IOException {
+    ContentGenerator generator = new ContentGenerator(1024, 1024, 10);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    generator.write(output);
+    Assert.assertArrayEquals(generator.getBuffer(), output.toByteArray());
+  }
+}

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
@@ -37,6 +37,17 @@ public class TestContentGenerator {
   }
 
   @Test
+  public void writeWithSmallerBuffers() throws IOException {
+    ContentGenerator generator = new ContentGenerator(10000, 1024, 3);
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    generator.write(baos);
+
+    Assert.assertEquals(10000, baos.toByteArray().length);
+  }
+
+  @Test
   public void writeWithByteLevelWrite() throws IOException {
     ContentGenerator generator = new ContentGenerator(1024, 1024, 1);
     ByteArrayOutputStream output = new ByteArrayOutputStream();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Teragen seems to use the byte level write method of `FSDataOutputStream` (`write(byte)` is used instead of `write(byte[], int, int)`).

It seems to be a good idea to extend existing `ContentGenerator` of ozone to support the write in smaller chunks to make it easier to reproduce performance problems.

Note: statistics from `FileSystem` instance:

```
Closing file system instance: 1257412274
   write.call: 100001066
   write.allTime: 215951
   hsync.call: 1
   hsync.allTime: 3
   hflush.call: 0
   hflush.allTime: 0
   close.call: 4
   close.allTime: 62
```

This was a teragen test with 1GB data (and statistics from one container). write method seems to be called multiple times which means smaller write buffer.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4094

## How was this patch tested?

Executed Freon test with or without turning on the new flag: 

https://elek.github.io/ozone-notes/performance/19_hcfs/
