### PR TITLE
HDDS-4176. Fix failed UT: test2WayCommitForTimeoutException

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ContainerTestHelper.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ContainerTestHelper.java
@@ -583,6 +583,11 @@ public final class ContainerTestHelper {
 
   private static RaftServerImpl getRaftServerImpl(HddsDatanodeService dn,
       Pipeline pipeline) throws Exception {
+    if (!pipeline.getNodes().contains(dn.getDatanodeDetails())) {
+      throw new IllegalArgumentException("Pipeline:" + pipeline.getId() +
+          " not exist in datanode:" + dn.getDatanodeDetails().getUuid());
+    }
+
     XceiverServerSpi server = dn.getDatanodeStateMachine().
         getContainer().getWriteChannel();
     RaftServerProxy proxy =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -298,10 +298,10 @@ public class TestWatchForCommit {
             xceiverClient.getPipeline()));
     reply.getResponse().get();
     Assert.assertEquals(3, ratisClient.getCommitInfoMap().size());
-    List<DatanodeDetails> datanodeDetails = pipeline.getNodes();
+    List<DatanodeDetails> nodesInPipeline = pipeline.getNodes();
     for (HddsDatanodeService dn : cluster.getHddsDatanodes()) {
       // shutdown the ratis follower
-      if (datanodeDetails.contains(dn.getDatanodeDetails())
+      if (nodesInPipeline.contains(dn.getDatanodeDetails())
           && ContainerTestHelper.isRatisFollower(dn, pipeline)) {
         cluster.shutdownHddsDatanode(dn.getDatanodeDetails());
         break;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
 import org.apache.hadoop.hdds.scm.*;
@@ -297,9 +298,11 @@ public class TestWatchForCommit {
             xceiverClient.getPipeline()));
     reply.getResponse().get();
     Assert.assertEquals(3, ratisClient.getCommitInfoMap().size());
+    List<DatanodeDetails> datanodeDetails = pipeline.getNodes();
     for (HddsDatanodeService dn : cluster.getHddsDatanodes()) {
       // shutdown the ratis follower
-      if (ContainerTestHelper.isRatisFollower(dn, pipeline)) {
+      if (datanodeDetails.contains(dn.getDatanodeDetails())
+          && ContainerTestHelper.isRatisFollower(dn, pipeline)) {
         cluster.shutdownHddsDatanode(dn.getDatanodeDetails());
         break;
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
**What's the problem ?**
![image](https://user-images.githubusercontent.com/51938049/91786207-a85a4280-ec39-11ea-8251-71f318fb5156.png)

**What's the reason of the failed ut ?**

When cluster create 9 nodes, the following code try to shutdown the follower of the pipeline. Actually, the pipeline only exist in 3 nodes, but the following code check 9 nodes, so the pipeline can not found in the other 6 nodes. 
```
    for (HddsDatanodeService dn : cluster.getHddsDatanodes()) {
      // shutdown the ratis follower
      if (ContainerTestHelper.isRatisFollower(dn, pipeline)) {
        cluster.shutdownHddsDatanode(dn.getDatanodeDetails());
        break;
      }
    }
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4176

## How was this patch tested?

Existed ut.
