### PR TITLE
HDDS-4244. Container deleted wrong replica cause mis-replicated.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -670,8 +670,9 @@ public class ReplicationManager
           // First remove the replica we are working on from the set, and then
           // check if the set is now mis-replicated.
           replicaSet.remove(r);
-          boolean nowSatisfied = getPlacementStatus(replicaSet, replicationFactor)
-              .isPolicySatisfied();
+          boolean nowSatisfied =
+              getPlacementStatus(replicaSet, replicationFactor)
+                  .isPolicySatisfied();
           if (!satisfied || nowSatisfied) {
             // Remove the replica if the container was already unsatisfied
             // OR if losing this replica still keep satisfied

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -660,9 +660,8 @@ public class ReplicationManager
       if (excess > 0) {
         eligibleReplicas.removeAll(unhealthyReplicas);
         Set<ContainerReplica> replicaSet = new HashSet<>(eligibleReplicas);
-        boolean satisfied =
-            getPlacementStatus(replicaSet, replicationFactor)
-                .isPolicySatisfied();
+        ContainerPlacementStatus ps =
+            getPlacementStatus(replicaSet, replicationFactor);
         for (ContainerReplica r : eligibleReplicas) {
           if (excess <= 0) {
             break;
@@ -670,11 +669,13 @@ public class ReplicationManager
           // First remove the replica we are working on from the set, and then
           // check if the set is now mis-replicated.
           replicaSet.remove(r);
-          boolean nowSatisfied =
-              getPlacementStatus(replicaSet, replicationFactor)
-                  .isPolicySatisfied();
-          if (!satisfied || nowSatisfied) {
+          ContainerPlacementStatus nowPS =
+              getPlacementStatus(replicaSet, replicationFactor);
+          if ((!ps.isPolicySatisfied()
+                && nowPS.actualPlacementCount() == ps.actualPlacementCount())
+              || (ps.isPolicySatisfied() && nowPS.isPolicySatisfied())) {
             // Remove the replica if the container was already unsatisfied
+            // and losing this replica keep actual placement count unchanged.
             // OR if losing this replica still keep satisfied
             sendDeleteCommand(container, r.getDatanodeDetails(), true);
             excess -= 1;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -661,7 +661,7 @@ public class ReplicationManager
         eligibleReplicas.removeAll(unhealthyReplicas);
         Set<ContainerReplica> replicaSet = new HashSet<>(eligibleReplicas);
         boolean misReplicated =
-            getPlacementStatus(replicaSet, replicationFactor)
+            !getPlacementStatus(replicaSet, replicationFactor)
                 .isPolicySatisfied();
         for (ContainerReplica r : eligibleReplicas) {
           if (excess <= 0) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -660,8 +660,8 @@ public class ReplicationManager
       if (excess > 0) {
         eligibleReplicas.removeAll(unhealthyReplicas);
         Set<ContainerReplica> replicaSet = new HashSet<>(eligibleReplicas);
-        boolean misReplicated =
-            !getPlacementStatus(replicaSet, replicationFactor)
+        boolean satisfied =
+            getPlacementStatus(replicaSet, replicationFactor)
                 .isPolicySatisfied();
         for (ContainerReplica r : eligibleReplicas) {
           if (excess <= 0) {
@@ -670,11 +670,11 @@ public class ReplicationManager
           // First remove the replica we are working on from the set, and then
           // check if the set is now mis-replicated.
           replicaSet.remove(r);
-          boolean nowMisRep = getPlacementStatus(replicaSet, replicationFactor)
+          boolean nowSatisfied = getPlacementStatus(replicaSet, replicationFactor)
               .isPolicySatisfied();
-          if (misReplicated || !nowMisRep) {
-            // Remove the replica if the container was already mis-replicated
-            // OR if losing this replica does not make it become mis-replicated
+          if (!satisfied || nowSatisfied) {
+            // Remove the replica if the container was already unsatisfied
+            // OR if losing this replica still keep satisfied
             sendDeleteCommand(container, r.getDatanodeDetails(), true);
             excess -= 1;
             continue;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
@@ -764,6 +764,44 @@ public class TestReplicationManager {
         replicaFive.getDatanodeDetails()));
   }
 
+  @Test
+  public void testOverReplicatedAndPolicySatisfied() throws
+      SCMException, ContainerNotFoundException, InterruptedException {
+    final ContainerInfo container = getContainer(LifeCycleState.CLOSED);
+    final ContainerID id = container.containerID();
+    final UUID originNodeId = UUID.randomUUID();
+    final ContainerReplica replicaOne = getReplicas(
+        id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+    final ContainerReplica replicaTwo = getReplicas(
+        id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+    final ContainerReplica replicaThree = getReplicas(
+        id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+    final ContainerReplica replicaFour = getReplicas(
+        id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+
+    containerStateManager.loadContainer(container);
+    containerStateManager.updateContainerReplica(id, replicaOne);
+    containerStateManager.updateContainerReplica(id, replicaTwo);
+    containerStateManager.updateContainerReplica(id, replicaThree);
+    containerStateManager.updateContainerReplica(id, replicaFour);
+
+    Mockito.when(containerPlacementPolicy.validateContainerPlacement(
+        Mockito.argThat(new ListOfNElements(3)),
+        Mockito.anyInt()
+    )).thenAnswer(
+        invocation -> new ContainerPlacementStatusDefault(2, 2, 3));
+
+
+    final int currentDeleteCommandCount = datanodeCommandHandler
+        .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand);
+
+    replicationManager.processContainersNow();
+    // Wait for EventQueue to call the event handler
+    Thread.sleep(100L);
+    Assert.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
+        .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
+  }
+
   @After
   public void teardown() throws IOException {
     containerStateManager.close();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
@@ -803,46 +803,6 @@ public class TestReplicationManager {
   }
 
   @Test
-  public void testOverReplicatedAndPolicyUnSatisfied() throws
-      SCMException, ContainerNotFoundException, InterruptedException {
-    final ContainerInfo container = getContainer(LifeCycleState.CLOSED);
-    final ContainerID id = container.containerID();
-    final UUID originNodeId = UUID.randomUUID();
-    final ContainerReplica replicaOne = getReplicas(
-        id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
-    final ContainerReplica replicaTwo = getReplicas(
-        id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
-    final ContainerReplica replicaThree = getReplicas(
-        id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
-    final ContainerReplica replicaFour = getReplicas(
-        id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
-    final ContainerReplica replicaFive = getReplicas(
-        id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
-
-    containerStateManager.loadContainer(container);
-    containerStateManager.updateContainerReplica(id, replicaOne);
-    containerStateManager.updateContainerReplica(id, replicaTwo);
-    containerStateManager.updateContainerReplica(id, replicaThree);
-    containerStateManager.updateContainerReplica(id, replicaFour);
-    containerStateManager.updateContainerReplica(id, replicaFive);
-
-    Mockito.when(containerPlacementPolicy.validateContainerPlacement(
-        Mockito.argThat(new ListOfNElements(3)),
-        Mockito.anyInt()
-    )).thenAnswer(
-        invocation -> new ContainerPlacementStatusDefault(1, 2, 3));
-
-    final int currentDeleteCommandCount = datanodeCommandHandler
-        .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand);
-
-    replicationManager.processContainersNow();
-    // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
-    Assert.assertEquals(currentDeleteCommandCount, datanodeCommandHandler
-        .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
-  }
-
-  @Test
   public void testOverReplicatedAndPolicyUnSatisfiedAndDeleted() throws
       SCMException, ContainerNotFoundException, InterruptedException {
     final ContainerInfo container = getContainer(LifeCycleState.CLOSED);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
@@ -912,7 +912,7 @@ public class TestReplicationManager {
 
   class FunctionMatcher extends ArgumentMatcher<List> {
 
-    Function<Object, Boolean> function;
+    private Function<Object, Boolean> function;
 
     FunctionMatcher(Function<Object, Boolean> function) {
       this.function = function;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
@@ -54,6 +54,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -841,6 +842,47 @@ public class TestReplicationManager {
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
   }
 
+  @Test
+  public void testOverReplicatedAndPolicyUnSatisfiedAndDeleted() throws
+      SCMException, ContainerNotFoundException, InterruptedException {
+    final ContainerInfo container = getContainer(LifeCycleState.CLOSED);
+    final ContainerID id = container.containerID();
+    final UUID originNodeId = UUID.randomUUID();
+    final ContainerReplica replicaOne = getReplicas(
+        id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+    final ContainerReplica replicaTwo = getReplicas(
+        id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+    final ContainerReplica replicaThree = getReplicas(
+        id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+    final ContainerReplica replicaFour = getReplicas(
+        id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+    final ContainerReplica replicaFive = getReplicas(
+        id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+
+    containerStateManager.loadContainer(container);
+    containerStateManager.updateContainerReplica(id, replicaOne);
+    containerStateManager.updateContainerReplica(id, replicaTwo);
+    containerStateManager.updateContainerReplica(id, replicaThree);
+    containerStateManager.updateContainerReplica(id, replicaFour);
+    containerStateManager.updateContainerReplica(id, replicaFive);
+
+    Mockito.when(containerPlacementPolicy.validateContainerPlacement(
+        Mockito.argThat(new FunctionMatcher(list ->
+            list != null && ((List) list).size() <= 4)),
+        Mockito.anyInt()
+    )).thenAnswer(
+        invocation -> new ContainerPlacementStatusDefault(1, 2, 3));
+
+    final int currentDeleteCommandCount = datanodeCommandHandler
+        .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand);
+
+    replicationManager.processContainersNow();
+    // Wait for EventQueue to call the event handler
+    Thread.sleep(100L);
+    Assert.assertEquals(currentDeleteCommandCount + 2, datanodeCommandHandler
+        .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
+  }
+
   @After
   public void teardown() throws IOException {
     containerStateManager.close();
@@ -908,4 +950,17 @@ public class TestReplicationManager {
     }
   }
 
+  class FunctionMatcher extends ArgumentMatcher<List> {
+
+    Function<Object, Boolean> function;
+
+    FunctionMatcher(Function<Object, Boolean> function) {
+      this.function = function;
+    }
+
+    @Override
+    public boolean matches(Object argument) {
+      return function.apply(argument);
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Container deleted wrong replica cause mis-replicated.

## What is the link to the Apache JIRA

HDDS-4244

## How was this patch tested?


- Related config file
  - ozone-site.xml
```xml
  <property>
    <name>ozone.scm.container.placement.impl</name>
    <value>org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementRackAware</value>
  </property>
  <property>
    <name>net.topology.node.switch.mapping.impl</name>
    <value>org.apache.hadoop.net.TableMapping</value>
  </property>
  <property>
    <name>net.topology.table.file.name</name>
    <value>/data/ozoneadmin/ozoneenv/ozone/etc/hadoop/network-config</value>
  </property>
```

  - network-config
```
192.168.1.100 /racks1
192.168.1.101 /racks1
192.168.1.102 /racks1
192.168.1.103 /racks2
192.168.1.104 /racks2
192.168.1.106 /racks2
```

First you should make the 3 replicas of the tested container on the same racks, like racks1.
secondly, change the config file update the request config.

2 ReplicationManager interval, you can use the following command to verify the container replicas are in the 2 racks.
```bash
ozone admin container info #xxx
```



