### PR TITLE
HDDS-4127. Components with web interface should depend on hdds-docs.

### DIFF
--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -70,6 +70,13 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-docs</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs</artifactId>

--- a/hadoop-hdds/server-scm/pom.xml
+++ b/hadoop-hdds/server-scm/pom.xml
@@ -60,6 +60,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-docs</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -43,6 +43,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-docs</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <!-- hdds.proto and generated files are required from there -->
@@ -68,6 +69,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-docs</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -72,12 +72,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
 
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-hdds-docs</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/hadoop-ozone/s3gateway/pom.xml
+++ b/hadoop-ozone/s3gateway/pom.xml
@@ -164,6 +164,11 @@
       <artifactId>hadoop-ozone-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-docs</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
## What changes were proposed in this pull request?

@ChenSammi  reported the problem that the ozone-0.6.0 branch couldn't be compiled after changing the version to 1.0.0.

```
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.0.2:unpack (copy-common-html) on project hadoop-hdds-container-service: Unable to find/resolve artifact.: Could not find artifact org.apache.hadoop:hadoop-hdds-docs:jar:1.0.0 in apache.snapshots.https (https://repository.apache.org/content/repositories/snapshots) -> [Help 1]
[ERROR]
```

Web components include the compiled docs (in case of hugo is on the path)

```XML
  <plugin>
        <groupId>org.apache.maven.plugins</groupId>
        <artifactId>maven-dependency-plugin</artifactId>
        <executions>
          <execution>
            <id>copy-common-html</id>
            <phase>prepare-package</phase>
            <goals>
              <goal>unpack</goal>
            </goals>
            <configuration>
              <artifactItems>
                <artifactItem>
                  <groupId>org.apache.hadoop</groupId>
                  <artifactId>hadoop-hdds-server-framework</artifactId>
                  <outputDirectory>${project.build.outputDirectory}
                  </outputDirectory>
                  <includes>webapps/static/**/*.*</includes>
                </artifactItem>
                <artifactItem>
                  <groupId>org.apache.hadoop</groupId>
                  <artifactId>hadoop-hdds-docs</artifactId>
                  <outputDirectory>${project.build.outputDirectory}/webapps/ozoneManager</outputDirectory>
                  <includes>docs/**/*.*</includes>
                </artifactItem>
              </artifactItems>
              <overWriteSnapshots>true</overWriteSnapshots>
            </configuration>
          </execution>
        </executions>
      </plugin>
```

But the explicit dependency between the container-service and hdds-docs accidentally missing. With adding a provided dependency, it can be fixed (maven will compile hdds-docs first)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4127

## How was this patch tested?

```
git checkout ozone-0.6.0
find . -name pom.xml -type f | xargs sed -i 's/0.6.0-SNAPSHOT/1.0.0/g'
# apply this patch
mvn clean install -DskipTests
```