### PR TITLE
HDDS-4210. ResolveBucket during checkAcls fails.

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha-s3/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha-s3/test.sh
@@ -30,6 +30,8 @@ execute_robot_test scm s3
 
 execute_robot_test scm freon
 
+execute_robot_test scm basic/links.robot
+
 stop_docker_env
 
 generate_report

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-om-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-om-ha/docker-config
@@ -55,7 +55,7 @@ HDFS-SITE.XML_dfs.datanode.address=0.0.0.0:1019
 HDFS-SITE.XML_dfs.datanode.http.address=0.0.0.0:1012
 CORE-SITE.XML_dfs.data.transfer.protection=authentication
 CORE-SITE.XML_hadoop.security.authentication=kerberos
-CORE-SITE.XML_hadoop.security.auth_to_local=RULE:[2:$1@$0](.*)s/.*/root/
+CORE-SITE.XML_hadoop.security.auth_to_local=RULE:[2:$1](testuser2.*) RULE:[2:$1@$0](.*)s/.*/root/
 CORE-SITE.XML_hadoop.security.key.provider.path=kms://http@kms:9600/kms
 
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-om-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-om-ha/test.sh
@@ -28,7 +28,7 @@ start_docker_env
 
 execute_robot_test scm kinit.robot
 
-execute_robot_test scm freon
+execute_robot_test scm freonexecute_robot_test scm basic/links.robot
 
 stop_docker_env
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-om-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-om-ha/test.sh
@@ -28,7 +28,9 @@ start_docker_env
 
 execute_robot_test scm kinit.robot
 
-execute_robot_test scm freonexecute_robot_test scm basic/links.robot
+execute_robot_test scm freon
+
+execute_robot_test scm basic/links.robot
 
 stop_docker_env
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
@@ -45,7 +45,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.UUID;
 
 import static org.apache.hadoop.ozone.MiniOzoneHAClusterImpl.NODE_FAILURE_TIMEOUT;
@@ -100,7 +99,6 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
 
     OzoneOutputStream ozoneOutputStream = ozoneBucket.createKey("file1", 0);
     ozoneOutputStream.close();
