### PR TITLE
HDDS-3927. Rename Ozone OM,DN,SCM runtime options to conform to naming conventions

### DIFF
--- a/hadoop-hdds/common/src/main/conf/hadoop-env.sh
+++ b/hadoop-hdds/common/src/main/conf/hadoop-env.sh
@@ -400,7 +400,16 @@ export HADOOP_OS_TYPE=${HADOOP_OS_TYPE:-$(uname -s)}
 # These options will be appended to the options specified as HADOOP_OPTS
 # and therefore may override any similar flags set in HADOOP_OPTS
 #
-# export HDFS_OM_OPTS=""
+# export OZONE_MANAGER_OPTS=""
+
+###
+# Ozone DataNode specific parameters
+###
+# Specify the JVM options to be used when starting Ozone DataNodes.
+# These options will be appended to the options specified as HADOOP_OPTS
+# and therefore may override any similar flags set in HADOOP_OPTS
+#
+# export OZONE_DATANODE_OPTS=""
 
 ###
 # HDFS StorageContainerManager specific parameters

--- a/hadoop-hdds/common/src/main/conf/hadoop-env.sh
+++ b/hadoop-hdds/common/src/main/conf/hadoop-env.sh
@@ -400,7 +400,7 @@ export HADOOP_OS_TYPE=${HADOOP_OS_TYPE:-$(uname -s)}
 # These options will be appended to the options specified as HADOOP_OPTS
 # and therefore may override any similar flags set in HADOOP_OPTS
 #
-# export OZONE_MANAGER_OPTS=""
+# export OZONE_OM_OPTS=""
 
 ###
 # Ozone DataNode specific parameters
@@ -418,7 +418,7 @@ export HADOOP_OS_TYPE=${HADOOP_OS_TYPE:-$(uname -s)}
 # These options will be appended to the options specified as HADOOP_OPTS
 # and therefore may override any similar flags set in HADOOP_OPTS
 #
-# export HDFS_STORAGECONTAINERMANAGER_OPTS=""
+# export OZONE_SCM_OPTS=""
 
 ###
 # Advanced Users Only!

--- a/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-config
@@ -36,8 +36,8 @@ OZONE-SITE.XML_ozone.network.topology.aware.read=true
 HDFS-SITE.XML_rpc.metrics.quantile.enable=true
 HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300
 ASYNC_PROFILER_HOME=/opt/profiler
-HDDS_DN_OPTS=-Dmodule.name=datanode
-HDFS_OM_OPTS=-Dmodule.name=om
+OZONE_DATANODE_OPTS=-Dmodule.name=datanode
+OZONE_MANAGER_OPTS=-Dmodule.name=om
 HDFS_STORAGECONTAINERMANAGER_OPTS=-Dmodule.name=scm
 HDFS_OM_SH_OPTS=-Dmodule.name=sh
 HDFS_SCM_CLI_OPTS=-Dmodule.name=admin

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -107,7 +107,6 @@ function ozonecmd_case
       # exception as mentioned in HDDS-3812
       hadoop_deprecate_envvar HDDS_DN_OPTS OZONE_DATANODE_OPTS
       OZONE_DATANODE_OPTS="-Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false -Dorg.apache.ratis.thirdparty.io.netty.leakDetection.level=disabled -Dlog4j.configurationFile=${HADOOP_CONF_DIR}/dn-audit-log4j2.properties ${OZONE_DATANODE_OPTS}"
-      HADOOP_OPTS="${HADOOP_OPTS} ${OZONE_DATANODE_OPTS}"
       HADOOP_CLASSNAME=org.apache.hadoop.ozone.HddsDatanodeService
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-datanode"
     ;;
@@ -155,9 +154,8 @@ function ozonecmd_case
     om)
       HADOOP_SUBCMD_SUPPORTDAEMONIZATION="true"
       HADOOP_CLASSNAME=org.apache.hadoop.ozone.om.OzoneManagerStarter
