### PR TITLE
HDDS-4118. Allow running Kubernetes example tests on k3d

### DIFF
--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -93,7 +93,10 @@ regenerate_resources() {
 
   PARENT_OF_PARENT=$(realpath ../..)
 
-  if [ $(basename $PARENT_OF_PARENT) == "k8s" ]; then
+  if [[ -n ${OZONE_ROOT} ]]; then
+    # use explicit OZONE_ROOT
+    :
+  elif [ $(basename $PARENT_OF_PARENT) == "k8s" ]; then
     #running from src dir
     OZONE_ROOT=$(realpath ../../../../../target/ozone-0.6.0-SNAPSHOT)
   else


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow explicitly setting `OZONE_ROOT` to the directory where Ozone binaries are available on the Kubernetes nodes.

https://issues.apache.org/jira/browse/HDDS-4118

## How was this patch tested?

k3d cluster can be created with volume mount for Ozone source root.

```
export OZONE_DIR=~/src/ozone
k3d cluster create ozone --agents 3 \
  --volume "${OZONE_DIR}":"${OZONE_DIR}"
```

Now tests can be run on k3d:

```
export OZONE_ROOT="${OZONE_DIR}/hadoop-ozone/dist/target/ozone-0.6.0-SNAPSHOT"
cd hadoop-ozone/dist/target/ozone-0.6.0-SNAPSHOT/kubernetes/examples/getting-started
./test.sh
```

```
...
**** Waiting until the k8s cluster is running ****
...
**** Cluster is up and running ****
...
**** Executing robot tests scm-0 ****

==============================================================================
Basic :: Smoketest ozone cluster startup
==============================================================================
Check webui static resources                                          | PASS |
------------------------------------------------------------------------------
Start freon testing                                                   | PASS |
------------------------------------------------------------------------------
Basic :: Smoketest ozone cluster startup                              | PASS |
2 critical tests, 2 passed, 0 failed
2 tests total, 2 passed, 0 failed
...
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/runs/984306516