### PR TITLE
HDDS-4186: Adjust RetryPolicy of SCMConnectionManager for SCM/Recon

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -241,6 +241,16 @@ public final class ScmConfigKeys {
   public static final String OZONE_SCM_HEARTBEAT_RPC_TIMEOUT_DEFAULT =
       "1s";
 
+  public static final String OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT =
+      "ozone.scm.heartbeat.rpc-retry-count";
+  public static final int OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT_DEFAULT =
+      30;
+
+  public static final String OZONE_RECON_HEARTBEAT_RPC_RETRY_COUNT =
+      "ozone.recon.heartbeat.rpc-retry-count";
+  public static final int OZONE_RECON_HEARTBEAT_RPC_RETRY_COUNT_DEFAULT =
+      30;
+
   /**
    * Defines how frequently we will log the missing of heartbeat to a specific
    * SCM. In the default case we will write a warning message for each 10

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -244,12 +244,7 @@ public final class ScmConfigKeys {
   public static final String OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT =
       "ozone.scm.heartbeat.rpc-retry-count";
   public static final int OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT_DEFAULT =
-      30;
-
-  public static final String OZONE_RECON_HEARTBEAT_RPC_RETRY_COUNT =
-      "ozone.recon.heartbeat.rpc-retry-count";
-  public static final int OZONE_RECON_HEARTBEAT_RPC_RETRY_COUNT_DEFAULT =
-      30;
+      15;
 
   /**
    * Defines how frequently we will log the missing of heartbeat to a specific

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -978,6 +978,22 @@
     </description>
   </property>
   <property>
+    <name>ozone.scm.heartbeat.rpc-retry-count</name>
+    <value>30</value>
+    <tag>OZONE, MANAGEMENT</tag>
+    <description>
+      Retry count for the RPC from Datanode to SCM.
+    </description>
+  </property>
+  <property>
+    <name>ozone.recon.heartbeat.rpc-retry-count</name>
+    <value>30</value>
+    <tag>OZONE, MANAGEMENT</tag>
+    <description>
+      Retry count for the RPC from Datanode to Recon.
+    </description>
+  </property>
+  <property>
     <name>ozone.scm.heartbeat.thread.interval</name>
     <value>3s</value>
     <tag>OZONE, MANAGEMENT</tag>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -979,18 +979,12 @@
   </property>
   <property>
     <name>ozone.scm.heartbeat.rpc-retry-count</name>
-    <value>30</value>
+    <value>15</value>
     <tag>OZONE, MANAGEMENT</tag>
     <description>
-      Retry count for the RPC from Datanode to SCM.
-    </description>
-  </property>
-  <property>
-    <name>ozone.recon.heartbeat.rpc-retry-count</name>
-    <value>30</value>
-    <tag>OZONE, MANAGEMENT</tag>
-    <description>
-      Retry count for the RPC from Datanode to Recon.
+      Retry count for the RPC from Datanode to SCM. The rpc-retry-interval
+      is 1s. Make sure rpc-retry-count * (rpc-timeout + rpc-retry-interval)
+      is less than hdds.heartbeat.interval.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
@@ -46,6 +46,8 @@ import org.apache.hadoop.security.UserGroupInformation;
 
 import static java.util.Collections.unmodifiableList;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmRpcTimeOutInMilliseconds;
+import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmRpcRetryCount;
+import static org.apache.hadoop.hdds.utils.HddsServerUtil.getReconRpcRetryCount;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -149,7 +151,8 @@ public class SCMConnectionManager
           RPC.getProtocolVersion(StorageContainerDatanodeProtocolPB.class);
 
       RetryPolicy retryPolicy =
-          RetryPolicies.retryForeverWithFixedSleep(
+          RetryPolicies.retryUpToMaximumCountWithFixedSleep(
+              getScmRpcRetryCount(conf),
               1000, TimeUnit.MILLISECONDS);
 
       StorageContainerDatanodeProtocolPB rpcProxy = RPC.getProtocolProxy(
@@ -193,8 +196,9 @@ public class SCMConnectionManager
           RPC.getProtocolVersion(ReconDatanodeProtocolPB.class);
 
       RetryPolicy retryPolicy =
-          RetryPolicies.retryUpToMaximumCountWithFixedSleep(10,
-              60000, TimeUnit.MILLISECONDS);
+          RetryPolicies.retryUpToMaximumCountWithFixedSleep(
+              getReconRpcRetryCount(conf),
+              1000, TimeUnit.MILLISECONDS);
       ReconDatanodeProtocolPB rpcProxy = RPC.getProtocolProxy(
           ReconDatanodeProtocolPB.class, version,
           address, UserGroupInformation.getCurrentUser(), hadoopConfig,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.security.UserGroupInformation;
 import static java.util.Collections.unmodifiableList;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmRpcTimeOutInMilliseconds;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmRpcRetryCount;
-import static org.apache.hadoop.hdds.utils.HddsServerUtil.getReconRpcRetryCount;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -197,7 +196,7 @@ public class SCMConnectionManager
 
       RetryPolicy retryPolicy =
           RetryPolicies.retryUpToMaximumCountWithFixedSleep(
-              getReconRpcRetryCount(conf),
+              getScmRpcRetryCount(conf),
               1000, TimeUnit.MILLISECONDS);
       ReconDatanodeProtocolPB rpcProxy = RPC.getProtocolProxy(
           ReconDatanodeProtocolPB.class, version,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -65,6 +65,10 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_LOG_W
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_TIMEOUT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT_DEFAULT;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_RECON_HEARTBEAT_RPC_RETRY_COUNT;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_RECON_HEARTBEAT_RPC_RETRY_COUNT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL_DEFAULT;
 import static org.apache.hadoop.hdds.server.ServerUtils.sanitizeUserArgs;
@@ -322,6 +326,28 @@ public final class HddsServerUtil {
   public static long getScmRpcTimeOutInMilliseconds(ConfigurationSource conf) {
     return conf.getTimeDuration(OZONE_SCM_HEARTBEAT_RPC_TIMEOUT,
         OZONE_SCM_HEARTBEAT_RPC_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Max retry count of rpcProxy for EndpointStateMachine of SCM.
+   *
+   * @param conf - Ozone Config
+   * @return - Max retry count.
+   */
+  public static int getScmRpcRetryCount(ConfigurationSource conf) {
+    return conf.getInt(OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT,
+        OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT_DEFAULT);
+  }
+
+  /**
+   * Max retry count of rpcProxy for EndpointStateMachine of Recon.
+   *
+   * @param conf - Ozone Config
+   * @return - Max retry count.
+   */
+  public static int getReconRpcRetryCount(ConfigurationSource conf) {
+    return conf.getInt(OZONE_RECON_HEARTBEAT_RPC_RETRY_COUNT,
+        OZONE_RECON_HEARTBEAT_RPC_RETRY_COUNT_DEFAULT);
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -67,8 +67,6 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_T
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT_DEFAULT;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_RECON_HEARTBEAT_RPC_RETRY_COUNT;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_RECON_HEARTBEAT_RPC_RETRY_COUNT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL_DEFAULT;
 import static org.apache.hadoop.hdds.server.ServerUtils.sanitizeUserArgs;
@@ -337,17 +335,6 @@ public final class HddsServerUtil {
   public static int getScmRpcRetryCount(ConfigurationSource conf) {
     return conf.getInt(OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT,
         OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT_DEFAULT);
-  }
-
-  /**
-   * Max retry count of rpcProxy for EndpointStateMachine of Recon.
-   *
-   * @param conf - Ozone Config
-   * @return - Max retry count.
-   */
-  public static int getReconRpcRetryCount(ConfigurationSource conf) {
-    return conf.getInt(OZONE_RECON_HEARTBEAT_RPC_RETRY_COUNT,
-        OZONE_RECON_HEARTBEAT_RPC_RETRY_COUNT_DEFAULT);
   }
 
   /**

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -60,7 +60,7 @@ find_tests(){
   echo $tests
 }
 
-## @description wait until safemode exit (or 180 seconds)
+## @description wait until safemode exit (or 240 seconds)
 wait_for_safemode_exit(){
   # version-dependent
   : ${OZONE_SAFEMODE_STATUS_COMMAND:=ozone admin safemode status --verbose}
@@ -68,8 +68,8 @@ wait_for_safemode_exit(){
   #Reset the timer
   SECONDS=0
 
-  #Don't give it up until 180 seconds
-  while [[ $SECONDS -lt 180 ]]; do
+  #Don't give it up until 240 seconds
+  while [[ $SECONDS -lt 240 ]]; do
 
      #This line checks the safemode status in scm
      local command="${OZONE_SAFEMODE_STATUS_COMMAND}"
@@ -78,6 +78,8 @@ wait_for_safemode_exit(){
      else
          status=$(docker-compose exec -T scm bash -c "$command")
      fi
+
+     echo "SECONDS: $SECONDS"
 
      echo $status
      if [[ "$status" ]]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

**The problem is:**
If setup one Recon and one SCM, then shutdown the Recon server, all Datanodes will be stale/dead very soon at SCM side.
 
**The root cause is:**
Current RetryPolicy of Datanode for SCM is retryForeverWithFixedSleep:
```
RetryPolicy retryPolicy =
    RetryPolicies.retryForeverWithFixedSleep(
        1000, TimeUnit.MILLISECONDS);

StorageContainerDatanodeProtocolPB rpcProxy = RPC.getProtocolProxy(
    StorageContainerDatanodeProtocolPB.class, version,
    address, UserGroupInformation.getCurrentUser(), hadoopConfig,
    NetUtils.getDefaultSocketFactory(hadoopConfig), getRpcTimeout(),
    retryPolicy).getProxy();
```

that for Recon is retryUpToMaximumCountWithFixedSleep:
```
RetryPolicy retryPolicy =
    RetryPolicies.retryUpToMaximumCountWithFixedSleep(10,
        60000, TimeUnit.MILLISECONDS);

ReconDatanodeProtocolPB rpcProxy = RPC.getProtocolProxy(
    ReconDatanodeProtocolPB.class, version,
    address, UserGroupInformation.getCurrentUser(), hadoopConfig,
    NetUtils.getDefaultSocketFactory(hadoopConfig), getRpcTimeout(),
    retryPolicy).getProxy();
```
 
The executorService in DatanodeStateMachine is Executors.newFixedThreadPool(...), whose default pool size is 2, one for Recon, another for SCM.
 
When encounter rpc failure, call() of RegisterEndpointTask, VersionEndpointTask, HeartbeatEndpointTask will retry while holding the rpcEndpoint.lock(). For example:
```
public EndpointStateMachine.EndPointStates call() throws Exception {
  rpcEndpoint.lock();

  try {

    ....
    SCMHeartbeatResponseProto reponse = rpcEndpoint.getEndPoint()
        .sendHeartbeat(request);
    ....

  } finally {
    rpcEndpoint.unlock();
  }

  return rpcEndpoint.getState();
}
```

If Recon is down, the thread running Recon task will retry due to rpc failure, meanwhile holds the lock of EndpointStateMachine for Recon. When DatanodeStateMachine schedule the next round of SCM/Recon task, the only left thread will be assigned to run Recon task, and blocked at waiting for the lock of EndpointStateMachine for Recon.
```
public EndpointStateMachine.EndPointStates call() throws Exception {
  rpcEndpoint.lock();
  ...
 ```

**The solution is:**
Since DatanodeStateMachine will periodically schedule SCM/Recon tasks, we may adjust RetryPolicy so that won't retry for longer that 1min. 

**The change has no side effect:**
1) VersionEndpointTask.call() is fine
2) RegisterEndpointTask.call() will query containerReport, nodeReport, pipelineReports from OzoneContainer, which is fine.
3) HeartbeatEndpointTask.call() will putBackReports(), which is fine.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4186

## How was this patch tested?

CI
