### PR TITLE
HDDS-4198. Compile Ozone with multiple Java versions

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -22,6 +22,10 @@ jobs:
   build:
     name: compile
     runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        java: [ 8, 11 ]
+      fail-fast: false
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
@@ -34,10 +38,17 @@ jobs:
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-
-      - name: Execute tests
-        uses: ./.github/buildenv
+      - name: Cache for maven dependencies
+        uses: actions/cache@v2
         with:
-          args: ./hadoop-ozone/dev-support/checks/build.sh
+          path: ~/.m2/repository
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Run a full build
+        run: hadoop-ozone/dev-support/checks/build.sh
   bats:
     runs-on: ubuntu-18.04
     steps:

--- a/hadoop-ozone/dev-support/checks/build.sh
+++ b/hadoop-ozone/dev-support/checks/build.sh
@@ -17,5 +17,5 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
 export MAVEN_OPTS="-Xmx4096m"
-mvn -B -Dmaven.javadoc.skip=true -DskipTests clean install "$@"
+mvn -V -B -Dmaven.javadoc.skip=true -DskipTests clean install "$@"
 exit $?

--- a/pom.xml
+++ b/pom.xml
@@ -1335,7 +1335,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.kohsuke.metainf-services</groupId>
         <artifactId>metainf-services</artifactId>
-        <version>1.1</version>
+        <version>1.8</version>
         <optional>true</optional>
       </dependency>
       <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Compile Ozone with both Java 8 and 11 in CI.

Note: this is based on top of #1386.

https://issues.apache.org/jira/browse/HDDS-4198

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/1063860191#step:6:10
https://github.com/adoroszlai/hadoop-ozone/runs/1063860210#step:6:10