### PR TITLE
HDDS-4168. Remove archaic reference to Skaffold

### DIFF
--- a/hadoop-ozone/dist/README.md
+++ b/hadoop-ozone/dist/README.md
@@ -14,63 +14,43 @@
 
 # Ozone Distribution
 
-This folder contains the project to create the binary ozone distribution and provide all the helper script and docker files to start it locally or in the cluster.
+This folder contains the project to create the binary Ozone distribution and provide all the helper scripts and Docker files to start Ozone locally or on a remote cluster.
 
 ## Testing with local docker based cluster
 
-After a full dist build you can find multiple docker-compose based cluster definition in the `target/ozone-*/compose` folder.
+After a full dist build you can find multiple docker-compose-based cluster definitions in the `target/ozone-*/compose` folder.
 
 Please check the README files there.
 
-Usually you can start the cluster with:
+Usually, you can start the cluster with:
 
 ```
 cd compose/ozone
 docker-compose up -d
 ```
 
+More information can be found in the Getting Started Guide:
+* [Getting Started: Run Ozone with Docker Compose](https://hadoop.apache.org/ozone/docs/current/start/runningviadocker.html)
+
 ## Testing on Kubernetes
 
-You can also test the ozone cluster in kubernetes. If you have no active kubernetes cluster you can start a local one with minikube:
 
-```
-minikube start
-```
+### Installation
 
-For testing in kubernetes you need to:
-
-1. Create a docker image with the new build
-2. Upload it to a docker registery
-3. Deploy the cluster with apply kubernetes resources
-
-The easiest way to do all these steps is using the [skaffold](https://github.com/GoogleContainerTools/skaffold) tool. After the [installation of skaffold](https://github.com/GoogleContainerTools/skaffold#installation), you can execute
-
-```
-skaffold run
-```
-
-in this  (`hadoop-ozone/dist`) folder.
-
-The default kubernetes resources set (`src/main/k8s/`) contains NodePort based service definitions for the Ozone Manager, Storage Container Manager and the S3 gateway.
-
-With minikube you can access the services with:
-
-```
-minikube service s3g-public
-minikube service om-public
-minikube service scm-public
-```
+Please refer to the Getting Started guide for a couple of options for testing Ozone on Kubernetes:
+* [Getting Started: Minikube and Ozone](https://hadoop.apache.org/ozone/docs/current/start/minikube.html)
+* [Getting Started: Ozone on Kubernetes](https://hadoop.apache.org/ozone/docs/current/start/kubernetes.html)
 
 ### Monitoring
 
-Apache Hadoop Ozone supports Prometheus out-of the box. It contains a prometheus compatible exporter servlet. To start the monitoring you need a prometheus deploy in your kubernetes  cluster:
+Apache Hadoop Ozone supports Prometheus out of the box. It contains a prometheus-compatible exporter servlet. To start monitoring you need a Prometheus deployment in your Kubernetes cluster:
 
 ```
 cd src/main/k8s/prometheus
 kubectl apply -f .
 ```
 
-The prometheus ui also could be access via a NodePort service:
+The Prometheus UI can be made accessible via a NodePort service:
 
 ```
 minikube service prometheus-public
@@ -78,8 +58,8 @@ minikube service prometheus-public
 
 ### Notes on the Kubernetes setup
 
-Please not that the provided kubernetes resources are not suitable production:
+Please note that the provided Kubernetes resources are not suitable for production:
 
-1. There are no security setup
-2. The datanode is started in StatefulSet instead of DaemonSet (To make it possible to scale it up on one node minikube cluster)
-3. All the UI pages are published with NodePort services
+1. There is no security setup.
+2. The datanode is started as a StatefulSet instead of DaemonSet.  This is to make it possible to scale it up on one-node minikube cluster.
+3. All of the UI pages are published with NodePort services.


### PR DESCRIPTION
## What changes were proposed in this pull request?

I got sidetracked when I ran into the README in the dist folder because it referenced Skaffold which hasn't been used in a while.

So that others don't get confused as I did, this PR points people to the relevant pages in the Getting Started guide.  In addition, I cleaned up some grammatical and typographical issues that I noticed.

I feel like the 'Monitoring' and 'Notes on the Kubernetes setup' Sections could also be moved to the Getting Started guide so that documentation is more consolidated in one place, but I didn't want to move too much too soon.  Let me know if this would be a good idea.
