### PR TITLE
Revert HDDS-3989 & HDDS-3960 from 0.6.0.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@
 .classpath
 .project
 .settings
-*.factorypath
 target
 build
 dependency-reduced-pom.xml
@@ -62,6 +61,5 @@ output.xml
 report.html
 
 hadoop-hdds/docs/public
-hadoop-ozone/recon/node_modules
 
 .mvn

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -49,8 +49,6 @@ public class DatanodeDetails extends NodeImpl implements
   private String hostName;
   private List<Port> ports;
   private String certSerialId;
-  private String version;
-  private long setupTime;
 
   /**
    * Constructs DatanodeDetails instance. DatanodeDetails.Builder is used
@@ -61,21 +59,15 @@ public class DatanodeDetails extends NodeImpl implements
    * @param networkLocation DataNode's network location path
    * @param ports Ports used by the DataNode
    * @param certSerialId serial id from SCM issued certificate.
-   * @param version DataNode's version
-   * @param setupTime the setup time of DataNode
    */
-  @SuppressWarnings("parameternumber")
   private DatanodeDetails(UUID uuid, String ipAddress, String hostName,
-      String networkLocation, List<Port> ports, String certSerialId,
-      String version, long setupTime) {
+      String networkLocation, List<Port> ports, String certSerialId) {
     super(hostName, networkLocation, NetConstants.NODE_COST_DEFAULT);
     this.uuid = uuid;
     this.ipAddress = ipAddress;
     this.hostName = hostName;
     this.ports = ports;
     this.certSerialId = certSerialId;
-    this.version = version;
-    this.setupTime = setupTime;
   }
 
   public DatanodeDetails(DatanodeDetails datanodeDetails) {
@@ -87,8 +79,6 @@ public class DatanodeDetails extends NodeImpl implements
     this.ports = datanodeDetails.ports;
     this.setNetworkName(datanodeDetails.getNetworkName());
     this.setParent(datanodeDetails.getParent());
-    this.version = datanodeDetails.version;
-    this.setupTime = datanodeDetails.setupTime;
   }
 
   /**
@@ -217,12 +207,6 @@ public class DatanodeDetails extends NodeImpl implements
     if (datanodeDetailsProto.hasNetworkLocation()) {
       builder.setNetworkLocation(datanodeDetailsProto.getNetworkLocation());
     }
-    if (datanodeDetailsProto.hasVersion()) {
-      builder.setVersion(datanodeDetailsProto.getVersion());
-    }
-    if (datanodeDetailsProto.hasSetupTime()) {
-      builder.setSetupTime(datanodeDetailsProto.getSetupTime());
-    }
     return builder.build();
   }
 
@@ -264,13 +248,6 @@ public class DatanodeDetails extends NodeImpl implements
           .setValue(port.getValue())
           .build());
     }
-
-    if (!Strings.isNullOrEmpty(getVersion())) {
-      builder.setVersion(getVersion());
-    }
-
-    builder.setSetupTime(getSetupTime());
-
     return builder.build();
   }
 
@@ -323,8 +300,6 @@ public class DatanodeDetails extends NodeImpl implements
     private String networkLocation;
     private List<Port> ports;
     private String certSerialId;
-    private String version;
-    private long setupTime;
 
     /**
      * Default private constructor. To create Builder instance use
@@ -414,30 +389,6 @@ public class DatanodeDetails extends NodeImpl implements
     }
 
     /**
-     * Sets the DataNode version.
-     *
-     * @param ver the version of DataNode.
-     *
-     * @return DatanodeDetails.Builder
-     */
-    public Builder setVersion(String ver) {
-      this.version = ver;
-      return this;
-    }
-
-    /**
-     * Sets the DataNode setup time.
-     *
-     * @param time the setup time of DataNode.
-     *
-     * @return DatanodeDetails.Builder
-     */
-    public Builder setSetupTime(long time) {
-      this.setupTime = time;
-      return this;
-    }
-
-    /**
      * Builds and returns DatanodeDetails instance.
      *
      * @return DatanodeDetails
@@ -448,7 +399,7 @@ public class DatanodeDetails extends NodeImpl implements
         networkLocation = NetConstants.DEFAULT_RACK;
       }
       DatanodeDetails dn = new DatanodeDetails(id, ipAddress, hostName,
-          networkLocation, ports, certSerialId, version, setupTime);
+          networkLocation, ports, certSerialId);
       if (networkName != null) {
         dn.setNetworkName(networkName);
       }
@@ -553,41 +504,5 @@ public class DatanodeDetails extends NodeImpl implements
    */
   public void setCertSerialId(String certSerialId) {
     this.certSerialId = certSerialId;
-  }
-
-  /**
-   * Returns the DataNode version.
-   *
-   * @return DataNode version
-   */
-  public String getVersion() {
-    return version;
-  }
-
-  /**
-   * Set DataNode version.
-   *
-   * @param version DataNode version
-   */
-  public void setVersion(String version) {
-    this.version = version;
-  }
-
-  /**
-   * Returns the DataNode setup time.
-   *
-   * @return DataNode setup time
-   */
-  public long getSetupTime() {
-    return setupTime;
-  }
-
-  /**
-   * Set DataNode setup time.
-   *
-   * @param setupTime DataNode setup time
-   */
-  public void setSetupTime(long setupTime) {
-    this.setupTime = setupTime;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -68,8 +68,6 @@ import static org.apache.hadoop.hdds.security.x509.certificate.utils.Certificate
 import static org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest.getEncodedString;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_DATANODE_PLUGINS_KEY;
 import static org.apache.hadoop.util.ExitUtil.terminate;
-
-import org.apache.hadoop.util.Time;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -205,9 +203,6 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
       datanodeDetails = initializeDatanodeDetails();
       datanodeDetails.setHostName(hostname);
       datanodeDetails.setIpAddress(ip);
-      datanodeDetails.setVersion(
-          HddsVersionInfo.HDDS_VERSION_INFO.getVersion());
-      datanodeDetails.setSetupTime(Time.now());
       TracingUtil.initTracing(
           "HddsDatanodeService." + datanodeDetails.getUuidString()
               .substring(0, 8), conf);

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -43,8 +43,6 @@ message DatanodeDetailsProto {
     // network name, can be Ip address or host name, depends
     optional string networkName = 6;
     optional string networkLocation = 7; // Network topology location
-    optional string version = 8;         // Datanode version
-    optional int64 setupTime = 9;
     // TODO(runzhiwang): when uuid is gone, specify 1 as the index of uuid128 and mark as required
     optional UUID uuid128 = 100; // UUID with 128 bits assigned to the Datanode.
 }

--- a/hadoop-hdds/interface-client/src/main/proto/proto.lock
+++ b/hadoop-hdds/interface-client/src/main/proto/proto.lock
@@ -1531,16 +1531,6 @@
                 "type": "string"
               },
               {
-                "id": 8,
-                "name": "version",
-                "type": "string"
-              },
-              {
-                "id": 9,
-                "name": "setupTime",
-                "type": "int64"
-              },
-              {
                 "id": 100,
                 "name": "uuid128",
                 "type": "UUID"

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/NodeEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/NodeEndpoint.java
@@ -121,8 +121,6 @@ public class NodeEndpoint {
           .withPipelines(pipelines)
           .withLeaderCount(leaderCount.get())
           .withUUid(datanode.getUuidString())
-          .withVersion(datanode.getVersion())
-          .withSetupTime(datanode.getSetupTime())
           .build());
     });
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/DatanodeMetadata.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/DatanodeMetadata.java
@@ -55,12 +55,6 @@ public final class DatanodeMetadata {
   @XmlElement(name = "leaderCount")
   private int leaderCount;
 
-  @XmlElement(name = "version")
-  private String version;
-
-  @XmlElement(name = "setupTime")
-  private long setupTime;
-
   private DatanodeMetadata(Builder builder) {
     this.hostname = builder.hostname;
     this.uuid = builder.uuid;
@@ -70,8 +64,6 @@ public final class DatanodeMetadata {
     this.pipelines = builder.pipelines;
     this.containers = builder.containers;
     this.leaderCount = builder.leaderCount;
-    this.version = builder.version;
-    this.setupTime = builder.setupTime;
   }
 
   public String getHostname() {
@@ -106,14 +98,6 @@ public final class DatanodeMetadata {
     return uuid;
   }
 
-  public String getVersion() {
-    return version;
-  }
-
-  public long getSetupTime() {
-    return  setupTime;
-  }
-
   /**
    * Returns new builder class that builds a DatanodeMetadata.
    *
@@ -136,8 +120,6 @@ public final class DatanodeMetadata {
     private List<DatanodePipeline> pipelines;
     private int containers;
     private int leaderCount;
-    private String version;
-    private long setupTime;
 
     public Builder() {
       this.containers = 0;
@@ -182,16 +164,6 @@ public final class DatanodeMetadata {
 
     public Builder withUUid(String uuid) {
       this.uuid = uuid;
-      return this;
-    }
-
-    public Builder withVersion(String version) {
-      this.version = version;
-      return this;
-    }
-
-    public Builder withSetupTime(long setupTime) {
-      this.setupTime = setupTime;
       return this;
     }
 

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/api/db.json
@@ -41,9 +41,7 @@
           }
         ],
         "containers": 80,
-        "leaderCount": 2,
-        "version": "0.6.0-SNAPSHOT",
-        "setupTime": 1574728775759
+        "leaderCount": 2
       },
       {
         "hostname": "localhost2.storage.enterprise.com",
@@ -70,9 +68,7 @@
           }
         ],
         "containers": 8192,
-        "leaderCount": 1,
-        "version": "0.6.0-SNAPSHOT",
-        "setupTime": 1574724805059
+        "leaderCount": 1
       },
       {
         "hostname": "localhost3.storage.enterprise.com",
@@ -105,9 +101,7 @@
           }
         ],
         "containers": 43,
-        "leaderCount": 2,
-        "version": "0.6.0-SNAPSHOT",
-        "setupTime": 1343544679543
+        "leaderCount": 2
       },
       {
         "hostname": "localhost4.storage.enterprise.com",
@@ -121,9 +115,7 @@
         },
         "pipelines": [],
         "containers": 0,
-        "leaderCount": 0,
-        "version": "0.6.0-SNAPSHOT",
-        "setupTime": 1074724802059
+        "leaderCount": 0
       },
       {
         "hostname": "localhost5.storage.enterprise.com",
@@ -150,9 +142,7 @@
           }
         ],
         "containers": 643,
-        "leaderCount": 2,
-        "version": "0.6.0-SNAPSHOT",
-        "setupTime": 1574724816029
+        "leaderCount": 2
       },
       {
         "hostname": "localhost6.storage.enterprise.com",
@@ -179,9 +169,7 @@
           }
         ],
         "containers": 5,
-        "leaderCount": 1,
-        "version": "0.6.0-SNAPSHOT",
-        "setupTime": 1574724802059
+        "leaderCount": 1
       },
       {
         "hostname": "localhost7.storage.enterprise.com",
@@ -214,9 +202,7 @@
           }
         ],
         "containers": 64,
-        "leaderCount": 2,
-        "version": "0.6.0-SNAPSHOT",
-        "setupTime": 1574724676009
+        "leaderCount": 2
       },
       {
         "hostname": "localhost8.storage.enterprise.com",
@@ -243,9 +229,7 @@
           }
         ],
         "containers": 21,
-        "leaderCount": 1,
-        "version": "0.6.0-SNAPSHOT",
-        "setupTime": 1574724276050
+        "leaderCount": 1
       },
       {
         "hostname": "localhost9.storage.enterprise.com",
@@ -272,9 +256,7 @@
           }
         ],
         "containers": 897,
-        "leaderCount": 1,
-        "version": "0.6.0-SNAPSHOT",
-        "setupTime": 1574724573011
+        "leaderCount": 1
       },
       {
         "hostname": "localhost10.storage.enterprise.com",
@@ -307,9 +289,7 @@
           }
         ],
         "containers": 6754,
-        "leaderCount": 2,
-        "version": "0.6.0-SNAPSHOT",
-        "setupTime": 1574723756059
+        "leaderCount": 2
       },
       {
         "hostname": "localhost11.storage.enterprise.com",
@@ -336,9 +316,7 @@
           }
         ],
         "containers": 78,
-        "leaderCount": 2,
-        "version": "0.6.0-SNAPSHOT",
-        "setupTime": 1474724705783
+        "leaderCount": 2
       },
       {
         "hostname": "localhost12.storage.enterprise.com",
@@ -365,9 +343,7 @@
           }
         ],
         "containers": 543,
-        "leaderCount": 1,
-        "version": "0.6.0-SNAPSHOT",
-        "setupTime": 1574724706232
+        "leaderCount": 1
       }
     ]
   },

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/autoReloadPanel/autoReloadPanel.tsx
@@ -42,9 +42,9 @@ class AutoReloadPanel extends React.Component<IAutoReloadPanelProps> {
     const lastUpdatedText = lastUpdated === 0 ? 'NA' :
       (
         <Tooltip
-          placement='bottom' title={moment(lastUpdated).format('ll LTS')}
+          placement='bottom' title={moment(lastUpdated).format('lll')}
         >
-          {moment(lastUpdated).format('LTS')}
+          {moment(lastUpdated).format('LT')}
         </Tooltip>
       );
     return (

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/multiSelect/multiSelect.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/components/multiSelect/multiSelect.tsx
@@ -36,7 +36,6 @@ interface IMultiSelectProps extends ReactSelectProps<IOption> {
   options: IOption[];
   allowSelectAll: boolean;
   allOption?: IOption;
-  maxShowValues?: number;
 }
 
 const defaultProps = {
@@ -49,7 +48,7 @@ const defaultProps = {
 export class MultiSelect extends PureComponent<IMultiSelectProps> {
   static defaultProps = defaultProps;
   render() {
-    const {allowSelectAll, allOption, options, maxShowValues = 5, onChange} = this.props;
+    const {allowSelectAll, allOption, options, onChange} = this.props;
     if (allowSelectAll) {
       const Option = (props: OptionProps<IOption>) => {
         return (
@@ -71,7 +70,7 @@ export class MultiSelect extends PureComponent<IMultiSelectProps> {
         let toBeRendered = children;
         if (currentValues.some(val => val.value === allOption!.value) && children) {
           toBeRendered = allOption!.label;
-        } else if (currentValues.length > maxShowValues) {
+        } else if (currentValues.length >= 5) {
           toBeRendered = `${currentValues.length} selected`;
         }
 

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.less
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.less
@@ -22,18 +22,4 @@
       margin-bottom: 5px;
     }
   }
-
-  .filter-block { 
-    font-size: 14px;
-    font-weight: normal;
-    display: inline-block;
-    margin-left: 20px;
-  }
-  
-  .multi-select-container {
-    padding-left: 5px;
-    margin-right: 5px;
-    display: inline-block;
-    min-width: 200px;
-  }
 }

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -135,7 +135,7 @@ const COLUMNS = [
     isVisible: true,
     sorter: (a: IDatanode, b: IDatanode) => a.lastHeartbeat - b.lastHeartbeat,
     render: (heartbeat: number) => {
-      return heartbeat > 0 ? moment(heartbeat).format('ll LTS') : 'NA';
+      return heartbeat > 0 ? moment(heartbeat).format('lll') : 'NA';
     }
   },
   {
@@ -197,7 +197,7 @@ const COLUMNS = [
     isVisible: false,
     sorter: (a: IDatanode, b: IDatanode) => a.setupTime - b.setupTime,
     render: (uptime: number) => {
-      return uptime > 0 ? moment(uptime).format('ll LTS') : 'NA';
+      return uptime > 0 ? moment(uptime).format('lll') : 'NA';
     }
   }
 ];

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -27,8 +27,6 @@ import {DatanodeStatus, IStorageReport} from 'types/datanode.types';
 import './datanodes.less';
 import {AutoReloadHelper} from 'utils/autoReloadHelper';
 import AutoReloadPanel from 'components/autoReloadPanel/autoReloadPanel';
-import {MultiSelect, IOption} from 'components/multiSelect/multiSelect';
-import {ActionMeta, ValueType} from 'react-select';
 import {showDataFetchError} from 'utils/common';
 
 interface IDatanodeResponse {
@@ -40,8 +38,6 @@ interface IDatanodeResponse {
   containers: number;
   leaderCount: number;
   uuid: string;
-  version: string;
-  setupTime: number;
 }
 
 interface IDatanodesResponse {
@@ -60,8 +56,6 @@ interface IDatanode {
   containers: number;
   leaderCount: number;
   uuid: string;
-  version: string;
-  setupTime: number;
 }
 
 interface IPipeline {
@@ -76,8 +70,6 @@ interface IDatanodesState {
   dataSource: IDatanode[];
   totalCount: number;
   lastUpdated: number;
-  selectedColumns: IOption[];
-  columnOptions: IOption[];
 }
 
 const renderDatanodeStatus = (status: DatanodeStatus) => {
@@ -97,7 +89,6 @@ const COLUMNS = [
     title: 'Status',
     dataIndex: 'state',
     key: 'state',
-    isVisible: true,
     render: (text: DatanodeStatus) => renderDatanodeStatus(text),
     sorter: (a: IDatanode, b: IDatanode) => a.state.localeCompare(b.state)
   },
@@ -105,7 +96,6 @@ const COLUMNS = [
     title: 'Uuid',
     dataIndex: 'uuid',
     key: 'uuid',
-    isVisible: true,
     sorter: (a: IDatanode, b: IDatanode) => a.uuid.localeCompare(b.uuid),
     defaultSortOrder: 'ascend' as const
   },
@@ -113,7 +103,6 @@ const COLUMNS = [
     title: 'Hostname',
     dataIndex: 'hostname',
     key: 'hostname',
-    isVisible: true,
     sorter: (a: IDatanode, b: IDatanode) => a.hostname.localeCompare(b.hostname),
     defaultSortOrder: 'ascend' as const
   },
@@ -121,7 +110,6 @@ const COLUMNS = [
     title: 'Storage Capacity',
     dataIndex: 'storageUsed',
     key: 'storageUsed',
-    isVisible: true,
     sorter: (a: IDatanode, b: IDatanode) => a.storageRemaining - b.storageRemaining,
     render: (text: string, record: IDatanode) => (
       <StorageBar
@@ -132,7 +120,6 @@ const COLUMNS = [
     title: 'Last Heartbeat',
     dataIndex: 'lastHeartbeat',
     key: 'lastHeartbeat',
-    isVisible: true,
     sorter: (a: IDatanode, b: IDatanode) => a.lastHeartbeat - b.lastHeartbeat,
     render: (heartbeat: number) => {
       return heartbeat > 0 ? moment(heartbeat).format('lll') : 'NA';
@@ -142,7 +129,6 @@ const COLUMNS = [
     title: 'Pipeline ID(s)',
     dataIndex: 'pipelines',
     key: 'pipelines',
-    isVisible: true,
     render: (pipelines: IPipeline[], record: IDatanode) => {
       return (
         <div>
@@ -172,45 +158,15 @@ const COLUMNS = [
   </span>,
     dataIndex: 'leaderCount',
     key: 'leaderCount',
-    isVisible: true,
     sorter: (a: IDatanode, b: IDatanode) => a.leaderCount - b.leaderCount
   },
   {
     title: 'Containers',
     dataIndex: 'containers',
     key: 'containers',
-    isVisible: true,
     sorter: (a: IDatanode, b: IDatanode) => a.containers - b.containers
-  },
-  {
-    title: 'Version',
-    dataIndex: 'version',
-    key: 'version',
-    isVisible: false,
-    sorter: (a: IDatanode, b: IDatanode) => a.version.localeCompare(b.version),
-    defaultSortOrder: 'ascend' as const
-  },
-  {
-    title: 'SetupTime',
-    dataIndex: 'setupTime',
-    key: 'setupTime',
-    isVisible: false,
-    sorter: (a: IDatanode, b: IDatanode) => a.setupTime - b.setupTime,
-    render: (uptime: number) => {
-      return uptime > 0 ? moment(uptime).format('lll') : 'NA';
-    }
   }
 ];
-
-const allColumnsOption: IOption = {
-  label: 'Select all',
-  value: '*'
-};
-
-const defaultColumns: IOption[] = COLUMNS.map(column => ({
-  label: column.key,
-  value: column.key
-}));
 
 export class Datanodes extends React.Component<Record<string, object>, IDatanodesState> {
   autoReload: AutoReloadHelper;
@@ -221,19 +177,10 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
       loading: false,
       dataSource: [],
       totalCount: 0,
-      lastUpdated: 0,
-      selectedColumns: [],
-      columnOptions: defaultColumns
+      lastUpdated: 0
     };
     this.autoReload = new AutoReloadHelper(this._loadData);
   }
-
-  _handleColumnChange = (selected: ValueType<IOption>, _action: ActionMeta<IOption>) => {
-    const selectedColumns = (selected as IOption[]);
-    this.setState({
-      selectedColumns
-    });
-  };
 
   _loadData = () => {
     this.setState({
@@ -254,23 +201,14 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
           storageRemaining: datanode.storageReport.remaining,
           pipelines: datanode.pipelines,
           containers: datanode.containers,
-          leaderCount: datanode.leaderCount,
-          version: datanode.version,
-          setupTime: datanode.setupTime
+          leaderCount: datanode.leaderCount
         };
       });
-      const selectedColumns: IOption[] = COLUMNS.filter(column => column.isVisible).map(column => ({
-        label: column.key,
-        value: column.key
-      }));
-
       this.setState({
         loading: false,
         dataSource,
         totalCount,
         lastUpdated: Number(moment())
-      }, () => {
-        this._handleColumnChange(selectedColumns, {action: 'select-option'});
       });
     }).catch(error => {
       this.setState({
@@ -295,7 +233,7 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
   };
 
   render() {
-    const {dataSource, loading, totalCount, lastUpdated, selectedColumns, columnOptions} = this.state;
+    const {dataSource, loading, totalCount, lastUpdated} = this.state;
     const paginationConfig: PaginationConfig = {
       showTotal: (total: number, range) => `${range[0]}-${range[1]} of ${total} datanodes`,
       showSizeChanger: true,
@@ -305,38 +243,10 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
       <div className='datanodes-container'>
         <div className='page-header'>
           Datanodes ({totalCount})
-          <div className='filter-block'>
-            <MultiSelect
-              allowSelectAll
-              isMulti
-              maxShowValues={3}
-              className='multi-select-container'
-              options={columnOptions}
-              closeMenuOnSelect={false}
-              hideSelectedOptions={false}
-              value={selectedColumns}
-              allOption={allColumnsOption}
-              onChange={this._handleColumnChange}
-            /> Columns
-          </div>
-          <AutoReloadPanel
-            isLoading={loading}
-            lastUpdated={lastUpdated}
-            togglePolling={this.autoReload.handleAutoReloadToggle}
-            onReload={this._loadData}
-          />
+          <AutoReloadPanel isLoading={loading} lastUpdated={lastUpdated} togglePolling={this.autoReload.handleAutoReloadToggle} onReload={this._loadData}/>
         </div>
-
         <div className='content-div'>
-          <Table
-            dataSource={dataSource}
-            columns={COLUMNS.filter(column =>
-              selectedColumns.some(e => e.value === column.key)
-            )}
-            loading={loading}
-            pagination={paginationConfig}
-            rowKey='hostname'
-          />
+          <Table dataSource={dataSource} columns={COLUMNS} loading={loading} pagination={paginationConfig} rowKey='hostname'/>
         </div>
       </div>
     );

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/pipelines/pipelines.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/pipelines/pipelines.tsx
@@ -114,7 +114,7 @@ const COLUMNS = [
     dataIndex: 'lastLeaderElection',
     key: 'lastLeaderElection',
     render: (lastLeaderElection: number) => lastLeaderElection > 0 ?
-      moment(lastLeaderElection).format('ll LTS') : 'NA',
+      moment(lastLeaderElection).format('lll') : 'NA',
     sorter: (a: IPipelineResponse, b: IPipelineResponse) => a.lastLeaderElection - b.lastLeaderElection
   },
   {


### PR DESCRIPTION
Following up on my comment in https://github.com/apache/hadoop-ozone/pull/1289/files#r468065882. Since the patches added a proto change which we want to be handled differently, I want to revert the changes from GA. That way, we dont need to live with those extra fields for ever in DatanodeDetails.proto.