### PR TITLE
HDDS-4166. Documentation index page redirects to the wrong address

### DIFF
--- a/hadoop-hdds/docs/content/concept/Overview.zh.md
+++ b/hadoop-hdds/docs/content/concept/Overview.zh.md
@@ -24,7 +24,7 @@ summary: 介绍 Ozone 的整体和各个组件。
 
 Ozone 是一个分布式、多副本的对象存储系统，并针对大数据场景进行了专门的优化。Ozone 主要围绕可扩展性进行设计，目标是十亿数量级以上的对象存储。
 
-Ozone 通过对命名空间与块空间的管理进行分离，大大增加了其可扩展性，其中命名空间由 [Ozone Manager ]({{< ref "OzoneManager.zh.md" >}})（OM）管理，块空间由 [Storage Container Manager] ({{< ref "StorageContainerManager.zh.md" >}})（SCM）管理。
+Ozone 通过对命名空间与块空间的管理进行分离，大大增加了其可扩展性，其中命名空间由 [Ozone Manager ]({{< ref "OzoneManager.zh.md" >}})（OM）管理，块空间由 [Storage Container Manager]({{< ref "StorageContainerManager.zh.md" >}})（SCM）管理。
 
 
 Ozone 的管理由卷、桶和键组成。卷类似于个人主目录，只有管理员可以创建。

--- a/hadoop-hdds/docs/content/interface/O3fs.zh.md
+++ b/hadoop-hdds/docs/content/interface/O3fs.zh.md
@@ -29,7 +29,7 @@ summary: Hadoop 文件系统兼容使得任何使用类 HDFS 接口的应用无�
 
 Hadoop 的文件系统接口兼容可以让任意像 Ozone 这样的存储后端轻松地整合进 Hadoop 生态系统，Ozone 文件系统就是一个兼容 Hadoop 的文件系统。
 目前ozone支持两种协议: o3fs和ofs。两者最大的区别是o3fs只支持在单个bucket上操作，而ofs则支持跨所有volume和bucket的操作。关于两者在操作
-上的具体区别可以参考ofs.md中的"Differences from existing o3fs"。
+上的具体区别可以参考[OFS(英文页面)]({{< relref path="interface/ofs.md" lang="en" >}})中的"Differences from o3fs"。
 
 ## o3fs的配置及使用
 
@@ -115,7 +115,7 @@ hdfs dfs -ls o3fs://bucket.volume.om-host.example.com:6789/key
 注意：在这种情况下，`ozone.om.address` 配置中只有端口号会被用到，主机名是被忽略的。
 
 ## ofs的配置及使用
-这只是一个通用的介绍。了解更详细的用法，可以请参考ofs.md。
+这只是一个通用的介绍。了解更详细的用法，可以请参考[OFS(英文页面)]({{< relref path="interface/ofs.md" lang="en" >}})。
 
 请在 core-site.xml 中添加以下条目：
 

--- a/hadoop-hdds/docs/content/interface/O3fs.zh.md
+++ b/hadoop-hdds/docs/content/interface/O3fs.zh.md
@@ -28,8 +28,7 @@ summary: Hadoop 文件系统兼容使得任何使用类 HDFS 接口的应用无�
 </div>
 
 Hadoop 的文件系统接口兼容可以让任意像 Ozone 这样的存储后端轻松地整合进 Hadoop 生态系统，Ozone 文件系统就是一个兼容 Hadoop 的文件系统。
-目前ozone支持两种协议: o3fs和ofs。两者最大的区别是o3fs只支持在单个bucket上操作，而ofs则支持跨所有volume和bucket的操作。关于两者在操作
-上的具体区别可以参考[OFS(英文页面)]({{< relref path="interface/ofs.md" lang="en" >}})中的"Differences from o3fs"。
+目前ozone支持两种协议: o3fs和ofs。两者最大的区别是o3fs只支持在单个bucket上操作，而ofs则支持跨所有volume和bucket的操作。关于两者在操作上的具体区别请参考[OFS(英文页面)]({{< relref path="interface/ofs.md" lang="en" >}})中的"Differences from o3fs"。
 
 ## o3fs的配置及使用
 
@@ -115,7 +114,7 @@ hdfs dfs -ls o3fs://bucket.volume.om-host.example.com:6789/key
 注意：在这种情况下，`ozone.om.address` 配置中只有端口号会被用到，主机名是被忽略的。
 
 ## ofs的配置及使用
