### PR TITLE
HDDS-4227. Implement a 'Prepare For Upgrade' step in OM that applies all committed Ratis transactions.

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -188,6 +188,14 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>hamcrest-all</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.codahale.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>3.0.2</version>
+      <scope>test</scope>
+      <!-- Needed for mocking RaftServerImpl -->
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisUpgradeUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisUpgradeUtils.java
@@ -51,9 +51,11 @@ public final class RatisUpgradeUtils {
       StateMachine stateMachine,
       RaftGroup raftGroup,
       RaftServerProxy server,
-      long maxTimeToWaitSeconds)
+      long maxTimeToWaitSeconds,
+      long timeBetweenRetryInSeconds)
       throws InterruptedException, IOException {
 
+    long intervalTime = TimeUnit.SECONDS.toMillis(timeBetweenRetryInSeconds);
     long endTime = System.currentTimeMillis() +
         TimeUnit.SECONDS.toMillis(maxTimeToWaitSeconds);
     boolean success = false;
@@ -62,12 +64,13 @@ public final class RatisUpgradeUtils {
       if (success) {
         break;
       }
-      Thread.sleep(5000L);
+      Thread.sleep(intervalTime);
     }
 
     if (!success) {
-      throw new IOException(String.format("After waiting for %d seconds, OM " +
-          "has not applied  all the transactions.", maxTimeToWaitSeconds));
+      throw new IOException(String.format("After waiting for %d seconds, " +
+          "State Machine has not applied  all the transactions.",
+          maxTimeToWaitSeconds));
     }
 
     long snapshotIndex = stateMachine.takeSnapshot();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisUpgradeUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisUpgradeUtils.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.hdds.ratis;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.server.impl.RaftServerImpl;
+import org.apache.ratis.server.impl.RaftServerProxy;
+import org.apache.ratis.statemachine.StateMachine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Ratis utility functions.
+ */
+public final class RatisUpgradeUtils {
+
+  private RatisUpgradeUtils() {
+  }
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(RatisUpgradeUtils.class);
+
+  /**
+   * Flush all committed transactions in a given Raft Server for a given group.
+   * @param stateMachine state machine to use
+   * @param raftGroup raft group
+   * @param server Raft server proxy instance.
+   * @param maxTimeToWaitSeconds Max time to wait before declaring failure.
+   * @throws InterruptedException when interrupted
+   * @throws IOException on error while waiting
+   */
+  public static void waitForAllTxnsApplied(
+      StateMachine stateMachine,
+      RaftGroup raftGroup,
+      RaftServerProxy server,
+      long maxTimeToWaitSeconds)
+      throws InterruptedException, IOException {
+
+    long endTime = System.currentTimeMillis() +
+        TimeUnit.SECONDS.toMillis(maxTimeToWaitSeconds);
+    boolean success = false;
+    while (System.currentTimeMillis() < endTime) {
+      success = checkIfAllTransactionsApplied(stateMachine, server, raftGroup);
+      if (success) {
+        break;
+      }
+      Thread.sleep(5000L);
+    }
+
+    if (!success) {
+      throw new IOException(String.format("After waiting for %d seconds, OM " +
+          "has not applied  all the transactions.", maxTimeToWaitSeconds));
+    }
+
+    long snapshotIndex = stateMachine.takeSnapshot();
+    if (snapshotIndex != stateMachine.getLastAppliedTermIndex().getIndex()) {
+      throw new IOException("Index from Snapshot does not match last applied " +
+          "Index");
+    }
+  }
+
+  private static boolean checkIfAllTransactionsApplied(
+      StateMachine stateMachine,
+      RaftServerProxy serverProxy,
+      RaftGroup raftGroup) throws IOException {
+    LOG.info("Checking for pending transactions to be applied.");
+    RaftServerImpl impl = serverProxy.getImpl(raftGroup.getGroupId());
+    long lastCommittedIndex = impl.getState().getLog().getLastCommittedIndex();
+    long appliedIndex = stateMachine.getLastAppliedTermIndex().getIndex();
+    LOG.info("lastCommittedIndex = {}, appliedIndex = {}",
+        lastCommittedIndex, appliedIndex);
+    return (lastCommittedIndex == appliedIndex);
+  }
+
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestRatisUpgradeUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestRatisUpgradeUtils.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.hdds.ratis;
+
+import static org.apache.hadoop.hdds.ratis.RatisUpgradeUtils.waitForAllTxnsApplied;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.apache.hadoop.test.LambdaTestUtils;
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.server.impl.RaftServerImpl;
+import org.apache.ratis.server.impl.RaftServerProxy;
+import org.apache.ratis.server.impl.ServerState;
+import org.apache.ratis.server.protocol.TermIndex;
+import org.apache.ratis.server.raftlog.RaftLog;
+import org.apache.ratis.statemachine.StateMachine;
+import org.junit.Test;
+
+/**
+ * Testing util methods in TestRatisUpgradeUtils.
+ */
+public class TestRatisUpgradeUtils {
+
+  @Test
+  public void testWaitForAllTxnsApplied() throws IOException,
+      InterruptedException {
+
+    StateMachine stateMachine = mock(StateMachine.class);
+    RaftGroup raftGroup = RaftGroup.emptyGroup();
+    RaftServerProxy raftServerProxy = mock(RaftServerProxy.class);
+    RaftServerImpl raftServer = mock(RaftServerImpl.class);
+    ServerState serverState = mock(ServerState.class);
+    RaftLog raftLog = mock(RaftLog.class);
+
+    when(raftServerProxy.getImpl(
+        raftGroup.getGroupId())).thenReturn(raftServer);
+    when(raftServer.getState()).thenReturn(serverState);
+    when(serverState.getLog()).thenReturn(raftLog);
+    when(raftLog.getLastCommittedIndex()).thenReturn(1L);
+
+    TermIndex termIndex = mock(TermIndex.class);
+    when(termIndex.getIndex()).thenReturn(0L).thenReturn(0L).thenReturn(1L);
+    when(stateMachine.getLastAppliedTermIndex()).thenReturn(termIndex);
+    when(stateMachine.takeSnapshot()).thenReturn(1L);
+
+    waitForAllTxnsApplied(stateMachine, raftGroup, raftServerProxy, 10, 2);
+    verify(stateMachine.getLastAppliedTermIndex(),
+        times(4)); // 3 checks + 1 after snapshot
+  }
+
+  @Test
+  public void testWaitForAllTxnsAppliedTimeOut() throws Exception {
+
+    StateMachine stateMachine = mock(StateMachine.class);
+    RaftGroup raftGroup = RaftGroup.emptyGroup();
+    RaftServerProxy raftServerProxy = mock(RaftServerProxy.class);
+    RaftServerImpl raftServer = mock(RaftServerImpl.class);
+    ServerState serverState = mock(ServerState.class);
+    RaftLog raftLog = mock(RaftLog.class);
+
+    when(raftServerProxy.getImpl(
+        raftGroup.getGroupId())).thenReturn(raftServer);
+    when(raftServer.getState()).thenReturn(serverState);
+    when(serverState.getLog()).thenReturn(raftLog);
+    when(raftLog.getLastCommittedIndex()).thenReturn(1L);
+
+    TermIndex termIndex = mock(TermIndex.class);
+    when(termIndex.getIndex()).thenReturn(0L);
+    when(stateMachine.getLastAppliedTermIndex()).thenReturn(termIndex);
+    when(stateMachine.takeSnapshot()).thenReturn(1L);
+
+    LambdaTestUtils.intercept(IOException.class, "State Machine has not " +
+        "applied  all the transactions", () ->
+        waitForAllTxnsApplied(stateMachine, raftGroup, raftServerProxy,
+            10, 2));
+  }
+
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -249,6 +249,5 @@ public final class OMConfigKeys {
 
   public static final long OZONE_OM_MAX_TIME_TO_WAIT_FLUSH_TXNS =
       TimeUnit.MINUTES.toSeconds(5);
-  public static final long OZONE_OM_FLUSH_TXNS_RETRY_INTERVAL_SECONDS =
-      TimeUnit.SECONDS.toMillis(5);
+  public static final long OZONE_OM_FLUSH_TXNS_RETRY_INTERVAL_SECONDS = 5L;
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -246,4 +246,9 @@ public final class OMConfigKeys {
       "ozone.om.enable.filesystem.paths";
   public static final boolean OZONE_OM_ENABLE_FILESYSTEM_PATHS_DEFAULT =
       false;
+
+  public static final long OZONE_OM_MAX_TIME_TO_WAIT_FLUSH_TXNS =
+      TimeUnit.MINUTES.toSeconds(5);
+  public static final long OZONE_OM_FLUSH_TXNS_RETRY_INTERVAL_SECONDS =
+      TimeUnit.SECONDS.toMillis(5);
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStarterInterface.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStarterInterface.java
@@ -30,4 +30,6 @@ public interface OMStarterInterface {
       AuthenticationException;
   boolean init(OzoneConfiguration conf) throws IOException,
       AuthenticationException;
+  boolean prepareForUpgrade(OzoneConfiguration conf) throws IOException,
+      AuthenticationException;
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
@@ -98,6 +98,28 @@ public class OzoneManagerStarter extends GenericCli {
     }
   }
 
+
+  /**
+   * This function implements a sub-command to allow the OM to be
+   * "prepared for upgrade".
+   */
+  @CommandLine.Command(name = "--prepareForUpgrade",
+      aliases = {"--prepareForDowngrade", "--flushTransactions"},
+      customSynopsis = "ozone om [global options] --prepareForUpgrade",
+      hidden = false,
+      description = "Prepare the OM for upgrade/downgrade. (Flush Raft log " +
+          "transactions.)",
+      mixinStandardHelpOptions = true,
+      versionProvider = HddsVersionProvider.class)
+  public void prepareOmForUpgrade() throws Exception {
+    commonInit();
+    boolean result = receiver.prepareForUpgrade(conf);
+    if (!result) {
+      throw new Exception("Prepare OM For Upgrade failed.");
+    }
+    System.exit(0);
+  }
+
   /**
    * This function should be called by each command to ensure the configuration
    * is set and print the startup banner message.
@@ -129,6 +151,22 @@ public class OzoneManagerStarter extends GenericCli {
     public boolean init(OzoneConfiguration conf) throws IOException,
         AuthenticationException {
       return OzoneManager.omInit(conf);
+    }
+
+    public boolean prepareForUpgrade(OzoneConfiguration conf)
+        throws IOException, AuthenticationException {
+      try (OzoneManager om = OzoneManager.createOmUpgradeMode(conf)) {
+        om.start();
+        boolean success = false;
+        try {
+          LOG.info("Preparing OM for upgrade.");
+          success = om.applyAllPendingTransactions();
+        } catch (InterruptedException e) {
+          LOG.error("Error preparing OM for upgrade.", e);
+          Thread.currentThread().interrupt();
+        }
+        return success;
+      }
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -319,7 +319,7 @@ public final class OzoneManagerDoubleBuffer {
 
           if (LOG.isDebugEnabled()) {
             LOG.debug("Sync Iteration {} flushed transactions in this " +
-                    "iteration{}", flushIterations.get(),
+                    "iteration {}", flushIterations.get(),
                 flushedTransactionsSize);
           }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -698,4 +698,8 @@ public final class OzoneManagerRatisServer {
   public TermIndex getLastAppliedTermIndex() {
     return omStateMachine.getLastAppliedTermIndex();
   }
+
+  public RaftServer getServer() {
+    return server;
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerStarter.java
@@ -133,6 +133,8 @@ public class TestOzoneManagerStarter {
     private boolean initStatus = true;
     private boolean throwOnStart = false;
     private boolean throwOnInit = false;
+    private boolean prepareUpgradeCalled = false;
+    private boolean throwOnPrepareUpgrade = false;
 
     public void start(OzoneConfiguration conf) throws IOException,
         AuthenticationException {
@@ -149,6 +151,15 @@ public class TestOzoneManagerStarter {
         throw new IOException("Simulated Exception");
       }
       return initStatus;
+    }
+
+    public boolean prepareForUpgrade(OzoneConfiguration conf)
+        throws IOException, AuthenticationException {
+      prepareUpgradeCalled = true;
+      if (throwOnPrepareUpgrade) {
+        throw new IOException("Simulated Exception");
+      }
+      return true;
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Through HDDS-4143, we have a generic factory to handle multiple versions of apply transaction implementations based on layout version. Hence, this factory can be used to handle versioned requests across layout versions, whenever both the versions need to exist in the code (Let's say for HDDS-2939).

However, it has been noticed that the OM ratis requests are still undergoing lot of minor changes (HDDS-4006, HDDS-4007, HDDS-3903), and in these cases it will become hard to maintain 2 versions of the code just to support clean upgrades.

Hence, this patch adds a pre-upgrade utility (client API) that makes sure that an OM instance has no "un-applied" transactions in its Raft log. Invoking this client API before updating the software version makes sure that the upgrade starts with a clean state. Of course, this would be needed only in a HA setup. In a non HA setup, this can either be skipped, or when invoked will be a No-Op (Non Ratis) or cause no harm (Single node Ratis).

More details in JIRA.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4227

## How was this patch tested?
Manually tested.
Unit/Acceptance tests pending.