### PR TITLE
HDDS-4201. Improve the performance of OmKeyLocationInfoGroup

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
@@ -36,8 +36,13 @@ public class OmKeyLocationInfoGroup {
   public OmKeyLocationInfoGroup(long version,
                                 List<OmKeyLocationInfo> locations) {
     this.version = version;
-    this.locationVersionMap = locations.stream()
-        .collect(Collectors.groupingBy(OmKeyLocationInfo::getCreateVersion));
+    locationVersionMap = new HashMap<>();
+    for (OmKeyLocationInfo info : locations) {
+      if (!locationVersionMap.containsKey(info.getCreateVersion())) {
+        locationVersionMap.put(info.getCreateVersion(), new ArrayList<>());
+      }
+      locationVersionMap.get(info.getCreateVersion()).add(info);
+    }
     //prevent NPE
     this.locationVersionMap.putIfAbsent(version, new ArrayList<>());
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
@@ -38,10 +38,9 @@ public class OmKeyLocationInfoGroup {
     this.version = version;
     locationVersionMap = new HashMap<>();
     for (OmKeyLocationInfo info : locations) {
-      if (!locationVersionMap.containsKey(info.getCreateVersion())) {
-        locationVersionMap.put(info.getCreateVersion(), new ArrayList<>());
-      }
-      locationVersionMap.get(info.getCreateVersion()).add(info);
+      locationVersionMap
+          .computeIfAbsent(info.getCreateVersion(), v -> new ArrayList<>())
+          .add(info);
     }
     //prevent NPE
     this.locationVersionMap.putIfAbsent(version, new ArrayList<>());


### PR DESCRIPTION
## What changes were proposed in this pull request?

   ` locations.stream().collect(Collectors.groupingBy(OmKeyLocationInfo::getCreateVersion))` cost 2-3ms even though the locations size is zero.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4201

## How was this patch tested?

no need to add test.