### PR TITLE
HDDS-4098. Improve om admin getserviceroles error message

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
@@ -80,8 +80,8 @@ public class OMAdmin extends GenericCli implements SubcommandWithParent {
       throw new OzoneClientException("This command works only on OzoneManager" +
           " HA cluster. Service ID specified does not match" +
           " with " + OZONE_OM_SERVICE_IDS_KEY + " defined in the " +
-              "configuration. Configured " + OZONE_OM_SERVICE_IDS_KEY + " are" +
-              conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY));
+              "configuration. Configured " + OZONE_OM_SERVICE_IDS_KEY + " are \n" +
+              conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY) + "\n");
     }
   }
 
@@ -101,8 +101,8 @@ public class OMAdmin extends GenericCli implements SubcommandWithParent {
       throw new OzoneClientException("This command works only on OzoneManager" +
           " HA cluster. Service ID specified does not match" +
           " with " + OZONE_OM_SERVICE_IDS_KEY + " defined in the " +
-          "configuration. Configured " + OZONE_OM_SERVICE_IDS_KEY + " are" +
-          conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY));
+          "configuration. Configured " + OZONE_OM_SERVICE_IDS_KEY + " are \n" +
+          conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY) + "\n");
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improve the Error Messages in Display.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4098?filter=-1

## How was this patch tested?

$ cd hadoop-ozone/dist/target/ozone-*/compose/ozone
$ docker-compose up -d
$ docker-compose exec scm bash
bash-4.2$ ozone admin om getserviceroles --service-id=om
Error: This command works only on OzoneManager HA cluster. Service ID specified does not match with ozone.om.service.ids defined in the configuration. Configured ozone.om.service.ids are 
[]
bash-4.2$
