### PR TITLE
HDDS-4114. Bump log4j2 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- SLF4J/LOG4J version -->
     <slf4j.version>1.7.25</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
-    <log4j2.version>2.11.0</log4j2.version>
+    <log4j2.version>2.13.3</log4j2.version>
     <disruptor.version>3.4.2</disruptor.version>
 
     <prometheus.version>0.7.0</prometheus.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are a bunch of bugfixes and improvements since the used 2.10:

https://logging.apache.org/log4j/2.x/changes-report.html#a2.13.3

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4114

## How was this patch tested?

Full CI: 

https://github.com/elek/hadoop-ozone/actions/runs/206787922

Checking if we got the new jar files:

```
$ cd hadoop-ozone/dist/target/ozone-0.6.0-SNAPSHOT

$ find -name "*log4j*.jar"
./share/ozone/lib/slf4j-log4j12-1.7.25.jar
./share/ozone/lib/log4j-core-2.13.3.jar
./share/ozone/lib/log4j-1.2.17.jar
./share/ozone/lib/log4j-api-2.13.3.jar
```