### PR TITLE
HDDS-4108. ozone debug ldb scan without arguments results in core dump

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -53,7 +53,8 @@ import picocli.CommandLine;
 public class DBScanner implements Callable<Void>, SubcommandWithParent {
 
   @CommandLine.Option(names = {"--column_family"},
-            description = "Table name")
+      required = true,
+      description = "Table name")
   private String tableName;
 
   @CommandLine.Option(names = {"--with-keys"},

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/RDBParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/RDBParser.java
@@ -41,8 +41,9 @@ public class RDBParser implements Callable<Void>, SubcommandWithParent {
   private CommandSpec spec;
 
   @CommandLine.Option(names = {"--db"},
-            description = "Database File Path")
-    private  String dbPath;
+      required = true,
+      description = "Database File Path")
+  private String dbPath;
 
   public String getDbPath() {
     return dbPath;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make `--db` mandatory for `ozone debug ldb` command to avoid segmentation fault in RocksDB call.

Also make `--column_family` mandatory for its `scan` subcommand, which does not work without it.

https://issues.apache.org/jira/browse/HDDS-4108

## How was this patch tested?

Tested in `ozone` compose environment.

```
$ cd hadoop-ozone/dist/target/ozone-0.6.0-SNAPSHOT/compose/ozone
$ OZONE_REPLICATION_FACTOR=3 ./run.sh -d
$ docker-compose exec scm bash

$ ozone debug ldb scan
Missing required option '--db=<dbPath>'
Usage: ozone debug ldb --db=<dbPath> [COMMAND]
Parse rocksdb file content
      --db=<dbPath>   Database File Path
Commands:
  scan                      Parse specified metadataTable
  list_column_families, ls  list all column families in db.

$ ozone debug ldb --db /data/metadata/scm.db scan
Missing required option '--column_family=<tableName>'
Usage: ozone debug ldb scan [--with-keys] --column_family=<tableName>
Parse specified metadataTable
      --column_family=<tableName>
                    Table name
      --with-keys   List Key -> Value instead of just Value.
                      Default: false

$ ozone debug ldb --db /data/metadata/scm.db ls
default
validCerts
deletedBlocks
pipelines
revokedCerts
containers

$ ozone debug ldb --db /data/metadata/scm.db scan --column_family pipelines
...
{
  "id": {
    "id": "05517d13-beb3-4d3c-8e8a-0055f7040035"
  },
  "type": "RATIS",
  "factor": "ONE",
  "state": "ALLOCATED",
  ...
```