### PR TITLE
HDDS-4197. Failed to load existing service definition files: ...SubcommandWithParent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1335,7 +1335,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.kohsuke.metainf-services</groupId>
         <artifactId>metainf-services</artifactId>
-        <version>1.1</version>
+        <version>1.8</version>
         <optional>true</optional>
       </dependency>
       <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Compile error with JDK 11 is caused by too old META-INF/services generator (1.1 is 10 years old).

```
[INFO] Apache Hadoop HDDS Tools ........................... FAILURE
...
[ERROR] Failed to load existing service definition files: java.nio.file.NoSuchFileException: hadoop-hdds/tools/target/classes/META-INF/services/org.apache.hadoop.hdds.cli.SubcommandWithParent
```

Fix by upgrading to latest version, which is [compatible with Java 9+](https://github.com/kohsuke/metainf-services/pull/15).

https://issues.apache.org/jira/browse/HDDS-4197

## How was this patch tested?

```
$ mvn -V -DskipTests clean verify
...
Java version: 11.0.7, vendor: Oracle Corporation, ...
...
[INFO] BUILD SUCCESS
```

https://github.com/adoroszlai/hadoop-ozone/runs/1063849815

Also [verified with Java 11 in CI](https://github.com/adoroszlai/hadoop-ozone/runs/1063860210) for HDDS-4198.