### PR TITLE
HDDS-4140. Auto-close /pending pull requests after 21 days of inactivity

### DIFF
--- a/.github/close-pending.sh
+++ b/.github/close-pending.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+MESSAGE=$(cat $SCRIPT_DIR/closing-message.txt)
+
+while IFS= read -r number &&
+      IFS= read -r title; do
+      echo "Closing PR ($number): $title"
+      curl -v \
+        -X POST \
+        --data "$(jq --arg body "$MESSAGE" -n '{body: $body}')" \
+        --header "authorization: Bearer $GITHUB_TOKEN" \
+        --header 'content-type: application/json' \
+        "https://api.github.com/repos/elek/hadoop-ozone/issues/$number/comments"
+
+      curl -v \
+        -X PATCH \
+        --data '{"state": "close"}' \
+        --header "authorization: Bearer $GITHUB_TOKEN" \
+        --header 'content-type: application/json' \
+        "https://api.github.com/repos/elek/hadoop-ozone/pulls/$number"
+
+#     "https://api.github.com/search/issues?q=repo:apache/hadoop-ozone+type:pr+updated:<$(date -d "-1 month" +%Y-%m-%d)+label:pending+is:open" \
+done < <(curl -H "Content-Type: application/json" \
+     --header "authorization: Bearer $GITHUB_TOKEN" \
+     "https://api.github.com/search/issues?q=repo:elek/hadoop-ozone+type:pr+label:pending+is:open" \
+    | jq -r '.items[] | (.number,.title)')

--- a/.github/close-pending.sh
+++ b/.github/close-pending.sh
@@ -37,5 +37,5 @@ while IFS= read -r number &&
         "https://api.github.com/repos/apache/hadoop-ozone/pulls/$number"
 done < <(curl -H "Content-Type: application/json" \
      --header "authorization: Bearer $GITHUB_TOKEN" \
-     "https://api.github.com/search/issues?q=repo:apache/hadoop-ozone+type:pr+updated:<$(date -d "-1 month" +%Y-%m-%d)+label:pending+is:open" \
+     "https://api.github.com/search/issues?q=repo:apache/hadoop-ozone+type:pr+updated:<$(date -d "-21 days" +%Y-%m-%d)+label:pending+is:open" \
      | jq -r '.items[] | (.number,.title)')

--- a/.github/close-pending.sh
+++ b/.github/close-pending.sh
@@ -22,22 +22,20 @@ MESSAGE=$(cat $SCRIPT_DIR/closing-message.txt)
 while IFS= read -r number &&
       IFS= read -r title; do
       echo "Closing PR ($number): $title"
-      curl -v \
+      curl -s -o /dev/null \
         -X POST \
         --data "$(jq --arg body "$MESSAGE" -n '{body: $body}')" \
         --header "authorization: Bearer $GITHUB_TOKEN" \
         --header 'content-type: application/json' \
-        "https://api.github.com/repos/elek/hadoop-ozone/issues/$number/comments"
+        "https://api.github.com/repos/apache/hadoop-ozone/issues/$number/comments"
 
-      curl -v \
+      curl -s -o /dev/null \
         -X PATCH \
         --data '{"state": "close"}' \
         --header "authorization: Bearer $GITHUB_TOKEN" \
         --header 'content-type: application/json' \
-        "https://api.github.com/repos/elek/hadoop-ozone/pulls/$number"
-
-#     "https://api.github.com/search/issues?q=repo:apache/hadoop-ozone+type:pr+updated:<$(date -d "-1 month" +%Y-%m-%d)+label:pending+is:open" \
+        "https://api.github.com/repos/apache/hadoop-ozone/pulls/$number"
 done < <(curl -H "Content-Type: application/json" \
      --header "authorization: Bearer $GITHUB_TOKEN" \
-     "https://api.github.com/search/issues?q=repo:elek/hadoop-ozone+type:pr+label:pending+is:open" \
-    | jq -r '.items[] | (.number,.title)')
+     "https://api.github.com/search/issues?q=repo:apache/hadoop-ozone+type:pr+updated:<$(date -d "-1 month" +%Y-%m-%d)+label:pending+is:open" \
+     | jq -r '.items[] | (.number,.title)')

--- a/.github/closing-message.txt
+++ b/.github/closing-message.txt
@@ -1,0 +1,7 @@
+Thank you very much for the patch. I am closing this PR __temporarily__ as there was no activity recently and it is waiting for response from its author.
+
+It doesn't mean that this PR is not important or ignored: feel free to reopen the PR at any time.
+
+It only means that attention of committers is not required. We prefer to keep the review queue clean. This ensures PRs in need of review are more visible, which results in faster feedback for all PRs.
+
+If you need ANY help to finish this PR, please [contact the community](https://github.com/apache/hadoop-ozone#contact) on the mailing list or the slack channel."

--- a/.github/comment-commands/pending.sh
+++ b/.github/comment-commands/pending.sh
@@ -20,6 +20,7 @@ MESSAGE="Marking this issue as un-mergeable as requested.
 
 Please use \`/ready\` comment when it's resolved.
 
+Please note that the PR will be closed after 21 days of inactivity from now. (But can be re-opened anytime later...)
 > $@"
 
 URL="$(jq -r '.issue.pull_request.url' "$GITHUB_EVENT_PATH")/reviews"

--- a/.github/workflows/close-pending.yaml
+++ b/.github/workflows/close-pending.yaml
@@ -16,7 +16,7 @@ name: close-prs
 
 on:
   schedule:
-  - cron:  '*/5 * * * *'
+  - cron:  '0 0 * * *'
 
 jobs:
   close-pending:

--- a/.github/workflows/close-pending.yaml
+++ b/.github/workflows/close-pending.yaml
@@ -26,6 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@master
       - name: Execute close-pending script
+        if: github.repository == 'apache/hadoop-ozone'
         run: ./.github/close-pending.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/close.yaml
+++ b/.github/workflows/close.yaml
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,23 +12,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+name: close-prs
 
-#doc: Close pending pull request temporary
-# shellcheck disable=SC2124
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-MESSAGE=$(cat $SCRIPT_DIR/../closing-message.txt)
+on:
+  schedule:
+  - cron:  '*/5 * * * *'
 
-set +x #GITHUB_TOKEN
-curl -s -o /dev/null \
-  -X POST \
-  --data "$(jq --arg body "$MESSAGE" -n '{body: $body}')" \
-  --header "authorization: Bearer $GITHUB_TOKEN" \
-  --header 'content-type: application/json' \
-  "$(jq -r '.issue.comments_url' "$GITHUB_EVENT_PATH")"
-
-curl -s -o /dev/null \
-  -X PATCH \
-  --data '{"state": "close"}' \
-  --header "authorization: Bearer $GITHUB_TOKEN" \
-  --header 'content-type: application/json' \
-  "$(jq -r '.issue.pull_request.url' "$GITHUB_EVENT_PATH")"
+jobs:
+  close-pending:
+    name: close-pending
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Execute close-pending script
+        run: ./.github/close-pending.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Earlier we introduced a way to mark the inactive pull requests with "pending" label (with the help of /pending comment).

This pull requests introduce a new scheduled build which closes the "pending" pull requests after 21 days of inactivity.

IMPORTANT: Only the pull requests which are pending on the author will be closed.

We should NEVER close a pull requests which are waiting for the attention of a committer.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4140

## How was this patch tested?

on the https://github.com/elek/hadoop-ozone/ fork with this PR: https://github.com/elek/hadoop-ozone/pull/13