### PR TITLE
HDDS-4228: add field 'num' to ALLOCATE_BLOCK of scm audit log.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -174,6 +174,7 @@ public class SCMBlockProtocolServer implements
       String owner, ExcludeList excludeList) throws IOException {
     Map<String, String> auditMap = Maps.newHashMap();
     auditMap.put("size", String.valueOf(size));
+    auditMap.put("num", String.valueOf(num));
     auditMap.put("type", type.name());
     auditMap.put("factor", factor.name());
     auditMap.put("owner", owner);


### PR DESCRIPTION
## What changes were proposed in this pull request?

The scm audit log for ALLOCATE_BLOCK is as follows:
`2020-09-10 03:42:08,196 | INFO | SCMAudit | user=root | ip=172.16.90.221 | op=ALLOCATE_BLOCK {owner=7da0b4c4-d053-4fa0-8648-44ff0b8ba1bf, size=268435456, type=RATIS, factor=THREE} | ret=SUCCESS |`
 
One might be interested about the num of blocks allocated, better add field 'num' to  ALLOCATE_BLOCK of scm audit log.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4228

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

CI