### PR TITLE
HDDS-3947: Sort DNs for client when the key is a file for #getFileStatus #listStatus APIs

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1030,6 +1030,7 @@ public class RpcClient implements ClientProtocol {
         .setBucketName(bucketName)
         .setKeyName(keyName)
         .setRefreshPipeline(true)
+        .setSortDatanodesInPipeline(topologyAwareReadEnabled)
         .build();
     return ozoneManagerClient.getFileStatus(keyArgs);
   }
@@ -1112,6 +1113,7 @@ public class RpcClient implements ClientProtocol {
         .setBucketName(bucketName)
         .setKeyName(keyName)
         .setRefreshPipeline(true)
+        .setSortDatanodesInPipeline(topologyAwareReadEnabled)
         .build();
     return ozoneManagerClient
         .listStatus(keyArgs, recursive, startKey, numEntries);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1177,6 +1177,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setVolumeName(args.getVolumeName())
         .setBucketName(args.getBucketName())
         .setKeyName(args.getKeyName())
+        .setSortDatanodes(args.getSortDatanodes())
         .build();
     GetFileStatusRequest req =
         GetFileStatusRequest.newBuilder()
@@ -1390,6 +1391,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setVolumeName(args.getVolumeName())
         .setBucketName(args.getBucketName())
         .setKeyName(args.getKeyName())
+        .setSortDatanodes(args.getSortDatanodes())
         .build();
     ListStatusRequest listStatusRequest =
         ListStatusRequest.newBuilder()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -210,7 +210,8 @@ public class TestKeyManagerImpl {
   @After
   public void cleanupTest() throws IOException {
     List<OzoneFileStatus> fileStatuses = keyManager
-        .listStatus(createBuilder().setKeyName("").build(), true, "", 100000);
+        .listStatus(createBuilder().setKeyName("").build(), true, "", 100000,
+                null);
     for (OzoneFileStatus fileStatus : fileStatuses) {
       if (fileStatus.isFile()) {
         keyManager.deleteKey(
@@ -833,17 +834,17 @@ public class TestKeyManagerImpl {
     OmKeyArgs rootDirArgs = createKeyArgs("");
     // Get entries in both TableCache and DB
     List<OzoneFileStatus> fileStatuses =
-        keyManager.listStatus(rootDirArgs, true, "", 1000);
+        keyManager.listStatus(rootDirArgs, true, "", 1000, null);
     Assert.assertEquals(100, fileStatuses.size());
 
     // Get entries with startKey=prefixKeyInDB
     fileStatuses =
-        keyManager.listStatus(rootDirArgs, true, prefixKeyInDB, 1000);
+        keyManager.listStatus(rootDirArgs, true, prefixKeyInDB, 1000, null);
     Assert.assertEquals(50, fileStatuses.size());
 
     // Get entries with startKey=prefixKeyInCache
     fileStatuses =
-        keyManager.listStatus(rootDirArgs, true, prefixKeyInCache, 1000);
+        keyManager.listStatus(rootDirArgs, true, prefixKeyInCache, 1000, null);
     Assert.assertEquals(100, fileStatuses.size());
 
     // Clean up cache by marking those keys in cache as deleted
@@ -875,12 +876,12 @@ public class TestKeyManagerImpl {
     OmKeyArgs rootDirArgs = createKeyArgs("");
     // Test listStatus with recursive=false, should only have dirs under root
     List<OzoneFileStatus> fileStatuses =
-        keyManager.listStatus(rootDirArgs, false, "", 1000);
+        keyManager.listStatus(rootDirArgs, false, "", 1000, null);
     Assert.assertEquals(2, fileStatuses.size());
 
     // Test listStatus with recursive=true, should have dirs under root and
     fileStatuses =
-        keyManager.listStatus(rootDirArgs, true, "", 1000);
+        keyManager.listStatus(rootDirArgs, true, "", 1000, null);
     Assert.assertEquals(3, fileStatuses.size());
 
     // Add a total of 10 key entries to DB and TableCache under dir1
@@ -904,12 +905,12 @@ public class TestKeyManagerImpl {
 
     // Test non-recursive, should return the dir under root
     fileStatuses =
-        keyManager.listStatus(rootDirArgs, false, "", 1000);
+        keyManager.listStatus(rootDirArgs, false, "", 1000, null);
     Assert.assertEquals(2, fileStatuses.size());
 
     // Test recursive, should return the dir and the keys in it
     fileStatuses =
-        keyManager.listStatus(rootDirArgs, true, "", 1000);
+        keyManager.listStatus(rootDirArgs, true, "", 1000, null);
     Assert.assertEquals(10 + 3, fileStatuses.size());
 
     // Clean up
@@ -954,12 +955,12 @@ public class TestKeyManagerImpl {
 
     OmKeyArgs rootDirArgs = createKeyArgs("");
     List<OzoneFileStatus> fileStatuses =
-        keyManager.listStatus(rootDirArgs, true, "", 1000);
+        keyManager.listStatus(rootDirArgs, true, "", 1000, null);
     // Should only get entries that are not marked as deleted.
     Assert.assertEquals(50, fileStatuses.size());
     // Test startKey
     fileStatuses =
-        keyManager.listStatus(rootDirArgs, true, prefixKey, 1000);
+        keyManager.listStatus(rootDirArgs, true, prefixKey, 1000, null);
     // Should only get entries that are not marked as deleted.
     Assert.assertEquals(50, fileStatuses.size());
     // Verify result
@@ -991,7 +992,7 @@ public class TestKeyManagerImpl {
     existKeySet.removeAll(deletedKeySet);
 
     fileStatuses = keyManager.listStatus(
-        rootDirArgs, true, "", 1000);
+        rootDirArgs, true, "", 1000, null);
     // Should only get entries that are not marked as deleted.
     Assert.assertEquals(50 / 2, fileStatuses.size());
 
@@ -1010,7 +1011,7 @@ public class TestKeyManagerImpl {
     expectedKeys.clear();
     do {
       fileStatuses = keyManager.listStatus(
-          rootDirArgs, true, startKey, batchSize);
+          rootDirArgs, true, startKey, batchSize, null);
       // Note fileStatuses will never be empty since we are using the last
       // keyName as the startKey of next batch,
       // the startKey itself will show up in the next batch of results.
@@ -1058,11 +1059,11 @@ public class TestKeyManagerImpl {
 
     OmKeyArgs rootDirArgs = createKeyArgs("");
     List<OzoneFileStatus> fileStatuses =
-        keyManager.listStatus(rootDirArgs, true, "", 100);
+        keyManager.listStatus(rootDirArgs, true, "", 100, null);
     // verify the number of status returned is same as number of entries
     Assert.assertEquals(numEntries, fileStatuses.size());
 
-    fileStatuses = keyManager.listStatus(rootDirArgs, false, "", 100);
+    fileStatuses = keyManager.listStatus(rootDirArgs, false, "", 100, null);
     // the number of immediate children of root is 1
     Assert.assertEquals(1, fileStatuses.size());
 
@@ -1070,19 +1071,19 @@ public class TestKeyManagerImpl {
     // return all the entries.
     String startKey = children.iterator().next();
     fileStatuses = keyManager.listStatus(rootDirArgs, true,
-        startKey.substring(0, startKey.length() - 1), 100);
+        startKey.substring(0, startKey.length() - 1), 100, null);
     Assert.assertEquals(numEntries, fileStatuses.size());
 
     for (String directory : directorySet) {
       // verify status list received for each directory with recursive flag set
       // to false
       OmKeyArgs dirArgs = createKeyArgs(directory);
-      fileStatuses = keyManager.listStatus(dirArgs, false, "", 100);
+      fileStatuses = keyManager.listStatus(dirArgs, false, "", 100, null);
       verifyFileStatus(directory, fileStatuses, directorySet, fileSet, false);
 
       // verify status list received for each directory with recursive flag set
       // to true
-      fileStatuses = keyManager.listStatus(dirArgs, true, "", 100);
+      fileStatuses = keyManager.listStatus(dirArgs, true, "", 100, null);
       verifyFileStatus(directory, fileStatuses, directorySet, fileSet, true);
 
       // verify list status call with using the startKey parameter and
@@ -1096,7 +1097,7 @@ public class TestKeyManagerImpl {
             tempFileStatus != null ?
                 tempFileStatus.get(tempFileStatus.size() - 1).getKeyInfo()
                     .getKeyName() : null,
-            2);
+            2, null);
         tmpStatusSet.addAll(tempFileStatus);
       } while (tempFileStatus.size() == 2);
       verifyFileStatus(directory, new ArrayList<>(tmpStatusSet), directorySet,
@@ -1114,7 +1115,7 @@ public class TestKeyManagerImpl {
                 tempFileStatus.get(tempFileStatus.size() - 1).getKeyInfo()
                     .getKeyName() :
                 null,
-            2);
+            2, null);
         tmpStatusSet.addAll(tempFileStatus);
       } while (tempFileStatus.size() == 2);
       verifyFileStatus(directory, new ArrayList<>(tmpStatusSet), directorySet,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -210,8 +210,7 @@ public class TestKeyManagerImpl {
   @After
   public void cleanupTest() throws IOException {
     List<OzoneFileStatus> fileStatuses = keyManager
-        .listStatus(createBuilder().setKeyName("").build(), true, "", 100000,
-                null);
+        .listStatus(createBuilder().setKeyName("").build(), true, "", 100000);
     for (OzoneFileStatus fileStatus : fileStatuses) {
       if (fileStatus.isFile()) {
         keyManager.deleteKey(
@@ -834,17 +833,17 @@ public class TestKeyManagerImpl {
     OmKeyArgs rootDirArgs = createKeyArgs("");
     // Get entries in both TableCache and DB
     List<OzoneFileStatus> fileStatuses =
-        keyManager.listStatus(rootDirArgs, true, "", 1000, null);
+        keyManager.listStatus(rootDirArgs, true, "", 1000);
     Assert.assertEquals(100, fileStatuses.size());
 
     // Get entries with startKey=prefixKeyInDB
     fileStatuses =
-        keyManager.listStatus(rootDirArgs, true, prefixKeyInDB, 1000, null);
+        keyManager.listStatus(rootDirArgs, true, prefixKeyInDB, 1000);
     Assert.assertEquals(50, fileStatuses.size());
 
     // Get entries with startKey=prefixKeyInCache
     fileStatuses =
-        keyManager.listStatus(rootDirArgs, true, prefixKeyInCache, 1000, null);
+        keyManager.listStatus(rootDirArgs, true, prefixKeyInCache, 1000);
     Assert.assertEquals(100, fileStatuses.size());
 
     // Clean up cache by marking those keys in cache as deleted
@@ -876,12 +875,12 @@ public class TestKeyManagerImpl {
     OmKeyArgs rootDirArgs = createKeyArgs("");
     // Test listStatus with recursive=false, should only have dirs under root
     List<OzoneFileStatus> fileStatuses =
-        keyManager.listStatus(rootDirArgs, false, "", 1000, null);
+        keyManager.listStatus(rootDirArgs, false, "", 1000);
     Assert.assertEquals(2, fileStatuses.size());
 
     // Test listStatus with recursive=true, should have dirs under root and
     fileStatuses =
-        keyManager.listStatus(rootDirArgs, true, "", 1000, null);
+        keyManager.listStatus(rootDirArgs, true, "", 1000);
     Assert.assertEquals(3, fileStatuses.size());
 
     // Add a total of 10 key entries to DB and TableCache under dir1
@@ -905,12 +904,12 @@ public class TestKeyManagerImpl {
 
     // Test non-recursive, should return the dir under root
     fileStatuses =
-        keyManager.listStatus(rootDirArgs, false, "", 1000, null);
+        keyManager.listStatus(rootDirArgs, false, "", 1000);
     Assert.assertEquals(2, fileStatuses.size());
 
     // Test recursive, should return the dir and the keys in it
     fileStatuses =
-        keyManager.listStatus(rootDirArgs, true, "", 1000, null);
+        keyManager.listStatus(rootDirArgs, true, "", 1000);
     Assert.assertEquals(10 + 3, fileStatuses.size());
 
     // Clean up
@@ -955,12 +954,12 @@ public class TestKeyManagerImpl {
 
     OmKeyArgs rootDirArgs = createKeyArgs("");
     List<OzoneFileStatus> fileStatuses =
-        keyManager.listStatus(rootDirArgs, true, "", 1000, null);
+        keyManager.listStatus(rootDirArgs, true, "", 1000);
     // Should only get entries that are not marked as deleted.
     Assert.assertEquals(50, fileStatuses.size());
     // Test startKey
     fileStatuses =
-        keyManager.listStatus(rootDirArgs, true, prefixKey, 1000, null);
+        keyManager.listStatus(rootDirArgs, true, prefixKey, 1000);
     // Should only get entries that are not marked as deleted.
     Assert.assertEquals(50, fileStatuses.size());
     // Verify result
@@ -992,7 +991,7 @@ public class TestKeyManagerImpl {
     existKeySet.removeAll(deletedKeySet);
 
     fileStatuses = keyManager.listStatus(
-        rootDirArgs, true, "", 1000, null);
+        rootDirArgs, true, "", 1000);
     // Should only get entries that are not marked as deleted.
     Assert.assertEquals(50 / 2, fileStatuses.size());
 
@@ -1011,7 +1010,7 @@ public class TestKeyManagerImpl {
     expectedKeys.clear();
     do {
       fileStatuses = keyManager.listStatus(
-          rootDirArgs, true, startKey, batchSize, null);
+          rootDirArgs, true, startKey, batchSize);
       // Note fileStatuses will never be empty since we are using the last
       // keyName as the startKey of next batch,
       // the startKey itself will show up in the next batch of results.
@@ -1059,11 +1058,11 @@ public class TestKeyManagerImpl {
 
     OmKeyArgs rootDirArgs = createKeyArgs("");
     List<OzoneFileStatus> fileStatuses =
-        keyManager.listStatus(rootDirArgs, true, "", 100, null);
+        keyManager.listStatus(rootDirArgs, true, "", 100);
     // verify the number of status returned is same as number of entries
     Assert.assertEquals(numEntries, fileStatuses.size());
 
-    fileStatuses = keyManager.listStatus(rootDirArgs, false, "", 100, null);
+    fileStatuses = keyManager.listStatus(rootDirArgs, false, "", 100);
     // the number of immediate children of root is 1
     Assert.assertEquals(1, fileStatuses.size());
 
@@ -1071,19 +1070,19 @@ public class TestKeyManagerImpl {
     // return all the entries.
     String startKey = children.iterator().next();
     fileStatuses = keyManager.listStatus(rootDirArgs, true,
-        startKey.substring(0, startKey.length() - 1), 100, null);
+        startKey.substring(0, startKey.length() - 1), 100);
     Assert.assertEquals(numEntries, fileStatuses.size());
 
     for (String directory : directorySet) {
       // verify status list received for each directory with recursive flag set
       // to false
       OmKeyArgs dirArgs = createKeyArgs(directory);
-      fileStatuses = keyManager.listStatus(dirArgs, false, "", 100, null);
+      fileStatuses = keyManager.listStatus(dirArgs, false, "", 100);
       verifyFileStatus(directory, fileStatuses, directorySet, fileSet, false);
 
       // verify status list received for each directory with recursive flag set
       // to true
-      fileStatuses = keyManager.listStatus(dirArgs, true, "", 100, null);
+      fileStatuses = keyManager.listStatus(dirArgs, true, "", 100);
       verifyFileStatus(directory, fileStatuses, directorySet, fileSet, true);
 
       // verify list status call with using the startKey parameter and
@@ -1096,8 +1095,7 @@ public class TestKeyManagerImpl {
         tempFileStatus = keyManager.listStatus(dirArgs, false,
             tempFileStatus != null ?
                 tempFileStatus.get(tempFileStatus.size() - 1).getKeyInfo()
-                    .getKeyName() : null,
-            2, null);
+                    .getKeyName() : null, 2);
         tmpStatusSet.addAll(tempFileStatus);
       } while (tempFileStatus.size() == 2);
       verifyFileStatus(directory, new ArrayList<>(tmpStatusSet), directorySet,
@@ -1113,9 +1111,7 @@ public class TestKeyManagerImpl {
         tempFileStatus = keyManager.listStatus(dirArgs, true,
             tempFileStatus != null ?
                 tempFileStatus.get(tempFileStatus.size() - 1).getKeyInfo()
-                    .getKeyName() :
-                null,
-            2, null);
+                    .getKeyName() : null, 2);
         tmpStatusSet.addAll(tempFileStatus);
       } while (tempFileStatus.size() == 2);
       verifyFileStatus(directory, new ArrayList<>(tmpStatusSet), directorySet,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -2069,18 +2069,18 @@ public class KeyManagerImpl implements KeyManager {
     // A set to keep track of keys deleted in cache but not flushed to DB.
     Set<String> deletedKeySet = new TreeSet<>();
 
+    if (Strings.isNullOrEmpty(startKey)) {
+      OzoneFileStatus fileStatus = getFileStatus(args, clientAddress);
+      if (fileStatus.isFile()) {
+        return Collections.singletonList(fileStatus);
+      }
+      // keyName is a directory
+      startKey = OzoneFSUtils.addTrailingSlashIfNeeded(keyName);
+    }
+
     metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
         bucketName);
     try {
-      if (Strings.isNullOrEmpty(startKey)) {
-        OzoneFileStatus fileStatus = getFileStatus(args);
-        if (fileStatus.isFile()) {
-          return Collections.singletonList(fileStatus);
-        }
-        // keyName is a directory
-        startKey = OzoneFSUtils.addTrailingSlashIfNeeded(keyName);
-      }
-
       Table keyTable = metadataManager.getKeyTable();
       Iterator<Map.Entry<CacheKey<String>, CacheValue<OmKeyInfo>>>
           cacheIter = keyTable.cacheIterator();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1802,9 +1802,10 @@ public class KeyManagerImpl implements KeyManager {
 
       // if the key is a file then do refresh pipeline info in OM by asking SCM
       if (fileKeyInfo != null) {
-        if (refreshPipeline) {
-          refreshPipeline(fileKeyInfo);
-        }
+        // refreshPipeline flag check has been removed as part of
+        // https://issues.apache.org/jira/browse/HDDS-3658.
+        // Please refer this jira for more details.
+        refreshPipeline(fileKeyInfo);
         if (sortDatanodes) {
           sortDatanodeInPipeline(fileKeyInfo, clientAddress);
         }
@@ -2029,6 +2030,25 @@ public class KeyManagerImpl implements KeyManager {
    * @param startKey   Key from which listing needs to start. If startKey exists
    *                   its status is included in the final list.
    * @param numEntries Number of entries to list from the start key
+   * @return list of file status
+   */
+  public List<OzoneFileStatus> listStatus(OmKeyArgs args, boolean recursive,
+                                          String startKey, long numEntries)
+          throws IOException {
+    return listStatus(args, recursive, startKey, numEntries, null);
+  }
+
+  /**
+   * List the status for a file or a directory and its contents.
+   *
+   * @param args       Key args
+   * @param recursive  For a directory if true all the descendants of a
+   *                   particular directory are listed
+   * @param startKey   Key from which listing needs to start. If startKey exists
+   *                   its status is included in the final list.
+   * @param numEntries Number of entries to list from the start key
+   * @param clientAddress a hint to key manager, order the datanode in returned
+   *                      pipeline by distance between client and datanode.
    * @return list of file status
    */
   public List<OzoneFileStatus> listStatus(OmKeyArgs args, boolean recursive,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2797,7 +2797,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     try {
       metrics.incNumGetFileStatus();
-      return keyManager.getFileStatus(args);
+      return keyManager.getFileStatus(args, getClientAddress());
     } catch (IOException ex) {
       metrics.incNumGetFileStatusFails();
       auditSuccess = false;
@@ -2921,7 +2921,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     try {
       metrics.incNumListStatus();
-      return keyManager.listStatus(args, recursive, startKey, numEntries);
+      return keyManager.listStatus(args, recursive, startKey, numEntries,
+              getClientAddress());
     } catch (Exception ex) {
       metrics.incNumListStatusFails();
       auditSuccess = false;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/fs/OzoneManagerFS.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/fs/OzoneManagerFS.java
@@ -31,7 +31,26 @@ import java.util.List;
  * Ozone Manager FileSystem interface.
  */
 public interface OzoneManagerFS extends IOzoneAcl {
+
+  /**
+   * Get file status for a file or a directory.
+   *
+   * @param args          the args of the key provided by client.
+   * @return file status.
+   * @throws IOException if file or bucket or volume does not exist
+   */
   OzoneFileStatus getFileStatus(OmKeyArgs args) throws IOException;
+
+  /**
+   * Get file status for a file or a directory.
+   *
+   * @param args          the args of the key provided by client.
+   * @param clientAddress a hint to key manager, order the datanode in returned
+   *                      pipeline by distance between client and datanode.
+   * @return file status.
+   * @throws IOException if file or bucket or volume does not exist
+   */
+  OzoneFileStatus getFileStatus(OmKeyArgs args, String clientAddress) throws IOException;
 
   void createDirectory(OmKeyArgs args) throws IOException;
 
@@ -49,6 +68,20 @@ public interface OzoneManagerFS extends IOzoneAcl {
    */
   OmKeyInfo lookupFile(OmKeyArgs args, String clientAddress) throws IOException;
 
+  /**
+   * List the status for a file or a directory and its contents.
+   *
+   * @param keyArgs       the args of the key provided by client.
+   * @param recursive     For a directory if true all the descendants of a
+   *                      particular directory are listed
+   * @param startKey      Key from which listing needs to start. If startKey
+   *                      exists its status is included in the final list.
+   * @param numEntries    Number of entries to list from the start key
+   * @param clientAddress a hint to key manager, order the datanode in returned
+   *                      pipeline by distance between client and datanode.
+   * @return list of file status
+   * @throws IOException if file or bucket or volume does not exist
+   */
   List<OzoneFileStatus> listStatus(OmKeyArgs keyArgs, boolean recursive,
-      String startKey, long numEntries) throws IOException;
+      String startKey, long numEntries, String clientAddress) throws IOException;
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/fs/OzoneManagerFS.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/fs/OzoneManagerFS.java
@@ -78,6 +78,22 @@ public interface OzoneManagerFS extends IOzoneAcl {
    * @param startKey      Key from which listing needs to start. If startKey
    *                      exists its status is included in the final list.
    * @param numEntries    Number of entries to list from the start key
+   * @return list of file status
+   * @throws IOException if file or bucket or volume does not exist
+   */
+  List<OzoneFileStatus> listStatus(OmKeyArgs keyArgs, boolean recursive,
+                                   String startKey, long numEntries)
+          throws IOException;
+
+  /**
+   * List the status for a file or a directory and its contents.
+   *
+   * @param keyArgs       the args of the key provided by client.
+   * @param recursive     For a directory if true all the descendants of a
+   *                      particular directory are listed
+   * @param startKey      Key from which listing needs to start. If startKey
+   *                      exists its status is included in the final list.
+   * @param numEntries    Number of entries to list from the start key
    * @param clientAddress a hint to key manager, order the datanode in returned
    *                      pipeline by distance between client and datanode.
    * @return list of file status

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/fs/OzoneManagerFS.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/fs/OzoneManagerFS.java
@@ -50,7 +50,8 @@ public interface OzoneManagerFS extends IOzoneAcl {
    * @return file status.
    * @throws IOException if file or bucket or volume does not exist
    */
-  OzoneFileStatus getFileStatus(OmKeyArgs args, String clientAddress) throws IOException;
+  OzoneFileStatus getFileStatus(OmKeyArgs args, String clientAddress)
+          throws IOException;
 
   void createDirectory(OmKeyArgs args) throws IOException;
 
@@ -83,5 +84,6 @@ public interface OzoneManagerFS extends IOzoneAcl {
    * @throws IOException if file or bucket or volume does not exist
    */
   List<OzoneFileStatus> listStatus(OmKeyArgs keyArgs, boolean recursive,
-      String startKey, long numEntries, String clientAddress) throws IOException;
+      String startKey, long numEntries, String clientAddress)
+          throws IOException;
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Similar to OzoneManagerFS#lookupFile(OmKeyArgs args, String clientAddress) interface, "clientAddress" has been passed as an argument to OzoneManagerFS#listStatus(), OzoneManagerFS#getFileStatus() APIs.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3947

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

Used existing TestKeyManagerImpl unit test cases.
