### PR TITLE
HDDS-4152. Archive container logs for kubernetes check

### DIFF
--- a/hadoop-ozone/dev-support/checks/kubernetes.sh
+++ b/hadoop-ozone/dev-support/checks/kubernetes.sh
@@ -31,6 +31,6 @@ mkdir -p "$REPORT_DIR"
 cd "$DIST_DIR/kubernetes/examples" || exit 1
 ./test-all.sh
 RES=$?
-cp result/* "$REPORT_DIR/"
+cp -r result/* "$REPORT_DIR/"
 cp "$REPORT_DIR/log.html" "$REPORT_DIR/summary.html"
 exit $RES

--- a/hadoop-ozone/dist/src/main/k8s/examples/getting-started/test.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/getting-started/test.sh
@@ -32,6 +32,8 @@ execute_robot_test scm-0 smoketest/basic/basic.robot
 
 combine_reports
 
+get_logs
+
 stop_k8s_env
 
 revert_resources

--- a/hadoop-ozone/dist/src/main/k8s/examples/minikube/test.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/minikube/test.sh
@@ -32,6 +32,8 @@ execute_robot_test scm-0 smoketest/basic/basic.robot
 
 combine_reports
 
+get_logs
+
 stop_k8s_env
 
 revert_resources

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/test.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/test.sh
@@ -32,6 +32,8 @@ execute_robot_test scm-0 smoketest/basic/basic.robot
 
 combine_reports
 
+get_logs
+
 stop_k8s_env
 
 revert_resources

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone/test.sh
@@ -32,6 +32,8 @@ execute_robot_test scm-0 smoketest/basic/basic.robot
 
 combine_reports
 
+get_logs
+
 stop_k8s_env
 
 revert_resources

--- a/hadoop-ozone/dist/src/main/k8s/examples/test-all.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/test-all.sh
@@ -31,13 +31,18 @@ RESULT=0
 IFS=$'\n'
 # shellcheck disable=SC2044
 for test in $(find "$SCRIPT_DIR" -name test.sh | grep "${OZONE_TEST_SELECTOR:-""}" |sort); do
-  echo ""
-  echo "#### Executing tests of $(dirname "$test") #####"
-  echo ""
   TEST_DIR="$(dirname $test)"
+  TEST_NAME="$(basename "$TEST_DIR")"
+
+  echo ""
+  echo "#### Executing tests of ${TEST_DIR} #####"
+  echo ""
   cd "$TEST_DIR" || continue
   ./test.sh
-  cp "$TEST_DIR"/result/output.xml "$ALL_RESULT_DIR"/"$(basename "$TEST_DIR")".xml
+
+  cp "$TEST_DIR"/result/output.xml "$ALL_RESULT_DIR"/"${TEST_NAME}".xml
+  mkdir -p "$ALL_RESULT_DIR"/"${TEST_NAME}"
+  mv "$TEST_DIR"/logs/*log "$ALL_RESULT_DIR"/"${TEST_NAME}"/
 done
 
 rebot -N "smoketests" -d "$ALL_RESULT_DIR/" "$ALL_RESULT_DIR/*.xml"

--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -77,6 +77,13 @@ start_k8s_env() {
    wait_for_startup
 }
 
+get_logs() {
+  mkdir -p logs
+  for pod in $(kubectl get pods -o custom-columns=NAME:.metadata.name | tail -n +2); do
+    kubectl logs "${pod}" > "logs/pod-${pod}.log"
+  done
+}
+
 stop_k8s_env() {
    if [ ! "$KEEP_RUNNING" ]; then
      kubectl delete -f .


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the last few days _kubernetes_ check has been failing very frequently.  This change let's it save logs from all containers to make it easier to find any problems.  (`docker-compose`-based _acceptance_ check also saves container logs.)

https://issues.apache.org/jira/browse/HDDS-4152

## How was this patch tested?

```
$ unzip -t kubernetes.zip
Archive:  kubernetes.zip
    testing: getting-started.xml      OK
    testing: getting-started/         OK
    testing: log.html                 OK
    testing: minikube.xml             OK
    testing: minikube/                OK
    testing: ozone-dev.xml            OK
    testing: ozone-dev/               OK
    testing: ozone.xml                OK
    testing: ozone/                   OK
    testing: report.html              OK
    testing: summary.html             OK
    testing: getting-started/pod-datanode-0.log   OK
    testing: getting-started/pod-datanode-1.log   OK
    testing: getting-started/pod-datanode-2.log   OK
    testing: getting-started/pod-om-0.log   OK
    testing: getting-started/pod-s3g-0.log   OK
    testing: getting-started/pod-scm-0.log   OK
    testing: minikube/pod-datanode-0.log   OK
    testing: minikube/pod-datanode-1.log   OK
    testing: minikube/pod-datanode-2.log   OK
    testing: minikube/pod-om-0.log    OK
    testing: minikube/pod-s3g-0.log   OK
    testing: minikube/pod-scm-0.log   OK
    testing: ozone-dev/pod-datanode-0.log   OK
    testing: ozone-dev/pod-datanode-1.log   OK
    testing: ozone-dev/pod-datanode-2.log   OK
    testing: ozone-dev/pod-jaeger-0.log   OK
    testing: ozone-dev/pod-om-0.log   OK
    testing: ozone-dev/pod-prometheus-584b7948d9-8fcb6.log   OK
    testing: ozone-dev/pod-s3g-0.log   OK
    testing: ozone-dev/pod-scm-0.log   OK
    testing: ozone/pod-datanode-0.log   OK
    testing: ozone/pod-datanode-1.log   OK
    testing: ozone/pod-datanode-2.log   OK
    testing: ozone/pod-om-0.log       OK
    testing: ozone/pod-s3g-0.log      OK
    testing: ozone/pod-scm-0.log      OK
```

https://github.com/adoroszlai/hadoop-ozone/runs/1031423764