### PR TITLE
HDDS-3751. Ozone sh client support bucket quota option.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/BucketArgs.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/BucketArgs.java
@@ -57,6 +57,9 @@ public final class BucketArgs {
   private final String sourceVolume;
   private final String sourceBucket;
 
+  private long quotaInBytes;
+  private long quotaInCounts;
+
   /**
    * Private constructor, constructed via builder.
    * @param versioning Bucket version flag.
@@ -66,10 +69,14 @@ public final class BucketArgs {
    * @param bucketEncryptionKey bucket encryption key name
    * @param sourceVolume
    * @param sourceBucket
+   * @param quotaInBytes Bucket quota in bytes.
+   * @param quotaInCounts Bucket quota in counts.
    */
+  @SuppressWarnings("parameternumber")
   private BucketArgs(Boolean versioning, StorageType storageType,
       List<OzoneAcl> acls, Map<String, String> metadata,
-      String bucketEncryptionKey, String sourceVolume, String sourceBucket) {
+      String bucketEncryptionKey, String sourceVolume, String sourceBucket,
+      long quotaInBytes, long quotaInCounts) {
     this.acls = acls;
     this.versioning = versioning;
     this.storageType = storageType;
@@ -77,6 +84,8 @@ public final class BucketArgs {
     this.bucketEncryptionKey = bucketEncryptionKey;
     this.sourceVolume = sourceVolume;
     this.sourceBucket = sourceBucket;
+    this.quotaInBytes = quotaInBytes;
+    this.quotaInCounts = quotaInCounts;
   }
 
   /**
@@ -138,6 +147,22 @@ public final class BucketArgs {
   }
 
   /**
+   * Returns Bucket Quota in bytes.
+   * @return quotaInBytes.
+   */
+  public long getQuotaInBytes() {
+    return quotaInBytes;
+  }
+
+  /**
+   * Returns Bucket Quota in key counts.
+   * @return quotaInCounts.
+   */
+  public long getQuotaInCounts() {
+    return quotaInCounts;
+  }
+
+  /**
    * Builder for OmBucketInfo.
    */
   public static class Builder {
@@ -148,6 +173,8 @@ public final class BucketArgs {
     private String bucketEncryptionKey;
     private String sourceVolume;
     private String sourceBucket;
+    private long quotaInBytes;
+    private long quotaInCounts;
 
     public Builder() {
       metadata = new HashMap<>();
@@ -188,13 +215,25 @@ public final class BucketArgs {
       return this;
     }
 
+    public BucketArgs.Builder setQuotaInBytes(long quota) {
+      quotaInBytes = quota;
+      return this;
+    }
+
+    public BucketArgs.Builder setQuotaInCounts(long quota) {
+      quotaInCounts = quota;
+      return this;
+    }
+
+
     /**
      * Constructs the BucketArgs.
      * @return instance of BucketArgs.
      */
     public BucketArgs build() {
       return new BucketArgs(versioning, storageType, acls, metadata,
-          bucketEncryptionKey, sourceVolume, sourceBucket);
+          bucketEncryptionKey, sourceVolume, sourceBucket, quotaInBytes,
+          quotaInCounts);
     }
   }
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneVolume.java
@@ -36,6 +36,8 @@ import org.apache.hadoop.ozone.om.helpers.WithMetadata;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
+import static org.apache.hadoop.ozone.OzoneConsts.QUOTA_RESET;
+
 /**
  * A class that encapsulates OzoneVolume.
  */
@@ -280,6 +282,30 @@ public class OzoneVolume extends WithMetadata {
     boolean result = proxy.setVolumeOwner(name, userName);
     this.owner = userName;
     return result;
+  }
+
+  /**
+   * Clean the space quota of the volume.
+   *
+   * @throws IOException
+   */
+  public void clearSpaceQuota() throws IOException {
+    OzoneVolume ozoneVolume = proxy.getVolumeDetails(name);
+    proxy.setVolumeQuota(name, ozoneVolume.getQuotaInCounts(), QUOTA_RESET);
+    this.quotaInBytes = QUOTA_RESET;
+    this.quotaInCounts = ozoneVolume.getQuotaInCounts();
+  }
+
+  /**
+   * Clean the count quota of the volume.
+   *
+   * @throws IOException
+   */
+  public void clearCountQuota() throws IOException {
+    OzoneVolume ozoneVolume = proxy.getVolumeDetails(name);
+    proxy.setVolumeQuota(name, QUOTA_RESET, ozoneVolume.getQuotaInBytes());
+    this.quotaInBytes = ozoneVolume.getQuotaInBytes();
+    this.quotaInCounts = QUOTA_RESET;
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/VolumeArgs.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/VolumeArgs.java
@@ -33,7 +33,7 @@ public final class VolumeArgs {
 
   private final String admin;
   private final String owner;
-  private final String quotaInBytes;
+  private final long quotaInBytes;
   private final long quotaInCounts;
   private final List<OzoneAcl> acls;
   private Map<String, String> metadata;
@@ -49,7 +49,7 @@ public final class VolumeArgs {
    */
   private VolumeArgs(String admin,
       String owner,
-      String quotaInBytes,
+      long quotaInBytes,
       long quotaInCounts,
       List<OzoneAcl> acls,
       Map<String, String> metadata) {
@@ -81,7 +81,7 @@ public final class VolumeArgs {
    * Returns Volume Quota in bytes.
    * @return quotaInBytes.
    */
-  public String getQuotaInBytes() {
+  public long getQuotaInBytes() {
     return quotaInBytes;
   }
 
@@ -120,7 +120,7 @@ public final class VolumeArgs {
   public static class Builder {
     private String adminName;
     private String ownerName;
-    private String quotaInBytes;
+    private long quotaInBytes;
     private long quotaInCounts;
     private List<OzoneAcl> listOfAcls;
     private Map<String, String> metadata = new HashMap<>();
@@ -136,7 +136,7 @@ public final class VolumeArgs {
       return this;
     }
 
-    public VolumeArgs.Builder setQuotaInBytes(String quota) {
+    public VolumeArgs.Builder setQuotaInBytes(long quota) {
       this.quotaInBytes = quota;
       return this;
     }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -100,11 +100,11 @@ public interface ClientProtocol {
   /**
    * Set Volume Quota.
    * @param volumeName Name of the Volume
-   * @param quotaInBytes The maximum size this volume can be used.
    * @param quotaInCounts The maximum number of buckets in this volume.
+   * @param quotaInBytes The maximum size this volume can be used.
    * @throws IOException
    */
-  void setVolumeQuota(String volumeName, long quotaInBytes, long quotaInCounts)
+  void setVolumeQuota(String volumeName, long quotaInCounts, long quotaInBytes)
       throws IOException;
 
   /**
@@ -655,4 +655,15 @@ public interface ClientProtocol {
    * Getter for OzoneManagerClient.
    */
   OzoneManagerProtocol getOzoneManagerClient();
+
+  /**
+   * Set Bucket Quota.
+   * @param volumeName Name of the Volume.
+   * @param bucketName Name of the Bucket.
+   * @param quotaInBytes The maximum size this buckets can be used.
+   * @param quotaInCounts The maximum number of keys in this bucket.
+   * @throws IOException
+   */
+  void setBucketQuota(String volumeName, String bucketName, long quotaInCounts,
+      long quotaInBytes) throws IOException;
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.crypto.CryptoInputStream;
 import org.apache.hadoop.crypto.CryptoOutputStream;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.fs.FileEncryptionInfo;
-import org.apache.hadoop.hdds.client.OzoneQuota;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
@@ -281,12 +280,8 @@ public class RpcClient implements ClientProtocol {
         ugi.getUserName() : volArgs.getAdmin();
     String owner = volArgs.getOwner() == null ?
         ugi.getUserName() : volArgs.getOwner();
-    long quotaInCounts = volArgs.getQuotaInCounts() == 0 ?
-        OzoneConsts.QUOTA_RESET : volArgs.getQuotaInCounts();
-    long quotaInBytes = volArgs.getQuotaInBytes() == null ?
-        OzoneConsts.QUOTA_RESET :
-        OzoneQuota.parseQuota(volArgs.getQuotaInBytes(), quotaInCounts)
-            .getQuotaInBytes();
+    long quotaInCounts = getQuotaValue(volArgs.getQuotaInCounts());
+    long quotaInBytes = getQuotaValue(volArgs.getQuotaInBytes());
     List<OzoneAcl> listOfAcls = new ArrayList<>();
     //User ACL
     listOfAcls.add(new OzoneAcl(ACLIdentityType.USER,
@@ -305,8 +300,8 @@ public class RpcClient implements ClientProtocol {
     builder.setVolume(volumeName);
     builder.setAdminName(admin);
     builder.setOwnerName(owner);
-    builder.setQuotaInBytes(quotaInBytes);
-    builder.setQuotaInCounts(quotaInCounts);
+    builder.setQuotaInBytes(getQuotaValue(volArgs.getQuotaInBytes()));
+    builder.setQuotaInCounts(getQuotaValue(volArgs.getQuotaInCounts()));
     builder.addAllMetadata(volArgs.getMetadata());
 
     //Remove duplicates and add ACLs
@@ -315,7 +310,7 @@ public class RpcClient implements ClientProtocol {
       builder.addOzoneAcls(OzoneAcl.toProtobuf(ozoneAcl));
     }
 
-    if (volArgs.getQuotaInBytes() == null) {
+    if (volArgs.getQuotaInBytes() == 0) {
       LOG.info("Creating Volume: {}, with {} as owner.", volumeName, owner);
     } else {
       LOG.info("Creating Volume: {}, with {} as owner "
@@ -337,14 +332,9 @@ public class RpcClient implements ClientProtocol {
   public void setVolumeQuota(String volumeName, long quotaInCounts,
       long quotaInBytes) throws IOException {
     HddsClientUtils.verifyResourceName(volumeName);
-    if ((quotaInCounts <= 0 && quotaInCounts != OzoneConsts.QUOTA_RESET)
-        || (quotaInBytes <= 0 && quotaInCounts != OzoneConsts.QUOTA_RESET)) {
-      throw new IllegalArgumentException("Invalid values for quota : " +
-          "counts quota is :" + quotaInCounts + " and " +
-          "space quota is :" + quotaInBytes);
-    }
+    verifyCountsQuota(quotaInCounts);
+    verifySpaceQuota(quotaInBytes);
     ozoneManagerClient.setQuota(volumeName, quotaInCounts, quotaInBytes);
-
   }
 
   @Override
@@ -441,6 +431,8 @@ public class RpcClient implements ClientProtocol {
     verifyVolumeName(volumeName);
     verifyBucketName(bucketName);
     Preconditions.checkNotNull(bucketArgs);
+    verifyCountsQuota(bucketArgs.getQuotaInCounts());
+    verifySpaceQuota(bucketArgs.getQuotaInBytes());
 
     Boolean isVersionEnabled = bucketArgs.getVersioning() == null ?
         Boolean.FALSE : bucketArgs.getVersioning();
@@ -466,6 +458,8 @@ public class RpcClient implements ClientProtocol {
         .setStorageType(storageType)
         .setSourceVolume(bucketArgs.getSourceVolume())
         .setSourceBucket(bucketArgs.getSourceBucket())
+        .setQuotaInBytes(getQuotaValue(bucketArgs.getQuotaInBytes()))
+        .setQuotaInCounts(getQuotaValue(bucketArgs.getQuotaInCounts()))
         .setAcls(listOfAcls.stream().distinct().collect(Collectors.toList()));
 
     if (bek != null) {
@@ -493,6 +487,28 @@ public class RpcClient implements ClientProtocol {
     } catch (IllegalArgumentException e) {
       throw new OMException(e.getMessage(),
           OMException.ResultCodes.INVALID_BUCKET_NAME);
+    }
+  }
+
+  private static void verifyCountsQuota(long quota) throws OMException {
+    if (quota < OzoneConsts.QUOTA_RESET) {
+      throw new IllegalArgumentException("Invalid values for quota : " +
+          "counts quota is :" + quota + ".");
+    }
+  }
+
+  private static void verifySpaceQuota(long quota) throws OMException {
+    if (quota < OzoneConsts.QUOTA_RESET) {
+      throw new IllegalArgumentException("Invalid values for quota : " +
+          "space quota is :" + quota + ".");
+    }
+  }
+
+  private static long getQuotaValue(long quota) throws OMException {
+    if (quota == 0) {
+      return OzoneConsts.QUOTA_RESET;
+    } else {
+      return quota;
     }
   }
 
@@ -601,6 +617,22 @@ public class RpcClient implements ClientProtocol {
   }
 
   @Override
+  public void setBucketQuota(String volumeName, String bucketName,
+      long quotaInCounts, long quotaInBytes) throws IOException {
+    HddsClientUtils.verifyResourceName(bucketName);
+    HddsClientUtils.verifyResourceName(volumeName);
+    verifyCountsQuota(quotaInCounts);
+    verifySpaceQuota(quotaInBytes);
+    OmBucketArgs.Builder builder = OmBucketArgs.newBuilder();
+    builder.setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setQuotaInBytes(quotaInBytes)
+        .setQuotaInCounts(quotaInCounts);
+    ozoneManagerClient.setBucketProperty(builder.build());
+
+  }
+
+  @Override
   public void deleteBucket(
       String volumeName, String bucketName) throws IOException {
     verifyVolumeName(volumeName);
@@ -635,7 +667,9 @@ public class RpcClient implements ClientProtocol {
             .getEncryptionKeyInfo().getKeyName() : null,
         bucketInfo.getSourceVolume(),
         bucketInfo.getSourceBucket(),
-        bucketInfo.getUsedBytes().sum()
+        bucketInfo.getUsedBytes().sum(),
+        bucketInfo.getQuotaInBytes(),
+        bucketInfo.getQuotaInCounts()
     );
   }
 
@@ -660,7 +694,9 @@ public class RpcClient implements ClientProtocol {
             .getEncryptionKeyInfo().getKeyName() : null,
         bucket.getSourceVolume(),
         bucket.getSourceBucket(),
-        bucket.getUsedBytes().sum()))
+        bucket.getUsedBytes().sum(),
+        bucket.getQuotaInBytes(),
+        bucket.getQuotaInCounts()))
         .collect(Collectors.toList());
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -275,6 +275,8 @@ public class RpcClient implements ClientProtocol {
       throws IOException {
     verifyVolumeName(volumeName);
     Preconditions.checkNotNull(volArgs);
+    verifyCountsQuota(volArgs.getQuotaInCounts());
+    verifySpaceQuota(volArgs.getQuotaInBytes());
 
     String admin = volArgs.getAdmin() == null ?
         ugi.getUserName() : volArgs.getAdmin();
@@ -300,8 +302,8 @@ public class RpcClient implements ClientProtocol {
     builder.setVolume(volumeName);
     builder.setAdminName(admin);
     builder.setOwnerName(owner);
-    builder.setQuotaInBytes(getQuotaValue(volArgs.getQuotaInBytes()));
-    builder.setQuotaInCounts(getQuotaValue(volArgs.getQuotaInCounts()));
+    builder.setQuotaInBytes(quotaInBytes);
+    builder.setQuotaInCounts(quotaInCounts);
     builder.addAllMetadata(volArgs.getMetadata());
 
     //Remove duplicates and add ACLs

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
@@ -49,21 +49,28 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
    */
   private StorageType storageType;
 
+  private long quotaInBytes;
+  private long quotaInCounts;
+
   /**
    * Private constructor, constructed via builder.
    * @param volumeName - Volume name.
    * @param bucketName - Bucket name.
    * @param isVersionEnabled - Bucket version flag.
    * @param storageType - Storage type to be used.
+   * @param quotaInBytes Volume quota in bytes.
+   * @param quotaInCounts Volume quota in counts.
    */
   private OmBucketArgs(String volumeName, String bucketName,
       Boolean isVersionEnabled, StorageType storageType,
-      Map<String, String> metadata) {
+      Map<String, String> metadata, long quotaInBytes, long quotaInCounts) {
     this.volumeName = volumeName;
     this.bucketName = bucketName;
     this.isVersionEnabled = isVersionEnabled;
     this.storageType = storageType;
     this.metadata = metadata;
+    this.quotaInBytes = quotaInBytes;
+    this.quotaInCounts = quotaInCounts;
   }
 
   /**
@@ -99,8 +106,23 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
   }
 
   /**
+   * Returns Bucket Quota in bytes.
+   * @return quotaInBytes.
+   */
+  public long getQuotaInBytes() {
+    return quotaInBytes;
+  }
+
+  /**
+   * Returns Bucket Quota in key counts.
+   * @return quotaInCounts.
+   */
+  public long getQuotaInCounts() {
+    return quotaInCounts;
+  }
+
+  /**
    * Returns new builder class that builds a OmBucketArgs.
-   *
    * @return Builder
    */
   public static Builder newBuilder() {
@@ -131,6 +153,8 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
     private Boolean isVersionEnabled;
     private StorageType storageType;
     private Map<String, String> metadata;
+    private long quotaInBytes;
+    private long quotaInCounts;
 
     public Builder setVolumeName(String volume) {
       this.volumeName = volume;
@@ -157,6 +181,16 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
       return this;
     }
 
+    public Builder setQuotaInBytes(long quota) {
+      quotaInBytes = quota;
+      return this;
+    }
+
+    public Builder setQuotaInCounts(long quota) {
+      quotaInCounts = quota;
+      return this;
+    }
+
     /**
      * Constructs the OmBucketArgs.
      * @return instance of OmBucketArgs.
@@ -165,7 +199,7 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
       Preconditions.checkNotNull(volumeName);
       Preconditions.checkNotNull(bucketName);
       return new OmBucketArgs(volumeName, bucketName, isVersionEnabled,
-          storageType, metadata);
+          storageType, metadata, quotaInBytes, quotaInCounts);
     }
   }
 
@@ -182,6 +216,12 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
     if(storageType != null) {
       builder.setStorageType(storageType.toProto());
     }
+    if(quotaInBytes > 0 || quotaInBytes == OzoneConsts.QUOTA_RESET) {
+      builder.setQuotaInBytes(quotaInBytes);
+    }
+    if(quotaInCounts > 0 || quotaInCounts == OzoneConsts.QUOTA_RESET) {
+      builder.setQuotaInCounts(quotaInCounts);
+    }
     return builder.build();
   }
 
@@ -197,6 +237,8 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
             bucketArgs.getIsVersionEnabled() : null,
         bucketArgs.hasStorageType() ? StorageType.valueOf(
             bucketArgs.getStorageType()) : null,
-        KeyValueUtil.getFromProtobuf(bucketArgs.getMetadataList()));
+        KeyValueUtil.getFromProtobuf(bucketArgs.getMetadataList()),
+        bucketArgs.getQuotaInBytes(),
+        bucketArgs.getQuotaInCounts());
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmVolumeArgs.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmVolumeArgs.java
@@ -41,8 +41,8 @@ public class TestOmVolumeArgs {
     String owner = UserGroupInformation.getCurrentUser().getUserName();
     OmVolumeArgs omVolumeArgs = new OmVolumeArgs.Builder().setVolume(volumeName)
         .setAdminName(admin).setCreationTime(Time.now()).setOwnerName(owner)
-        .setObjectID(1L).setUpdateID(1L).setQuotaInBytes(100L).addMetadata(
-            "key1", "value1").addMetadata("key2", "value2")
+        .setObjectID(1L).setUpdateID(1L).setQuotaInBytes(Long.MAX_VALUE)
+        .addMetadata("key1", "value1").addMetadata("key2", "value2")
         .addOzoneAcls(OzoneAcl.toProtobuf(
             new OzoneAcl(IAccessAuthorizer.ACLIdentityType.USER, "user1",
                 IAccessAuthorizer.ACLType.READ, ACCESS))).build();

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -31,24 +31,67 @@ Test ozone shell
     [arguments]     ${protocol}         ${server}       ${volume}
     ${result} =     Execute And Ignore Error    ozone sh volume info ${protocol}${server}/${volume}
                     Should contain      ${result}       VOLUME_NOT_FOUND
-    ${result} =     Execute             ozone sh volume create ${protocol}${server}/${volume} --spaceQuota 100TB --bucketQuota 100
+    ${result} =     Execute             ozone sh volume create ${protocol}${server}/${volume} --space-quota 100TB --bucket-quota 100
                     Should not contain  ${result}       Failed
     ${result} =     Execute             ozone sh volume list ${protocol}${server}/ | jq -r '. | select(.name=="${volume}")'
                     Should contain      ${result}       creationTime
     ${result} =     Execute             ozone sh volume list | jq -r '. | select(.name=="${volume}")'
                     Should contain      ${result}       creationTime
 # TODO: Disable updating the owner, acls should be used to give access to other user.        
-                    Execute             ozone sh volume update ${protocol}${server}/${volume} --spaceQuota 10TB --bucketQuota 100
+                    Execute             ozone sh volume setquota ${protocol}${server}/${volume} --space-quota 10TB --bucket-quota 100
 #    ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.volumeName=="${volume}") | .owner | .name'
 #                    Should Be Equal     ${result}       bill
     ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInBytes'
                     Should Be Equal     ${result}       10995116277760
-                    Execute             ozone sh bucket create ${protocol}${server}/${volume}/bb1
+                    Execute             ozone sh bucket create ${protocol}${server}/${volume}/bb1 --space-quota 10TB --key-quota 100
     ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .storageType'
                     Should Be Equal     ${result}       DISK
+    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInBytes'
+                    Should Be Equal     ${result}       10995116277760
+    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInCounts'
+                    Should Be Equal     ${result}       100
+                    Execute             ozone sh bucket setquota ${protocol}${server}/${volume}/bb1 --space-quota 1TB --key-quota 1000
+    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInBytes'
+                    Should Be Equal     ${result}       1099511627776
+    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInCounts'
+                    Should Be Equal     ${result}       1000
     ${result} =     Execute             ozone sh bucket list ${protocol}${server}/${volume}/ | jq -r '. | select(.name=="bb1") | .volumeName'
                     Should Be Equal     ${result}       ${volume}
                     Run Keyword         Test key handling       ${protocol}       ${server}       ${volume}
+                    Execute             ozone sh bucket clrquota --space-quota ${protocol}${server}/${volume}/bb1
+    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInBytes'
+                    Should Be Equal     ${result}       -1
+                    Execute             ozone sh bucket clrquota --key-quota ${protocol}${server}/${volume}/bb1
+    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInCounts'
+                    Should Be Equal     ${result}       -1
+                    Execute             ozone sh volume clrquota --space-quota ${protocol}${server}/${volume}
+    ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInBytes'
+                    Should Be Equal     ${result}       -1
+                    Execute             ozone sh volume clrquota --bucket-quota ${protocol}${server}/${volume}
+    ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInCounts'
+                    Should Be Equal     ${result}       -1
+                    Execute             ozone sh bucket delete ${protocol}${server}/${volume}/bb1
+                    Execute             ozone sh volume delete ${protocol}${server}/${volume}
+                    Execute             ozone sh volume create ${protocol}${server}/${volume}
+    ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInBytes'
+                    Should Be Equal     ${result}       -1
+    ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInCounts'
+                    Should Be Equal     ${result}       -1
+                    Execute             ozone sh bucket create ${protocol}${server}/${volume}/bb1
+    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInBytes'
+                    Should Be Equal     ${result}       -1
+    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInCounts'
+                    Should Be Equal     ${result}       -1
+                    Execute             ozone sh volume setquota ${protocol}${server}/${volume} --space-quota 0TB --bucket-quota 0
+    ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInBytes'
+                    Should Be Equal     ${result}       -1
+    ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInCounts'
+                    Should Be Equal     ${result}       -1
+                    Execute             ozone sh bucket setquota ${protocol}${server}/${volume}/bb1 --space-quota 0TB --key-quota 0
+    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInBytes'
+                    Should Be Equal     ${result}       -1
+    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInCounts'
+                    Should Be Equal     ${result}       -1
                     Execute             ozone sh bucket delete ${protocol}${server}/${volume}/bb1
                     Execute             ozone sh volume delete ${protocol}${server}/${volume}
 

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -31,26 +31,26 @@ Test ozone shell
     [arguments]     ${protocol}         ${server}       ${volume}
     ${result} =     Execute And Ignore Error    ozone sh volume info ${protocol}${server}/${volume}
                     Should contain      ${result}       VOLUME_NOT_FOUND
-    ${result} =     Execute             ozone sh volume create ${protocol}${server}/${volume} --space-quota 100TB --bucket-quota 100
+    ${result} =     Execute             ozone sh volume create ${protocol}${server}/${volume} --space-quota 100TB --count-quota 100
                     Should not contain  ${result}       Failed
     ${result} =     Execute             ozone sh volume list ${protocol}${server}/ | jq -r '. | select(.name=="${volume}")'
                     Should contain      ${result}       creationTime
     ${result} =     Execute             ozone sh volume list | jq -r '. | select(.name=="${volume}")'
                     Should contain      ${result}       creationTime
 # TODO: Disable updating the owner, acls should be used to give access to other user.        
-                    Execute             ozone sh volume setquota ${protocol}${server}/${volume} --space-quota 10TB --bucket-quota 100
+                    Execute             ozone sh volume setquota ${protocol}${server}/${volume} --space-quota 10TB --count-quota 100
 #    ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.volumeName=="${volume}") | .owner | .name'
 #                    Should Be Equal     ${result}       bill
     ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInBytes'
                     Should Be Equal     ${result}       10995116277760
-                    Execute             ozone sh bucket create ${protocol}${server}/${volume}/bb1 --space-quota 10TB --key-quota 100
+                    Execute             ozone sh bucket create ${protocol}${server}/${volume}/bb1 --space-quota 10TB --count-quota 100
     ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .storageType'
                     Should Be Equal     ${result}       DISK
     ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInBytes'
                     Should Be Equal     ${result}       10995116277760
     ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInCounts'
                     Should Be Equal     ${result}       100
-                    Execute             ozone sh bucket setquota ${protocol}${server}/${volume}/bb1 --space-quota 1TB --key-quota 1000
+                    Execute             ozone sh bucket setquota ${protocol}${server}/${volume}/bb1 --space-quota 1TB --count-quota 1000
     ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInBytes'
                     Should Be Equal     ${result}       1099511627776
     ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInCounts'
@@ -61,13 +61,13 @@ Test ozone shell
                     Execute             ozone sh bucket clrquota --space-quota ${protocol}${server}/${volume}/bb1
     ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInBytes'
                     Should Be Equal     ${result}       -1
-                    Execute             ozone sh bucket clrquota --key-quota ${protocol}${server}/${volume}/bb1
+                    Execute             ozone sh bucket clrquota --count-quota ${protocol}${server}/${volume}/bb1
     ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInCounts'
                     Should Be Equal     ${result}       -1
                     Execute             ozone sh volume clrquota --space-quota ${protocol}${server}/${volume}
     ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInBytes'
                     Should Be Equal     ${result}       -1
-                    Execute             ozone sh volume clrquota --bucket-quota ${protocol}${server}/${volume}
+                    Execute             ozone sh volume clrquota --count-quota ${protocol}${server}/${volume}
     ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInCounts'
                     Should Be Equal     ${result}       -1
                     Execute             ozone sh bucket delete ${protocol}${server}/${volume}/bb1
@@ -82,12 +82,12 @@ Test ozone shell
                     Should Be Equal     ${result}       -1
     ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInCounts'
                     Should Be Equal     ${result}       -1
-                    Execute             ozone sh volume setquota ${protocol}${server}/${volume} --space-quota 0TB --bucket-quota 0
+                    Execute             ozone sh volume setquota ${protocol}${server}/${volume} --space-quota 0TB --count-quota 0
     ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInBytes'
                     Should Be Equal     ${result}       -1
     ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInCounts'
                     Should Be Equal     ${result}       -1
-                    Execute             ozone sh bucket setquota ${protocol}${server}/${volume}/bb1 --space-quota 0TB --key-quota 0
+                    Execute             ozone sh bucket setquota ${protocol}${server}/${volume}/bb1 --space-quota 0TB --count-quota 0
     ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInBytes'
                     Should Be Equal     ${result}       -1
     ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInCounts'

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-single.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-single.robot
@@ -18,7 +18,7 @@ Documentation       Test ozone shell CLI usage
 Library             OperatingSystem
 Resource            ../commonlib.robot
 Resource            ozone-shell-lib.robot
-Test Timeout        2 minute
+Test Timeout        5 minute
 Suite Setup         Generate prefix
 
 *** Test Cases ***

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
@@ -19,7 +19,7 @@ Library             OperatingSystem
 Resource            ../commonlib.robot
 Resource            ozone-shell-lib.robot
 Test Setup          Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
-Test Timeout        2 minute
+Test Timeout        5 minute
 Suite Setup         Generate prefix
 
 *** Test Cases ***

--- a/hadoop-ozone/dist/src/main/smoketest/createbucketenv.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/createbucketenv.robot
@@ -27,7 +27,7 @@ ${bucket}       bucket1
 
 *** Keywords ***
 Create volume
-    ${result} =     Execute             ozone sh volume create /${volume} --user hadoop --spaceQuota 100TB --bucketQuota 100
+    ${result} =     Execute             ozone sh volume create /${volume} --user hadoop --space-quota 100TB --bucket-quota 100
                     Should not contain  ${result}       Failed
 Create bucket
                     Execute             ozone sh bucket create /${volume}/${bucket}

--- a/hadoop-ozone/dist/src/main/smoketest/createbucketenv.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/createbucketenv.robot
@@ -27,7 +27,7 @@ ${bucket}       bucket1
 
 *** Keywords ***
 Create volume
-    ${result} =     Execute             ozone sh volume create /${volume} --user hadoop --space-quota 100TB --bucket-quota 100
+    ${result} =     Execute             ozone sh volume create /${volume} --user hadoop --space-quota 100TB --count-quota 100
                     Should not contain  ${result}       Failed
 Create bucket
                     Execute             ozone sh bucket create /${volume}/${bucket}

--- a/hadoop-ozone/dist/src/main/smoketest/createmrenv.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/createmrenv.robot
@@ -29,7 +29,7 @@ ${bucket}       bucket1
 
 *** Keywords ***
 Create volume
-    ${result} =     Execute             ozone sh volume create /${volume} --user hadoop --spaceQuota 100TB --bucketQuota 100
+    ${result} =     Execute             ozone sh volume create /${volume} --user hadoop --space-quota 100TB --bucket-quota 100
                     Should not contain  ${result}       Failed
 Create bucket
                     Execute             ozone sh bucket create /${volume}/${bucket}

--- a/hadoop-ozone/dist/src/main/smoketest/createmrenv.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/createmrenv.robot
@@ -29,7 +29,7 @@ ${bucket}       bucket1
 
 *** Keywords ***
 Create volume
-    ${result} =     Execute             ozone sh volume create /${volume} --user hadoop --space-quota 100TB --bucket-quota 100
+    ${result} =     Execute             ozone sh volume create /${volume} --user hadoop --space-quota 100TB --count-quota 100
                     Should not contain  ${result}       Failed
 Create bucket
                     Execute             ozone sh bucket create /${volume}/${bucket}

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug.robot
@@ -23,7 +23,7 @@ Suite Setup         Write key
 
 *** Keywords ***
 Write key
-    Execute             ozone sh volume create o3://om/vol1 --spaceQuota 100TB --bucketQuota 100
+    Execute             ozone sh volume create o3://om/vol1 --space-quota 100TB --bucket-quota 100
     Execute             ozone sh bucket create o3://om/vol1/bucket1
     Execute             ozone sh key put o3://om/vol1/bucket1/debugKey /opt/hadoop/NOTICE.txt
 

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug.robot
@@ -23,7 +23,7 @@ Suite Setup         Write key
 
 *** Keywords ***
 Write key
-    Execute             ozone sh volume create o3://om/vol1 --space-quota 100TB --bucket-quota 100
+    Execute             ozone sh volume create o3://om/vol1 --space-quota 100TB --count-quota 100
     Execute             ozone sh bucket create o3://om/vol1/bucket1
     Execute             ozone sh key put o3://om/vol1/bucket1/debugKey /opt/hadoop/NOTICE.txt
 

--- a/hadoop-ozone/dist/src/main/smoketest/gdpr/gdpr.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/gdpr/gdpr.robot
@@ -46,7 +46,7 @@ Test GDPR -g=false
 *** Keywords ***
 Test GDPR(disabled) without explicit options
     [arguments]     ${volume}
-                    Execute             ozone sh volume create /${volume} --spaceQuota 100TB --bucketQuota 100
+                    Execute             ozone sh volume create /${volume} --space-quota 100TB --bucket-quota 100
                     Execute             ozone sh bucket create /${volume}/mybucket1
     ${result} =     Execute             ozone sh bucket info /${volume}/mybucket1 | jq -r '. | select(.name=="mybucket1") | .metadata | .gdprEnabled'
                     Should Be Equal     ${result}       null

--- a/hadoop-ozone/dist/src/main/smoketest/gdpr/gdpr.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/gdpr/gdpr.robot
@@ -46,7 +46,7 @@ Test GDPR -g=false
 *** Keywords ***
 Test GDPR(disabled) without explicit options
     [arguments]     ${volume}
-                    Execute             ozone sh volume create /${volume} --space-quota 100TB --bucket-quota 100
+                    Execute             ozone sh volume create /${volume} --space-quota 100TB --count-quota 100
                     Execute             ozone sh bucket create /${volume}/mybucket1
     ${result} =     Execute             ozone sh bucket info /${volume}/mybucket1 | jq -r '. | select(.name=="mybucket1") | .metadata | .gdprEnabled'
                     Should Be Equal     ${result}       null

--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/setup.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/setup.robot
@@ -37,8 +37,8 @@ Setup for FS test
     Log    Completed setup for ${SCHEME} tests with ${BUCKET_TYPE}s in ${VOLUME}/${BUCKET} using FS base URL: ${BASE_URL}
 
 Create volumes for FS test
-    Execute And Ignore Error    ozone sh volume create ${VOLUME} --spaceQuota 100TB
-    Execute And Ignore Error    ozone sh volume create ${VOL2} --spaceQuota 100TB
+    Execute And Ignore Error    ozone sh volume create ${VOLUME} --space-quota 100TB
+    Execute And Ignore Error    ozone sh volume create ${VOL2} --space-quota 100TB
 
 Create buckets for FS test
     Execute                     ozone sh bucket create ${VOLUME}/${BUCKET}
@@ -46,8 +46,8 @@ Create buckets for FS test
     Execute                     ozone sh bucket create ${VOL2}/${BUCKET_IN_VOL2}
 
 Create links for FS test
-    Execute And Ignore Error    ozone sh volume create ${VOLUME}-src --spaceQuota 100TB
-    Execute And Ignore Error    ozone sh volume create ${VOL2}-src --spaceQuota 100TB
+    Execute And Ignore Error    ozone sh volume create ${VOLUME}-src --space-quota 100TB
+    Execute And Ignore Error    ozone sh volume create ${VOL2}-src --space-quota 100TB
     Execute                     ozone sh bucket create ${VOLUME}-src/${BUCKET}-src
     Execute                     ozone sh bucket create ${VOLUME}-src/${BUCKET2}-src
     Execute                     ozone sh bucket create ${VOL2}-src/${BUCKET_IN_VOL2}-src

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -818,11 +818,11 @@ public class TestRootedOzoneFileSystem {
     VolumeArgs volumeArgs = new VolumeArgs.Builder()
         .setAcls(Collections.singletonList(aclWorldAccess))
         .setQuotaInCounts(1000)
-        .setQuotaInBytes("1TB").build();
+        .setQuotaInBytes(Long.MAX_VALUE).build();
     // Sanity check
     Assert.assertNull(volumeArgs.getOwner());
     Assert.assertNull(volumeArgs.getAdmin());
-    Assert.assertEquals("1TB", volumeArgs.getQuotaInBytes());
+    Assert.assertEquals(Long.MAX_VALUE, volumeArgs.getQuotaInBytes());
     Assert.assertEquals(1000, volumeArgs.getQuotaInCounts());
     Assert.assertEquals(0, volumeArgs.getMetadata().size());
     Assert.assertEquals(1, volumeArgs.getAcls().size());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -113,6 +113,7 @@ import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConsts.GB;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.PARTIAL_RENAME;
@@ -274,6 +275,105 @@ public abstract class TestOzoneRpcClientAbstract {
   }
 
   @Test
+  public void testSetAndClrQuota() throws IOException {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    OzoneVolume volume = null;
+    store.createVolume(volumeName);
+
+    store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
+        "0GB", 0L));
+    volume = store.getVolume(volumeName);
+    Assert.assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInBytes());
+    Assert.assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInCounts());
+
+    store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
+        "10GB", 10000L));
+    store.getVolume(volumeName).createBucket(bucketName);
+    volume = store.getVolume(volumeName);
+    Assert.assertEquals(10 * GB, volume.getQuotaInBytes());
+    Assert.assertEquals(10000L, volume.getQuotaInCounts());
+    OzoneBucket bucket = store.getVolume(volumeName).getBucket(bucketName);
+    Assert.assertEquals(OzoneConsts.QUOTA_RESET, bucket.getQuotaInBytes());
+    Assert.assertEquals(OzoneConsts.QUOTA_RESET, bucket.getQuotaInCounts());
+
+    store.getVolume(volumeName).getBucket(bucketName).setQuota(
+        OzoneQuota.parseQuota("0GB", 0));
+    Assert.assertEquals(OzoneConsts.QUOTA_RESET, bucket.getQuotaInBytes());
+    Assert.assertEquals(OzoneConsts.QUOTA_RESET, bucket.getQuotaInCounts());
+
+    store.getVolume(volumeName).getBucket(bucketName).setQuota(
+        OzoneQuota.parseQuota("1GB", 1000L));
+    OzoneBucket ozoneBucket = store.getVolume(volumeName).getBucket(bucketName);
+    Assert.assertEquals(1024 * 1024 * 1024,
+        ozoneBucket.getQuotaInBytes());
+    Assert.assertEquals(1000L, ozoneBucket.getQuotaInCounts());
+
+    store.getVolume(volumeName).clearSpaceQuota();
+    store.getVolume(volumeName).clearCountQuota();
+    OzoneVolume clrVolume = store.getVolume(volumeName);
+    Assert.assertEquals(OzoneConsts.QUOTA_RESET, clrVolume.getQuotaInBytes());
+    Assert.assertEquals(OzoneConsts.QUOTA_RESET, clrVolume.getQuotaInCounts());
+
+    ozoneBucket.clearSpaceQuota();
+    ozoneBucket.clearCountQuota();
+    OzoneBucket clrBucket = store.getVolume(volumeName).getBucket(bucketName);
+    Assert.assertEquals(OzoneConsts.QUOTA_RESET, clrBucket.getQuotaInBytes());
+    Assert.assertEquals(OzoneConsts.QUOTA_RESET, clrBucket.getQuotaInCounts());
+  }
+
+  @Test
+  public void testSetBucketQuotaIllegal() throws IOException {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    store.createVolume(volumeName);
+    store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
+        "10GB", 1000L));
+    store.getVolume(volumeName).createBucket(bucketName);
+
+    int countException = 0;
+    try {
+      store.getVolume(volumeName).getBucket(bucketName).setQuota(
+          OzoneQuota.parseQuota("1GB", -100L));
+    } catch (IllegalArgumentException ex) {
+      countException++;
+      GenericTestUtils.assertExceptionContains(
+          "Invalid values for quota", ex);
+    }
+    // The unit should be legal.
+    try {
+      store.getVolume(volumeName).getBucket(bucketName).setQuota(
+          OzoneQuota.parseQuota("1TEST", 100L));
+    } catch (IllegalArgumentException ex) {
+      countException++;
+      GenericTestUtils.assertExceptionContains(
+          "Invalid values for quota", ex);
+    }
+
+    // The setting value cannot be greater than LONG.MAX_VALUE BYTES.
+    try {
+      store.getVolume(volumeName).getBucket(bucketName).setQuota(
+          OzoneQuota.parseQuota("9223372036854775808 BYTES", 100L));
+    } catch (IllegalArgumentException ex) {
+      countException++;
+      GenericTestUtils.assertExceptionContains(
+          "Invalid values for quota", ex);
+    }
+
+    // The value cannot be negative.
+    try {
+      store.getVolume(volumeName).getBucket(bucketName).setQuota(
+          OzoneQuota.parseQuota("-10GB", 100L));
+    } catch (IllegalArgumentException ex) {
+      countException++;
+      GenericTestUtils.assertExceptionContains(
+          "Quota cannot be negative.", ex);
+    }
+
+    Assert.assertEquals(4, countException);
+  }
+
+  @Test
   public void testSetVolumeQuota() throws IOException {
     String volumeName = UUID.randomUUID().toString();
     store.createVolume(volumeName);
@@ -293,11 +393,13 @@ public abstract class TestOzoneRpcClientAbstract {
       throws IOException {
     String volumeName = UUID.randomUUID().toString();
     store.createVolume(volumeName);
+    int countException = 0;
     // The unit should be legal.
     try {
       store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
           "1TEST", 1000L));
     } catch (IllegalArgumentException ex) {
+      countException++;
       GenericTestUtils.assertExceptionContains(
           "Invalid values for quota", ex);
     }
@@ -305,8 +407,9 @@ public abstract class TestOzoneRpcClientAbstract {
     // The setting value cannot be greater than LONG.MAX_VALUE BYTES.
     try {
       store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
-          "9999999999999GB", 1000L));
+          "9223372036854775808 BYTES", 1000L));
     } catch (IllegalArgumentException ex) {
+      countException++;
       GenericTestUtils.assertExceptionContains(
           "Invalid values for quota", ex);
     }
@@ -316,9 +419,11 @@ public abstract class TestOzoneRpcClientAbstract {
       store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
           "-10GB", 1000L));
     } catch (IllegalArgumentException ex) {
+      countException++;
       GenericTestUtils.assertExceptionContains(
           "Quota cannot be negative.", ex);
     }
+    Assert.assertEquals(3, countException);
   }
 
   @Test

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -502,6 +502,8 @@ message BucketInfo {
     optional string sourceVolume = 12;
     optional string sourceBucket = 13;
     optional uint64 usedBytes = 14;
+    optional uint64 quotaInBytes = 15;
+    optional uint64 quotaInCounts = 16;
 }
 
 enum StorageTypeProto {
@@ -571,6 +573,8 @@ message BucketArgs {
     optional bool isVersionEnabled = 5;
     optional StorageTypeProto storageType = 6;
     repeated hadoop.hdds.KeyValue metadata = 7;
+    optional uint64 quotaInBytes = 8;
+    optional uint64 quotaInCounts = 9;
 }
 
 message PrefixInfo {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -27,6 +27,7 @@ import com.google.common.base.Optional;
 
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
@@ -192,6 +193,10 @@ public class OMBucketCreateRequest extends OMClientRequest {
         throw new OMException("Bucket already exist", BUCKET_ALREADY_EXISTS);
       }
 
+      //Check quotaInBytes to update
+      checkQuotaBytesValid(metadataManager, omVolumeArgs, omBucketInfo,
+          volumeKey);
+
       // Add objectID and updateID
       omBucketInfo.setObjectID(
           OMFileRequest.getObjIDFromTxId(transactionLogIndex));
@@ -297,4 +302,37 @@ public class OMBucketCreateRequest extends OMClientRequest {
             CipherSuite.convert(metadata.getCipher())));
     return bekb.build();
   }
+
+  public boolean checkQuotaBytesValid(OMMetadataManager metadataManager,
+      OmVolumeArgs omVolumeArgs, OmBucketInfo omBucketInfo, String volumeKey)
+      throws IOException {
+    long quotaInBytes = omBucketInfo.getQuotaInBytes();
+    long volumeQuotaInBytes = omVolumeArgs.getQuotaInBytes();
+
+    long totalBucketQuota = 0;
+    if (quotaInBytes == OzoneConsts.QUOTA_RESET || quotaInBytes == 0) {
+      return false;
+    } else if (quotaInBytes > OzoneConsts.QUOTA_RESET) {
+      totalBucketQuota = quotaInBytes;
+    }
+
+    List<OmBucketInfo>  bucketList = metadataManager.listBuckets(
+        omVolumeArgs.getVolume(), null, null, Integer.MAX_VALUE);
+    for(OmBucketInfo bucketInfo : bucketList) {
+      long nextQuotaInBytes = bucketInfo.getQuotaInBytes();
+      if(nextQuotaInBytes > OzoneConsts.QUOTA_RESET) {
+        totalBucketQuota += nextQuotaInBytes;
+      }
+    }
+    if(volumeQuotaInBytes < totalBucketQuota
+        && volumeQuotaInBytes != OzoneConsts.QUOTA_RESET) {
+      throw new IllegalArgumentException("Total buckets quota in this volume " +
+          "should not be greater than volume quota : the total space quota is" +
+          " set to:" + totalBucketQuota + ". But the volume space quota is:" +
+          volumeQuotaInBytes);
+    }
+    return true;
+
+  }
+
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -19,11 +19,14 @@
 package org.apache.hadoop.ozone.om.request.bucket;
 
 import java.io.IOException;
+import java.util.List;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.OMAction;
+import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.slf4j.Logger;
@@ -150,6 +153,22 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
             .setIsVersionEnabled(dbBucketInfo.getIsVersionEnabled());
       }
 
+      //Check quotaInBytes and quotaInCounts to update
+      String volumeKey = omMetadataManager.getVolumeKey(volumeName);
+      OmVolumeArgs omVolumeArgs = omMetadataManager.getVolumeTable()
+          .get(volumeKey);
+      if (checkQuotaBytesValid(omMetadataManager, omVolumeArgs, omBucketArgs,
+          volumeKey)) {
+        bucketInfoBuilder.setQuotaInBytes(omBucketArgs.getQuotaInBytes());
+      } else {
+        bucketInfoBuilder.setQuotaInBytes(dbBucketInfo.getQuotaInBytes());
+      }
+      if (checkQuotaCountsValid(omVolumeArgs, omBucketArgs)) {
+        bucketInfoBuilder.setQuotaInCounts(omBucketArgs.getQuotaInCounts());
+      } else {
+        bucketInfoBuilder.setQuotaInCounts(dbBucketInfo.getQuotaInCounts());
+      }
+
       bucketInfoBuilder.setCreationTime(dbBucketInfo.getCreationTime());
 
       // Set acls from dbBucketInfo if it has any.
@@ -205,5 +224,50 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
       omMetrics.incNumBucketUpdateFails();
       return omClientResponse;
     }
+  }
+
+  public boolean checkQuotaBytesValid(OMMetadataManager metadataManager,
+      OmVolumeArgs omVolumeArgs, OmBucketArgs omBucketArgs, String volumeKey)
+      throws IOException {
+    long quotaInBytes = omBucketArgs.getQuotaInBytes();
+
+    if (quotaInBytes == 0) {
+      return false;
+    }
+
+    long totalBucketQuota = 0;
+    long volumeQuotaInBytes = omVolumeArgs.getQuotaInBytes();
+
+    if (quotaInBytes > OzoneConsts.QUOTA_RESET) {
+      totalBucketQuota = quotaInBytes;
+    }
+    List<OmBucketInfo> bucketList = metadataManager.listBuckets(
+        omVolumeArgs.getVolume(), null, null, Integer.MAX_VALUE);
+    for(OmBucketInfo bucketInfo : bucketList) {
+      long nextQuotaInBytes = bucketInfo.getQuotaInBytes();
+      if(nextQuotaInBytes > OzoneConsts.QUOTA_RESET &&
+          !omBucketArgs.getBucketName().equals(bucketInfo.getBucketName())) {
+        totalBucketQuota += nextQuotaInBytes;
+      }
+    }
+
+    if(volumeQuotaInBytes < totalBucketQuota &&
+        volumeQuotaInBytes != OzoneConsts.QUOTA_RESET) {
+      throw new IllegalArgumentException("Total buckets quota in this volume " +
+          "should not be greater than volume quota : the total space quota is" +
+          " set to:" + totalBucketQuota + ". But the volume space quota is:" +
+          volumeQuotaInBytes);
+    }
+    return true;
+  }
+
+  public boolean checkQuotaCountsValid(OmVolumeArgs omVolumeArgs,
+      OmBucketArgs omBucketArgs) {
+    long quotaInCounts = omBucketArgs.getQuotaInCounts();
+
+    if ((quotaInCounts <= 0 && quotaInCounts != OzoneConsts.QUOTA_RESET)) {
+      return false;
+    }
+    return true;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -274,6 +274,29 @@ public final class TestOMRequestUtils {
   /**
    * Add volume creation entry to OM DB.
    * @param volumeName
+   * @param omMetadataManager
+   * @param quotaInBytes
+   * @throws Exception
+   */
+  public static void addVolumeToDB(String volumeName,
+      OMMetadataManager omMetadataManager, long quotaInBytes) throws Exception {
+    OmVolumeArgs omVolumeArgs =
+        OmVolumeArgs.newBuilder().setCreationTime(Time.now())
+            .setVolume(volumeName).setAdminName(volumeName)
+            .setOwnerName(volumeName).setQuotaInBytes(quotaInBytes)
+            .setQuotaInCounts(10000L).build();
+    omMetadataManager.getVolumeTable().put(
+        omMetadataManager.getVolumeKey(volumeName), omVolumeArgs);
+
+    // Add to cache.
+    omMetadataManager.getVolumeTable().addCacheEntry(
+        new CacheKey<>(omMetadataManager.getVolumeKey(volumeName)),
+        new CacheValue<>(Optional.of(omVolumeArgs), 1L));
+  }
+
+  /**
+   * Add volume creation entry to OM DB.
+   * @param volumeName
    * @param ownerName
    * @param omMetadataManager
    * @throws Exception
@@ -283,8 +306,8 @@ public final class TestOMRequestUtils {
     OmVolumeArgs omVolumeArgs =
         OmVolumeArgs.newBuilder().setCreationTime(Time.now())
             .setVolume(volumeName).setAdminName(ownerName)
-            .setQuotaInBytes(Long.MAX_VALUE)
-            .setOwnerName(ownerName).build();
+            .setOwnerName(ownerName).setQuotaInBytes(Long.MAX_VALUE)
+            .setQuotaInCounts(10000L).build();
     omMetadataManager.getVolumeTable().put(
         omMetadataManager.getVolumeKey(volumeName), omVolumeArgs);
 
@@ -307,6 +330,28 @@ public final class TestOMRequestUtils {
     OmBucketInfo omBucketInfo =
         OmBucketInfo.newBuilder().setVolumeName(volumeName)
             .setBucketName(bucketName).setCreationTime(Time.now()).build();
+
+    // Add to cache.
+    omMetadataManager.getBucketTable().addCacheEntry(
+        new CacheKey<>(omMetadataManager.getBucketKey(volumeName, bucketName)),
+        new CacheValue<>(Optional.of(omBucketInfo), 1L));
+  }
+
+  /**
+   * Add bucket creation entry to OM DB.
+   * @param volumeName
+   * @param bucketName
+   * @param omMetadataManager
+   * @param quotaInBytes
+   * @throws Exception
+   */
+  public static void addBucketToDB(String volumeName, String bucketName,
+      OMMetadataManager omMetadataManager, long quotaInBytes) throws Exception {
+
+    OmBucketInfo omBucketInfo =
+        OmBucketInfo.newBuilder().setVolumeName(volumeName)
+            .setBucketName(bucketName).setCreationTime(Time.now())
+            .setQuotaInBytes(quotaInBytes).build();
 
     // Add to cache.
     omMetadataManager.getBucketTable().addCacheEntry(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetQuotaRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetQuotaRequest.java
@@ -23,11 +23,14 @@ import java.util.UUID;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+
+import static org.apache.hadoop.ozone.OzoneConsts.GB;
 
 /**
  * Tests set volume property request.
@@ -157,5 +160,35 @@ public class TestOMVolumeSetQuotaRequest extends TestOMVolumeRequest {
     Assert.assertNotNull(omResponse.getCreateVolumeResponse());
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.INVALID_REQUEST,
         omResponse.getStatus());
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheWithQuota() throws Exception {
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+
+    TestOMRequestUtils.addVolumeToDB(
+        volumeName, omMetadataManager, 10 * GB);
+    TestOMRequestUtils.addBucketToDB(
+        volumeName, bucketName, omMetadataManager, 8 * GB);
+    OMRequest originalRequest =
+        TestOMRequestUtils.createSetVolumePropertyRequest(volumeName,
+            5 * GB, 100L);
+
+    OMVolumeSetQuotaRequest omVolumeSetQuotaRequest =
+        new OMVolumeSetQuotaRequest(originalRequest);
+
+    int countException = 0;
+    try {
+      OMClientResponse omClientResponse =
+          omVolumeSetQuotaRequest.validateAndUpdateCache(ozoneManager, 1,
+              ozoneManagerDoubleBufferHelper);
+    } catch (IllegalArgumentException ex) {
+      countException++;
+      GenericTestUtils.assertExceptionContains(
+          "Total buckets quota in this volume should not be", ex);
+    }
+    Assert.assertEquals(1, countException);
   }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ObjectStoreStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/ObjectStoreStub.java
@@ -55,7 +55,7 @@ public class ObjectStoreStub extends ObjectStore {
         VolumeArgs.newBuilder()
             .setAdmin("root")
             .setOwner("root")
-            .setQuotaInBytes("" + Integer.MAX_VALUE)
+            .setQuotaInBytes(Integer.MAX_VALUE)
             .setAcls(new ArrayList<>()).build());
   }
 
@@ -65,7 +65,7 @@ public class ObjectStoreStub extends ObjectStore {
         new OzoneVolumeStub(volumeName,
             volumeArgs.getAdmin(),
             volumeArgs.getOwner(),
-            Long.parseLong(volumeArgs.getQuotaInBytes()),
+            volumeArgs.getQuotaInBytes(),
             volumeArgs.getQuotaInCounts(),
             Time.now(),
             volumeArgs.getAcls());

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/ClearSpaceQuotaOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/ClearSpaceQuotaOptions.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.shell;
+
+import picocli.CommandLine;
+
+/**
+ * Common options for 'clrquota' commands.
+ */
+public class ClearSpaceQuotaOptions {
+
+  @CommandLine.Option(names = {"--space-quota"},
+      description = "clear space quota")
+  private boolean clrSpaceQuota;
+
+  public boolean getClrSpaceQuota() {
+    return clrSpaceQuota;
+  }
+
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/ClearSpaceQuotaOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/ClearSpaceQuotaOptions.java
@@ -28,8 +28,16 @@ public class ClearSpaceQuotaOptions {
       description = "clear space quota")
   private boolean clrSpaceQuota;
 
+  @CommandLine.Option(names = {"--count-quota"},
+      description = "clear count quota")
+  private boolean clrCountQuota;
+
   public boolean getClrSpaceQuota() {
     return clrSpaceQuota;
+  }
+
+  public boolean getClrCountQuota() {
+    return clrCountQuota;
   }
 
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/SetSpaceQuotaOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/SetSpaceQuotaOptions.java
@@ -28,8 +28,17 @@ public class SetSpaceQuotaOptions {
       description = "The maximum space quota can be used (eg. 1GB)")
   private String quotaInBytes;
 
+  @CommandLine.Option(names = {"--count-quota"},
+      description = "For volume this parameter represents the number of " +
+          "buckets, and for buckets represents the number of keys (eg. 5)")
+  private long quotaInCounts;
+
   public String getQuotaInBytes() {
     return quotaInBytes;
+  }
+
+  public long getQuotaInCounts() {
+    return quotaInCounts;
   }
 
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/SetSpaceQuotaOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/SetSpaceQuotaOptions.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.shell;
+
+import picocli.CommandLine;
+
+/**
+ * Common options for 'quota' commands.
+ */
+public class SetSpaceQuotaOptions {
+
+  @CommandLine.Option(names = {"--space-quota"},
+      description = "The maximum space quota can be used (eg. 1GB)")
+  private String quotaInBytes;
+
+  public String getQuotaInBytes() {
+    return quotaInBytes;
+  }
+
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/BucketCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/BucketCommands.java
@@ -41,12 +41,14 @@ import picocli.CommandLine.ParentCommand;
         InfoBucketHandler.class,
         ListBucketHandler.class,
         CreateBucketHandler.class,
+        SetQuotaHandler.class,
         LinkBucketHandler.class,
         DeleteBucketHandler.class,
         AddAclBucketHandler.class,
         RemoveAclBucketHandler.class,
         GetAclBucketHandler.class,
-        SetAclBucketHandler.class
+        SetAclBucketHandler.class,
+        ClearQuotaHandler.class
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/ClearQuotaHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/ClearQuotaHandler.java
@@ -16,44 +16,44 @@
  *  limitations under the License.
  */
 
-package org.apache.hadoop.ozone.shell.volume;
+package org.apache.hadoop.ozone.shell.bucket;
 
+import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
-
+import org.apache.hadoop.ozone.shell.ClearSpaceQuotaOptions;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
 
 import java.io.IOException;
 
 /**
- * Executes update volume calls.
+ * clean quota of the bucket.
  */
-@Command(name = "update",
-    description = "Updates parameter of the volumes")
-public class UpdateVolumeHandler extends VolumeHandler {
+@Command(name = "clrquota",
+    description = "clear quota of the bucket")
+public class ClearQuotaHandler extends BucketHandler {
 
-  @Option(names = {"--user"},
-      description = "Owner of the volume to set")
-  private String ownerName;
+  @CommandLine.Mixin
+  private ClearSpaceQuotaOptions clrSpaceQuota;
+
+  @CommandLine.Option(names = {"--key-quota"},
+      description = "clear count quota")
+  private boolean clrKeyQuota;
 
   @Override
   protected void execute(OzoneClient client, OzoneAddress address)
       throws IOException {
     String volumeName = address.getVolumeName();
-    OzoneVolume volume = client.getObjectStore().getVolume(volumeName);
+    String bucketName = address.getBucketName();
+    OzoneBucket bucket = client.getObjectStore().getVolume(volumeName)
+        .getBucket(bucketName);
 
-    if (ownerName != null && !ownerName.isEmpty()) {
-      boolean result = volume.setOwner(ownerName);
-      if (LOG.isDebugEnabled() && !result) {
-        out().format("Volume '%s' owner is already '%s'. Unchanged.%n",
-            volumeName, ownerName);
-      }
+    if (clrSpaceQuota.getClrSpaceQuota()) {
+      bucket.clearSpaceQuota();
     }
-
-    // For printing newer modificationTime.
-    OzoneVolume updatedVolume = client.getObjectStore().getVolume(volumeName);
-    printObjectAsJson(updatedVolume);
+    if (clrKeyQuota) {
+      bucket.clearCountQuota();
+    }
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/ClearQuotaHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/ClearQuotaHandler.java
@@ -37,10 +37,6 @@ public class ClearQuotaHandler extends BucketHandler {
   @CommandLine.Mixin
   private ClearSpaceQuotaOptions clrSpaceQuota;
 
-  @CommandLine.Option(names = {"--key-quota"},
-      description = "clear count quota")
-  private boolean clrKeyQuota;
-
   @Override
   protected void execute(OzoneClient client, OzoneAddress address)
       throws IOException {
@@ -52,7 +48,7 @@ public class ClearQuotaHandler extends BucketHandler {
     if (clrSpaceQuota.getClrSpaceQuota()) {
       bucket.clearSpaceQuota();
     }
-    if (clrKeyQuota) {
+    if (clrSpaceQuota.getClrCountQuota()) {
       bucket.clearCountQuota();
     }
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
@@ -52,10 +52,6 @@ public class CreateBucketHandler extends BucketHandler {
   @CommandLine.Mixin
   private SetSpaceQuotaOptions quotaOptions;
 
-  @Option(names = {"--key-quota"},
-      description = "Key counts of the newly created bucket (eg. 5)")
-  private long quotaInCounts = OzoneConsts.QUOTA_RESET;
-
   /**
    * Executes create bucket.
    */
@@ -86,10 +82,10 @@ public class CreateBucketHandler extends BucketHandler {
 
     if (quotaOptions.getQuotaInBytes() != null) {
       bb.setQuotaInBytes(OzoneQuota.parseQuota(quotaOptions.getQuotaInBytes(),
-          quotaInCounts).getQuotaInBytes());
+          quotaOptions.getQuotaInCounts()).getQuotaInBytes());
     }
 
-    bb.setQuotaInCounts(quotaInCounts);
+    bb.setQuotaInCounts(quotaOptions.getQuotaInCounts());
 
     String volumeName = address.getVolumeName();
     String bucketName = address.getBucketName();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.shell.bucket;
 
+import org.apache.hadoop.hdds.client.OzoneQuota;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.BucketArgs;
@@ -25,6 +26,8 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 
+import org.apache.hadoop.ozone.shell.SetSpaceQuotaOptions;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -45,6 +48,13 @@ public class CreateBucketHandler extends BucketHandler {
       description = "if true, indicates GDPR enforced bucket, " +
           "false/unspecified indicates otherwise")
   private Boolean isGdprEnforced;
+
+  @CommandLine.Mixin
+  private SetSpaceQuotaOptions quotaOptions;
+
+  @Option(names = {"--key-quota"},
+      description = "Key counts of the newly created bucket (eg. 5)")
+  private long quotaInCounts = OzoneConsts.QUOTA_RESET;
 
   /**
    * Executes create bucket.
@@ -73,6 +83,13 @@ public class CreateBucketHandler extends BucketHandler {
             bekName);
       }
     }
+
+    if (quotaOptions.getQuotaInBytes() != null) {
+      bb.setQuotaInBytes(OzoneQuota.parseQuota(quotaOptions.getQuotaInBytes(),
+          quotaInCounts).getQuotaInBytes());
+    }
+
+    bb.setQuotaInCounts(quotaInCounts);
 
     String volumeName = address.getVolumeName();
     String bucketName = address.getBucketName();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/SetQuotaHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/SetQuotaHandler.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.shell.bucket;
+
+import org.apache.hadoop.hdds.client.OzoneQuota;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.shell.OzoneAddress;
+import org.apache.hadoop.ozone.shell.SetSpaceQuotaOptions;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import java.io.IOException;
+
+/**
+ * set quota of the bucket.
+ */
+@Command(name = "setquota",
+    description = "Set quota of the buckets")
+public class SetQuotaHandler extends BucketHandler {
+
+  @CommandLine.Mixin
+  private SetSpaceQuotaOptions quotaOptions;
+
+  @Option(names = {"--key-quota"},
+      description = "Key counts of the newly created bucket (eg. 5)")
+  private long quotaInCounts = OzoneConsts.QUOTA_RESET;
+
+  @Override
+  public void execute(OzoneClient client, OzoneAddress address)
+      throws IOException {
+
+    String volumeName = address.getVolumeName();
+    String bucketName = address.getBucketName();
+    OzoneBucket bucket = client.getObjectStore().getVolume(volumeName)
+        .getBucket(bucketName);
+    long spaceQuota = bucket.getQuotaInBytes();
+    long countQuota = bucket.getQuotaInCounts();
+
+    if (quotaOptions.getQuotaInBytes() != null
+        && !quotaOptions.getQuotaInBytes().isEmpty()) {
+      spaceQuota = OzoneQuota.parseQuota(quotaOptions.getQuotaInBytes(),
+          quotaInCounts).getQuotaInBytes();
+    }
+    if (quotaInCounts >= 0) {
+      countQuota = quotaInCounts;
+    }
+
+    bucket.setQuota(OzoneQuota.getOzoneQuota(spaceQuota, countQuota));
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/SetQuotaHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/SetQuotaHandler.java
@@ -18,14 +18,12 @@
 package org.apache.hadoop.ozone.shell.bucket;
 
 import org.apache.hadoop.hdds.client.OzoneQuota;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.shell.SetSpaceQuotaOptions;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
 
 import java.io.IOException;
 
@@ -38,10 +36,6 @@ public class SetQuotaHandler extends BucketHandler {
 
   @CommandLine.Mixin
   private SetSpaceQuotaOptions quotaOptions;
-
-  @Option(names = {"--key-quota"},
-      description = "Key counts of the newly created bucket (eg. 5)")
-  private long quotaInCounts = OzoneConsts.QUOTA_RESET;
 
   @Override
   public void execute(OzoneClient client, OzoneAddress address)
@@ -57,10 +51,10 @@ public class SetQuotaHandler extends BucketHandler {
     if (quotaOptions.getQuotaInBytes() != null
         && !quotaOptions.getQuotaInBytes().isEmpty()) {
       spaceQuota = OzoneQuota.parseQuota(quotaOptions.getQuotaInBytes(),
-          quotaInCounts).getQuotaInBytes();
+          quotaOptions.getQuotaInCounts()).getQuotaInBytes();
     }
-    if (quotaInCounts >= 0) {
-      countQuota = quotaInCounts;
+    if (quotaOptions.getQuotaInCounts() >= 0) {
+      countQuota = quotaOptions.getQuotaInCounts();
     }
 
     bucket.setQuota(OzoneQuota.getOzoneQuota(spaceQuota, countQuota));

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/ClearQuotaHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/ClearQuotaHandler.java
@@ -37,10 +37,6 @@ public class ClearQuotaHandler extends VolumeHandler {
   @CommandLine.Mixin
   private ClearSpaceQuotaOptions clrSpaceQuota;
 
-  @CommandLine.Option(names = {"--bucket-quota"},
-      description = "clear count quota")
-  private boolean clrKeyQuota;
-
   @Override
   protected void execute(OzoneClient client, OzoneAddress address)
       throws IOException {
@@ -50,7 +46,7 @@ public class ClearQuotaHandler extends VolumeHandler {
     if (clrSpaceQuota.getClrSpaceQuota()) {
       volume.clearSpaceQuota();
     }
-    if (clrKeyQuota) {
+    if (clrSpaceQuota.getClrCountQuota()) {
       volume.clearCountQuota();
     }
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/ClearQuotaHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/ClearQuotaHandler.java
@@ -21,22 +21,25 @@ package org.apache.hadoop.ozone.shell.volume;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
-
+import org.apache.hadoop.ozone.shell.ClearSpaceQuotaOptions;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
 
 import java.io.IOException;
 
 /**
- * Executes update volume calls.
+ * clear quota of the volume.
  */
-@Command(name = "update",
-    description = "Updates parameter of the volumes")
-public class UpdateVolumeHandler extends VolumeHandler {
+@Command(name = "clrquota",
+    description = "clear quota of the volume")
+public class ClearQuotaHandler extends VolumeHandler {
 
-  @Option(names = {"--user"},
-      description = "Owner of the volume to set")
-  private String ownerName;
+  @CommandLine.Mixin
+  private ClearSpaceQuotaOptions clrSpaceQuota;
+
+  @CommandLine.Option(names = {"--bucket-quota"},
+      description = "clear count quota")
+  private boolean clrKeyQuota;
 
   @Override
   protected void execute(OzoneClient client, OzoneAddress address)
@@ -44,16 +47,11 @@ public class UpdateVolumeHandler extends VolumeHandler {
     String volumeName = address.getVolumeName();
     OzoneVolume volume = client.getObjectStore().getVolume(volumeName);
 
-    if (ownerName != null && !ownerName.isEmpty()) {
-      boolean result = volume.setOwner(ownerName);
-      if (LOG.isDebugEnabled() && !result) {
-        out().format("Volume '%s' owner is already '%s'. Unchanged.%n",
-            volumeName, ownerName);
-      }
+    if (clrSpaceQuota.getClrSpaceQuota()) {
+      volume.clearSpaceQuota();
     }
-
-    // For printing newer modificationTime.
-    OzoneVolume updatedVolume = client.getObjectStore().getVolume(volumeName);
-    printObjectAsJson(updatedVolume);
+    if (clrKeyQuota) {
+      volume.clearCountQuota();
+    }
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/CreateVolumeHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/CreateVolumeHandler.java
@@ -18,13 +18,16 @@
 
 package org.apache.hadoop.ozone.shell.volume;
 
+import org.apache.hadoop.hdds.client.OzoneQuota;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.VolumeArgs;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
+import org.apache.hadoop.ozone.shell.SetSpaceQuotaOptions;
 import org.apache.hadoop.security.UserGroupInformation;
 
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -41,11 +44,10 @@ public class CreateVolumeHandler extends VolumeHandler {
       description = "Owner of the volume")
   private String ownerName;
 
-  @Option(names = {"--spaceQuota", "-sq"},
-      description = "Quota in bytes of the newly created volume (eg. 1GB)")
-  private String quotaInBytes;
+  @CommandLine.Mixin
+  private SetSpaceQuotaOptions quotaOptions;
 
-  @Option(names = {"--bucketQuota", "-bq"},
+  @Option(names = {"--bucket-quota"},
       description = "Bucket counts of the newly created volume (eg. 5)")
   private long quotaInCounts = OzoneConsts.QUOTA_RESET;
 
@@ -62,8 +64,10 @@ public class CreateVolumeHandler extends VolumeHandler {
     VolumeArgs.Builder volumeArgsBuilder = VolumeArgs.newBuilder()
         .setAdmin(adminName)
         .setOwner(ownerName);
-    if (quotaInBytes != null) {
-      volumeArgsBuilder.setQuotaInBytes(quotaInBytes);
+    if (quotaOptions.getQuotaInBytes() != null) {
+      volumeArgsBuilder.setQuotaInBytes(OzoneQuota.parseQuota(
+          quotaOptions.getQuotaInBytes(),
+          quotaInCounts).getQuotaInBytes());
     }
 
     volumeArgsBuilder.setQuotaInCounts(quotaInCounts);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/CreateVolumeHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/CreateVolumeHandler.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.ozone.shell.volume;
 
 import org.apache.hadoop.hdds.client.OzoneQuota;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.VolumeArgs;
@@ -47,10 +46,6 @@ public class CreateVolumeHandler extends VolumeHandler {
   @CommandLine.Mixin
   private SetSpaceQuotaOptions quotaOptions;
 
-  @Option(names = {"--bucket-quota"},
-      description = "Bucket counts of the newly created volume (eg. 5)")
-  private long quotaInCounts = OzoneConsts.QUOTA_RESET;
-
   @Override
   protected void execute(OzoneClient client, OzoneAddress address)
       throws IOException {
@@ -67,10 +62,10 @@ public class CreateVolumeHandler extends VolumeHandler {
     if (quotaOptions.getQuotaInBytes() != null) {
       volumeArgsBuilder.setQuotaInBytes(OzoneQuota.parseQuota(
           quotaOptions.getQuotaInBytes(),
-          quotaInCounts).getQuotaInBytes());
+          quotaOptions.getQuotaInCounts()).getQuotaInBytes());
     }
 
-    volumeArgsBuilder.setQuotaInCounts(quotaInCounts);
+    volumeArgsBuilder.setQuotaInCounts(quotaOptions.getQuotaInCounts());
 
     client.getObjectStore().createVolume(volumeName,
         volumeArgsBuilder.build());

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/SetQuotaHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/SetQuotaHandler.java
@@ -18,25 +18,31 @@
 
 package org.apache.hadoop.ozone.shell.volume;
 
+import org.apache.hadoop.hdds.client.OzoneQuota;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
-
+import org.apache.hadoop.ozone.shell.SetSpaceQuotaOptions;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 import java.io.IOException;
 
 /**
- * Executes update volume calls.
+ * Executes set volume quota calls.
  */
-@Command(name = "update",
-    description = "Updates parameter of the volumes")
-public class UpdateVolumeHandler extends VolumeHandler {
+@Command(name = "setquota",
+    description = "Set quota of the volumes")
+public class SetQuotaHandler extends VolumeHandler {
 
-  @Option(names = {"--user"},
-      description = "Owner of the volume to set")
-  private String ownerName;
+  @CommandLine.Mixin
+  private SetSpaceQuotaOptions quotaOptions;
+
+  @Option(names = {"--bucket-quota"},
+      description = "Bucket counts of the volume to create (eg. 5)")
+  private long quotaInCounts = OzoneConsts.QUOTA_RESET;
 
   @Override
   protected void execute(OzoneClient client, OzoneAddress address)
@@ -44,16 +50,18 @@ public class UpdateVolumeHandler extends VolumeHandler {
     String volumeName = address.getVolumeName();
     OzoneVolume volume = client.getObjectStore().getVolume(volumeName);
 
-    if (ownerName != null && !ownerName.isEmpty()) {
-      boolean result = volume.setOwner(ownerName);
-      if (LOG.isDebugEnabled() && !result) {
-        out().format("Volume '%s' owner is already '%s'. Unchanged.%n",
-            volumeName, ownerName);
-      }
+    long spaceQuota = volume.getQuotaInBytes();
+    long countQuota = volume.getQuotaInCounts();
+
+    if (quotaOptions.getQuotaInBytes() != null
+        && !quotaOptions.getQuotaInBytes().isEmpty()) {
+      spaceQuota = OzoneQuota.parseQuota(quotaOptions.getQuotaInBytes(),
+          quotaInCounts).getQuotaInBytes();
+    }
+    if (quotaInCounts >= 0) {
+      countQuota = quotaInCounts;
     }
 
-    // For printing newer modificationTime.
-    OzoneVolume updatedVolume = client.getObjectStore().getVolume(volumeName);
-    printObjectAsJson(updatedVolume);
+    volume.setQuota(OzoneQuota.getOzoneQuota(spaceQuota, countQuota));
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/SetQuotaHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/SetQuotaHandler.java
@@ -19,14 +19,12 @@
 package org.apache.hadoop.ozone.shell.volume;
 
 import org.apache.hadoop.hdds.client.OzoneQuota;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.shell.SetSpaceQuotaOptions;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
 
 import java.io.IOException;
 
@@ -40,10 +38,6 @@ public class SetQuotaHandler extends VolumeHandler {
   @CommandLine.Mixin
   private SetSpaceQuotaOptions quotaOptions;
 
-  @Option(names = {"--bucket-quota"},
-      description = "Bucket counts of the volume to create (eg. 5)")
-  private long quotaInCounts = OzoneConsts.QUOTA_RESET;
-
   @Override
   protected void execute(OzoneClient client, OzoneAddress address)
       throws IOException {
@@ -56,10 +50,10 @@ public class SetQuotaHandler extends VolumeHandler {
     if (quotaOptions.getQuotaInBytes() != null
         && !quotaOptions.getQuotaInBytes().isEmpty()) {
       spaceQuota = OzoneQuota.parseQuota(quotaOptions.getQuotaInBytes(),
-          quotaInCounts).getQuotaInBytes();
+          quotaOptions.getQuotaInCounts()).getQuotaInBytes();
     }
-    if (quotaInCounts >= 0) {
-      countQuota = quotaInCounts;
+    if (quotaOptions.getQuotaInCounts() >= 0) {
+      countQuota = quotaOptions.getQuotaInCounts();
     }
 
     volume.setQuota(OzoneQuota.getOzoneQuota(spaceQuota, countQuota));

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/VolumeCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/VolumeCommands.java
@@ -47,7 +47,9 @@ import picocli.CommandLine.ParentCommand;
         AddAclVolumeHandler.class,
         RemoveAclVolumeHandler.class,
         SetAclVolumeHandler.class,
-        GetAclVolumeHandler.class
+        GetAclVolumeHandler.class,
+        SetQuotaHandler.class,
+        ClearQuotaHandler.class
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)


### PR DESCRIPTION
## What changes were proposed in this pull request?

By HDDS-3725 Ozone currently supports Set volume quota. This PR refers to the implementation of HDDS-3725, and make  Ozone shell support set bucket quota.
The current Quota setting does not take effect. HDDS-541 gives all the work needed to perfect Quota.
This PR is a subtask of HDDS-541. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3751

## How was this patch tested?

UT added
