### PR TITLE
HDDS-4102. Normalize Keypath for lookupKey.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -326,9 +326,9 @@ public class TestOzoneFileSystem {
 
     // Deleting the only child should create the parent dir key if it does
     // not exist
-    String parentKey = o3fs.pathToKey(parent) + "/";
-    OzoneKeyDetails parentKeyInfo = getKey(parent, true);
-    assertEquals(parentKey, parentKeyInfo.getName());
+    FileStatus fileStatus = o3fs.getFileStatus(parent);
+    Assert.assertTrue(fileStatus.isDirectory());
+    assertEquals(parent.toString(), fileStatus.getPath().toUri().getPath());
   }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When ozone.om.enable.filesystem.paths, OM normalizes path, and stores the Keyname.

Now when user tries to read the file from S3 using the keyName which user has used to create the Key, it will return error KEY_NOT_FOUND

The issue is, lookupKey also need to normalize path, when ozone.om.enable.filesystem.paths is enabled. This is a common API used by S3/FS.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4102

## How was this patch tested?

Added a test.