-      hadoop_deprecate_envvar HDFS_OM_OPTS OZONE_MANAGER_OPTS
-      OZONE_MANAGER_OPTS="${OZONE_MANAGER_OPTS} -Dlog4j.configurationFile=${HADOOP_CONF_DIR}/om-audit-log4j2.properties"
-      HADOOP_OPTS="${HADOOP_OPTS} ${OZONE_MANAGER_OPTS}"
+      hadoop_deprecate_envvar HDFS_OM_OPTS OZONE_OM_OPTS
+      OZONE_OM_OPTS="${OZONE_OM_OPTS} -Dlog4j.configurationFile=${HADOOP_CONF_DIR}/om-audit-log4j2.properties"
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-ozone-manager"
     ;;
     sh | shell)
@@ -174,9 +172,8 @@ function ozonecmd_case
     scm)
       HADOOP_SUBCMD_SUPPORTDAEMONIZATION="true"
       HADOOP_CLASSNAME='org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter'
-      hadoop_debug "Appending HDFS_STORAGECONTAINERMANAGER_OPTS onto HADOOP_OPTS"
-      HDFS_STORAGECONTAINERMANAGER_OPTS="${HDFS_STORAGECONTAINERMANAGER_OPTS} -Dlog4j.configurationFile=${HADOOP_CONF_DIR}/scm-audit-log4j2.properties"
-      HADOOP_OPTS="${HADOOP_OPTS} ${HDFS_STORAGECONTAINERMANAGER_OPTS}"
+      hadoop_deprecate_envvar HDFS_STORAGECONTAINERMANAGER_OPTS OZONE_SCM_OPTS
+      OZONE_SCM_OPTS="${OZONE_SCM_OPTS} -Dlog4j.configurationFile=${HADOOP_CONF_DIR}/scm-audit-log4j2.properties"
       OZONE_RUN_ARTIFACT_NAME="hadoop-hdds-server-scm"
     ;;
     s3g)

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -105,8 +105,9 @@ function ozonecmd_case
       # Corresponding Ratis issue https://issues.apache.org/jira/browse/RATIS-534.
       # TODO: Fix the problem related to netty resource leak detector throwing
       # exception as mentioned in HDDS-3812
-      HDDS_DN_OPTS="-Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false -Dorg.apache.ratis.thirdparty.io.netty.leakDetection.level=disabled -Dlog4j.configurationFile=${HADOOP_CONF_DIR}/dn-audit-log4j2.properties ${HDDS_DN_OPTS}"
-      HADOOP_OPTS="${HADOOP_OPTS} ${HDDS_DN_OPTS}"
+      hadoop_deprecate_envvar HDDS_DN_OPTS OZONE_DATANODE_OPTS
+      OZONE_DATANODE_OPTS="-Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false -Dorg.apache.ratis.thirdparty.io.netty.leakDetection.level=disabled -Dlog4j.configurationFile=${HADOOP_CONF_DIR}/dn-audit-log4j2.properties ${OZONE_DATANODE_OPTS}"
+      HADOOP_OPTS="${HADOOP_OPTS} ${OZONE_DATANODE_OPTS}"
       HADOOP_CLASSNAME=org.apache.hadoop.ozone.HddsDatanodeService
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-datanode"
     ;;
@@ -154,8 +155,9 @@ function ozonecmd_case
     om)
       HADOOP_SUBCMD_SUPPORTDAEMONIZATION="true"
       HADOOP_CLASSNAME=org.apache.hadoop.ozone.om.OzoneManagerStarter
-      HDFS_OM_OPTS="${HDFS_OM_OPTS} -Dlog4j.configurationFile=${HADOOP_CONF_DIR}/om-audit-log4j2.properties"
-      HADOOP_OPTS="${HADOOP_OPTS} ${HDFS_OM_OPTS}"
+      hadoop_deprecate_envvar HDFS_OM_OPTS OZONE_MANAGER_OPTS
+      OZONE_MANAGER_OPTS="${OZONE_MANAGER_OPTS} -Dlog4j.configurationFile=${HADOOP_CONF_DIR}/om-audit-log4j2.properties"
+      HADOOP_OPTS="${HADOOP_OPTS} ${OZONE_MANAGER_OPTS}"
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-ozone-manager"
     ;;
     sh | shell)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Rename the environment variables to be in accordance with the convention, and keep the compatibility by deprecating the old variable names.

