### PR TITLE
HDDS-4209. S3A Filesystem does not work with Ozone S3.

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -186,7 +186,7 @@ public class ObjectEndpoint extends EndpointBase {
 
       // S3A Filesystem when create directory creates a put object with 0 bytes.
       // So, we can safely call create directory.
-      // And also in S3 world, there is no such an API to create a directory.
+      // And also in S3 world, there is no such API to create a directory.
       // If some one is passing key with trailing "/" and length 0, Ozone S3
       // can create directory.
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -184,6 +184,18 @@ public class ObjectEndpoint extends EndpointBase {
       // Normal put object
       OzoneBucket bucket = getBucket(bucketName);
 
+      // As S3A when create directory creates a put object with 0 bytes.
+      // So, we can safely call create directory.
+      // And also in S3 world, there is no such an API to create a directory.
+      // If some one is passing key with trailing "/" and length 0, Ozone S3
+      // can create directory.
+
+      if (length == 0 && keyPath.endsWith("/")) {
+        bucket.createDirectory(keyPath);
+        return Response.ok().status(HttpStatus.SC_OK)
+            .build();
+      }
+
       output = bucket.createKey(keyPath, length, replicationType,
           replicationFactor, new HashMap<>());
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -184,7 +184,7 @@ public class ObjectEndpoint extends EndpointBase {
       // Normal put object
       OzoneBucket bucket = getBucket(bucketName);
 
-      // As S3A when create directory creates a put object with 0 bytes.
+      // S3A Filesystem when create directory creates a put object with 0 bytes.
       // So, we can safely call create directory.
       // And also in S3 world, there is no such an API to create a directory.
       // If some one is passing key with trailing "/" and length 0, Ozone S3


### PR DESCRIPTION
## What changes were proposed in this pull request?

When Key is 0 bytes, and ending with "/" call createDirectory API. In this way below scenario can work from S3A.

```
hdfs dfs -mkdir s3a://sept11-1/dir1/dir2/dir3
hdfs dfs -put /etc/hadoop/conf/ozone-site.xml s3a://sept11-1/dir1/dir2/dir3/key1
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4209

## How was this patch tested?

Tested it on a cluster

[root@bvoz-1 ~]# oapi create-bucket --bucket sept11-1
{
    "Location": "https://bvoz-1.bvoz.root.hwx.site:9879/sept11-1"
}

[root@bvoz-1 ~]# hdfs dfs -put /etc/hadoop/conf/ozone-site.xml s3a://sept11-1/dir1/dir2/dir3/key1

[root@bvoz-1 ~]# hdfs dfs -ls -R  s3a://sept11-1/
log4j:WARN No appenders could be found for logger (org.apache.hadoop.util.Shell).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
drwxrwxrwx   - root root          0 2020-09-11 23:28 s3a://sept11-1/dir1
drwxrwxrwx   - root root          0 2020-09-11 23:28 s3a://sept11-1/dir1/dir2
drwxrwxrwx   - root root          0 2020-09-11 23:28 s3a://sept11-1/dir1/dir2/dir3
-rw-rw-rw-   1 root root       2271 2020-09-11 23:28 s3a://sept11-1/dir1/dir2/dir3/key1
