### PR TITLE
HDDS-4231. Background Service blocks on task results.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
@@ -118,8 +118,8 @@ public abstract class BackgroundService {
           } finally {
             long endTime = System.nanoTime();
             if (endTime - startTime > serviceTimeoutInNanos) {
-              LOG.warn("Background task execution took {}ns > {}ns(timeout)",
-                  endTime - startTime, serviceTimeoutInNanos);
+              LOG.warn("{} Background task execution took {}ns > {}ns(timeout)",
+                  serviceName, endTime - startTime, serviceTimeoutInNanos);
             }
           }
         }, exec);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
@@ -18,22 +18,17 @@
 package org.apache.hadoop.hdds.utils;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.concurrent.CompletionService;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * An abstract class for a background service in ozone.
@@ -50,10 +45,9 @@ public abstract class BackgroundService {
   // Executor to launch child tasks
   private final ScheduledExecutorService exec;
   private final ThreadGroup threadGroup;
-  private final ThreadFactory threadFactory;
   private final String serviceName;
   private final long interval;
-  private final long serviceTimeout;
+  private final long serviceTimeoutInNanos;
   private final TimeUnit unit;
   private final PeriodicalTask service;
 
@@ -62,11 +56,11 @@ public abstract class BackgroundService {
     this.interval = interval;
     this.unit = unit;
     this.serviceName = serviceName;
-    this.serviceTimeout = serviceTimeout;
+    this.serviceTimeoutInNanos = TimeDuration.valueOf(serviceTimeout, unit)
+            .toLong(TimeUnit.NANOSECONDS);
     threadGroup = new ThreadGroup(serviceName);
-    ThreadFactory tf = r -> new Thread(threadGroup, r);
-    threadFactory = new ThreadFactoryBuilder()
-        .setThreadFactory(tf)
+    ThreadFactory threadFactory = new ThreadFactoryBuilder()
+        .setThreadFactory(r -> new Thread(threadGroup, r))
         .setDaemon(true)
         .setNameFormat(serviceName + "#%d")
         .build();
@@ -83,17 +77,12 @@ public abstract class BackgroundService {
     return threadGroup.activeCount();
   }
 
-  @VisibleForTesting
-  public void triggerBackgroundTaskForTesting() {
-    service.run();
-  }
-
   // start service
   public void start() {
     exec.scheduleWithFixedDelay(service, 0, interval, unit);
   }
 
-  public abstract BackgroundTaskQueue getTasks();
+  public abstract BackgroundTaskQueue<BackgroundTaskResult> getTasks();
 
   /**
    * Run one or more background tasks concurrently.
@@ -105,7 +94,7 @@ public abstract class BackgroundService {
       if (LOG.isDebugEnabled()) {
         LOG.debug("Running background service : {}", serviceName);
       }
-      BackgroundTaskQueue tasks = getTasks();
+      BackgroundTaskQueue<BackgroundTaskResult> tasks = getTasks();
       if (tasks.isEmpty()) {
         // No task found, or some problems to init tasks
         // return and retry in next interval.
@@ -114,41 +103,27 @@ public abstract class BackgroundService {
       if (LOG.isDebugEnabled()) {
         LOG.debug("Number of background tasks to execute : {}", tasks.size());
       }
-      CompletionService<BackgroundTaskResult> taskCompletionService =
-          new ExecutorCompletionService<>(exec);
 
-      List<Future<BackgroundTaskResult>> results = Lists.newArrayList();
       while (tasks.size() > 0) {
-        BackgroundTask task = tasks.poll();
-        Future<BackgroundTaskResult> result =
-            taskCompletionService.submit(task);
-        results.add(result);
-      }
-
-      results.parallelStream().forEach(taskResultFuture -> {
-        try {
-          // Collect task results
-          BackgroundTaskResult result = serviceTimeout > 0
-              ? taskResultFuture.get(serviceTimeout, unit)
-              : taskResultFuture.get();
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("task execution result size {}", result.getSize());
+        BackgroundTask<BackgroundTaskResult> task = tasks.poll();
+        CompletableFuture.runAsync(() -> {
+          long startTime = System.nanoTime();
+          try {
+            BackgroundTaskResult result = task.call();
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("task execution result size {}", result.getSize());
+            }
+          } catch (Exception e) {
+            LOG.warn("Background task execution failed", e);
+          } finally {
+            long endTime = System.nanoTime();
+            if (endTime - startTime > serviceTimeoutInNanos) {
+              LOG.warn("Background task execution took {}ns > {}ns(timeout)",
+                  endTime - startTime, serviceTimeoutInNanos);
+            }
           }
-        } catch (InterruptedException e) {
-          LOG.warn(
-              "Background task failed due to interruption, retrying in " +
-                  "next interval", e);
-          // Re-interrupt the thread while catching InterruptedException
-          Thread.currentThread().interrupt();
-        } catch (ExecutionException e) {
-          LOG.warn(
-              "Background task fails to execute, "
-                  + "retrying in next interval", e);
-        } catch (TimeoutException e) {
-          LOG.warn("Background task executes timed out, "
-              + "retrying in next interval", e);
-        }
-      });
+        }, exec);
+      }
     }
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundService.java
@@ -82,7 +82,7 @@ public abstract class BackgroundService {
     exec.scheduleWithFixedDelay(service, 0, interval, unit);
   }
 
-  public abstract BackgroundTaskQueue<BackgroundTaskResult> getTasks();
+  public abstract BackgroundTaskQueue getTasks();
 
   /**
    * Run one or more background tasks concurrently.
@@ -94,7 +94,7 @@ public abstract class BackgroundService {
       if (LOG.isDebugEnabled()) {
         LOG.debug("Running background service : {}", serviceName);
       }
-      BackgroundTaskQueue<BackgroundTaskResult> tasks = getTasks();
+      BackgroundTaskQueue tasks = getTasks();
       if (tasks.isEmpty()) {
         // No task found, or some problems to init tasks
         // return and retry in next interval.
@@ -105,7 +105,7 @@ public abstract class BackgroundService {
       }
 
       while (tasks.size() > 0) {
-        BackgroundTask<BackgroundTaskResult> task = tasks.poll();
+        BackgroundTask task = tasks.poll();
         CompletableFuture.runAsync(() -> {
           long startTime = System.nanoTime();
           try {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundTask.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundTask.java
@@ -22,7 +22,9 @@ import java.util.concurrent.Callable;
 /**
  * A task thread to run by {@link BackgroundService}.
  */
-public interface BackgroundTask<T> extends Callable<T> {
+public interface BackgroundTask extends Callable<BackgroundTaskResult> {
+
+  BackgroundTaskResult call() throws Exception;
 
   int getPriority();
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundTaskQueue.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundTaskQueue.java
@@ -17,24 +17,25 @@
 
 package org.apache.hadoop.hdds.utils;
 
+import java.util.Comparator;
 import java.util.PriorityQueue;
 
 /**
  * A priority queue that stores a number of {@link BackgroundTask}.
  */
-public class BackgroundTaskQueue {
+public class BackgroundTaskQueue<T> {
 
-  private final PriorityQueue<BackgroundTask> tasks;
+  private final PriorityQueue<BackgroundTask<T>> tasks;
 
   public BackgroundTaskQueue() {
-    tasks = new PriorityQueue<>((task1, task2)
-        -> task1.getPriority() - task2.getPriority());
+    tasks = new PriorityQueue<>(
+        Comparator.comparingInt(BackgroundTask::getPriority));
   }
 
   /**
    * @return the head task in this queue.
    */
-  public synchronized BackgroundTask poll() {
+  public synchronized BackgroundTask<T> poll() {
     return tasks.poll();
   }
 
@@ -44,7 +45,7 @@ public class BackgroundTaskQueue {
    *
    * @param task
    */
-  public synchronized void add(BackgroundTask task) {
+  public synchronized void add(BackgroundTask<T> task) {
     tasks.add(task);
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundTaskQueue.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/BackgroundTaskQueue.java
@@ -23,9 +23,9 @@ import java.util.PriorityQueue;
 /**
  * A priority queue that stores a number of {@link BackgroundTask}.
  */
-public class BackgroundTaskQueue<T> {
+public class BackgroundTaskQueue {
 
-  private final PriorityQueue<BackgroundTask<T>> tasks;
+  private final PriorityQueue<BackgroundTask> tasks;
 
   public BackgroundTaskQueue() {
     tasks = new PriorityQueue<>(
@@ -35,7 +35,7 @@ public class BackgroundTaskQueue<T> {
   /**
    * @return the head task in this queue.
    */
-  public synchronized BackgroundTask<T> poll() {
+  public synchronized BackgroundTask poll() {
     return tasks.poll();
   }
 
@@ -45,7 +45,7 @@ public class BackgroundTaskQueue<T> {
    *
    * @param task
    */
-  public synchronized void add(BackgroundTask<T> task) {
+  public synchronized void add(BackgroundTask task) {
     tasks.add(task);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -233,8 +233,7 @@ public class BlockDeletingService extends BackgroundService {
     }
   }
 
-  private class BlockDeletingTask
-      implements BackgroundTask<BackgroundTaskResult> {
+  private class BlockDeletingTask implements BackgroundTask {
 
     private final int priority;
     private final KeyValueContainerData containerData;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -323,8 +323,7 @@ public class TestBlockDeletingService {
 
     LogCapturer log = LogCapturer.captureLogs(BackgroundService.LOG);
     GenericTestUtils.waitFor(() -> {
-      if(log.getOutput().contains(
-          "Background task executes timed out, retrying in next interval")) {
+      if (log.getOutput().contains("Background task execution took")) {
         log.stopCapturing();
         return true;
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -118,8 +118,7 @@ public class SCMBlockDeletingService extends BackgroundService {
     }
   }
 
-  private class DeletedBlockTransactionScanner
-      implements BackgroundTask<EmptyTaskResult> {
+  private class DeletedBlockTransactionScanner implements BackgroundTask {
 
     @Override
     public int getPriority() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyDeletingService.java
@@ -141,8 +141,7 @@ public class KeyDeletingService extends BackgroundService {
    * the blocks info in its deletedBlockLog), it removes these keys from the
    * DB.
    */
-  private class KeyDeletingTask implements
-      BackgroundTask<BackgroundTaskResult> {
+  private class KeyDeletingTask implements BackgroundTask {
 
     @Override
     public int getPriority() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OpenKeyCleanupService.java
@@ -62,8 +62,7 @@ public class OpenKeyCleanupService extends BackgroundService {
     return queue;
   }
 
-  private class OpenKeyDeletingTask
-      implements BackgroundTask<BackgroundTaskResult> {
+  private class OpenKeyDeletingTask implements BackgroundTask {
 
     @Override
     public int getPriority() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Background service currently waits on the results of the tasks. The idea is to track the time it took for the task to execute and log if task takes more than configured timeout.
This does not require waiting on the task results and can be achieved by just comparing the execution time of a task with the timeout value.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4231

## How was this patch tested?

This was one of the reasons for failure of TestBlockDeletion tracked in HDDS-3432. Please check https://github.com/apache/hadoop-ozone/pull/1121/commits/a3feb31ae94e2c1a127f3d84f08ccc4edfb0e0ac . HDDS-3432 is blocked on a ratis bug.