-这只是一个通用的介绍。了解更详细的用法，可以请参考[OFS(英文页面)]({{< relref path="interface/ofs.md" lang="en" >}})。
+这只是一个通用的介绍。了解更详细的用法，请参考[OFS(英文页面)]({{< relref path="interface/ofs.md" lang="en" >}})。
 
 请在 core-site.xml 中添加以下条目：
 

--- a/hadoop-hdds/docs/content/security/SecureOzone.zh.md
+++ b/hadoop-hdds/docs/content/security/SecureOzone.zh.md
@@ -52,8 +52,7 @@ S3 使用了一种不一样的共享秘密的安全机制，Ozone 支持 AWS Sig
 S3 token 功能在启用安全机制的情况下也默认开启。
 
 
-Ozone 的每个服务进程都需要一个 Kerberos 服务主体名和对应的 [kerberos keytab](https://web.mit.edu/kerberos/krb5-latest/doc/basic
-/keytab_def.html) 文件。
+Ozone 的每个服务进程都需要一个 Kerberos 服务主体名和对应的 [kerberos keytab](https://web.mit.edu/kerberos/krb5-latest/doc/basic/keytab_def.html) 文件。
 
 ozone-site.xml 中应进行如下配置：
 

--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/_default/single.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/_default/single.html
@@ -30,7 +30,7 @@
         <div class="col-md-9">
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
-                  <li class="breadcrumb-item"><a href="/">Home</a></li>
+                  <li class="breadcrumb-item"><a href="{{ "index.html" | relLangURL }}">Home</a></li>
                   <li class="breadcrumb-item" aria-current="page"><a href="{{.CurrentSection.Permalink}}">{{.CurrentSection.Title}}</a></li>
                   <li class="breadcrumb-item active" aria-current="page">{{ .Title }}</li>
                 </ol>

--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/languages.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/languages.html
@@ -18,7 +18,8 @@
 <div class="pull-right">
     {{ range .AllTranslations }}
     {{ if ne $.Language .Language}}
-    <a href="{{.Permalink}}"><span class="label label-success">{{ .Language.LanguageName }}</span></a>
+    {{ $permalink := cond (strings.HasSuffix .Permalink ".html") .Permalink (printf "%sindex.html" .Permalink)}}
+    <a href="{{$permalink}}"><span class="label label-success">{{ .Language.LanguageName }}</span></a>
     {{end}}
     {{ end }}
 </div>

--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/navbar.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/navbar.html
@@ -23,10 +23,10 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a href="#" class="navbar-left" style="height: 50px; padding: 5px 5px 5px 0;">
-        <img src="{{ "ozone-logo-small.png" | relURL }}" width="40"/>
+      <a href="{{ "index.html" | relLangURL }}" class="navbar-left" style="height: 50px; padding: 5px 10px 5px 0px;">
+        <img src="{{ "ozone-logo-small.png" | relURL }}" style="width: 40px; padding: 0px;"/>
       </a>
-      <a class="navbar-brand hidden-xs" href="#">
+      <a class="navbar-brand hidden-xs" href="{{ "index.html" | relLangURL }}">
         Apache Hadoop Ozone/HDDS documentation
       </a>
       <a class="navbar-brand visible-xs-inline" href="#">Hadoop Ozone</a>

--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/sidebar.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/sidebar.html
@@ -48,8 +48,8 @@
             </li>
         {{ else }}
             <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }}">
-                {{ if eq .URL "/" }}
-                   <a href="{{ "index.html" | relURL }}">
+                {{ if not (strings.HasSuffix .URL ".html")}}
+                   <a href="{{ "index.html" | relLangURL }}">
                 {{ else }}
                    <a href="{{ .URL | relURL }}">
                 {{ end }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

The server for the edge version of the documentation doesn't appear to use `index.html` as the default index page, but instead displays a list of directories. 

If the file name of the page is `index.html`, it doesn't add `index.html` to the `Permalink` parameters, which seems to be hugo's style. I found similar cases on the internet. (ref. [https://discourse.gohugo.io/t/ugly-urls-with-page-resources/10037](https://discourse.gohugo.io/t/ugly-urls-with-page-resources/10037))

The easiest solution is to check the permalink suffix and if it's not `.html` then print `index.html` at the end.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4166

## How was this patch tested?

Tested locally using `hugo serve`

![擷取](https://user-images.githubusercontent.com/14295594/91790360-253dea00-ec43-11ea-9837-b68580d228d0.PNG)

