### PR TITLE
HDDS-4165. GitHub Actions cache does not work outside of workspace

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -164,6 +164,8 @@ jobs:
           - misc
       fail-fast: false
     steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
       - name: Cache for maven dependencies
         uses: actions/cache@v2
         with:
@@ -290,6 +292,8 @@ jobs:
   kubernetes:
     runs-on: ubuntu-18.04
     steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
       - name: Cache for maven dependencies
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Checkout project to its regular location (inside `GITHUB_WORKSPACE`) before attempting to restore cache.  This allows calculation of hash of cache key files (`pom.xml`, `pnpm-lock.yaml`)

https://issues.apache.org/jira/browse/HDDS-4165

## How was this patch tested?

Verified that cache key now includes hash of files:

```
Cache not found for input keys: maven-repo-78a78691596adf599a9afd1481471aa13fb05402873415b8199d404fd937eae2
...
Cache not found for input keys: Linux-pnpm-17a93e576bec6596513e8336af475af9b856a1ba83ab27dd39d06fe763dac835, Linux-pnpm-
```

https://github.com/adoroszlai/hadoop-ozone/runs/1042731167#step:3:5
https://github.com/adoroszlai/hadoop-ozone/runs/1042730953#step:4:9

and subsequent build on same branch reuses cache:

```
Cache restored from key: maven-repo-78a78691596adf599a9afd1481471aa13fb05402873415b8199d404fd937eae2
...
Cache restored from key: Linux-pnpm-17a93e576bec6596513e8336af475af9b856a1ba83ab27dd39d06fe763dac835
```

https://github.com/adoroszlai/hadoop-ozone/runs/1042919167#step:3:10
https://github.com/adoroszlai/hadoop-ozone/runs/1042919016#step:4:13