### PR TITLE
HDDS-4199. Fix failed UT: TestOMAllocateBlockRequest#testValidateAndUpdateCache

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
@@ -53,20 +53,18 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
 
   @Test
   public void testValidateAndUpdateCache() throws Exception {
-
-    OMRequest modifiedOmRequest =
-        doPreExecute(createAllocateBlockRequest());
-
-    OMAllocateBlockRequest omAllocateBlockRequest =
-        new OMAllocateBlockRequest(modifiedOmRequest);
-
-
     // Add volume, bucket, key entries to DB.
     TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager);
 
     TestOMRequestUtils.addKeyToTable(true, volumeName, bucketName, keyName,
         clientID, replicationType, replicationFactor, omMetadataManager);
+
+    OMRequest modifiedOmRequest =
+        doPreExecute(createAllocateBlockRequest());
+
+    OMAllocateBlockRequest omAllocateBlockRequest =
+        new OMAllocateBlockRequest(modifiedOmRequest);
 
     // Check before calling validateAndUpdateCache. As adding DB entry has
     // not added any blocks, so size should be zero.
@@ -97,6 +95,11 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
     // Check modification time
     Assert.assertEquals(modifiedOmRequest.getAllocateBlockRequest()
         .getKeyArgs().getModificationTime(), omKeyInfo.getModificationTime());
+
+    // creationTime was assigned at TestOMRequestUtils.addKeyToTable
+    // modificationTime was assigned at doPreExecute(createAllocateBlockRequest())
+    Assert.assertTrue(
+        omKeyInfo.getCreationTime() <= omKeyInfo.getModificationTime());
 
     // Check data of the block
     OzoneManagerProtocolProtos.KeyLocation keyLocation =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
@@ -97,8 +97,6 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
     // Check modification time
     Assert.assertEquals(modifiedOmRequest.getAllocateBlockRequest()
         .getKeyArgs().getModificationTime(), omKeyInfo.getModificationTime());
-    Assert.assertNotEquals(omKeyInfo.getCreationTime(),
-        omKeyInfo.getModificationTime());
 
     // Check data of the block
     OzoneManagerProtocolProtos.KeyLocation keyLocation =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
@@ -97,7 +97,8 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
         .getKeyArgs().getModificationTime(), omKeyInfo.getModificationTime());
 
     // creationTime was assigned at TestOMRequestUtils.addKeyToTable
-    // modificationTime was assigned at doPreExecute(createAllocateBlockRequest())
+    // modificationTime was assigned at
+    // doPreExecute(createAllocateBlockRequest())
     Assert.assertTrue(
         omKeyInfo.getCreationTime() <= omKeyInfo.getModificationTime());
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

**What's the problem ?**

![image](https://user-images.githubusercontent.com/51938049/92061322-87742780-edc8-11ea-80f9-7521a18b1ac4.png)

**What's the reason ?**

we can not make sure `omKeyInfo.getCreationTime()` different from ` omKeyInfo.getModificationTime()`

1. the creationTime was set in OmKeyInfo at [TestOMRequestUtils.addKeyToTable](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java#L68) -> [OmKeyInfo#createOmKeyInfo](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java#L253)
2. the modificationTime was set in KeyArgs at [doPreExecute(createAllocateBlockRequest())](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java#L58) -> [OMRequest#preExecute](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java#L115). 
 And the KeyArgs.modificationTime was set in OmKeyInfo at [omAllocateBlockRequest.validateAndUpdateCache](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java#L84) -> [openKeyInfo.setModificationTime](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java#L203).

3. Between [doPreExecute(createAllocateBlockRequest())](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java#L58) and [TestOMRequestUtils.addKeyToTable](https://github.com/apache/hadoop-ozone/blob/master/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java#L68), there is no time consuming code, so we can not make sure the millisecond time is different.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4199

## How was this patch tested?

no need new test.
