### PR TITLE
HDDS-4204. upgrade docker environment does not work with KEEP_RUNNING=true

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -26,7 +26,6 @@ export COMPOSE_DIR
 export OZONE_VOLUME
 
 mkdir -p "${OZONE_VOLUME}"/{dn1,dn2,dn3,om,recon,s3g,scm}
-mkdir -p "${OZONE_VOLUME}/debug"
 
 if [[ -n "${OZONE_VOLUME_OWNER}" ]]; then
   current_user=$(whoami)
@@ -47,7 +46,7 @@ source "${COMPOSE_DIR}/../testlib.sh"
 # prepare pre-upgrade cluster
 start_docker_env
 execute_robot_test scm topology/loaddata.robot
-stop_docker_env
+KEEP_RUNNING=false stop_docker_env
 
 # run upgrade scripts
 SCRIPT_DIR=../../libexec/upgrade


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone `upgrade` test fails if run with `KEEP_RUNNING=true`.  The variable is applied to both runs (pre- and post-upgrade), but pre-upgrade containers should be stopped regardless, since they will be replaced by the new ones.

Also remove leftover `debug` directory creation.

https://issues.apache.org/jira/browse/HDDS-4204

## How was this patch tested?

Tested locally:

```
$ cd hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT/compose/upgrade
$ KEEP_RUNNING=true ./test.sh
...
Stopping upgrade_om_1    ...
...
Readdata :: Smoketest ozone cluster startup                           | PASS |
...
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/runs/1067273739