### PR TITLE
HDDS-4233. Interrupted exeception printed out from DatanodeStateMachine

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -230,7 +230,6 @@ public class DatanodeStateMachine implements Closeable {
         // Some one has sent interrupt signal, this could be because
         // 1. Trigger heartbeat immediately
         // 2. Shutdown has be initiated.
-        LOG.warn("Interrupt the execution.", e);
         Thread.currentThread().interrupt();
       } catch (Exception e) {
         LOG.error("Unable to finish the execution.", e);
@@ -242,7 +241,7 @@ public class DatanodeStateMachine implements Closeable {
           try {
             Thread.sleep(nextHB.get() - now);
           } catch (InterruptedException e) {
-            LOG.warn("Interrupt the execution.", e);
+            //triggerHeartbeat is called during the sleep
           }
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hide Interrupted exceptions from WARN level as they are expected.
 
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4233

## How was this patch tested?

CI. Simple change.