### PR TITLE
HDDS-4213. Log when a datanode has become dead in the DeadNodeHandler

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
@@ -74,7 +74,7 @@ public class DeadNodeHandler implements EventHandler<DatanodeDetails> {
        * To be on a safer side, we double check here and take appropriate
        * action.
        */
-      LOG.warn("A dead datanode detected. {}", datanodeDetails);
+      LOG.warn("A dead datanode is detected. {}", datanodeDetails);
       destroyPipelines(datanodeDetails);
       closeContainers(datanodeDetails, publisher);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
@@ -74,7 +74,7 @@ public class DeadNodeHandler implements EventHandler<DatanodeDetails> {
        * To be on a safer side, we double check here and take appropriate
        * action.
        */
-
+      LOG.warn("A dead datanode detected. {}", datanodeDetails);
       destroyPipelines(datanodeDetails);
       closeContainers(datanodeDetails, publisher);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DeadNodeHandler.java
@@ -74,7 +74,7 @@ public class DeadNodeHandler implements EventHandler<DatanodeDetails> {
        * To be on a safer side, we double check here and take appropriate
        * action.
        */
-      LOG.warn("A dead datanode is detected. {}", datanodeDetails);
+      LOG.info("A dead datanode is detected. {}", datanodeDetails);
       destroyPipelines(datanodeDetails);
       closeContainers(datanodeDetails, publisher);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Print the dead datanode when DEAD message comming

## What is the link to the Apache JIRA

HDDS-4213

## How was this patch tested?

Kill a datanode, after x minute past, watching the log of SCM, you can see the log `A dead datanode detected.`, and you can get the dead datanode information clearly.
