### PR TITLE
HDDS-4202. Upgrade ratis to 1.1.0-ea949f1-SNAPSHOT

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -87,6 +87,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
 
     <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+    </dependency>
+
+    <dependency>
       <artifactId>ratis-server</artifactId>
       <groupId>org.apache.ratis</groupId>
       <exclusions>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -733,7 +733,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     GroupManagementRequest request = GroupManagementRequest.newRemove(
         clientId, server.getId(), nextCallId(),
         RaftGroupId.valueOf(PipelineID.getFromProtobuf(pipelineId).getId()),
-        true);
+        true, false);
 
     RaftClientReply reply;
     try {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineUtils.java
@@ -95,7 +95,7 @@ public final class RatisPipelineUtils {
         .newRaftClient(SupportedRpcType.valueOfIgnoreCase(rpcType), p,
             retryPolicy, grpcTlsConfig, ozoneConf)) {
       client.groupRemove(RaftGroupId.valueOf(pipelineID.getId()),
-          true, p.getId());
+          true, false, p.getId());
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,10 +79,10 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>1.0.0</ratis.version>
+    <ratis.version>1.1.0-ea949f1-SNAPSHOT</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
-    <ratis.thirdparty.version>0.5.0</ratis.thirdparty.version>
+    <ratis.thirdparty.version>0.6.0-SNAPSHOT</ratis.thirdparty.version>
 
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Upgrade ratis to 1.1.0-ea949f1-SNAPSHOT to support the feature of HDDS-2922. Balance ratis leader distribution in datanodes.
2. We need to add `metrics-core` dependency in hadoop-hdds/common/pom.xml in ozone, because https://github.com/apache/incubator-ratis/commit/aab414f2af73809168657beb17419be87b0aa259 import MetricRegistry in ratis-client, if ozone does not add this dependency, hdfs o3fs will report NoClassDef

![image](https://user-images.githubusercontent.com/51938049/92066302-23eff700-edd4-11ea-930c-d6367acc2055.png)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4202

## How was this patch tested?

no need add test
