### PR TITLE
HDDS-4167. Acceptance test logs missing if SCM fails to exit safe mode

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/test.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,29 +16,22 @@
 # limitations under the License.
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )
 ALL_RESULT_DIR="$SCRIPT_DIR/result"
+mkdir -p "$ALL_RESULT_DIR"
+rm "$ALL_RESULT_DIR/*" || true
 source "$SCRIPT_DIR/../testlib.sh"
 
 tests=$(find_tests)
+cd "$SCRIPT_DIR"
 
 RESULT=0
 # shellcheck disable=SC2044
 for t in ${tests}; do
   d="$(dirname "${t}")"
-  echo "Executing test in ${d}"
 
-  #required to read the .env file from the right location
-  cd "${d}" || continue
-  ./test.sh
-  ret=$?
-  if [[ $ret -ne 0 ]]; then
-      RESULT=1
-      echo "ERROR: Test execution of ${d} is FAILED!!!!"
+  if ! run_test_script "${d}"; then
+    RESULT=1
   fi
-  cd "$SCRIPT_DIR"
-  RESULT_DIR="${d}/result"
-  TEST_DIR_NAME=$(basename ${d})
-  rebot -N $TEST_DIR_NAME -o "$ALL_RESULT_DIR"/$TEST_DIR_NAME.xml "$RESULT_DIR"/"*.xml"
-  cp "$RESULT_DIR"/docker-*.log "$ALL_RESULT_DIR"/
-  cp "$RESULT_DIR"/*.out* "$ALL_RESULT_DIR"/ || true
+
+  copy_results "${d}" "${ALL_RESULT_DIR}"
 done
 

--- a/hadoop-ozone/dist/src/main/compose/test-all.sh
+++ b/hadoop-ozone/dist/src/main/compose/test-all.sh
@@ -34,29 +34,18 @@ if [ "$OZONE_WITH_COVERAGE" ]; then
 fi
 
 tests=$(find_tests)
+cd "$SCRIPT_DIR"
 
 RESULT=0
 # shellcheck disable=SC2044
 for t in ${tests}; do
   d="$(dirname "${t}")"
-  echo "Executing test in ${d}"
 
-  #required to read the .env file from the right location
-  cd "${d}" || continue
-  set +e
-  ./test.sh
-  ret=$?
-  set -e
-  if [[ $ret -ne 0 ]]; then
-      RESULT=1
-      echo "ERROR: Test execution of ${d} is FAILED!!!!"
+  if ! run_test_script "${d}"; then
+    RESULT=1
   fi
-  cd "$SCRIPT_DIR"
-  RESULT_DIR="${d}/result"
-  TEST_DIR_NAME=$(basename ${d})
-  rebot --nostatusrc -N $TEST_DIR_NAME -o "$ALL_RESULT_DIR"/$TEST_DIR_NAME.xml "$RESULT_DIR"/"*.xml"
-  cp "$RESULT_DIR"/docker-*.log "$ALL_RESULT_DIR"/
-  cp "$RESULT_DIR"/*.out* "$ALL_RESULT_DIR"/ || true
+
+  copy_results "${d}" "${ALL_RESULT_DIR}"
 done
 
 rebot --nostatusrc -N acceptance -d "$ALL_RESULT_DIR" "$ALL_RESULT_DIR"/*.xml

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -247,3 +247,39 @@ generate_report(){
      exit 1
   fi
 }
+
+## @description  Copy results of a single test environment to the "all tests" dir.
+copy_results() {
+  local test_dir="$1"
+  local all_result_dir="$2"
+
+  local result_dir="${test_dir}/result"
+  local test_dir_name=$(basename ${test_dir})
+  if [[ -n "$(find "${result_dir}" -name "*.xml")" ]]; then
+    rebot --nostatusrc -N "${test_dir_name}" -o "${all_result_dir}/${test_dir_name}.xml" "${result_dir}/*.xml"
+  fi
+
+  cp "${result_dir}"/docker-*.log "${all_result_dir}"/
+  if [[ -n "$(find "${result_dir}" -name "*.out")" ]]; then
+    cp "${result_dir}"/*.out* "${all_result_dir}"/
+  fi
+}
+
+run_test_script() {
+  local d="$1"
+
+  echo "Executing test in ${d}"
+
+  #required to read the .env file from the right location
+  cd "${d}" || return
+
+  ret=0
+  if ! ./test.sh; then
+    ret=1
+    echo "ERROR: Test execution of ${d} is FAILED!!!!"
+  fi
+
+  cd - > /dev/null
+
+  return ${ret}
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Acceptance test sometimes fails due to SCM not coming out of safe mode. If this happens, the cluster is stopped without running Robot tests. rebot command to process test results fails due to missing input, and acceptance check is abruptly stopped without fetching docker logs or running tests in other environments.

Fix:

1. Only run intermediate `rebot` processing if input files are available (it is safe to let the final one in `test-all.sh` fail)
2. Pre-create results dir for `ozone-mr`, which contains multiple test sub-directories, to avoid error in `find`

And some cleanup:

3. Reduce some code duplication between `test-all.sh` and `ozone-mr/test.sh` by extracting functions for the shared code being fixed
4. Replace `set +e; ...; set -e` with `if ! ...; then ...` (partly belongs to HDDS-4101) in the code being fixed

https://issues.apache.org/jira/browse/HDDS-4167

## How was this patch tested?

Temporarily reduced wait time for exit from safe mode to 10 seconds, causing all tests to fail early.  Verified that docker logs were still added to the bundle:

```
unzip -t acceptance-misc.zip
Archive:  acceptance-misc.zip
    testing: docker-hadoop27.log      OK
    testing: docker-hadoop31.log      OK
    testing: docker-hadoop32.log      OK
    testing: docker-ozone-csi.log     OK
    testing: docker-ozone-ha.log      OK
    testing: docker-ozone-om-ha-s3.log   OK
    testing: docker-ozone-topology.log   OK
    testing: docker-ozones3-haproxy.log   OK
    testing: docker-ozonesecure-mr.log   OK
    testing: docker-ozonesecure-om-ha.log   OK
    testing: docker-upgrade.log       OK
```

https://github.com/adoroszlai/hadoop-ozone/runs/1045059176

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/runs/1045057585