### PR TITLE
HDDS-3805. [OFS] Remove usage of OzoneClientAdapter interface

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -81,7 +81,9 @@ public class ObjectStore {
     proxy = null;
   }
 
-  @VisibleForTesting
+  /**
+   * Returns the ClientProtocol of the ObjectStore.
+   */
   public ClientProtocol getClientProxy() {
     return proxy;
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -107,7 +107,7 @@ public class TestRootedOzoneFileSystem {
   private static FileSystem fs;
   private static RootedOzoneFileSystem ofs;
   private static ObjectStore objectStore;
-  private static BasicRootedOzoneClientAdapterImpl adapter;
+  private static BasicRootedOzoneClientAdapterImpl impl;
   private static Trash trash;
 
   private static String volumeName;
@@ -147,7 +147,7 @@ public class TestRootedOzoneFileSystem {
     fs = FileSystem.get(conf);
     trash = new Trash(conf);
     ofs = (RootedOzoneFileSystem) fs;
-    adapter = (BasicRootedOzoneClientAdapterImpl) ofs.getAdapter();
+    impl = ofs.getImpl();
   }
 
   @AfterClass
@@ -664,7 +664,7 @@ public class TestRootedOzoneFileSystem {
    */
   private List<FileStatus> callAdapterListStatus(String pathStr,
       boolean recursive, String startPath, long numEntries) throws IOException {
-    return adapter.listStatus(pathStr, recursive, startPath, numEntries,
+    return impl.listStatus(pathStr, recursive, startPath, numEntries,
         ofs.getUri(), ofs.getWorkingDirectory(), ofs.getUsername())
         .stream().map(ofs::convertFileStatus).collect(Collectors.toList());
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
-import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -334,6 +335,11 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
       }
       throw e;
     }
+  }
+
+  @Override
+  public ClientProtocol getClientProtocol() {
+    return objectStore.getClientProxy();
   }
 
   @Override

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -228,11 +228,6 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
     bucket.renameKey(key, newKeyName);
   }
 
-  @Override
-  public void rename(String pathStr, String newPath) throws IOException {
-    throw new IOException("Please use renameKey instead for o3fs.");
-  }
-
   /**
    * Helper method to create an directory specified by key name in bucket.
    *

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -338,11 +338,6 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   }
 
   @Override
-  public ClientProtocol getClientProtocol() {
-    return objectStore.getClientProxy();
-  }
-
-  @Override
   public Token<OzoneTokenIdentifier> getDelegationToken(String renewer)
       throws IOException {
     if (!securityEnabled) {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -93,6 +93,7 @@ public class BasicRootedOzoneClientAdapterImpl {
   static final Logger LOG =
       LoggerFactory.getLogger(BasicRootedOzoneClientAdapterImpl.class);
 
+  private ObjectStore objectStore;
   private ClientProtocol proxy;
   private ReplicationType replicationType;
   private ReplicationFactor replicationFactor;
@@ -180,7 +181,7 @@ public class BasicRootedOzoneClientAdapterImpl {
       } else {
         ozoneClient = OzoneClientFactory.getRpcClient(conf);
       }
-      ObjectStore objectStore = ozoneClient.getObjectStore();
+      objectStore = ozoneClient.getObjectStore();
       proxy = objectStore.getClientProxy();
       this.replicationType = ReplicationType.valueOf(replicationTypeConf);
       this.replicationFactor = ReplicationFactor.valueOf(replicationCountConf);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -88,8 +88,7 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes
  * <p>
  * For full featured version use RootedOzoneClientAdapterImpl.
  */
-public class BasicRootedOzoneClientAdapterImpl
-    implements OzoneClientAdapter {
+public class BasicRootedOzoneClientAdapterImpl {
 
   static final Logger LOG =
       LoggerFactory.getLogger(BasicRootedOzoneClientAdapterImpl.class);
@@ -269,17 +268,14 @@ public class BasicRootedOzoneClientAdapterImpl
     return bucket;
   }
 
-  @Override
   public short getDefaultReplication() {
     return (short) replicationFactor.getValue();
   }
 
-  @Override
   public void close() throws IOException {
     proxy.close();
   }
 
-  @Override
   public InputStream readFile(String pathStr) throws IOException {
     incrementCounter(Statistic.OBJECTS_READ, 1);
     OFSPath ofsPath = new OFSPath(pathStr);
@@ -302,7 +298,6 @@ public class BasicRootedOzoneClientAdapterImpl
     //noop: Use RootedOzoneClientAdapterImpl which supports statistics.
   }
 
-  @Override
   public OzoneFSOutputStream createFile(String pathStr, short replication,
       boolean overWrite, boolean recursive) throws IOException {
     incrementCounter(Statistic.OBJECTS_CREATED, 1);
@@ -337,11 +332,6 @@ public class BasicRootedOzoneClientAdapterImpl
     }
   }
 
-  @Override
-  public void renameKey(String key, String newKeyName) throws IOException {
-    throw new IOException("OFS doesn't support renameKey, use rename instead.");
-  }
-
   /**
    * Rename a path into another.
    *
@@ -353,7 +343,6 @@ public class BasicRootedOzoneClientAdapterImpl
    * @param newPath Target path
    * @throws IOException
    */
-  @Override
   public void rename(String path, String newPath) throws IOException {
     incrementCounter(Statistic.OBJECTS_RENAMED, 1);
     OFSPath ofsPath = new OFSPath(path);
@@ -396,7 +385,6 @@ public class BasicRootedOzoneClientAdapterImpl
    * @param pathStr path to be created as directory
    * @return true if the key is created, false otherwise
    */
-  @Override
   public boolean createDirectory(String pathStr) throws IOException {
     LOG.trace("creating dir for path: {}", pathStr);
     incrementCounter(Statistic.OBJECTS_CREATED, 1);
@@ -435,7 +423,6 @@ public class BasicRootedOzoneClientAdapterImpl
    * @param path path to a key to be deleted
    * @return true if the key is deleted, false otherwise
    */
-  @Override
   public boolean deleteObject(String path) {
     LOG.trace("issuing delete for path to key: {}", path);
     incrementCounter(Statistic.OBJECTS_DELETED, 1);
@@ -751,7 +738,6 @@ public class BasicRootedOzoneClientAdapterImpl
     }
   }
 
-  @Override
   public Token<OzoneTokenIdentifier> getDelegationToken(String renewer)
       throws IOException {
     if (!securityEnabled) {
@@ -764,17 +750,14 @@ public class BasicRootedOzoneClientAdapterImpl
 
   }
 
-  @Override
   public KeyProvider getKeyProvider() throws IOException {
     return proxy.getKeyProvider();
   }
 
-  @Override
   public URI getKeyProviderUri() throws IOException {
     return proxy.getKeyProviderUri();
   }
 
-  @Override
   public String getCanonicalServiceName() {
     return proxy.getCanonicalServiceName();
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -468,7 +468,6 @@ public class BasicRootedOzoneClientAdapterImpl {
    * @param keyNameList key name list to be deleted
    * @return true if the key deletion is successful, false otherwise
    */
-  @Override
   public boolean deleteObjects(List<String> keyNameList) {
     if (keyNameList.size() == 0) {
       return true;
@@ -597,7 +596,6 @@ public class BasicRootedOzoneClientAdapterImpl {
     return ret;
   }
 
-  @Override
   public Iterator<BasicKeyInfo> listKeys(String pathStr) {
     incrementCounter(Statistic.OBJECTS_LIST, 1);
     OFSPath ofsPath = new OFSPath(pathStr);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -752,11 +752,6 @@ public class BasicRootedOzoneClientAdapterImpl
   }
 
   @Override
-  public ClientProtocol getClientProtocol() {
-    return proxy;
-  }
-
-  @Override
   public Token<OzoneTokenIdentifier> getDelegationToken(String renewer)
       throws IOException {
     if (!securityEnabled) {
@@ -782,6 +777,14 @@ public class BasicRootedOzoneClientAdapterImpl
   @Override
   public String getCanonicalServiceName() {
     return proxy.getCanonicalServiceName();
+  }
+
+  public OzoneVolume getVolumeDetails(String volumeName) throws IOException {
+    return proxy.getVolumeDetails(volumeName);
+  }
+
+  public void deleteVolume(String volumeName) throws IOException {
+    proxy.deleteVolume(volumeName);
   }
 
   /**

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -686,7 +686,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   public Collection<FileStatus> getTrashRoots(boolean allUsers) {
     // Since get all trash roots for one or more users requires listing all
     // volumes and buckets, we will let adapter impl handle it.
-    return adapterImpl.getTrashRoots(allUsers, this);
+    return impl.getTrashRoots(allUsers, this);
   }
 
   /**

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
@@ -91,7 +92,6 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   private String userName;
   private Path workingDir;
   private OzoneClientAdapter adapter;
-  private BasicRootedOzoneClientAdapterImpl adapterImpl;
 
   private static final String URI_EXCEPTION_TEXT =
       "URL should be one of the following formats: " +
@@ -143,7 +143,6 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
         source = new LegacyHadoopConfigurationSource(conf);
       }
       this.adapter = createAdapter(source, omHostOrServiceId, omPort);
-      this.adapterImpl = (BasicRootedOzoneClientAdapterImpl) this.adapter;
 
       try {
         this.userName =
@@ -502,13 +501,14 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
         return false;
       }
 
+      ClientProtocol proxy = adapter.getClientProtocol();
+
       // Handle delete volume
       if (ofsPath.isVolume()) {
         String volumeName = ofsPath.getVolumeName();
         if (recursive) {
           // Delete all buckets first
-          OzoneVolume volume =
-              adapterImpl.getObjectStore().getVolume(volumeName);
+          OzoneVolume volume = proxy.getVolumeDetails(volumeName);
           Iterator<? extends OzoneBucket> it = volume.listBuckets("");
           String prefixVolumePathStr = addTrailingSlashIfNeeded(f.toString());
           while (it.hasNext()) {
@@ -518,7 +518,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
           }
         }
         try {
-          adapterImpl.getObjectStore().deleteVolume(volumeName);
+          proxy.deleteVolume(volumeName);
           return true;
         } catch (OMException ex) {
           // volume is not empty
@@ -534,8 +534,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
       // Handle delete bucket
       if (ofsPath.isBucket()) {
-        OzoneVolume volume =
-            adapterImpl.getObjectStore().getVolume(ofsPath.getVolumeName());
+        OzoneVolume volume = proxy.getVolumeDetails(ofsPath.getVolumeName());
         try {
           volume.deleteBucket(ofsPath.getBucketName());
           return result;

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
-import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
@@ -890,7 +889,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     }
   }
 
-  public OzoneClientAdapter getImpl() {
+  public BasicRootedOzoneClientAdapterImpl getImpl() {
     return impl;
   }
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.security.token.Token;
 
@@ -46,9 +45,6 @@ public interface OzoneClientAdapter {
       boolean overWrite, boolean recursive) throws IOException;
 
   void renameKey(String key, String newKeyName) throws IOException;
-
-  // Users should use rename instead of renameKey in OFS.
-  void rename(String pathStr, String newPath) throws IOException;
 
   boolean createDirectory(String keyName) throws IOException;
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.security.token.Token;
 
@@ -60,6 +61,8 @@ public interface OzoneClientAdapter {
   List<FileStatusAdapter> listStatus(String keyName, boolean recursive,
       String startKey, long numEntries, URI uri,
       Path workingDir, String username) throws IOException;
+
+  ClientProtocol getClientProtocol();
 
   Token<OzoneTokenIdentifier> getDelegationToken(String renewer)
       throws IOException;

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
@@ -62,8 +62,6 @@ public interface OzoneClientAdapter {
       String startKey, long numEntries, URI uri,
       Path workingDir, String username) throws IOException;
 
-  ClientProtocol getClientProtocol();
-
   Token<OzoneTokenIdentifier> getDelegationToken(String renewer)
       throws IOException;
 

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.fs.ozone;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
-import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.crypto.key.KeyProviderTokenIssuer;
 import org.apache.hadoop.fs.FileSystem;
@@ -51,12 +50,12 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
 
   @Override
   public KeyProvider getKeyProvider() throws IOException {
-    return getAdapter().getKeyProvider();
+    return getImpl().getKeyProvider();
   }
 
   @Override
   public URI getKeyProviderUri() throws IOException {
-    return getAdapter().getKeyProviderUri();
+    return getImpl().getKeyProviderUri();
   }
 
   @Override
@@ -84,12 +83,5 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
     if (storageStatistics != null) {
       storageStatistics.incrementCounter(statistic, count);
     }
-  }
-
-  @Override
-  protected OzoneClientAdapter createAdapter(ConfigurationSource conf,
-      String omHost, int omPort) throws IOException {
-    return new RootedOzoneClientAdapterImpl(omHost, omPort, conf,
-        storageStatistics);
   }
 }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.fs.ozone;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
-import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.crypto.key.KeyProviderTokenIssuer;
 import org.apache.hadoop.fs.FileSystem;
@@ -51,12 +50,12 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
 
   @Override
   public KeyProvider getKeyProvider() throws IOException {
-    return getAdapter().getKeyProvider();
+    return getImpl().getKeyProvider();
   }
 
   @Override
   public URI getKeyProviderUri() throws IOException {
-    return getAdapter().getKeyProviderUri();
+    return getImpl().getKeyProviderUri();
   }
 
   @Override
@@ -84,12 +83,5 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
     if (storageStatistics != null) {
       storageStatistics.incrementCounter(statistic, count);
     }
-  }
-
-  @Override
-  protected OzoneClientAdapter createAdapter(ConfigurationSource conf,
-      String omHost, int omPort) throws IOException {
-    return new RootedOzoneClientAdapterImpl(omHost, omPort, conf,
-        storageStatistics);
   }
 }


### PR DESCRIPTION
This PR is derived from https://github.com/apache/hadoop-ozone/pull/1088 as the previous one is split into multiple jiras and needs rebase. I'm hoping opening up a brand new PR for the original jira would make things simpler.

## What changes were proposed in this pull request?

Use ClientProtocol directly in Adapter and FS.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3805

## How was this patch tested?

Existing tests should pass.