### PR TITLE
HDDS-4241. Support HADOOP_TOKEN_FILE_LOCATION for Ozone token CLI.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneTokenIdentifier.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/security/OzoneTokenIdentifier.java
@@ -21,6 +21,7 @@ import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -374,8 +375,8 @@ public class OzoneTokenIdentifier extends
         .append(" owner=").append(getOwner())
         .append(", renewer=").append(getRenewer())
         .append(", realUser=").append(getRealUser())
-        .append(", issueDate=").append(getIssueDate())
-        .append(", maxDate=").append(getMaxDate())
+        .append(", issueDate=").append(Instant.ofEpochMilli(getIssueDate()))
+        .append(", maxDate=").append(Instant.ofEpochMilli(getMaxDate()))
         .append(", sequenceNumber=").append(getSequenceNumber())
         .append(", masterKeyId=").append(getMasterKeyId())
         .append(", strToSign=").append(getStrToSign())

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
@@ -26,11 +26,11 @@ Get and use Token in Secure Cluster
     Execute                      ozone sh token get -t /tmp/ozone.token
     File Should Not Be Empty     /tmp/ozone.token
     Execute                      kdestroy
-    Execute                      export HADOOP_TOKEN_FILE_LOCATION=/tmp/ozone.token
+    Set Environment Variable     HADOOP_TOKEN_FILE_LOCATION    /tmp/ozone.token
     ${output} =                  Execute             ozone sh volume list /
     Should not contain           ${output}           Client cannot authenticate
-    Execute                      unset HADOOP_TOKEN_FILE_LOCATION
-    ${output} =                  Execute             ozone sh volume list /
+    Remove Environment Variable  HADOOP_TOKEN_FILE_LOCATION
+    ${output} =                  Execute and Ignore Error  ozone sh volume list /
     Should contain               ${output}           Client cannot authenticate
     Run Keyword                  Kinit test user     testuser  testuser.keytab
 

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
@@ -22,9 +22,19 @@ Resource            ../commonlib.robot
 Test Timeout        5 minutes
 
 *** Keywords ***
-Get Token in Secure Cluster
-    Execute                      ozone sh token get > /tmp/token.txt
-    File Should Not Be Empty     /tmp/token.txt
+Get and use Token in Secure Cluster
+    Execute                      ozone sh token get > /tmp/ozone.token
+    File Should Not Be Empty     /tmp/ozone.token
+    Execute                      kdestroy
+    ${output} =                  klist
+    Should contain               ${output}           No credentials cache found
+    Execute                      export HADOOP_TOKEN_FILE_LOCATION=/tmp/ozone.token
+    ${output} =                  Execute             ozone sh volume list /
+    Should not contain           ${output}           Client cannot authenticate
+    Execute                      unset HADOOP_TOKEN_FILE_LOCATION
+    ${output} =                  Execute             ozone sh volume list /
+    Should contain               ${output}           Client cannot authenticate
+    Execute                      Kinit test user     testuser     testuser.keytab
 
 Get Token in Unsecure Cluster
     ${output} =                  Execute             ozone sh token get
@@ -59,7 +69,7 @@ Cancel Token in Unsecure Cluster
     Should Contain               ${output}           only when security is enabled
 
 Token Test in Secure Cluster
-    Get Token in Secure Cluster
+    Get and use Token in Secure Cluster
     Print Valid Token File
     Renew Token in Secure Cluster
     Cancel Token in Secure Cluster

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
@@ -32,7 +32,7 @@ Get and use Token in Secure Cluster
     Execute                      unset HADOOP_TOKEN_FILE_LOCATION
     ${output} =                  Execute             ozone sh volume list /
     Should contain               ${output}           Client cannot authenticate
-    Execute                      Kinit test user     testuser     testuser.keytab
+    Run Keyword                  Kinit test user     testuser  testuser.keytab
 
 Get Token in Unsecure Cluster
     ${output} =                  Execute             ozone sh token get

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
@@ -26,8 +26,6 @@ Get and use Token in Secure Cluster
     Execute                      ozone sh token get > /tmp/ozone.token
     File Should Not Be Empty     /tmp/ozone.token
     Execute                      kdestroy
-    ${output} =                  klist
-    Should contain               ${output}           No credentials cache found
     Execute                      export HADOOP_TOKEN_FILE_LOCATION=/tmp/ozone.token
     ${output} =                  Execute             ozone sh volume list /
     Should not contain           ${output}           Client cannot authenticate

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
@@ -23,7 +23,7 @@ Test Timeout        5 minutes
 
 *** Keywords ***
 Get and use Token in Secure Cluster
