### PR TITLE
HDDS-4247. Fixed log4j usage in some places

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/Scheduler.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/Scheduler.java
@@ -96,7 +96,7 @@ public class Scheduler {
       try {
         scheduledExecutorService.awaitTermination(60, TimeUnit.SECONDS);
       } catch (InterruptedException e) {
-        LOG.info("{} interrupted while waiting for task completion {}",
+        LOG.info("{} interrupted while waiting for task completion.",
                 threadName, e);
         // Re-interrupt the thread while catching InterruptedException
         Thread.currentThread().interrupt();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/HddsVolumeUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/HddsVolumeUtil.java
@@ -180,7 +180,7 @@ public final class HddsVolumeUtil {
     try {
       hddsVolume.format(clusterId);
     } catch (IOException ex) {
-      logger.error("Error during formatting volume {}, exception is {}",
+      logger.error("Error during formatting volume {}.",
           volumeRoot, ex);
       return false;
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReportHandler.java
@@ -140,7 +140,7 @@ public class ContainerReportHandler extends AbstractContainerReportHandler
       containerManager.notifyContainerReportProcessing(true, true);
     } catch (NodeNotFoundException ex) {
       containerManager.notifyContainerReportProcessing(true, false);
-      LOG.error("Received container report from unknown datanode {} {}",
+      LOG.error("Received container report from unknown datanode {}.",
           datanodeDetails, ex);
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
@@ -463,7 +463,7 @@ public class SCMContainerManager implements ContainerManager {
         return containerInfo;
       }
     } catch (Exception e) {
-      LOG.warn("Container allocation failed for pipeline={} requiredSize={} {}",
+      LOG.warn("Container allocation failed for pipeline={} requiredSize={}.",
               pipeline, sizeRequired, e);
       return null;
     }
@@ -519,7 +519,7 @@ public class SCMContainerManager implements ContainerManager {
           containerIDIterator.remove();
         }
       } catch (ContainerNotFoundException e) {
-        LOG.error("Could not find container info for container id={} {}", cid,
+        LOG.error("Could not find container info for container id={}.", cid,
             e);
         containerIDIterator.remove();
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreator.java
@@ -125,7 +125,7 @@ class BackgroundPipelineCreator {
         try {
           pipelineManager.scrubPipeline(type, factor);
         } catch (IOException e) {
-          LOG.error("Error while scrubbing pipelines {}", e);
+          LOG.error("Error while scrubbing pipelines.", e);
         }
       }
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
@@ -83,7 +83,7 @@ public class PipelineReportHandler implements
       try {
         processPipelineReport(report, dn, publisher);
       } catch (IOException e) {
-        LOGGER.error("Could not process pipeline report={} from dn={} {}",
+        LOGGER.error("Could not process pipeline report={} from dn={}.",
             report, dn, e);
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketManagerImpl.java
@@ -562,7 +562,7 @@ public class BucketManagerImpl implements BucketManager {
       return bucketInfo.getAcls();
     } catch (IOException ex) {
       if (!(ex instanceof OMException)) {
-        LOG.error("Get acl operation failed for bucket:{}/{} acl:{}",
+        LOG.error("Get acl operation failed for bucket:{}/{}.",
             volume, bucket, ex);
       }
       throw ex;
@@ -607,7 +607,7 @@ public class BucketManagerImpl implements BucketManager {
       if(ex instanceof OMException) {
         throw (OMException) ex;
       }
-      LOG.error("CheckAccess operation failed for bucket:{}/{} acl:{}",
+      LOG.error("CheckAccess operation failed for bucket:{}/{}.",
           volume, bucket, ex);
       throw new OMException("Check access operation failed for " +
           "bucket:" + bucket, ex, INTERNAL_ERROR);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -263,7 +263,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
       // the OM process should be terminated.
       File markerFile = new File(metaDir, DB_TRANSIENT_MARKER);
       if (markerFile.exists()) {
-        LOG.error("File {} marks that OM DB is in an inconsistent state.");
+        LOG.error("File {} marks that OM DB is in an inconsistent state.",
+                markerFile);
         // Note - The marker file should be deleted only after fixing the DB.
         // In an HA setup, this can be done by replacing this DB with a
         // checkpoint from another OM.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3124,7 +3124,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     try {
       termIndex = installCheckpoint(leaderId, omDBCheckpoint);
     } catch (Exception ex) {
-      LOG.error("Failed to install snapshot from Leader OM: {}", ex);
+      LOG.error("Failed to install snapshot from Leader OM.", ex);
     }
     return termIndex;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -329,7 +329,7 @@ public class OMFileCreateRequest extends OMKeyRequest {
           bucketName, keyName);
       break;
     case FAILURE:
-      LOG.error("File create failed. Volume:{}, Bucket:{}, Key{}. Exception:{}",
+      LOG.error("File create failed. Volume:{}, Bucket:{}, Key{}.",
           volumeName, bucketName, keyName, exception);
       break;
     default:

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -229,7 +229,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
           bucketName, keyName);
       break;
     case FAILURE:
-      LOG.error("Key commit failed. Volume:{}, Bucket:{}, Key:{}. Exception:{}",
+      LOG.error("Key commit failed. Volume:{}, Bucket:{}, Key:{}.",
           volumeName, bucketName, keyName, exception);
       omMetrics.incNumKeyCommitFails();
       break;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -600,7 +600,7 @@ public class OzoneDelegationTokenSecretManager
 
         }
       } catch (InterruptedException ie) {
-        LOG.error("ExpiredTokenRemover received {}", ie);
+        LOG.error("ExpiredTokenRemover received.", ie);
         Thread.currentThread().interrupt();
       } catch (Exception t) {
         LOG.error("ExpiredTokenRemover thread received unexpected exception",

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -600,7 +600,7 @@ public class OzoneDelegationTokenSecretManager
 
         }
       } catch (InterruptedException ie) {
-        LOG.error("ExpiredTokenRemover received.", ie);
+        LOG.info("ExpiredTokenRemover was interrupted.", ie);
         Thread.currentThread().interrupt();
       } catch (Exception t) {
         LOG.error("ExpiredTokenRemover thread received unexpected exception",

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconSchemaManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconSchemaManager.java
@@ -49,7 +49,7 @@ public class ReconSchemaManager {
       try {
         reconSchemaDefinition.initializeSchema();
       } catch (SQLException e) {
-        LOG.error("Error creating Recon schema {} : {}",
+        LOG.error("Error creating Recon schema {}.",
             reconSchemaDefinition.getClass().getSimpleName(), e);
       }
     });

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconIncrementalContainerReportHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconIncrementalContainerReportHandler.java
@@ -86,7 +86,7 @@ public class ReconIncrementalContainerReportHandler
         LOG.warn("Container {} not found!", replicaProto.getContainerID());
       } catch (NodeNotFoundException ex) {
         success = false;
-        LOG.error("Received ICR from unknown datanode {} {}",
+        LOG.error("Received ICR from unknown datanode {}.",
             report.getDatanodeDetails(), ex);
       } catch (IOException e) {
         success = false;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed log4j usage in some places.

Examples, `{}` is redundant.
```
LOG.error("Error while scrubbing pipelines {}", e);
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-4247

## How was this patch tested?

not need.