- `HDFS_OM_OPTS` -> `OZONE_OM_OPTS`
- `HDDS_DN_OPTS` -> `OZONE_DATANODE_OPTS`
- `HDFS_STORAGECONTAINERMANAGER_OPTS` -> `OZONE_SCM_OPTS`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3927

## How was this patch tested?

No new tests added. Tested manually:

1. `HADOOP_SHELL_SCRIPT_DEBUG=1 OZONE_OM_OPTS=-Dtest123 ./ozone om`
```
DEBUG: Appending OZONE_OM_OPTS onto HADOOP_OPTS
...
DEBUG: Final HADOOP_OPTS: -Djava.net.preferIPv4Stack=true -XX:ParallelGCThreads=8 -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -Dtest123 -Dlog4j.configurationFile=/Users/smeng/repo/ozone/hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT/etc/hadoop/om-audit-log4j2.properties -Dhadoop.log.dir=/Users/smeng/repo/ozone/hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT/logs -Dhadoop.log.file=hadoop.log -Dhadoop.home.dir=/Users/smeng/repo/ozone/hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT -Dhadoop.id.str=smeng -Dhadoop.root.logger=INFO,console -Dhadoop.policy.file=hadoop-policy.xml -Dhadoop.security.logger=INFO,NullAppender
```

2. `HADOOP_SHELL_SCRIPT_DEBUG=1 OZONE_DATANODE_OPTS=-Dtest123 ./ozone datanode`
```
DEBUG: Appending OZONE_DATANODE_OPTS onto HADOOP_OPTS
...
DEBUG: Final HADOOP_OPTS: -Djava.net.preferIPv4Stack=true -XX:ParallelGCThreads=8 -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false -Dorg.apache.ratis.thirdparty.io.netty.leakDetection.level=disabled -Dlog4j.configurationFile=/Users/smeng/repo/ozone/hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT/etc/hadoop/dn-audit-log4j2.properties -Dtest123 -Dhadoop.log.dir=/Users/smeng/repo/ozone/hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT/logs -Dhadoop.log.file=hadoop.log -Dhadoop.home.dir=/Users/smeng/repo/ozone/hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT -Dhadoop.id.str=smeng -Dhadoop.root.logger=INFO,console -Dhadoop.policy.file=hadoop-policy.xml -Dhadoop.security.logger=INFO,NullAppender
```

3. `HADOOP_SHELL_SCRIPT_DEBUG=1 OZONE_SCM_OPTS=-Dtest123 ./ozone scm`
```
DEBUG: Appending OZONE_SCM_OPTS onto HADOOP_OPTS
...
DEBUG: Final HADOOP_OPTS: -Djava.net.preferIPv4Stack=true -XX:ParallelGCThreads=8 -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -Dtest123 -Dlog4j.configurationFile=/Users/smeng/repo/ozone/hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT/etc/hadoop/scm-audit-log4j2.properties -Dhadoop.log.dir=/Users/smeng/repo/ozone/hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT/logs -Dhadoop.log.file=hadoop.log -Dhadoop.home.dir=/Users/smeng/repo/ozone/hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT -Dhadoop.id.str=smeng -Dhadoop.root.logger=INFO,console -Dhadoop.policy.file=hadoop-policy.xml -Dhadoop.security.logger=INFO,NullAppender
```

4. Deprecation warning: `HADOOP_SHELL_SCRIPT_DEBUG=1 HDFS_OM_OPTS=-Dtest123 ./ozone om`
```
WARNING: HDFS_OM_OPTS has been replaced by OZONE_OM_OPTS. Using value of HDFS_OM_OPTS.
```

Caveat: when both deprecated and new variables names are present, the new variable will be ignored. So admins should refrain from using both at the same time. e.g. for `HDFS_OM_OPTS=-Dtest123 OZONE_OM_OPTS=-Dtest456 ./ozone om`, `OZONE_OM_OPTS=-Dtest456` will be completely ignored, only `HDFS_OM_OPTS=-Dtest123` will be respected.

## Note

[`hadoop_deprecate_envvar`](https://github.com/apache/hadoop/blob/9fe4c37c25b256d31202854066eb7e15c6335b9f/hadoop-common-project/hadoop-common/src/main/bin/hadoop-functions.sh#L506-L524) takes care of the copying the values from the old variable name to the new one, and prints the deprecation warning.