### PR TITLE
HDDS-4074. [OFS] Implement AbstractFileSystem for RootedOzoneFileSystem

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/docker-config
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 CORE-SITE.xml_fs.AbstractFileSystem.o3fs.impl=org.apache.hadoop.fs.ozone.OzFs
+CORE-SITE.xml_fs.AbstractFileSystem.ofs.impl=org.apache.hadoop.fs.ozone.RootedOzFs
 MAPRED-SITE.XML_mapreduce.application.classpath=/opt/hadoop/share/hadoop/mapreduce/*:/opt/hadoop/share/hadoop/mapreduce/lib/*:/opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-hadoop2-@project.version@.jar
 
 no_proxy=om,scm,s3g,recon,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/docker-config
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 CORE-SITE.xml_fs.AbstractFileSystem.o3fs.impl=org.apache.hadoop.fs.ozone.OzFs
+CORE-SITE.xml_fs.AbstractFileSystem.ofs.impl=org.apache.hadoop.fs.ozone.RootedOzFs
 MAPRED-SITE.XML_mapreduce.application.classpath=/opt/hadoop/share/hadoop/mapreduce/*:/opt/hadoop/share/hadoop/mapreduce/lib/*:/opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-hadoop3-@project.version@.jar
 
 no_proxy=om,scm,s3g,recon,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/docker-config
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 CORE-SITE.xml_fs.AbstractFileSystem.o3fs.impl=org.apache.hadoop.fs.ozone.OzFs
+CORE-SITE.xml_fs.AbstractFileSystem.ofs.impl=org.apache.hadoop.fs.ozone.RootedOzFs
 MAPRED-SITE.XML_mapreduce.application.classpath=/opt/hadoop/share/hadoop/mapreduce/*:/opt/hadoop/share/hadoop/mapreduce/lib/*:/opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-hadoop3-@project.version@.jar
 
 no_proxy=om,scm,s3g,recon,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
@@ -67,6 +67,7 @@ HDFS-SITE.XML_rpc.metrics.quantile.enable=true
 HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300
 
 CORE-SITE.XML_fs.AbstractFileSystem.o3fs.impl=org.apache.hadoop.fs.ozone.OzFs
+CORE-SITE.XML_fs.AbstractFileSystem.ofs.impl=org.apache.hadoop.fs.ozone.RootedOzFs
 CORE-SITE.XML_fs.defaultFS=o3fs://bucket1.volume1/
 
 MAPRED-SITE.XML_mapreduce.framework.name=yarn

--- a/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
+++ b/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
@@ -38,7 +38,7 @@ public class RootedOzFs extends DelegateToFileSystem {
 
   public RootedOzFs(URI theUri, Configuration conf)
       throws IOException, URISyntaxException {
-    super(theUri, new OzoneFileSystem(), conf,
+    super(theUri, new RootedOzoneFileSystem(), conf,
         OzoneConsts.OZONE_OFS_URI_SCHEME, false);
   }
 }

--- a/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
+++ b/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.ozone;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.DelegateToFileSystem;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceStability;
+import org.apache.hadoop.ozone.OzoneConsts;
+
+/**
+ * Ozone implementation of AbstractFileSystem.
+ * This impl delegates to the RootedOzoneFileSystem
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public class RootedOzFs extends DelegateToFileSystem {
+
+  public RootedOzFs(URI theUri, Configuration conf)
+      throws IOException, URISyntaxException {
+    super(theUri, new OzoneFileSystem(), conf,
+        OzoneConsts.OZONE_OFS_URI_SCHEME, false);
+  }
+}

--- a/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
+++ b/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
@@ -41,4 +41,9 @@ public class RootedOzFs extends DelegateToFileSystem {
     super(theUri, new RootedOzoneFileSystem(), conf,
         OzoneConsts.OZONE_OFS_URI_SCHEME, false);
   }
+
+  @Override
+  public int getUriDefaultPort() {
+    return -1;
+  }
 }

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
@@ -38,7 +38,7 @@ public class RootedOzFs extends DelegateToFileSystem {
 
   public RootedOzFs(URI theUri, Configuration conf)
       throws IOException, URISyntaxException {
-    super(theUri, new OzoneFileSystem(), conf,
+    super(theUri, new RootedOzoneFileSystem(), conf,
         OzoneConsts.OZONE_OFS_URI_SCHEME, false);
   }
 }

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.ozone;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.DelegateToFileSystem;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceStability;
+import org.apache.hadoop.ozone.OzoneConsts;
+
+/**
+ * Ozone implementation of AbstractFileSystem.
+ * This impl delegates to the RootedOzoneFileSystem
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public class RootedOzFs extends DelegateToFileSystem {
+
+  public RootedOzFs(URI theUri, Configuration conf)
+      throws IOException, URISyntaxException {
+    super(theUri, new OzoneFileSystem(), conf,
+        OzoneConsts.OZONE_OFS_URI_SCHEME, false);
+  }
+}

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
@@ -38,7 +38,7 @@ public class RootedOzFs extends DelegateToFileSystem {
 
   public RootedOzFs(URI theUri, Configuration conf)
       throws IOException, URISyntaxException {
-    super(theUri, new OzoneFileSystem(), conf,
+    super(theUri, new RootedOzoneFileSystem(), conf,
         OzoneConsts.OZONE_OFS_URI_SCHEME, false);
   }
 }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzFs.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.ozone;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.DelegateToFileSystem;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceStability;
+import org.apache.hadoop.ozone.OzoneConsts;
+
+/**
+ * Ozone implementation of AbstractFileSystem.
+ * This impl delegates to the RootedOzoneFileSystem
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public class RootedOzFs extends DelegateToFileSystem {
+
+  public RootedOzFs(URI theUri, Configuration conf)
+      throws IOException, URISyntaxException {
+    super(theUri, new OzoneFileSystem(), conf,
+        OzoneConsts.OZONE_OFS_URI_SCHEME, false);
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `RootedOzFs`, implementation of `AbstractFileSystem` for `RootedOzoneFileSystem`.  This will allow running MapReduce tests with OFS.

Extracted from #1088.  Also applied the fix from HDDS-3482.

https://issues.apache.org/jira/browse/HDDS-4074

## How was this patch tested?

Executed `ozone-mr` acceptance tests locally:

```
export OZONE_TEST_SELECTOR='ozone-mr\|hadoop..'
hadoop-ozone/dev-support/checks/acceptance.sh
```

after tweaking config and MR test to use `ofs` instead of `o3fs`:

```diff
diff --git hadoop-ozone/dist/src/main/compose/ozone-mr/common-config hadoop-ozone/dist/src/main/compose/ozone-mr/common-config
index 46e752731..91588aa77 100644
--- hadoop-ozone/dist/src/main/compose/ozone-mr/common-config
+++ hadoop-ozone/dist/src/main/compose/ozone-mr/common-config
@@ -30,7 +30,8 @@ OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 HDFS-SITE.XML_dfs.datanode.address=0.0.0.0:1019
 HDFS-SITE.XML_dfs.datanode.http.address=0.0.0.0:1012

-CORE-SITE.xml_fs.defaultFS=o3fs://bucket1.volume1/
+CORE-SITE.xml_fs.defaultFS=ofs://om/volume1/bucket1/
+CORE-SITE.XML_fs.ofs.impl=org.apache.hadoop.fs.ozone.RootedOzoneFileSystem

 MAPRED-SITE.XML_mapreduce.framework.name=yarn
 MAPRED-SITE.XML_yarn.app.mapreduce.am.env=HADOOP_MAPRED_HOME=$HADOOP_HOME
diff --git hadoop-ozone/dist/src/main/smoketest/mapreduce.robot hadoop-ozone/dist/src/main/smoketest/mapreduce.robot
index 654dd49c6..e2dfd11a1 100644
--- hadoop-ozone/dist/src/main/smoketest/mapreduce.robot
+++ hadoop-ozone/dist/src/main/smoketest/mapreduce.robot
@@ -39,5 +39,5 @@ Execute PI calculation
 Execute WordCount
                     ${exampleJar}    Find example jar
                     ${random}        Generate Random String  2   [NUMBERS]
-                    ${output} =      Execute                 yarn jar ${exampleJar} wordcount o3fs://bucket1.volume1/key1 o3fs://bucket1.volume1/key1-${random}.count
+                    ${output} =      Execute                 yarn jar ${exampleJar} wordcount ofs://om/volume1/bucket1/key1 ofs://om/volume1/bucket1/key1-${random}.count
                     Should Contain   ${output}               completed successfully

```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/runs/975699201