### PR TITLE
HDDS-4107: replace scmID with clusterID for container and volume at Datanode side

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -282,9 +282,8 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
    * datanode.
    */
   private void startRatisForTest() throws IOException {
-    String scmId = "scm-01";
     String clusterId = "clusterId";
-    datanodeStateMachine.getContainer().start(scmId);
+    datanodeStateMachine.getContainer().start(clusterId);
     MutableVolumeSet volumeSet =
         getDatanodeStateMachine().getContainer().getVolumeSet();
 
@@ -292,7 +291,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
 
     for (Map.Entry<String, HddsVolume> entry : volumeMap.entrySet()) {
       HddsVolume hddsVolume = entry.getValue();
-      boolean result = HddsVolumeUtil.checkVolume(hddsVolume, scmId,
+      boolean result = HddsVolumeUtil.checkVolume(hddsVolume,
           clusterId, LOG);
       if (!result) {
         volumeSet.failVolume(hddsVolume.getHddsRootDir().getPath());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -86,7 +86,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
   private final StateContext context;
   private final float containerCloseThreshold;
   private final ProtocolMessageMetrics<ProtocolMessageEnum> protocolMetrics;
-  private String scmID;
+  private String clusterId;
   private ContainerMetrics metrics;
   private final TokenVerifier tokenVerifier;
   private final boolean isBlockTokenEnabled;
@@ -545,12 +545,12 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
   }
 
   @Override
-  public void setScmId(String scmId) {
-    Preconditions.checkNotNull(scmId, "scmId Cannot be null");
-    if (this.scmID == null) {
-      this.scmID = scmId;
+  public void setClusterId(String clusterId) {
+    Preconditions.checkNotNull(clusterId, "clusterId Cannot be null");
+    if (this.clusterId == null) {
+      this.clusterId = clusterId;
       for (Map.Entry<ContainerType, Handler> handlerMap : handlers.entrySet()) {
-        handlerMap.getValue().setScmID(scmID);
+        handlerMap.getValue().setClusterId(this.clusterId);
       }
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Container.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Container.java
@@ -48,7 +48,7 @@ public interface Container<CONTAINERDATA extends ContainerData> extends RwLock {
    * @throws StorageContainerException
    */
   void create(VolumeSet volumeSet, VolumeChoosingPolicy volumeChoosingPolicy,
-              String scmId) throws StorageContainerException;
+              String clusterId) throws StorageContainerException;
 
   /**
    * Deletes the container.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/ContainerDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/ContainerDispatcher.java
@@ -79,8 +79,8 @@ public interface ContainerDispatcher {
   Handler getHandler(ContainerProtos.ContainerType containerType);
 
   /**
-   * If scmId is not set, this will set scmId, otherwise it is a no-op.
-   * @param scmId
+   * If clusterId is not set, this will set clusterId, otherwise it is a no-op.
+   * @param clusterId
    */
-  void setScmId(String scmId);
+  void setClusterId(String clusterId);
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Handler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Handler.java
@@ -48,7 +48,7 @@ public abstract class Handler {
   protected final ConfigurationSource conf;
   protected final ContainerSet containerSet;
   protected final VolumeSet volumeSet;
-  protected String scmID;
+  protected String clusterId;
   protected final ContainerMetrics metrics;
   protected String datanodeId;
   private Consumer<ContainerReplicaProto> icrSender;
@@ -186,8 +186,8 @@ public abstract class Handler {
   public abstract void deleteBlock(Container container, BlockData blockData)
       throws IOException;
 
-  public void setScmID(String scmId) {
-    this.scmID = scmId;
+  public void setClusterId(String clusterId) {
+    this.clusterId = clusterId;
   }
 
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
@@ -93,7 +93,7 @@ public class VersionEndpointTask implements
 
             for (Map.Entry<String, HddsVolume> entry : volumeMap.entrySet()) {
               HddsVolume hddsVolume = entry.getValue();
-              boolean result = HddsVolumeUtil.checkVolume(hddsVolume, scmId,
+              boolean result = HddsVolumeUtil.checkVolume(hddsVolume,
                   clusterId, LOG);
               if (!result) {
                 volumeSet.failVolume(hddsVolume.getHddsRootDir().getPath());
@@ -109,7 +109,7 @@ public class VersionEndpointTask implements
           }
 
           // Start the container services after getting the version information
-          ozoneContainer.start(scmId);
+          ozoneContainer.start(clusterId);
         }
         EndpointStateMachine.EndPointStates nextState =
             rpcEndPoint.getState().getNextState();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/HddsVolumeUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/HddsVolumeUtil.java
@@ -166,16 +166,15 @@ public final class HddsVolumeUtil {
   /**
    * Check Volume is in consistent state or not.
    * @param hddsVolume
-   * @param scmId
    * @param clusterId
    * @param logger
    * @return true - if volume is in consistent state, otherwise false.
    */
-  public static boolean checkVolume(HddsVolume hddsVolume, String scmId, String
+  public static boolean checkVolume(HddsVolume hddsVolume, String
       clusterId, Logger logger) {
     File hddsRoot = hddsVolume.getHddsRootDir();
     String volumeRoot = hddsRoot.getPath();
-    File scmDir = new File(hddsRoot, scmId);
+    File clusterDir = new File(hddsRoot, clusterId);
 
     try {
       hddsVolume.format(clusterId);
@@ -187,25 +186,25 @@ public final class HddsVolumeUtil {
 
     File[] hddsFiles = hddsRoot.listFiles();
 
-    if(hddsFiles == null) {
+    if (hddsFiles == null) {
       // This is the case for IOException, where listFiles returns null.
       // So, we fail the volume.
       return false;
     } else if (hddsFiles.length == 1) {
       // DN started for first time or this is a newly added volume.
-      // So we create scm directory.
-      if (!scmDir.mkdir()) {
-        logger.error("Unable to create scmDir {}", scmDir);
+      // So we create Cluster directory.
+      if (!clusterDir.mkdir()) {
+        logger.error("Unable to create clusterDir {}", clusterDir);
         return false;
       }
       return true;
-    } else if(hddsFiles.length == 2) {
-      // The files should be Version and SCM directory
-      if (scmDir.exists()) {
+    } else if (hddsFiles.length == 2) {
+      // The files should be Version and Cluster directory
+      if (clusterDir.exists()) {
         return true;
       } else {
-        logger.error("Volume {} is in Inconsistent state, expected scm " +
-                "directory {} does not exist", volumeRoot, scmDir
+        logger.error("Volume {} is in Inconsistent state, expected cluster " +
+                "directory {} does not exist", volumeRoot, clusterDir
             .getAbsolutePath());
         return false;
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -52,14 +52,14 @@ import org.slf4j.LoggerFactory;
  * <p>
  * The disk layout per volume is as follows:
  * <p>../hdds/VERSION
- * <p>{@literal ../hdds/<<scmUuid>>/current/<<containerDir>>/<<containerID
+ * <p>{@literal ../hdds/<<clusterID>>/current/<<containerDir>>/<<containerID
  * >>/metadata}
- * <p>{@literal ../hdds/<<scmUuid>>/current/<<containerDir>>/<<containerID
+ * <p>{@literal ../hdds/<<clusterID>>/current/<<containerDir>>/<<containerID
  * >>/<<dataDir>>}
  * <p>
  * Each hdds volume has its own VERSION file. The hdds volume will have one
- * scmUuid directory for each SCM it is a part of (currently only one SCM is
- * supported).
+ * clusterID directory for each Cluster it is a part of (currently only one
+ * Cluster is supported).
  *
  * During DN startup, if the VERSION file exists, we verify that the
  * clusterID in the version file matches the clusterID from SCM.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -96,11 +96,11 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
 
   @Override
   public void create(VolumeSet volumeSet, VolumeChoosingPolicy
-      volumeChoosingPolicy, String scmId) throws StorageContainerException {
+      volumeChoosingPolicy, String clusterId) throws StorageContainerException {
     Preconditions.checkNotNull(volumeChoosingPolicy, "VolumeChoosingPolicy " +
         "cannot be null");
     Preconditions.checkNotNull(volumeSet, "VolumeSet cannot be null");
-    Preconditions.checkNotNull(scmId, "scmId cannot be null");
+    Preconditions.checkNotNull(clusterId, "clusterId cannot be null");
 
     File containerMetaDataPath = null;
     //acquiring volumeset read lock
@@ -114,11 +114,11 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
       long containerID = containerData.getContainerID();
 
       containerMetaDataPath = KeyValueContainerLocationUtil
-          .getContainerMetaDataPath(hddsVolumeDir, scmId, containerID);
+          .getContainerMetaDataPath(hddsVolumeDir, clusterId, containerID);
       containerData.setMetadataPath(containerMetaDataPath.getPath());
 
       File chunksPath = KeyValueContainerLocationUtil.getChunksLocationPath(
-          hddsVolumeDir, scmId, containerID);
+          hddsVolumeDir, clusterId, containerID);
 
       // Check if it is new Container.
       ContainerUtils.verifyIsNewContainer(containerMetaDataPath);
@@ -164,23 +164,23 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
   }
 
   /**
-   * Set all of the path realted container data fields based on the name
+   * Set all of the path related container data fields based on the name
    * conventions.
    *
-   * @param scmId
+   * @param clusterId
    * @param containerVolume
    * @param hddsVolumeDir
    */
-  public void populatePathFields(String scmId,
+  public void populatePathFields(String clusterId,
       HddsVolume containerVolume, String hddsVolumeDir) {
 
     long containerId = containerData.getContainerID();
 
     File containerMetaDataPath = KeyValueContainerLocationUtil
-        .getContainerMetaDataPath(hddsVolumeDir, scmId, containerId);
+        .getContainerMetaDataPath(hddsVolumeDir, clusterId, containerId);
 
     File chunksPath = KeyValueContainerLocationUtil.getChunksLocationPath(
-        hddsVolumeDir, scmId, containerId);
+        hddsVolumeDir, clusterId, containerId);
     File dbFile = KeyValueContainerLocationUtil.getContainerDBFile(
         containerMetaDataPath, containerId);
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -247,7 +247,7 @@ public class KeyValueHandler extends Handler {
     boolean created = false;
     try (AutoCloseableLock l = containerCreationLock.acquire()) {
       if (containerSet.getContainer(containerID) == null) {
-        newContainer.create(volumeSet, volumeChoosingPolicy, scmID);
+        newContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
         created = containerSet.addContainer(newContainer);
       } else {
         // The create container request for an already existing container can
@@ -276,7 +276,7 @@ public class KeyValueHandler extends Handler {
       HddsVolume containerVolume = volumeChoosingPolicy.chooseVolume(volumeSet
           .getVolumesList(), container.getContainerData().getMaxSize());
       String hddsVolumeDir = containerVolume.getHddsRootDir().toString();
-      container.populatePathFields(scmID, containerVolume, hddsVolumeDir);
+      container.populatePathFields(clusterId, containerVolume, hddsVolumeDir);
     } finally {
       volumeSet.readUnlock();
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerLocationUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerLocationUtil.java
@@ -36,16 +36,16 @@ public final class KeyValueContainerLocationUtil {
    * Returns Container Metadata Location.
    * @param hddsVolumeDir base dir of the hdds volume where scm directories
    *                      are stored
-   * @param scmId
+   * @param clusterId
    * @param containerId
    * @return containerMetadata Path to container metadata location where
    * .container file will be stored.
    */
   public static File getContainerMetaDataPath(String hddsVolumeDir,
-                                              String scmId,
+                                              String clusterId,
                                               long containerId) {
     String containerMetaDataPath =
-        getBaseContainerLocation(hddsVolumeDir, scmId,
+        getBaseContainerLocation(hddsVolumeDir, clusterId,
             containerId);
     containerMetaDataPath = containerMetaDataPath + File.separator +
         OzoneConsts.CONTAINER_META_PATH;
@@ -56,35 +56,35 @@ public final class KeyValueContainerLocationUtil {
   /**
    * Returns Container Chunks Location.
    * @param baseDir
-   * @param scmId
+   * @param clusterId
    * @param containerId
    * @return chunksPath
    */
-  public static File getChunksLocationPath(String baseDir, String scmId,
+  public static File getChunksLocationPath(String baseDir, String clusterId,
                                            long containerId) {
-    String chunksPath = getBaseContainerLocation(baseDir, scmId, containerId)
-        + File.separator + OzoneConsts.STORAGE_DIR_CHUNKS;
+    String chunksPath = getBaseContainerLocation(baseDir, clusterId,
+        containerId) + File.separator + OzoneConsts.STORAGE_DIR_CHUNKS;
     return new File(chunksPath);
   }
 
   /**
    * Returns base directory for specified container.
    * @param hddsVolumeDir
-   * @param scmId
+   * @param clusterId
    * @param containerId
    * @return base directory for container.
    */
   private static String getBaseContainerLocation(String hddsVolumeDir,
-                                                 String scmId,
+                                                 String clusterId,
                                                  long containerId) {
     Preconditions.checkNotNull(hddsVolumeDir, "Base Directory cannot be null");
-    Preconditions.checkNotNull(scmId, "scmUuid cannot be null");
+    Preconditions.checkNotNull(clusterId, "clusterId cannot be null");
     Preconditions.checkState(containerId >= 0,
         "Container Id cannot be negative.");
 
     String containerSubDirectory = getContainerSubDirectory(containerId);
 
-    String containerMetaDataPath = hddsVolumeDir  + File.separator + scmId +
+    String containerMetaDataPath = hddsVolumeDir  + File.separator + clusterId +
         File.separator + Storage.STORAGE_DIR_CURRENT + File.separator +
         containerSubDirectory + File.separator + containerId;
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -241,13 +241,13 @@ public class OzoneContainer {
    *
    * @throws IOException
    */
-  public void start(String scmId) throws IOException {
+  public void start(String clusterId) throws IOException {
     LOG.info("Attempting to start container services.");
     startContainerScrub();
     writeChannel.start();
     readChannel.start();
     hddsDispatcher.init();
-    hddsDispatcher.setScmId(scmId);
+    hddsDispatcher.setClusterId(clusterId);
     blockDeletingService.start();
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ScmTestMock.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ScmTestMock.java
@@ -338,18 +338,18 @@ public class ScmTestMock implements StorageContainerDatanodeProtocol {
   }
 
   /**
-   * Set scmId.
+   * Set clusterId.
    * @param id
    */
-  public void setScmId(String id) {
-    this.scmId = id;
+  public void setClusterId(String id) {
+    this.clusterId = id;
   }
 
   /**
-   * Set scmId.
-   * @return scmId
+   * Get clusterId.
+   * @return clusterId
    */
-  public String getScmId() {
-    return scmId;
+  public String getClusterId() {
+    return clusterId;
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -140,7 +140,7 @@ public class TestBlockDeletingService {
       data.closeContainer();
       KeyValueContainer container = new KeyValueContainer(data, conf);
       container.create(new MutableVolumeSet(scmId, clusterID, conf),
-          new RoundRobinVolumeChoosingPolicy(), scmId);
+          new RoundRobinVolumeChoosingPolicy(), clusterID);
       containerSet.addContainer(container);
       data = (KeyValueContainerData) containerSet.getContainer(
           containerID).getContainerData();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
@@ -92,7 +92,7 @@ import static org.junit.Assert.fail;
 @RunWith(Parameterized.class)
 public class TestContainerPersistence {
   private static final String DATANODE_UUID = UUID.randomUUID().toString();
-  private static final String SCM_ID = UUID.randomUUID().toString();
+  private static final String CLUSTER_ID = UUID.randomUUID().toString();
   private static Logger log =
       LoggerFactory.getLogger(TestContainerPersistence.class);
   private static String hddsPath;
@@ -181,7 +181,7 @@ public class TestContainerPersistence {
     data.addMetadata("VOLUME", "shire");
     data.addMetadata("owner)", "bilbo");
     KeyValueContainer container = new KeyValueContainer(data, conf);
-    container.create(volumeSet, volumeChoosingPolicy, SCM_ID);
+    container.create(volumeSet, volumeChoosingPolicy, CLUSTER_ID);
     commitBytesBefore = container.getContainerData()
         .getVolume().getCommittedBytes();
     cSet.addContainer(container);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -103,7 +103,7 @@ public class TestHddsDispatcher {
     MutableVolumeSet volumeSet = new MutableVolumeSet(dd.getUuidString(), conf);
 
     try {
-      UUID scmId = UUID.randomUUID();
+      UUID clusterId = UUID.randomUUID();
       ContainerSet containerSet = new ContainerSet();
 
       DatanodeStateMachine stateMachine = Mockito.mock(
@@ -117,7 +117,7 @@ public class TestHddsDispatcher {
           dd.getUuidString());
       Container container = new KeyValueContainer(containerData, conf);
       container.create(volumeSet, new RoundRobinVolumeChoosingPolicy(),
-          scmId.toString());
+          clusterId.toString());
       containerSet.addContainer(container);
       ContainerMetrics metrics = ContainerMetrics.create(conf);
       Map<ContainerType, Handler> handlers = Maps.newHashMap();
@@ -129,7 +129,7 @@ public class TestHddsDispatcher {
       }
       HddsDispatcher hddsDispatcher = new HddsDispatcher(
           conf, containerSet, volumeSet, handlers, context, metrics, null);
-      hddsDispatcher.setScmId(scmId.toString());
+      hddsDispatcher.setClusterId(clusterId.toString());
       ContainerCommandResponseProto responseOne = hddsDispatcher
           .dispatch(getWriteChunkRequest(dd.getUuidString(), 1L, 1L), null);
       Assert.assertEquals(ContainerProtos.Result.SUCCESS,
@@ -158,11 +158,11 @@ public class TestHddsDispatcher {
     String testDir =
         GenericTestUtils.getTempPath(TestHddsDispatcher.class.getSimpleName());
     try {
-      UUID scmId = UUID.randomUUID();
+      UUID clusterId = UUID.randomUUID();
       OzoneConfiguration conf = new OzoneConfiguration();
       conf.set(HDDS_DATANODE_DIR_KEY, testDir);
       DatanodeDetails dd = randomDatanodeDetails();
-      HddsDispatcher hddsDispatcher = createDispatcher(dd, scmId, conf);
+      HddsDispatcher hddsDispatcher = createDispatcher(dd, clusterId, conf);
       ContainerCommandRequestProto writeChunkRequest =
           getWriteChunkRequest(dd.getUuidString(), 1L, 1L);
       // send read chunk request and make sure container does not exist
@@ -191,11 +191,11 @@ public class TestHddsDispatcher {
     String testDir =
         GenericTestUtils.getTempPath(TestHddsDispatcher.class.getSimpleName());
     try {
-      UUID scmId = UUID.randomUUID();
+      UUID clusterId = UUID.randomUUID();
       OzoneConfiguration conf = new OzoneConfiguration();
       conf.set(HDDS_DATANODE_DIR_KEY, testDir);
       DatanodeDetails dd = randomDatanodeDetails();
-      HddsDispatcher hddsDispatcher = createDispatcher(dd, scmId, conf);
+      HddsDispatcher hddsDispatcher = createDispatcher(dd, clusterId, conf);
       ContainerCommandRequestProto writeChunkRequest =
           getWriteChunkRequest(dd.getUuidString(), 1L, 1L);
 
@@ -232,11 +232,11 @@ public class TestHddsDispatcher {
     String testDir = GenericTestUtils.getTempPath(
         TestHddsDispatcher.class.getSimpleName());
     try {
-      UUID scmId = UUID.randomUUID();
+      UUID clusterId = UUID.randomUUID();
       OzoneConfiguration conf = new OzoneConfiguration();
       conf.set(HDDS_DATANODE_DIR_KEY, testDir);
       DatanodeDetails dd = randomDatanodeDetails();
-      HddsDispatcher hddsDispatcher = createDispatcher(dd, scmId, conf);
+      HddsDispatcher hddsDispatcher = createDispatcher(dd, clusterId, conf);
       ContainerCommandRequestProto writeChunkRequest = getWriteChunkRequest(
           dd.getUuidString(), 1L, 1L);
 
@@ -266,12 +266,12 @@ public class TestHddsDispatcher {
   /**
    * Creates HddsDispatcher instance with given infos.
    * @param dd datanode detail info.
-   * @param scmId UUID of scm id.
+   * @param clusterId UUID of cluster id.
    * @param conf configuration be used.
    * @return HddsDispatcher HddsDispatcher instance.
    * @throws IOException
    */
-  private HddsDispatcher createDispatcher(DatanodeDetails dd, UUID scmId,
+  private HddsDispatcher createDispatcher(DatanodeDetails dd, UUID clusterId,
       OzoneConfiguration conf) throws IOException {
     ContainerSet containerSet = new ContainerSet();
     VolumeSet volumeSet = new MutableVolumeSet(dd.getUuidString(), conf);
@@ -291,7 +291,7 @@ public class TestHddsDispatcher {
 
     HddsDispatcher hddsDispatcher = new HddsDispatcher(
         conf, containerSet, volumeSet, handlers, context, metrics, null);
-    hddsDispatcher.setScmId(scmId.toString());
+    hddsDispatcher.setClusterId(clusterId.toString());
     return hddsDispatcher;
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -84,7 +84,7 @@ public class TestKeyValueContainer {
   public TemporaryFolder folder = new TemporaryFolder();
 
   private OzoneConfiguration conf;
-  private String scmId = UUID.randomUUID().toString();
+  private String clusterId = UUID.randomUUID().toString();
   private VolumeSet volumeSet;
   private RoundRobinVolumeChoosingPolicy volumeChoosingPolicy;
   private KeyValueContainerData keyValueContainerData;
@@ -131,7 +131,7 @@ public class TestKeyValueContainer {
         datanodeId.toString());
     keyValueContainer = new KeyValueContainer(
         keyValueContainerData, conf);
-    keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+    keyValueContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
     KeyValueBlockIterator blockIterator = keyValueContainer.blockIterator();
     //As no blocks created, hasNext should return false.
     assertFalse(blockIterator.hasNext());
@@ -176,7 +176,7 @@ public class TestKeyValueContainer {
   public void testCreateContainer() throws Exception {
 
     // Create Container.
-    keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+    keyValueContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
 
     keyValueContainerData = keyValueContainer.getContainerData();
 
@@ -198,7 +198,7 @@ public class TestKeyValueContainer {
 
     long containerId = keyValueContainer.getContainerData().getContainerID();
     // Create Container.
-    keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+    keyValueContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
 
 
     keyValueContainerData = keyValueContainer
@@ -253,7 +253,7 @@ public class TestKeyValueContainer {
         .getVolumesList(), 1);
     String hddsVolumeDir = containerVolume.getHddsRootDir().toString();
 
-    container.populatePathFields(scmId, containerVolume, hddsVolumeDir);
+    container.populatePathFields(clusterId, containerVolume, hddsVolumeDir);
     try (FileInputStream fis = new FileInputStream(folderToExport)) {
       container.importContainerData(fis, packer);
     }
@@ -288,8 +288,8 @@ public class TestKeyValueContainer {
   public void testDuplicateContainer() throws Exception {
     try {
       // Create Container.
-      keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
-      keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+      keyValueContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
+      keyValueContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
       fail("testDuplicateContainer failed");
     } catch (StorageContainerException ex) {
       GenericTestUtils.assertExceptionContains("ContainerFile already " +
@@ -305,7 +305,7 @@ public class TestKeyValueContainer {
     Mockito.when(volumeChoosingPolicy.chooseVolume(anyList(), anyLong()))
         .thenThrow(DiskChecker.DiskOutOfSpaceException.class);
     try {
-      keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+      keyValueContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
       fail("testDiskFullExceptionCreateContainer failed");
     } catch (StorageContainerException ex) {
       GenericTestUtils.assertExceptionContains("disk out of space",
@@ -320,7 +320,7 @@ public class TestKeyValueContainer {
         .CLOSED);
     keyValueContainer = new KeyValueContainer(
         keyValueContainerData, conf);
-    keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+    keyValueContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
     keyValueContainer.delete();
 
     String containerMetaDataPath = keyValueContainerData
@@ -338,7 +338,7 @@ public class TestKeyValueContainer {
 
   @Test
   public void testCloseContainer() throws Exception {
-    keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+    keyValueContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
     keyValueContainer.close();
 
     keyValueContainerData = keyValueContainer
@@ -360,7 +360,7 @@ public class TestKeyValueContainer {
 
   @Test
   public void testReportOfUnhealthyContainer() throws Exception {
-    keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+    keyValueContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
     Assert.assertNotNull(keyValueContainer.getContainerReport());
     keyValueContainer.markContainerUnhealthy();
     File containerFile = keyValueContainer.getContainerFile();
@@ -373,7 +373,7 @@ public class TestKeyValueContainer {
 
   @Test
   public void testUpdateContainer() throws IOException {
-    keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+    keyValueContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
     Map<String, String> metadata = new HashMap<>();
     metadata.put(OzoneConsts.VOLUME, OzoneConsts.OZONE);
     metadata.put(OzoneConsts.OWNER, OzoneConsts.OZONE_SIMPLE_HDFS_USER);
@@ -399,7 +399,7 @@ public class TestKeyValueContainer {
       keyValueContainerData.setState(
           ContainerProtos.ContainerDataProto.State.CLOSED);
       keyValueContainer = new KeyValueContainer(keyValueContainerData, conf);
-      keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+      keyValueContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
       Map<String, String> metadata = new HashMap<>();
       metadata.put(OzoneConsts.VOLUME, OzoneConsts.OZONE);
       keyValueContainer.update(metadata, false);
@@ -417,7 +417,7 @@ public class TestKeyValueContainer {
     int initialSize = MetadataStoreBuilder.CACHED_OPTS.size();
 
     // Create Container 1
-    keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+    keyValueContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
     Assert.assertTrue("Rocks DB options should be cached.",
         MetadataStoreBuilder.CACHED_OPTS.containsKey(conf));
 
@@ -430,7 +430,7 @@ public class TestKeyValueContainer {
         datanodeId.toString());
 
     keyValueContainer = new KeyValueContainer(keyValueContainerData, conf);
-    keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+    keyValueContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
 
     assertEquals(initialSize + 1, MetadataStoreBuilder.CACHED_OPTS.size());
     Options cachedOpts = MetadataStoreBuilder.CACHED_OPTS.get(conf);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMarkUnhealthy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerMarkUnhealthy.java
@@ -72,7 +72,7 @@ public class TestKeyValueContainerMarkUnhealthy {
   public ExpectedException thrown = ExpectedException.none();
 
   private OzoneConfiguration conf;
-  private String scmId = UUID.randomUUID().toString();
+  private String clusterId = UUID.randomUUID().toString();
   private VolumeSet volumeSet;
   private RoundRobinVolumeChoosingPolicy volumeChoosingPolicy;
   private KeyValueContainerData keyValueContainerData;
@@ -161,7 +161,7 @@ public class TestKeyValueContainerMarkUnhealthy {
   public void testMarkClosedContainerAsUnhealthy() throws IOException {
     // We need to create the container so the compact-on-close operation
     // does not NPE.
-    keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+    keyValueContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
     keyValueContainer.close();
     keyValueContainer.markContainerUnhealthy();
     assertThat(keyValueContainerData.getState(), is(UNHEALTHY));
@@ -174,7 +174,7 @@ public class TestKeyValueContainerMarkUnhealthy {
   public void testMarkQuasiClosedContainerAsUnhealthy() throws IOException {
     // We need to create the container so the sync-on-quasi-close operation
     // does not NPE.
-    keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+    keyValueContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
     keyValueContainer.quasiClose();
     keyValueContainer.markContainerUnhealthy();
     assertThat(keyValueContainerData.getState(), is(UNHEALTHY));

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
@@ -372,7 +372,7 @@ public class TestKeyValueHandler {
       final KeyValueHandler kvHandler = new KeyValueHandler(conf,
           UUID.randomUUID().toString(), containerSet, volumeSet, metrics,
           c -> icrReceived.incrementAndGet());
-      kvHandler.setScmID(UUID.randomUUID().toString());
+      kvHandler.setClusterId(UUID.randomUUID().toString());
 
       final ContainerCommandRequestProto createContainer =
           ContainerCommandRequestProto.newBuilder()

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestBlockManagerImpl.java
@@ -64,7 +64,7 @@ public class TestBlockManagerImpl {
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
   private OzoneConfiguration config;
-  private String scmId = UUID.randomUUID().toString();
+  private String clusterId = UUID.randomUUID().toString();
   private VolumeSet volumeSet;
   private RoundRobinVolumeChoosingPolicy volumeChoosingPolicy;
   private KeyValueContainerData keyValueContainerData;
@@ -106,7 +106,7 @@ public class TestBlockManagerImpl {
     keyValueContainer = new KeyValueContainer(
         keyValueContainerData, config);
 
-    keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+    keyValueContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
 
     // Creating BlockData
     blockID = new BlockID(1L, 1L);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
@@ -74,7 +74,7 @@ public class TestContainerReader {
 
   private RoundRobinVolumeChoosingPolicy volumeChoosingPolicy;
   private UUID datanodeId;
-  private String scmId = UUID.randomUUID().toString();
+  private String clusterId = UUID.randomUUID().toString();
   private int blockCount = 10;
   private long blockLen = 1024;
 
@@ -105,7 +105,7 @@ public class TestContainerReader {
       KeyValueContainer keyValueContainer =
           new KeyValueContainer(keyValueContainerData,
               conf);
-      keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+      keyValueContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
 
 
       List<Long> blkNames;
@@ -251,7 +251,7 @@ public class TestContainerReader {
       KeyValueContainer keyValueContainer =
           new KeyValueContainer(keyValueContainerData,
               conf);
-      keyValueContainer.create(volumeSets, policy, scmId);
+      keyValueContainer.create(volumeSets, policy, clusterId);
 
       List<Long> blkNames;
       if (i % 2 == 0) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -76,7 +76,7 @@ public class TestOzoneContainer {
   public TemporaryFolder folder = new TemporaryFolder();
 
   private OzoneConfiguration conf;
-  private String scmId = UUID.randomUUID().toString();
+  private String clusterId = UUID.randomUUID().toString();
   private MutableVolumeSet volumeSet;
   private RoundRobinVolumeChoosingPolicy volumeChoosingPolicy;
   private KeyValueContainerData keyValueContainerData;
@@ -138,7 +138,7 @@ public class TestOzoneContainer {
           datanodeDetails.getUuidString());
       keyValueContainer = new KeyValueContainer(
           keyValueContainerData, conf);
-      keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+      keyValueContainer.create(volumeSet, volumeChoosingPolicy, clusterId);
       myVolume = keyValueContainer.getContainerData().getVolume();
 
       freeBytes = addBlocks(keyValueContainer, 2, 3);
@@ -233,7 +233,8 @@ public class TestOzoneContainer {
     // we expect an out of space Exception
     StorageContainerException e = LambdaTestUtils.intercept(
         StorageContainerException.class,
-        () -> keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId)
+        () -> keyValueContainer.create(volumeSet,
+            volumeChoosingPolicy, clusterId)
     );
     if (!DISK_OUT_OF_SPACE.equals(e.getResult())) {
       LOG.info("Unexpected error during container creation", e);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
@@ -180,10 +180,10 @@ public class TestEndPoint {
       // Now rpcEndpoint should remember the version it got from SCM
       Assert.assertNotNull(rpcEndPoint.getVersion());
 
-      // Now change server scmId, so datanode scmId  will be
-      // different from SCM server response scmId
-      String newScmId = UUID.randomUUID().toString();
-      scmServerImpl.setScmId(newScmId);
+      // Now change server clusterId, so datanode clusterId will be
+      // different from SCM server response clusterId
+      String newClusterId = UUID.randomUUID().toString();
+      scmServerImpl.setClusterId(newClusterId);
       rpcEndPoint.setState(EndpointStateMachine.EndPointStates.GETVERSION);
       newState = versionTask.call();
       Assert.assertEquals(EndpointStateMachine.EndPointStates.SHUTDOWN,
@@ -192,10 +192,9 @@ public class TestEndPoint {
           .getFailedVolumesList();
       Assert.assertTrue(volumesList.size() == 1);
       File expectedScmDir = new File(volumesList.get(0).getHddsRootDir(),
-          scmServerImpl.getScmId());
-      Assert.assertTrue(logCapturer.getOutput().contains("expected scm " +
-          "directory " + expectedScmDir.getAbsolutePath() + " does not " +
-          "exist"));
+          scmServerImpl.getClusterId());
+      Assert.assertTrue(logCapturer.getOutput()
+          .contains("Mismatched ClusterIDs"));
       Assert.assertTrue(ozoneContainer.getVolumeSet().getVolumesList().size()
           == 0);
       Assert.assertTrue(ozoneContainer.getVolumeSet().getFailedVolumesList()

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.Collections;
+import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.lang3.RandomUtils;
@@ -259,6 +260,8 @@ public class MiniOzoneChaosCluster extends MiniOzoneHAClusterImpl {
 
     @Override
     public MiniOzoneChaosCluster build() throws IOException {
+      // in case User does not set
+      setClusterId(UUID.randomUUID().toString());
 
       DefaultMetricsSystem.setMiniClusterMode(true);
       initializeConfiguration();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.conf.StorageUnit;
@@ -310,7 +309,6 @@ public interface MiniOzoneCluster {
 
     protected Builder(OzoneConfiguration conf) {
       this.conf = conf;
-      setClusterId(UUID.randomUUID().toString());
     }
 
     /**
@@ -321,9 +319,11 @@ public interface MiniOzoneCluster {
      * @return MiniOzoneCluster.Builder
      */
     public Builder setClusterId(String id) {
-      clusterId = id;
-      path = GenericTestUtils.getTempPath(
-          MiniOzoneClusterImpl.class.getSimpleName() + "-" + clusterId);
+      if (clusterId == null) {
+        clusterId = id;
+        path = GenericTestUtils.getTempPath(
+            MiniOzoneClusterImpl.class.getSimpleName() + "-" + clusterId);
+      }
       return this;
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -516,6 +516,9 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
 
     @Override
     public MiniOzoneCluster build() throws IOException {
+      // in case User does not set
+      setClusterId(UUID.randomUUID().toString());
+
       DefaultMetricsSystem.setMiniClusterMode(true);
       initializeConfiguration();
       StorageContainerManager scm = null;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
 
@@ -265,6 +266,9 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
 
     @Override
     public MiniOzoneCluster build() throws IOException {
+      // in case User does not set
+      setClusterId(UUID.randomUUID().toString());
+
       if (numOfActiveOMs > numOfOMs) {
         throw new IllegalArgumentException("Number of active OMs cannot be " +
             "more than the total number of OMs");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -150,6 +150,7 @@ public abstract class TestOzoneRpcClientAbstract {
       remoteGroupName, READ, ACCESS);
 
   private static String scmId = UUID.randomUUID().toString();
+  private static String clusterId = UUID.randomUUID().toString();
 
   /**
    * Create a MiniOzoneCluster for testing.
@@ -161,6 +162,7 @@ public abstract class TestOzoneRpcClientAbstract {
         .setNumDatanodes(3)
         .setTotalPipelineNumLimit(10)
         .setScmId(scmId)
+        .setClusterId(clusterId)
         .build();
     cluster.waitForClusterToBeReady();
     ozClient = OzoneClientFactory.getRpcClient(conf);
@@ -212,6 +214,10 @@ public abstract class TestOzoneRpcClientAbstract {
 
   public static ObjectStore getStore() {
     return TestOzoneRpcClientAbstract.store;
+  }
+
+  public static String getClusterId() {
+    return clusterId;
   }
 
   public static void setScmId(String scmId) {
@@ -1172,7 +1178,7 @@ public abstract class TestOzoneRpcClientAbstract {
       String containreBaseDir =
           container.getContainerData().getVolume().getHddsRootDir().getPath();
       File chunksLocationPath = KeyValueContainerLocationUtil
-          .getChunksLocationPath(containreBaseDir, scmId, containerID);
+          .getChunksLocationPath(containreBaseDir, clusterId, containerID);
       byte[] corruptData = "corrupted data".getBytes();
       // Corrupt the contents of chunk files
       for (File file : FileUtils.listFiles(chunksLocationPath, null, false)) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
@@ -111,6 +111,7 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(10)
         .setScmId(SCM_ID)
+        .setClusterId(getClusterId())
         .setCertificateClient(certificateClientTest)
         .build();
     String user = UserGroupInformation.getCurrentUser().getShortUserName();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestCSMMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/TestCSMMetrics.java
@@ -225,7 +225,7 @@ public class TestCSMMetrics {
     }
 
     @Override
-    public void setScmId(String scmId) {
+    public void setClusterId(String clusterId) {
 
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestContainerMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestContainerMetrics.java
@@ -124,7 +124,7 @@ public class TestContainerMetrics {
       }
       HddsDispatcher dispatcher = new HddsDispatcher(conf, containerSet,
           volumeSet, handlers, context, metrics, null);
-      dispatcher.setScmId(UUID.randomUUID().toString());
+      dispatcher.setClusterId(UUID.randomUUID().toString());
 
       server = new XceiverServerGrpc(datanodeDetails, conf, dispatcher, null,
           createReplicationService(new ContainerController(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -85,7 +85,7 @@ public class TestOzoneContainer {
       Mockito.when(dsm.getDatanodeDetails()).thenReturn(datanodeDetails);
       Mockito.when(context.getParent()).thenReturn(dsm);
       container = new OzoneContainer(datanodeDetails, conf, context, null);
-      //Set scmId and manually start ozone container.
+      //Set clusterId and manually start ozone container.
       container.start(UUID.randomUUID().toString());
 
       XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf);
@@ -128,10 +128,10 @@ public class TestOzoneContainer {
       container = new OzoneContainer(datanodeDetails, conf,
           context, null);
 
-      String scmId = UUID.randomUUID().toString();
-      container.start(scmId);
+      String clusterId = UUID.randomUUID().toString();
+      container.start(clusterId);
       try {
-        container.start(scmId);
+        container.start(clusterId);
       } catch (Exception e) {
         Assert.fail();
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainerWithTLS.java
@@ -147,7 +147,7 @@ public class TestOzoneContainerWithTLS {
           OzoneConfigKeys.DFS_CONTAINER_IPC_RANDOM_PORT, false);
 
       container = new OzoneContainer(dn, conf, getContext(dn), caClient);
-      //Set scmId and manually start ozone container.
+      //Set clusterId and manually start ozone container.
       container.start(UUID.randomUUID().toString());
 
       XceiverClientGrpc client = new XceiverClientGrpc(pipeline, conf,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestSecureOzoneContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestSecureOzoneContainer.java
@@ -146,7 +146,7 @@ public class TestSecureOzoneContainer {
 
       DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
       container = new OzoneContainer(dn, conf, getContext(dn), caClient);
-      //Set scmId and manually start ozone container.
+      //Set clusterId and manually start ozone container.
       container.start(UUID.randomUUID().toString());
 
       UserGroupInformation ugi = UserGroupInformation.createUserForTesting(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestContainerServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestContainerServer.java
@@ -203,7 +203,7 @@ public class TestContainerServer {
   public void testClientServerWithContainerDispatcher() throws Exception {
     XceiverServerGrpc server = null;
     XceiverClientGrpc client = null;
-    UUID scmId = UUID.randomUUID();
+    UUID clusterId = UUID.randomUUID();
     try {
       Pipeline pipeline = MockPipeline.createSingleNodePipeline();
       OzoneConfiguration conf = new OzoneConfiguration();
@@ -234,7 +234,7 @@ public class TestContainerServer {
       }
       HddsDispatcher dispatcher = new HddsDispatcher(
           conf, containerSet, volumeSet, handlers, context, metrics, null);
-      dispatcher.setScmId(scmId.toString());
+      dispatcher.setClusterId(clusterId.toString());
       dispatcher.init();
 
       server = new XceiverServerGrpc(datanodeDetails, conf, dispatcher,
@@ -292,7 +292,7 @@ public class TestContainerServer {
     }
 
     @Override
-    public void setScmId(String scmId) {
+    public void setClusterId(String clusterId) {
 
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
@@ -142,8 +142,8 @@ public class TestSecureContainerServer {
             createReplicationService(controller)), (dn, p) -> {}, (p) -> {});
   }
 
-  private static HddsDispatcher createDispatcher(DatanodeDetails dd, UUID scmId,
-      OzoneConfiguration conf) throws IOException {
+  private static HddsDispatcher createDispatcher(DatanodeDetails dd,
+      UUID clusterId, OzoneConfiguration conf) throws IOException {
     ContainerSet containerSet = new ContainerSet();
     conf.set(HDDS_DATANODE_DIR_KEY,
         Paths.get(TEST_DIR, "dfs", "data", "hdds",
@@ -167,7 +167,7 @@ public class TestSecureContainerServer {
     HddsDispatcher hddsDispatcher = new HddsDispatcher(
         conf, containerSet, volumeSet, handlers, context, metrics,
         new BlockTokenVerifier(new SecurityConfig((conf)), caClient));
-    hddsDispatcher.setScmId(scmId.toString());
+    hddsDispatcher.setClusterId(clusterId.toString());
     return hddsDispatcher;
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ChunkManagerDiskWrite.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ChunkManagerDiskWrite.java
@@ -126,7 +126,7 @@ public class ChunkManagerDiskWrite extends BaseFreonGenerator implements
         KeyValueContainer keyValueContainer =
             new KeyValueContainer(keyValueContainerData, ozoneConfiguration);
 
-        keyValueContainer.create(volumeSet, volumeChoicePolicy, "scmid");
+        keyValueContainer.create(volumeSet, volumeChoicePolicy, "clusterId");
 
         containersPerThread.put(i, keyValueContainer);
       }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkDatanodeDispatcher.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkDatanodeDispatcher.java
@@ -113,7 +113,7 @@ public class BenchMarkDatanodeDispatcher {
           containerType, conf, "datanodeid",
           containerSet, volumeSet, metrics,
           c -> {});
-      handler.setScmID("scm");
+      handler.setClusterId("clusterId");
       handlers.put(containerType, handler);
     }
     dispatcher = new HddsDispatcher(conf, containerSet, volumeSet, handlers,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchmarkChunkManager.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchmarkChunkManager.java
@@ -83,7 +83,7 @@ public class BenchmarkChunkManager {
   private static final long CONTAINER_SIZE = OzoneConsts.GB;
   private static final long BLOCK_SIZE = 256 * OzoneConsts.MB;
 
-  private static final String SCM_ID = UUID.randomUUID().toString();
+  private static final String CLUSTER_ID = UUID.randomUUID().toString();
   private static final String DATANODE_ID = UUID.randomUUID().toString();
 
   /**
@@ -155,7 +155,8 @@ public class BenchmarkChunkManager {
             DATANODE_ID);
     KeyValueContainer container =
         new KeyValueContainer(containerData, state.config);
-    container.create(state.volumeSet, (volumes, any) -> volumes.get(0), SCM_ID);
+    container.create(state.volumeSet,
+        (volumes, any) -> volumes.get(0), CLUSTER_ID);
 
     final long blockCount = CONTAINER_SIZE / BLOCK_SIZE;
     final long chunkCount = BLOCK_SIZE / state.chunkSize;


### PR DESCRIPTION
## What changes were proposed in this pull request?

The disk layout per volume is as follows:
```
../hdds/VERSION
../hdds/<<scmUuid>>/current/<<containerDir>>/<<containerID>>/metadata
../hdds/<<scmUuid>>/current/<<containerDir>>/<<containerID>>/<<dataDir>>
```

However, after SCM-HA is enabled, a typical SCM group will consists of 3 SCMs, each of the SCMs has its own scmUuid, meanwhile share the same clusterID.
Since federation is not supported yet, only one cluster is supported now, this Jira will change scmID to clusterID for container and volume at Datanode side.

The disk layout after the change will be as follows:
```
../hdds/VERSION
../hdds/<<clusterID>>/current/<<containerDir>>/<<containerID>>/metadata
../hdds/<<clusterID>>/current/<<containerDir>>/<<containerID>>/<<dataDir>>
```
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4107

## How was this patch tested?

CI