-    Execute                      ozone sh token get > /tmp/ozone.token
+    Execute                      ozone sh token get -t /tmp/ozone.token
     File Should Not Be Empty     /tmp/ozone.token
     Execute                      kdestroy
     Execute                      export HADOOP_TOKEN_FILE_LOCATION=/tmp/ozone.token

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/GetTokenHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/GetTokenHandler.java
@@ -69,9 +69,9 @@ public class GetTokenHandler extends Handler {
       err().println("Error: Get delegation token operation failed. " +
           "Check OzoneManager logs for more details.");
     } else {
-      System.out.println("Successfully get token for service " +
+      out().println("Successfully get token for service " +
           token.getService());
-      System.out.println(token.toString());
+      out().println(token.toString());
       tokenFile.persistToken(token);
     }
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/GetTokenHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/GetTokenHandler.java
@@ -46,6 +46,9 @@ public class GetTokenHandler extends Handler {
   @CommandLine.Mixin
   private RenewerOption renewer;
 
+  @CommandLine.Mixin
+  private TokenOption tokenFile;
+
   @Override
   protected OzoneAddress getAddress() throws OzoneClientException {
     return new OzoneAddress(uri);
@@ -66,7 +69,10 @@ public class GetTokenHandler extends Handler {
       err().println("Error: Get delegation token operation failed. " +
           "Check OzoneManager logs for more details.");
     } else {
-      printObjectAsJson(token.encodeToUrlString());
+      System.out.println("Successfully get token for service " +
+          token.getService());
+      System.out.println(token.toString());
+      tokenFile.persistToken(token);
     }
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/PrintTokenHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/PrintTokenHandler.java
@@ -41,7 +41,7 @@ public class PrintTokenHandler implements Callable<Void> {
   public Void call() throws Exception {
     if (tokenFile.exists()) {
       Token<OzoneTokenIdentifier> token = tokenFile.decode();
-      System.out.print(token.toString());
+      System.out.println(token.toString());
     }
     return null;
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/PrintTokenHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/PrintTokenHandler.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.shell.token;
 
-import org.apache.hadoop.hdds.server.JsonUtils;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.security.token.Token;
 
@@ -42,7 +41,7 @@ public class PrintTokenHandler implements Callable<Void> {
   public Void call() throws Exception {
     if (tokenFile.exists()) {
       Token<OzoneTokenIdentifier> token = tokenFile.decode();
-      System.out.print(JsonUtils.toJsonStringWithDefaultPrettyPrinter(token));
+      System.out.print(token.toString());
     }
     return null;
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/RenewTokenHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/RenewTokenHandler.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.ozone.shell.OzoneAddress;
 import picocli.CommandLine.Command;
 
 import java.io.IOException;
+import java.time.Instant;
 
 /**
  * Executes renewDelegationToken api.
@@ -36,6 +37,7 @@ public class RenewTokenHandler extends TokenHandler {
   protected void execute(OzoneClient client, OzoneAddress address)
       throws IOException, OzoneClientException {
     long expiryTime = client.getObjectStore().renewDelegationToken(getToken());
-    out().printf("Token renewed successfully, expiry time: %s.%n", expiryTime);
+    out().printf("Token renewed successfully, expiry time: %s.%n",
+        Instant.ofEpochMilli(expiryTime));
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/TokenOption.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/token/TokenOption.java
@@ -18,13 +18,17 @@
 package org.apache.hadoop.ozone.shell.token;
 
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
+import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.security.token.TokenIdentifier;
 import picocli.CommandLine;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 
 /**
  * Option for token file.
@@ -33,7 +37,7 @@ public class TokenOption {
 
   @CommandLine.Option(names = {"--token", "-t"},
       description = "file containing encoded token",
-      defaultValue = "/tmp/token.txt",
+      defaultValue = "/tmp/ozone.token",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
   private File tokenFile;
 
@@ -47,10 +51,30 @@ public class TokenOption {
   }
 
   public Token<OzoneTokenIdentifier> decode() throws IOException {
-    Token<OzoneTokenIdentifier> token = new Token<>();
-    token.decodeFromUrlString(new String(Files.readAllBytes(tokenFile.toPath()),
-        StandardCharsets.UTF_8));
-    return token;
+    Credentials creds = new Credentials();
+    try (FileInputStream fis = new FileInputStream(tokenFile)) {
+      try (DataInputStream dis = new DataInputStream(fis)) {
+        creds.readTokenStorageStream(dis);
+      }
+    }
+    for (Token<? extends TokenIdentifier> token: creds.getAllTokens()) {
+      if (token.getKind().equals(OzoneTokenIdentifier.KIND_NAME)) {
+        return (Token<OzoneTokenIdentifier>) token;
+      }
+    }
+    return null;
   }
 
+  public void persistToken(Token<OzoneTokenIdentifier> token)
+      throws IOException {
+    try (FileOutputStream fos = new FileOutputStream(tokenFile)) {
+      try (DataOutputStream dos = new DataOutputStream(fos)) {
+        Credentials ts = new Credentials();
+        ts.addToken(token.getService(), token);
+        ts.writeTokenStorageToStream(dos);
+        System.out.println("Token persisted to " + tokenFile.toString() +
+            " successfully!");
+      }
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Ozone token CLI should persist the token in a format that is compatible with HADOOP_TOKEN_FILE_LOCATION so that it can be used by Hadoop/Ozone CLI for authentication. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4241

## How was this patch tested?
New acceptance test added along with existing ones. 