### PR TITLE
HDDS-3762. Intermittent failure in TestDeleteWithSlowFollower

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -95,7 +95,6 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
         return;
       }
       LOG.debug("Processing block deletion command.");
-      invocationCount++;
 
       // move blocks to deleting state.
       // this is a metadata update, the actual deletion happens in another
@@ -177,6 +176,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       updateCommandStatus(context, command, statusUpdater, LOG);
       long endTime = Time.monotonicNow();
       totalTime += endTime - startTime;
+      invocationCount++;
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Intermittent failure in `testDeleteKeyWithSlowFollower` seems to be caused by:

* `DeleteBlocksCommandHandler` increments `invocationCount` near the beginning of `handle()`, and only updates `deleteTransactionId` later
* `TestDeleteWithSlowFollower` waits for `invocationCount >= 1`, then asserts `deleteTransactionId` also increased

The test is fixed by changing the order in the handler: only increment `invocationCount` at the end, when `deleteTransactionId` is already updated.

I think `invocationCount` should be updated together with `totalTime` to provide (slightly more) correct average run time (`getAverageRunTime`).

https://issues.apache.org/jira/browse/HDDS-3762

## How was this patch tested?

Passed 50x:
https://github.com/adoroszlai/hadoop-ozone/runs/1059570465#step:5:4

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/runs/1059560880