### PR TITLE
HDDS-4153. Increase default timeout in kubernetes tests

### DIFF
--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -17,14 +17,14 @@
 
 retry() {
    n=0
-   until [ $n -ge 30 ]
+   until [ $n -ge 100 ]
    do
       "$@" && break
       n=$[$n+1]
       echo "$n '$@' is failed..."
       sleep ${RETRY_SLEEP:-3}
    done
-   if [ $n -eq 30 ]; then
+   if [ $n -eq 100 ]; then
       return 255
    fi
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Kubernetes tests are timing out sometimes. (eg. here: https://github.com/elek/ozone-build-results/tree/master/2020/08/26/2562/kubernetes)

Based on the log, SCM couldn't move out from safe mode. It's either a real issue or github environment is slow sometimes.

To make it clear what is the problem I propose to increase the default timeout from 90 sec to 300 sec (5 min).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4153

## How was this patch tested?

CI (did the same two days ago in https://github.com/elek/ozone-perf-env)