### PR TITLE
HDDS-4099. No Log4j 2 configuration file found error appears in CLI

### DIFF
--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -66,6 +66,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-ozone-recon</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-jdbc</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

e219aae7c added Recon as a dependency for Ozone Tools.  Recon's Spring dependency initializes Log4J 2 logging.   But Ozone Tools does not have any config file for Log4J 2, since it is only used for audit logging in Ozone servers.

This change just excludes Spring JDBC from Ozone Tools to avoid the error message due to missing config.

https://issues.apache.org/jira/browse/HDDS-4099

## How was this patch tested?

Tested in `ozone` compose environment:

```
$ docker-compose exec -T scm ozone freon ockg -n1 -t1
2020-08-12 10:03:45,020 [main] INFO impl.MetricsConfig: Loaded properties from hadoop-metrics2.properties
2020-08-12 10:03:45,190 [main] INFO impl.MetricsSystemImpl: Scheduled Metric snapshot period at 10 second(s).
2020-08-12 10:03:45,190 [main] INFO impl.MetricsSystemImpl: ozone-freon metrics system started
2020-08-12 10:03:45,355 [main] INFO freon.BaseFreonGenerator: Executing test with prefix unqxdb0xk2
2020-08-12 10:03:45,361 [Thread-3] INFO freon.ProgressBar: Progress: 0.00 % (0 out of 1)
2020-08-12 10:03:46,366 [Thread-3] INFO freon.ProgressBar: Progress: 0.00 % (0 out of 1)
2020-08-12 10:03:46,729 [pool-1-thread-1] WARN impl.MetricsSystemImpl: ozone-freon metrics system already initialized!
2020-08-12 10:03:47,367 [Thread-3] INFO freon.ProgressBar: Progress: 0.00 % (0 out of 1)
2020-08-12 10:03:48,336 [Thread-3] INFO freon.ProgressBar: Progress: 100.00 % (1 out of 1)
2020-08-12 10:03:48,497 [Thread-2] INFO metrics: type=TIMER, name=key-create, count=1, min=1642.1666, max=1642.1666, mean=1642.1666, stddev=0.0, median=1642.1666, p75=1642.1666, p95=1642.1666, p98=1642.1666, p99=1642.1666, p999=1642.1666, mean_rate=0.41119973196356674, m1=0.0, m5=0.0, m15=0.0, rate_unit=events/second, duration_unit=milliseconds
2020-08-12 10:03:48,498 [Thread-2] INFO freon.BaseFreonGenerator: Total execution time (sec): 3
2020-08-12 10:03:48,498 [Thread-2] INFO freon.BaseFreonGenerator: Failures: 0
2020-08-12 10:03:48,499 [Thread-2] INFO freon.BaseFreonGenerator: Successful executions: 1

$ docker-compose exec -T scm ozone sh key put /vol1/bucket1/passwd /etc/passwd

$ docker-compose exec -T scm ozone fs -ls ofs://om/vol1/bucket1/
Found 3 items
drwxrwxrwx   - hadoop hadoop          0 2020-08-12 10:07 ofs://om/vol1/bucket1/j45hhfoj1q
-rw-rw-rw-   3 hadoop hadoop        671 2020-08-12 10:05 ofs://om/vol1/bucket1/passwd
drwxrwxrwx   - hadoop hadoop          0 2020-08-12 10:07 ofs://om/vol1/bucket1/unqxdb0xk2
```

Checked `ozone debug` on Recon for regression:

```
$ docker-compose exec -T recon ozone debug ldb --db /data/metadata/recon-scm.db ls
default
validCerts
deletedBlocks
pipelines
nodes
revokedCerts
containers

$ docker-compose exec -T recon ozone debug ldb --db /data/metadata/recon-scm.db scan --column_family nodes
2020-08-12 10:12:02,406 [main] INFO codec.RepeatedOmKeyInfoCodec: RepeatedOmKeyInfoCodec ignorePipeline = true
2020-08-12 10:12:02,413 [main] INFO codec.OmKeyInfoCodec: OmKeyInfoCodec ignorePipeline = true
2020-08-12 10:12:02,413 [main] INFO codec.OmKeyInfoCodec: OmKeyInfoCodec ignorePipeline = true
{
  "uuid": "65d32e5c-c580-4358-97f5-a423c0a9017c",
  "ipAddress": "172.25.0.3",
  "hostName": "ozone_datanode_2.ozone_default",
  ...

$ docker-compose exec -T recon ozone debug ldb --db /data/metadata/om.snapshot.db_1597227039505 ls
default
deletedTable
userTable
volumeTable
s3SecretTable
transactionInfoTable
openKeyTable
prefixTable
keyTable
dTokenTable
bucketTable
multipartInfoTable

$ docker-compose exec -T recon ozone debug ldb --db /data/metadata/om.snapshot.db_1597227039505 scan --column_family volumeTable
2020-08-12 10:13:57,493 [main] INFO codec.RepeatedOmKeyInfoCodec: RepeatedOmKeyInfoCodec ignorePipeline = true
2020-08-12 10:13:57,502 [main] INFO codec.OmKeyInfoCodec: OmKeyInfoCodec ignorePipeline = true
2020-08-12 10:13:57,502 [main] INFO codec.OmKeyInfoCodec: OmKeyInfoCodec ignorePipeline = true
{
  "adminName": "hadoop",
  "ownerName": "hadoop",
  "volume": "s3v",
  ...
```

Downloaded acceptance test artifacts from https://github.com/adoroszlai/hadoop-ozone/actions/runs/205247856 and verified that the error message no longer appears:

```
$ grep -c 'No Log4j 2 configuration file found' *.xml
ozone-csi.xml:0
ozone-ha.xml:0
ozone-mr.xml:0
ozone-om-ha-s3.xml:0
ozone-topology.xml:0
ozone.xml:0
ozones3-haproxy.xml:0
ozonesecure-mr.xml:0
ozonesecure-om-ha.xml:0
ozonesecure.xml:0
upgrade.xml:0
```