### PR TITLE
HDDS-4109. Tests in TestOzoneFileSystem should use the existing MiniOzoneCluster

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -107,7 +107,6 @@ public class TestOzoneFileSystem {
   private int rootItemCount;
   private Trash trash;
 
-  @Test(timeout = 300_000)
   public void testCreateFileShouldCheckExistenceOfDirWithSameName()
       throws Exception {
     /*
@@ -120,7 +119,6 @@ public class TestOzoneFileSystem {
      *
      * Op 3. create file -> /d1/d2/d3 (d3 as a file inside /d1/d2)
      */
-    setupOzoneFileSystem();
 
     Path parent = new Path("/d1/d2/d3/d4/");
     Path file1 = new Path(parent, "key1");
@@ -154,6 +152,9 @@ public class TestOzoneFileSystem {
     } catch (FileAlreadyExistsException fae) {
       // ignore as its expected
     }
+
+    // Cleanup
+    fs.delete(new Path("/d1/"), true);
   }
 
   /**
@@ -161,14 +162,11 @@ public class TestOzoneFileSystem {
    * directories. Has roughly the semantics of Unix @{code mkdir -p}.
    * {@link FileSystem#mkdirs(Path)}
    */
-  @Test(timeout = 300_000)
   public void testMakeDirsWithAnExistingDirectoryPath() throws Exception {
     /*
      * Op 1. create file -> /d1/d2/d3/d4/k1 (d3 is a sub-dir inside /d1/d2)
      * Op 2. create dir -> /d1/d2
      */
-    setupOzoneFileSystem();
-
     Path parent = new Path("/d1/d2/d3/d4/");
     Path file1 = new Path(parent, "key1");
     try (FSDataOutputStream outputStream = fs.create(file1, false)) {
@@ -178,11 +176,11 @@ public class TestOzoneFileSystem {
     Path subdir = new Path("/d1/d2/");
     boolean status = fs.mkdirs(subdir);
     assertTrue("Shouldn't send error if dir exists", status);
+    // Cleanup
+    fs.delete(new Path("/d1"), true);
   }
 
-  @Test
   public void testCreateWithInvalidPaths() throws Exception {
-    setupOzoneFileSystem();
     Path parent = new Path("../../../../../d1/d2/");
     Path file1 = new Path(parent, "key1");
     checkInvalidPath(file1);
@@ -211,6 +209,11 @@ public class TestOzoneFileSystem {
 
     testOzoneFsServiceLoader();
     o3fs = (OzoneFileSystem) fs;
+
+    testCreateFileShouldCheckExistenceOfDirWithSameName();
+    testMakeDirsWithAnExistingDirectoryPath();
+    testCreateWithInvalidPaths();
+    testListStatusWithIntermediateDir();
 
     testRenameToTrashDisabled();
 
@@ -459,9 +462,7 @@ public class TestOzoneFileSystem {
         3, fileStatuses.length);
   }
 
-  @Test
   public void testListStatusWithIntermediateDir() throws Exception {
-    setupOzoneFileSystem();
     String keyName = "object-dir/object-name";
     OmKeyArgs keyArgs = new OmKeyArgs.Builder()
         .setVolumeName(volumeName)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -76,6 +76,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Ozone file system tests that are not covered by contract tests.
+ *
+ * Note: When adding new test(s), please append it in testFileSystem() to
+ * avoid test run time regression.
  */
 @RunWith(Parameterized.class)
 public class TestOzoneFileSystem {


### PR DESCRIPTION
## What changes were proposed in this pull request?

4 new tests have been added since HDDS-2833 and are not sharing that MiniOzoneCluster.

I am able to cut down the run time of TestOzoneFileSystem from 3m18s to 1m2s on my Mac. It would only save more run time on GitHub Workflow.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4109

## How was this patch tested?

No new tests needed.