-
 
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
@@ -21,7 +21,6 @@ import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
@@ -68,38 +67,6 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
   public void testAllOMNodesRunning() throws Exception {
     createVolumeTest(true);
     createKeyTest(true);
-  }
-
-  @Test
-  public void testBucketLinkOps() throws Exception {
-
-    String srcVolume = UUID.randomUUID().toString();
-    getObjectStore().createVolume(srcVolume);
-
-    OzoneVolume ozoneVolume = getObjectStore().getVolume(srcVolume);
-
-    String srcBucket = UUID.randomUUID().toString();
-    ozoneVolume.createBucket(srcBucket);
-
-    OzoneVolume s3Volume = getObjectStore().getVolume("s3v");
-
-    String linkBucket = UUID.randomUUID().toString();
-    s3Volume.createBucket(linkBucket,
-        BucketArgs.newBuilder().setSourceVolume(srcVolume)
-            .setSourceBucket(srcBucket).build());
-
-
-    String linkToLinkBucket = UUID.randomUUID().toString();
-
-    s3Volume.createBucket(linkToLinkBucket,
-        BucketArgs.newBuilder().setSourceVolume("s3v")
-        .setSourceBucket(linkBucket).build());
-
-    OzoneBucket ozoneBucket = s3Volume.getBucket(linkToLinkBucket);
-
-    OzoneOutputStream ozoneOutputStream = ozoneBucket.createKey("file1", 0);
-    ozoneOutputStream.close();
-
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3503,9 +3503,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     Pair<String, String> resolved;
     if (isAclEnabled) {
       resolved = resolveBucketLink(requested, new HashSet<>(),
-              ProtobufRpcEngine.Server.getRemoteUser(),
-              ProtobufRpcEngine.Server.getRemoteIp(),
-              ProtobufRpcEngine.Server.getRemoteIp().getHostName());
+              Server.getRemoteUser(),
+              Server.getRemoteIp(),
+              Server.getRemoteIp().getHostName());
     } else {
       resolved = resolveBucketLink(requested, new HashSet<>(),
           null, null, null);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -62,6 +62,9 @@ public abstract class OMClientRequest implements RequestAuditor {
       LoggerFactory.getLogger(OMClientRequest.class);
   private OMRequest omRequest;
 
+  private UserGroupInformation userGroupInformation;
+  private InetAddress inetAddress;
+
   /**
    * Stores the result of request execution in
    * OMClientRequest#validateAndUpdateCache.
@@ -160,10 +163,16 @@ public abstract class OMClientRequest implements RequestAuditor {
    */
   @VisibleForTesting
   public UserGroupInformation createUGI() {
+
+    if (userGroupInformation != null) {
+      return userGroupInformation;
+    }
+
     if (omRequest.hasUserInfo() &&
         !StringUtils.isBlank(omRequest.getUserInfo().getUserName())) {
-      return UserGroupInformation.createRemoteUser(
+      userGroupInformation = UserGroupInformation.createRemoteUser(
           omRequest.getUserInfo().getUserName());
+      return userGroupInformation;
     } else {
       // This will never happen, as for every OM request preExecute, we
       // should add userInfo.
@@ -179,9 +188,14 @@ public abstract class OMClientRequest implements RequestAuditor {
    */
   @VisibleForTesting
   public InetAddress getRemoteAddress() throws IOException {
+    if (inetAddress != null) {
+      return inetAddress;
+    }
+
     if (omRequest.hasUserInfo()) {
-      return InetAddress.getByName(omRequest.getUserInfo()
+      inetAddress = InetAddress.getByName(omRequest.getUserInfo()
           .getRemoteAddress());
+      return inetAddress;
     } else {
       return null;
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -32,7 +32,6 @@ import java.util.Map;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.PrefixManager;
 import org.apache.hadoop.ozone.om.ResolvedBucket;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.om.request.key;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.security.GeneralSecurityException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
@@ -31,6 +32,7 @@ import java.util.Map;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.PrefixManager;
 import org.apache.hadoop.ozone.om.ResolvedBucket;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.om.request.key;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.security.GeneralSecurityException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
@@ -90,10 +91,10 @@ public abstract class OMKeyRequest extends OMClientRequest {
     super(omRequest);
   }
 
-  protected static KeyArgs resolveBucketLink(
+  protected KeyArgs resolveBucketLink(
       OzoneManager ozoneManager, KeyArgs keyArgs,
       Map<String, String> auditMap) throws IOException {
-    ResolvedBucket bucket = ozoneManager.resolveBucketLink(keyArgs);
+    ResolvedBucket bucket = ozoneManager.resolveBucketLink(keyArgs, this);
     keyArgs = bucket.update(keyArgs);
     bucket.audit(auditMap);
     return keyArgs;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om.request.key;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.security.GeneralSecurityException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMReque
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMReque
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,7 +114,7 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
     boolean deleteStatus = true;
     try {
       ResolvedBucket bucket = ozoneManager.resolveBucketLink(
-          Pair.of(volumeName, bucketName));
+          Pair.of(volumeName, bucketName), this);
       bucket.audit(auditMap);
       volumeName = bucket.realVolume();
       bucketName = bucket.realBucket();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
@@ -109,7 +109,7 @@ public class OMKeysRenameRequest extends OMKeyRequest {
 
     try {
       ResolvedBucket bucket = ozoneManager.resolveBucketLink(
-          Pair.of(volumeName, bucketName));
+          Pair.of(volumeName, bucketName), this);
       bucket.audit(auditMap);
       volumeName = bucket.realVolume();
       bucketName = bucket.realBucket();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMTrashRecoverRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMTrashRecoverRequest.java
@@ -89,7 +89,7 @@ public class OMTrashRecoverRequest extends OMKeyRequest {
     OMClientResponse omClientResponse = null;
     try {
       ResolvedBucket bucket = ozoneManager.resolveBucketLink(
-          Pair.of(volumeName, destinationBucket));
+          Pair.of(volumeName, destinationBucket), this);
       volumeName = bucket.realVolume();
       destinationBucket = bucket.realBucket();
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.ResolvedBucket;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
+import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.junit.After;
@@ -88,7 +89,8 @@ public class TestOMDirectoryCreateRequest {
     auditLogger = Mockito.mock(AuditLogger.class);
     when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
     Mockito.doNothing().when(auditLogger).logWrite(any(AuditMessage.class));
-    when(ozoneManager.resolveBucketLink(any(KeyArgs.class)))
+    when(ozoneManager.resolveBucketLink(any(KeyArgs.class),
+        any(OMClientRequest.class)))
         .thenReturn(new ResolvedBucket(Pair.of("", ""), Pair.of("", "")));
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.ozone.om.ResolvedBucket;
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.KeyManagerImpl;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
+import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.junit.After;
 import org.junit.Before;
@@ -160,9 +161,11 @@ public class TestOMKeyRequest {
     dataSize = 1000L;
 
     Pair<String, String> volumeAndBucket = Pair.of(volumeName, bucketName);
-    when(ozoneManager.resolveBucketLink(any(KeyArgs.class)))
+    when(ozoneManager.resolveBucketLink(any(KeyArgs.class),
+        any(OMClientRequest.class)))
         .thenReturn(new ResolvedBucket(volumeAndBucket, volumeAndBucket));
-    when(ozoneManager.resolveBucketLink(any(Pair.class)))
+    when(ozoneManager.resolveBucketLink(any(Pair.class),
+        any(OMClientRequest.class)))
         .thenReturn(new ResolvedBucket(volumeAndBucket, volumeAndBucket));
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
@@ -22,6 +22,7 @@ package org.apache.hadoop.ozone.om.request.s3.multipart;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -82,7 +83,8 @@ public class TestS3MultipartRequest {
     auditLogger = Mockito.mock(AuditLogger.class);
     when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
     Mockito.doNothing().when(auditLogger).logWrite(any(AuditMessage.class));
-    when(ozoneManager.resolveBucketLink(any(KeyArgs.class)))
+    when(ozoneManager.resolveBucketLink(any(KeyArgs.class),
+        any(OMClientRequest.class)))
         .thenAnswer(inv -> {
           KeyArgs args = (KeyArgs) inv.getArguments()[0];
           return new ResolvedBucket(


### PR DESCRIPTION
## What changes were proposed in this pull request?

When bucket links are levels, When ACLS are enabled, during `checkAcls` It will fail with NPE.
Finally in HA, this causes OM to be terminated.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4210

## How was this patch tested?

Added UT.

The same test will fail without the fix.
