### PR TITLE
HDDS-4131. Container report should update container key count and bytes used if they differ in SCM

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.container;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleEvent;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
@@ -28,6 +29,9 @@ import org.apache.hadoop.hdds.protocol.proto
 import org.slf4j.Logger;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -76,7 +80,7 @@ public class AbstractContainerReportHandler {
     // Synchronized block should be replaced by container lock,
     // once we have introduced lock inside ContainerInfo.
     synchronized (containerManager.getContainer(containerId)) {
-      updateContainerStats(containerId, replicaProto);
+      updateContainerStats(datanodeDetails, containerId, replicaProto);
       updateContainerState(datanodeDetails, containerId, replicaProto);
       updateContainerReplica(datanodeDetails, containerId, replicaProto);
     }
@@ -90,7 +94,8 @@ public class AbstractContainerReportHandler {
    * @param replicaProto Container Replica information
    * @throws ContainerNotFoundException If the container is not present
    */
-  private void updateContainerStats(final ContainerID containerId,
+  private void updateContainerStats(final DatanodeDetails datanodeDetails,
+                                    final ContainerID containerId,
                                     final ContainerReplicaProto replicaProto)
       throws ContainerNotFoundException {
 
@@ -103,13 +108,44 @@ public class AbstractContainerReportHandler {
         containerInfo.updateSequenceId(
             replicaProto.getBlockCommitSequenceId());
       }
-      if (containerInfo.getUsedBytes() != replicaProto.getUsed()) {
-        containerInfo.setUsedBytes(replicaProto.getUsed());
+      List<ContainerReplica> otherReplicas =
+          getOtherReplicas(containerId, datanodeDetails);
+      long usedBytes = replicaProto.getUsed();
+      long keyCount = replicaProto.getKeyCount();
+      for (ContainerReplica r : otherReplicas) {
+        // Open containers are generally growing in key count and size, the
+        // overall size should be the min of all reported replicas.
+        if (containerInfo.getState().equals(HddsProtos.LifeCycleState.OPEN)) {
+          usedBytes = Math.min(usedBytes, r.getBytesUsed());
+          keyCount = Math.min(keyCount, r.getKeyCount());
+        } else {
+          // Containers which are not open can only shrink in size, so use the
+          // largest values reported.
+          usedBytes = Math.max(usedBytes, r.getBytesUsed());
+          keyCount = Math.max(keyCount, r.getKeyCount());
+        }
       }
-      if (containerInfo.getNumberOfKeys() != replicaProto.getKeyCount()) {
-        containerInfo.setNumberOfKeys(replicaProto.getKeyCount());
+
+      if (containerInfo.getUsedBytes() != usedBytes) {
+        containerInfo.setUsedBytes(usedBytes);
+      }
+      if (containerInfo.getNumberOfKeys() != keyCount) {
+        containerInfo.setNumberOfKeys(keyCount);
       }
     }
+  }
+
+  private List<ContainerReplica> getOtherReplicas(ContainerID containerId,
+      DatanodeDetails exclude) throws ContainerNotFoundException {
+    List<ContainerReplica> filteredReplicas = new ArrayList<>();
+    Set<ContainerReplica> replicas
+        = containerManager.getContainerReplicas(containerId);
+    for (ContainerReplica r : replicas) {
+      if (!r.getDatanodeDetails().equals(exclude)) {
+        filteredReplicas.add(r);
+      }
+    }
+    return filteredReplicas;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/AbstractContainerReportHandler.java
@@ -103,11 +103,10 @@ public class AbstractContainerReportHandler {
         containerInfo.updateSequenceId(
             replicaProto.getBlockCommitSequenceId());
       }
-
-      if (containerInfo.getUsedBytes() < replicaProto.getUsed()) {
+      if (containerInfo.getUsedBytes() != replicaProto.getUsed()) {
         containerInfo.setUsedBytes(replicaProto.getUsed());
       }
-      if (containerInfo.getNumberOfKeys() < replicaProto.getKeyCount()) {
+      if (containerInfo.getNumberOfKeys() != replicaProto.getKeyCount()) {
         containerInfo.setNumberOfKeys(replicaProto.getKeyCount());
       }
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -313,14 +313,6 @@ public class ReplicationManager
               .noneMatch(r -> r.getDatanodeDetails().equals(action.datanode)));
 
       /*
-       * If the container is in CLOSED state, check and update it's key count
-       * and bytes used statistics if needed.
-       */
-      if (state == LifeCycleState.CLOSED) {
-        checkAndUpdateContainerInfo(container, replicas);
-      }
-
-      /*
        * We don't have to take any action if the container is healthy.
        *
        * According to ReplicationMonitor container is considered healthy if
@@ -771,32 +763,6 @@ public class ReplicationManager
     unhealthyReplicas.stream().findFirst().ifPresent(replica ->
         sendDeleteCommand(container, replica.getDatanodeDetails(), false));
 
-  }
-
-  /**
-   * Check and update Container key count and used bytes based on it's replica's
-   * data.
-   */
-  private void checkAndUpdateContainerInfo(final ContainerInfo container,
-      final Set<ContainerReplica> replicas) {
-    // check container key count and bytes used
-    long maxUsedBytes = 0;
-    long maxKeyCount = 0;
-    ContainerReplica[] rps = replicas.toArray(new ContainerReplica[0]);
-    for (int i = 0; i < rps.length; i++) {
-      maxUsedBytes = Math.max(maxUsedBytes, rps[i].getBytesUsed());
-      maxKeyCount = Math.max(maxKeyCount, rps[i].getKeyCount());
-    }
-    if (maxKeyCount < container.getNumberOfKeys()) {
-      LOG.debug("Container {} key count changed from {} to {}",
-          container.containerID(), container.getNumberOfKeys(), maxKeyCount);
-      container.setNumberOfKeys(maxKeyCount);
-    }
-    if (maxUsedBytes < container.getUsedBytes()) {
-      LOG.debug("Container {} used bytes changed from {} to {}",
-          container.containerID(), container.getUsedBytes(), maxUsedBytes);
-      container.setUsedBytes(maxUsedBytes);
-    }
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
@@ -398,8 +398,6 @@ public class SCMContainerManager implements ContainerManager {
               SCMException.ResultCodes.FAILED_TO_FIND_CONTAINER);
         }
         containerInfo.updateDeleteTransactionId(entry.getValue());
-        containerInfo.setNumberOfKeys(containerInfoInMem.getNumberOfKeys());
-        containerInfo.setUsedBytes(containerInfoInMem.getUsedBytes());
         containerStore
             .putWithBatch(batchOperation, containerIdObject, containerInfo);
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
@@ -398,6 +398,8 @@ public class SCMContainerManager implements ContainerManager {
               SCMException.ResultCodes.FAILED_TO_FIND_CONTAINER);
         }
         containerInfo.updateDeleteTransactionId(entry.getValue());
+        containerInfo.setNumberOfKeys(containerInfoInMem.getNumberOfKeys());
+        containerInfo.setUsedBytes(containerInfoInMem.getUsedBytes());
         containerStore
             .putWithBatch(batchOperation, containerIdObject, containerInfo);
       }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
@@ -640,7 +640,7 @@ public class TestContainerReportHandler {
       final ContainerID containerId, final ContainerReplicaProto.State state,
       final String originNodeId) {
     return getContainerReportsProto(containerId, state, originNodeId,
-        100000000L, 2000000000L);
+        2000000000L, 100000000L);
   }
 
   private static ContainerReportsProto getContainerReportsProto(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
@@ -39,11 +39,13 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static junit.framework.TestCase.assertEquals;
 import static org.apache.hadoop.hdds.scm.TestUtils.getReplicas;
 import static org.apache.hadoop.hdds.scm.TestUtils.getContainer;
 
@@ -483,9 +485,167 @@ public class TestContainerReportHandler {
     Assert.assertEquals(LifeCycleState.CLOSED, containerOne.getState());
   }
 
+  @Test
+  public void openContainerKeyAndBytesUsedUpdatedToMinimumOfAllReplicas()
+      throws SCMException {
+    final ContainerReportHandler reportHandler = new ContainerReportHandler(
+        nodeManager, containerManager);
+    final Iterator<DatanodeDetails> nodeIterator = nodeManager.getNodes(
+        NodeState.HEALTHY).iterator();
+
+    final DatanodeDetails datanodeOne = nodeIterator.next();
+    final DatanodeDetails datanodeTwo = nodeIterator.next();
+    final DatanodeDetails datanodeThree = nodeIterator.next();
+
+    final ContainerReplicaProto.State replicaState
+        = ContainerReplicaProto.State.OPEN;
+    final ContainerInfo containerOne = getContainer(LifeCycleState.OPEN);
+
+    final Set<ContainerID> containerIDSet = new HashSet<>();
+    containerIDSet.add(containerOne.containerID());
+
+    containerStateManager.loadContainer(containerOne);
+    // Container loaded, no replicas reported from DNs. Expect zeros for
+    // usage values.
+    assertEquals(0L, containerOne.getUsedBytes());
+    assertEquals(0L, containerOne.getNumberOfKeys());
+
+    reportHandler.onMessage(getContainerReportFromDatanode(
+        containerOne.containerID(), replicaState,
+        datanodeOne, 50L, 60L), publisher);
+
+    // Single replica reported - ensure values are updated
+    assertEquals(50L, containerOne.getUsedBytes());
+    assertEquals(60L, containerOne.getNumberOfKeys());
+
+    reportHandler.onMessage(getContainerReportFromDatanode(
+        containerOne.containerID(), replicaState,
+        datanodeTwo, 50L, 60L), publisher);
+    reportHandler.onMessage(getContainerReportFromDatanode(
+        containerOne.containerID(), replicaState,
+        datanodeThree, 50L, 60L), publisher);
+
+    // All 3 DNs are reporting the same values. Counts should be as expected.
+    assertEquals(50L, containerOne.getUsedBytes());
+    assertEquals(60L, containerOne.getNumberOfKeys());
+
+    // Now each DN reports a different lesser value. Counts should be the min
+    // reported.
+    reportHandler.onMessage(getContainerReportFromDatanode(
+        containerOne.containerID(), replicaState,
+        datanodeOne, 1L, 10L), publisher);
+    reportHandler.onMessage(getContainerReportFromDatanode(
+        containerOne.containerID(), replicaState,
+        datanodeTwo, 2L, 11L), publisher);
+    reportHandler.onMessage(getContainerReportFromDatanode(
+        containerOne.containerID(), replicaState,
+        datanodeThree, 3L, 12L), publisher);
+
+    // All 3 DNs are reporting different values. The actual value should be the
+    // minimum.
+    assertEquals(1L, containerOne.getUsedBytes());
+    assertEquals(10L, containerOne.getNumberOfKeys());
+
+    // Have the lowest value report a higher value and ensure the new value
+    // is the minimum
+    reportHandler.onMessage(getContainerReportFromDatanode(
+        containerOne.containerID(), replicaState,
+        datanodeOne, 3L, 12L), publisher);
+
+    assertEquals(2L, containerOne.getUsedBytes());
+    assertEquals(11L, containerOne.getNumberOfKeys());
+  }
+
+  @Test
+  public void notOpenContainerKeyAndBytesUsedUpdatedToMaximumOfAllReplicas()
+      throws SCMException {
+    final ContainerReportHandler reportHandler = new ContainerReportHandler(
+        nodeManager, containerManager);
+    final Iterator<DatanodeDetails> nodeIterator = nodeManager.getNodes(
+        NodeState.HEALTHY).iterator();
+
+    final DatanodeDetails datanodeOne = nodeIterator.next();
+    final DatanodeDetails datanodeTwo = nodeIterator.next();
+    final DatanodeDetails datanodeThree = nodeIterator.next();
+
+    final ContainerReplicaProto.State replicaState
+        = ContainerReplicaProto.State.CLOSED;
+    final ContainerInfo containerOne = getContainer(LifeCycleState.CLOSED);
+
+    final Set<ContainerID> containerIDSet = new HashSet<>();
+    containerIDSet.add(containerOne.containerID());
+
+    containerStateManager.loadContainer(containerOne);
+    // Container loaded, no replicas reported from DNs. Expect zeros for
+    // usage values.
+    assertEquals(0L, containerOne.getUsedBytes());
+    assertEquals(0L, containerOne.getNumberOfKeys());
+
+    reportHandler.onMessage(getContainerReportFromDatanode(
+        containerOne.containerID(), replicaState,
+        datanodeOne, 50L, 60L), publisher);
+
+    // Single replica reported - ensure values are updated
+    assertEquals(50L, containerOne.getUsedBytes());
+    assertEquals(60L, containerOne.getNumberOfKeys());
+
+    reportHandler.onMessage(getContainerReportFromDatanode(
+        containerOne.containerID(), replicaState,
+        datanodeTwo, 50L, 60L), publisher);
+    reportHandler.onMessage(getContainerReportFromDatanode(
+        containerOne.containerID(), replicaState,
+        datanodeThree, 50L, 60L), publisher);
+
+    // All 3 DNs are reporting the same values. Counts should be as expected.
+    assertEquals(50L, containerOne.getUsedBytes());
+    assertEquals(60L, containerOne.getNumberOfKeys());
+
+    // Now each DN reports a different lesser value. Counts should be the max
+    // reported.
+    reportHandler.onMessage(getContainerReportFromDatanode(
+        containerOne.containerID(), replicaState,
+        datanodeOne, 1L, 10L), publisher);
+    reportHandler.onMessage(getContainerReportFromDatanode(
+        containerOne.containerID(), replicaState,
+        datanodeTwo, 2L, 11L), publisher);
+    reportHandler.onMessage(getContainerReportFromDatanode(
+        containerOne.containerID(), replicaState,
+        datanodeThree, 3L, 12L), publisher);
+
+    // All 3 DNs are reporting different values. The actual value should be the
+    // maximum.
+    assertEquals(3L, containerOne.getUsedBytes());
+    assertEquals(12L, containerOne.getNumberOfKeys());
+
+    // Have the highest value report a lower value and ensure the new value
+    // is the new maximumu
+    reportHandler.onMessage(getContainerReportFromDatanode(
+        containerOne.containerID(), replicaState,
+        datanodeThree, 1L, 10L), publisher);
+
+    assertEquals(2L, containerOne.getUsedBytes());
+    assertEquals(11L, containerOne.getNumberOfKeys());
+  }
+
+  private ContainerReportFromDatanode getContainerReportFromDatanode(
+      ContainerID containerId, ContainerReplicaProto.State state,
+      DatanodeDetails dn, long bytesUsed, long keyCount) {
+    ContainerReportsProto containerReport = getContainerReportsProto(
+        containerId, state, dn.getUuidString(), bytesUsed, keyCount);
+
+    return new ContainerReportFromDatanode(dn, containerReport);
+  }
+
   private static ContainerReportsProto getContainerReportsProto(
       final ContainerID containerId, final ContainerReplicaProto.State state,
       final String originNodeId) {
+    return getContainerReportsProto(containerId, state, originNodeId,
+        100000000L, 2000000000L);
+  }
+
+  private static ContainerReportsProto getContainerReportsProto(
+      final ContainerID containerId, final ContainerReplicaProto.State state,
+      final String originNodeId, final long usedBytes, final long keyCount) {
     final ContainerReportsProto.Builder crBuilder =
         ContainerReportsProto.newBuilder();
     final ContainerReplicaProto replicaProto =
@@ -495,8 +655,8 @@ public class TestContainerReportHandler {
             .setOriginNodeId(originNodeId)
             .setFinalhash("e16cc9d6024365750ed8dbd194ea46d2")
             .setSize(5368709120L)
-            .setUsed(2000000000L)
-            .setKeyCount(100000000L)
+            .setUsed(usedBytes)
+            .setKeyCount(keyCount)
             .setReadCount(100000000L)
             .setWriteCount(100000000L)
             .setReadBytes(2000000000L)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -270,11 +270,8 @@ public class TestBlockDeletion {
     });
 
     om.deleteKey(keyArgs);
-    // Want for blocks to be deleted
+    // Wait for blocks to be deleted and container reports to be processed
     Thread.sleep(5000);
-    scm.getReplicationManager().processContainersNow();
-    // Wait for container statistics change
-    Thread.sleep(1000);
     containerInfos = scm.getContainerManager().getContainers();
     containerInfos.stream().forEach(container -> {
       Assert.assertEquals(0, container.getUsedBytes());


### PR DESCRIPTION
## What changes were proposed in this pull request?

In HDDS-4037 it was noted that when blocks are deleted from closed containers, the bytesUsed and Key Count metrics on the SCM container are not updated correctly.

These stats should be updated via the container reports issued by the DNs to SCM periodically. However, in `AbstractContainerReportHandler#updateContainerStats`, the code assumes the values are always increasing and it will not update them if they are decreasing:

```
  private void updateContainerStats(final ContainerID containerId,
                                    final ContainerReplicaProto replicaProto)
      throws ContainerNotFoundException {
    if (isHealthy(replicaProto::getState)) {
      final ContainerInfo containerInfo = containerManager
          .getContainer(containerId);

      if (containerInfo.getSequenceId() <
          replicaProto.getBlockCommitSequenceId()) {
        containerInfo.updateSequenceId(
            replicaProto.getBlockCommitSequenceId());
      }
      if (containerInfo.getUsedBytes() < replicaProto.getUsed()) {
        containerInfo.setUsedBytes(replicaProto.getUsed());
      }
      if (containerInfo.getNumberOfKeys() < replicaProto.getKeyCount()) {
        containerInfo.setNumberOfKeys(replicaProto.getKeyCount());
      }
    }
  }
```

In HDDS-4037 a change was made to the Replication Manager, so it updates the stats. However I don't believe that is the correct place to perform this check, and the issue is caused by the logic shared above.

In this Jira, I have removed the changes to Replication Manager in HDDS-4037 (but retained the other changes in that Jira), ensuring the problem statistics are only updated via the containers reports if they are different in SCM from what is reported.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4131

## How was this patch tested?

Small change to existing unit test. Used it to reproduce the problem before making the changed.