### PR TITLE
HDDS-4149. Implement OzoneFileStatus#toString

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFileStatus.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFileStatus.java
@@ -130,4 +130,22 @@ public class OzoneFileStatus {
   public int hashCode() {
     return Objects.hash(getTrimmedName());
   }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(getClass().getSimpleName());
+    sb.append("{");
+    if (keyInfo == null) {
+      sb.append("<root>");
+    } else {
+      sb.append(getTrimmedName());
+      if (isDirectory) {
+        sb.append(" (dir)");
+      }
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implement `toString()` in `OzoneFileStatus` for debug purposes.

https://issues.apache.org/jira/browse/HDDS-4149

## How was this patch tested?

Added debug log via byteman, output from `OzoneFileStatus#toString()` is shown as the parameter of `getBlockLocations()`:

```
getBlockLocations(OzoneFileStatus{input/README.md}): [0,3841,ozone-datanode-2.ozone-datanode.default.svc.cluster.local,ozone-datanode-1.ozone-datanode.default.svc.cluster.local,ozone-datanode-0.ozone-datanode.default.svc.cluster.local]
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/runs/1031492588