### PR TITLE
HDDS-4193. Range used by S3 MultipartUpload copy-from-source should be inclusive.

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
@@ -258,12 +258,12 @@ Test Multipart Upload Put With Copy and range
                         Should contain           ${result}    ${BUCKET}
                         Should contain           ${result}    UploadId
 
-    ${result} =         Execute AWSS3APICli      upload-part-copy --bucket ${BUCKET} --key copyrange/destination --upload-id ${uploadID} --part-number 1 --copy-source ${BUCKET}/copyrange/source --copy-source-range bytes=0-10485758
+    ${result} =         Execute AWSS3APICli      upload-part-copy --bucket ${BUCKET} --key copyrange/destination --upload-id ${uploadID} --part-number 1 --copy-source ${BUCKET}/copyrange/source --copy-source-range bytes=0-10485757
                         Should contain           ${result}    ETag
                         Should contain           ${result}    LastModified
     ${eTag1} =          Execute and checkrc      echo '${result}' | jq -r '.CopyPartResult.ETag'   0
 
-    ${result} =         Execute AWSS3APICli      upload-part-copy --bucket ${BUCKET} --key copyrange/destination --upload-id ${uploadID} --part-number 2 --copy-source ${BUCKET}/copyrange/source --copy-source-range bytes=10485758-10485760
+    ${result} =         Execute AWSS3APICli      upload-part-copy --bucket ${BUCKET} --key copyrange/destination --upload-id ${uploadID} --part-number 2 --copy-source ${BUCKET}/copyrange/source --copy-source-range bytes=10485758-10485759
                         Should contain           ${result}    ETag
                         Should contain           ${result}    LastModified
     ${eTag2} =          Execute and checkrc      echo '${result}' | jq -r '.CopyPartResult.ETag'   0

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -567,7 +567,8 @@ public class ObjectEndpoint extends EndpointBase {
                         + rangeHeader.getStartOffset() + " actual: " + skipped);
               }
               IOUtils.copyLarge(sourceObject, ozoneOutputStream, 0,
-                  rangeHeader.getEndOffset() - rangeHeader.getStartOffset());
+                  rangeHeader.getEndOffset() - rangeHeader.getStartOffset()
+                      + 1);
             } else {
               IOUtils.copy(sourceObject, ozoneOutputStream);
             }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadWithCopy.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadWithCopy.java
@@ -99,16 +99,19 @@ public class TestMultipartUploadWithCopy {
 
     // Upload parts
     String content = "Multipart Upload 1";
-    int partNumber = 1;
 
-    Part part1 = uploadPart(KEY, uploadID, partNumber, content);
+    Part part1 = uploadPart(KEY, uploadID, 1, content);
     partsList.add(part1);
 
-    partNumber = 2;
     Part part2 =
-        uploadPartWithCopy(KEY, uploadID, partNumber,
+        uploadPartWithCopy(KEY, uploadID, 2,
             OzoneConsts.S3_BUCKET + "/" + EXISTING_KEY, null);
     partsList.add(part2);
+
+    Part part3 =
+        uploadPartWithCopy(KEY, uploadID, 3,
+            OzoneConsts.S3_BUCKET + "/" + EXISTING_KEY, "bytes=0-3");
+    partsList.add(part3);
 
     // complete multipart upload
     CompleteMultipartUploadRequest completeMultipartUploadRequest = new
@@ -122,7 +125,9 @@ public class TestMultipartUploadWithCopy {
         CLIENT.getObjectStore().getS3Bucket(OzoneConsts.S3_BUCKET);
     try (InputStream is = bucket.readKey(KEY)) {
       String keyContent = new Scanner(is).useDelimiter("\\A").next();
-      Assert.assertEquals(content + EXISTING_KEY_CONTENT, keyContent);
+      Assert.assertEquals(
+          content + EXISTING_KEY_CONTENT + EXISTING_KEY_CONTENT.substring(0, 4),
+          keyContent);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

S3 API provides a feature to copy a specific range from an existing key.

Based on the documentation, this range definitions is inclusive:

https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html

> 
>     -copy-source-range (string)
> 
>     The range of bytes to copy from the source object. The range value must use the form bytes=first-last, where the first and last are the zero-based byte offsets to copy. For example, bytes=0-9 indicates that you want to copy the first 10 bytes of the source. You can copy a range only if the source object is greater than 5 MB.
> 

But as it's visible from our robot test, in our case we use exclusive range:

```
upload-part-copy ... --copy-source-range bytes=0-10485758
upload-part-copy ... --copy-source-range bytes=10485758-10485760
```

Based on this AWS documentation it will return with a (10485758 + 1) + 3 bytes long key, which is impossible if our original source key is just 10485760.

I think the right usage to get the original key is the following:

```shell
upload-part-copy ... --copy-source-range bytes=0-10485757
upload-part-copy ... --copy-source-range bytes=10485758-10485759
```

(Note, this bug is found with the script in HDDS-4194, which showed that AWS S3 is working in different way).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4193

## How was this patch tested?

Unit test and acceptance tests are updated.

The truth of the specification is tested with https://issues.apache.org/jira/browse/HDDS-4194