### PR TITLE
HDDS-4232. Use single thread for KeyDeletingService.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyDeletingService.java
@@ -66,9 +66,6 @@ public class KeyDeletingService extends BackgroundService {
   private static final Logger LOG =
       LoggerFactory.getLogger(KeyDeletingService.class);
 
-  // The thread pool size for key deleting service.
-  private final static int KEY_DELETING_CORE_POOL_SIZE = 2;
-
   private final OzoneManager ozoneManager;
   private final ScmBlockLocationProtocol scmClient;
   private final KeyManager manager;
@@ -82,7 +79,7 @@ public class KeyDeletingService extends BackgroundService {
       KeyManager manager, long serviceInterval,
       long serviceTimeout, ConfigurationSource conf) {
     super("KeyDeletingService", serviceInterval, TimeUnit.MILLISECONDS,
-        KEY_DELETING_CORE_POOL_SIZE, serviceTimeout);
+        1, serviceTimeout);
     this.ozoneManager = ozoneManager;
     this.scmClient = scmClient;
     this.manager = manager;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyDeletingService.java
@@ -66,6 +66,11 @@ public class KeyDeletingService extends BackgroundService {
   private static final Logger LOG =
       LoggerFactory.getLogger(KeyDeletingService.class);
 
+  // Use only a single thread for KeyDeletion. Multiple threads would read
+  // from the same table and can send deletion requests for same key multiple
+  // times.
+  private final static int KEY_DELETING_CORE_POOL_SIZE = 1;
+
   private final OzoneManager ozoneManager;
   private final ScmBlockLocationProtocol scmClient;
   private final KeyManager manager;
@@ -79,7 +84,7 @@ public class KeyDeletingService extends BackgroundService {
       KeyManager manager, long serviceInterval,
       long serviceTimeout, ConfigurationSource conf) {
     super("KeyDeletingService", serviceInterval, TimeUnit.MILLISECONDS,
-        1, serviceTimeout);
+        KEY_DELETING_CORE_POOL_SIZE, serviceTimeout);
     this.ozoneManager = ozoneManager;
     this.scmClient = scmClient;
     this.manager = manager;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OpenKeyCleanupService.java
@@ -41,6 +41,8 @@ public class OpenKeyCleanupService extends BackgroundService {
   private static final Logger LOG =
       LoggerFactory.getLogger(OpenKeyCleanupService.class);
 
+  private final static int OPEN_KEY_DELETING_CORE_POOL_SIZE = 2;
+
   private final KeyManager keyManager;
   private final ScmBlockLocationProtocol scmClient;
 
@@ -48,7 +50,7 @@ public class OpenKeyCleanupService extends BackgroundService {
       KeyManager keyManager, int serviceInterval,
       long serviceTimeout) {
     super("OpenKeyCleanupService", serviceInterval, TimeUnit.SECONDS,
-        1, serviceTimeout);
+        OPEN_KEY_DELETING_CORE_POOL_SIZE, serviceTimeout);
     this.keyManager = keyManager;
     this.scmClient = scmClient;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OpenKeyCleanupService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OpenKeyCleanupService.java
@@ -41,8 +41,6 @@ public class OpenKeyCleanupService extends BackgroundService {
   private static final Logger LOG =
       LoggerFactory.getLogger(OpenKeyCleanupService.class);
 
-  private final static int OPEN_KEY_DELETING_CORE_POOL_SIZE = 2;
-
   private final KeyManager keyManager;
   private final ScmBlockLocationProtocol scmClient;
 
@@ -50,7 +48,7 @@ public class OpenKeyCleanupService extends BackgroundService {
       KeyManager keyManager, int serviceInterval,
       long serviceTimeout) {
     super("OpenKeyCleanupService", serviceInterval, TimeUnit.SECONDS,
-        OPEN_KEY_DELETING_CORE_POOL_SIZE, serviceTimeout);
+        1, serviceTimeout);
     this.keyManager = keyManager;
     this.scmClient = scmClient;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

KeyDeletingService scan the keys from a particular rocksdb table and sends deletion request to SCM. Every thread would scan the table and send deletion requests. This can lead to multiple deletion request for a particular block. There is currently no way to distribute the keys to be deleted amongst multiple threads.

## What is the link to the Apache JIRA

HDDS-4232

## How was this patch tested?

This lead to failure in TestBlockDeletion. Please refer https://github.com/apache/hadoop-ozone/pull/1121/commits/49b610a9feb54899ae226d3b6f2e36c5f8cc784f
