### PR TITLE
HDDS-4125: Pipeline is not removed when a datanode goes stale

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerV2Impl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerV2Impl.java
@@ -416,10 +416,7 @@ public final class PipelineManagerV2Impl implements PipelineManager {
   public void scrubPipeline(ReplicationType type, ReplicationFactor factor)
       throws IOException {
     checkLeader();
-    if (type != ReplicationType.RATIS || factor != ReplicationFactor.THREE) {
-      // Only srub pipeline for RATIS THREE pipeline
-      return;
-    }
+
     Instant currentTime = Instant.now();
     Long pipelineScrubTimeoutInMills = conf.getTimeDuration(
         ScmConfigKeys.OZONE_SCM_PIPELINE_ALLOCATED_TIMEOUT,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Let scrubPipeline() handles the destroy of all kinds of pipeline. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4125

## How was this patch tested?

CI
