### PR TITLE
HDDS-4205. Make coverage upload to codecov optional

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -279,10 +279,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
+        if: github.repository == 'apache/hadoop-ozone' && github.event_name != 'pull_request'
         with:
           file: ./target/coverage/all.xml
           name: codecov-umbrella
-          fail_ci_if_error: true
+          fail_ci_if_error: false
       - name: Archive build results
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Motivation is discussed on the Apache jira:

 1. We make codecov upload optional (accept failures)
 2. And execute it only for the master branch

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4205

## How was this patch tested?

As modification explicit says that it will be executed on non-apache repositories: it's not easy to test. But it's a small change and copied the same condition from the Sonar upload.