### PR TITLE
HDDS-4146. Show the ScmId and ClusterId in the scm web ui.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMMXBean.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMMXBean.java
@@ -66,4 +66,8 @@ public interface SCMMXBean extends ServiceRuntimeInfo {
   Map<String, Integer> getContainerStateCount();
 
   Map<String, String> getRuleStatusMetrics();
+
+  String getScmId();
+
+  String getClusterId();
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1141,4 +1141,12 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   public PipelineChoosePolicy getPipelineChoosePolicy() {
     return this.pipelineChoosePolicy;
   }
+
+  public String getScmId() {
+    return getScmStorageConfig().getScmId();
+  }
+
+  public String getClusterId() {
+    return getScmStorageConfig().getClusterID();
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -14,6 +14,20 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
+<h2>SCM Information</h2>
+<table class="table table-bordered table-striped">
+    <tbody>
+    <tr>
+        <td>Scm Id:</td>
+        <td>{{$ctrl.overview.jmx.ScmId}}</td>
+    </tr>
+    <tr>
+        <td>Cluster Id:</td>
+        <td>{{$ctrl.overview.jmx.ClusterId}}</td>
+    </tr>
+    </tbody>
+</table>
+
 <h2>Node counts</h2>
 
 <table class="table table-bordered table-striped" class="col-md-6">


### PR DESCRIPTION
## What changes were proposed in this pull request?

Show the ScmId and ClusterId in the scm web ui, so that we can easy to identify the cluster.

## What is the link to the Apache JIRA

HDDS-4146

## How was this patch tested?

Start scm web ui and check the homepage, a SCM Information table will appear.