### PR TITLE
HDDS-4254. Bucket space: add usedBytes and update it when create and delete key.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -93,6 +93,11 @@ public class OzoneBucket extends WithMetadata {
   private int listCacheSize;
 
   /**
+   * Used bytes of the bucket.
+   */
+  private long usedBytes;
+
+  /**
    * Creation time of the bucket.
    */
   private Instant creationTime;
@@ -171,6 +176,18 @@ public class OzoneBucket extends WithMetadata {
       String sourceVolume, String sourceBucket) {
     this(conf, proxy, volumeName, bucketName, storageType, versioning,
         creationTime, metadata, encryptionKeyName, sourceVolume, sourceBucket);
+    this.modificationTime = Instant.ofEpochMilli(modificationTime);
+  }
+
+  @SuppressWarnings("parameternumber")
+  public OzoneBucket(ConfigurationSource conf, ClientProtocol proxy,
+      String volumeName, String bucketName, StorageType storageType,
+      Boolean versioning, long creationTime, long modificationTime,
+      Map<String, String> metadata, String encryptionKeyName,
+      String sourceVolume, String sourceBucket, long usedBytes) {
+    this(conf, proxy, volumeName, bucketName, storageType, versioning,
+        creationTime, metadata, encryptionKeyName, sourceVolume, sourceBucket);
+    this.usedBytes = usedBytes;
     this.modificationTime = Instant.ofEpochMilli(modificationTime);
   }
 
@@ -414,6 +431,10 @@ public class OzoneBucket extends WithMetadata {
    */
   public OzoneKeyDetails getKey(String key) throws IOException {
     return proxy.getKeyDetails(volumeName, name, key);
+  }
+
+  public long getUsedBytes() {
+    return usedBytes;
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -634,7 +634,8 @@ public class RpcClient implements ClientProtocol {
         bucketInfo.getEncryptionKeyInfo() != null ? bucketInfo
             .getEncryptionKeyInfo().getKeyName() : null,
         bucketInfo.getSourceVolume(),
-        bucketInfo.getSourceBucket()
+        bucketInfo.getSourceBucket(),
+        bucketInfo.getUsedBytes().sum()
     );
   }
 
@@ -658,7 +659,8 @@ public class RpcClient implements ClientProtocol {
         bucket.getEncryptionKeyInfo() != null ? bucket
             .getEncryptionKeyInfo().getKeyName() : null,
         bucket.getSourceVolume(),
-        bucket.getSourceBucket()))
+        bucket.getSourceBucket(),
+        bucket.getUsedBytes().sum()))
         .collect(Collectors.toList());
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -708,7 +708,8 @@ public abstract class TestOzoneRpcClientAbstract {
   }
 
   @Test
-  public void testUsedBytes() throws IOException {
+  @SuppressWarnings("methodlength")
+  public void testVolumeAndBucketUsedBytes() throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     OzoneVolume volume = null;
@@ -947,7 +948,7 @@ public abstract class TestOzoneRpcClientAbstract {
   }
 
   @Test
-  public void testVolumeQuotaWithUploadPart() throws IOException {
+  public void testUsedBytesWithUploadPart() throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     String keyName = UUID.randomUUID().toString();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -708,10 +708,11 @@ public abstract class TestOzoneRpcClientAbstract {
   }
 
   @Test
-  public void testVolumeUsedBytes() throws IOException {
+  public void testUsedBytes() throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     OzoneVolume volume = null;
+    OzoneBucket bucket = null;
 
     int blockSize = (int) ozoneManager.getConfiguration().getStorageSize(
         OZONE_SCM_BLOCK_SIZE, OZONE_SCM_BLOCK_SIZE_DEFAULT, StorageUnit.BYTES);
@@ -727,13 +728,15 @@ public abstract class TestOzoneRpcClientAbstract {
     // The initial value should be 0
     Assert.assertEquals(0L, volume.getUsedBytes());
     volume.createBucket(bucketName);
-    OzoneBucket bucket = volume.getBucket(bucketName);
+    bucket = volume.getBucket(bucketName);
 
     //Case1: Test the volumeUsedBytes of ONE replications.
     String keyName1 = UUID.randomUUID().toString();
     writeKey(bucket, keyName1, ONE, value, valueLength);
     volume = store.getVolume(volumeName);
+    bucket = volume.getBucket(bucketName);
     Assert.assertEquals(valueLength, volume.getUsedBytes());
+    Assert.assertEquals(valueLength, bucket.getUsedBytes());
     currentQuotaUsage += valueLength;
 
     // Case2: Test overwrite the same KeyName under ONE Replicates, the
@@ -743,16 +746,22 @@ public abstract class TestOzoneRpcClientAbstract {
     // Overwrite the keyName2
     writeKey(bucket, keyName2, ONE, value, valueLength);
     volume = store.getVolume(volumeName);
+    bucket = volume.getBucket(bucketName);
     Assert.assertEquals(valueLength * 2 + currentQuotaUsage,
         volume.getUsedBytes());
+    Assert.assertEquals(valueLength * 2 + currentQuotaUsage,
+        bucket.getUsedBytes());
     currentQuotaUsage += valueLength * 2;
 
     // Case3: Test the volumeUsedBytes of THREE replications.
     String keyName3 = UUID.randomUUID().toString();
     writeKey(bucket, keyName3, THREE, value, valueLength);
     volume = store.getVolume(volumeName);
+    bucket = volume.getBucket(bucketName);
     Assert.assertEquals(valueLength * 3 + currentQuotaUsage,
         volume.getUsedBytes());
+    Assert.assertEquals(valueLength * 3 + currentQuotaUsage,
+        bucket.getUsedBytes());
     currentQuotaUsage += valueLength * 3;
 
     // Case4: Test overwrite the same KeyName under THREE Replicates, the
@@ -762,8 +771,11 @@ public abstract class TestOzoneRpcClientAbstract {
     // Overwrite the keyName4
     writeKey(bucket, keyName4, THREE, value, valueLength);
     volume = store.getVolume(volumeName);
+    bucket = volume.getBucket(bucketName);
     Assert.assertEquals(valueLength * 3 * 2 + currentQuotaUsage,
         volume.getUsedBytes());
+    Assert.assertEquals(valueLength * 3 * 2 + currentQuotaUsage,
+        bucket.getUsedBytes());
     currentQuotaUsage += valueLength * 3 * 2;
 
     //Case5: Do not specify the value Length, simulate HDFS api writing.
@@ -771,8 +783,11 @@ public abstract class TestOzoneRpcClientAbstract {
     String keyName5 = UUID.randomUUID().toString();
     writeFile(bucket, keyName5, ONE, value, 0);
     volume = store.getVolume(volumeName);
+    bucket = volume.getBucket(bucketName);
     Assert.assertEquals(valueLength + currentQuotaUsage,
         volume.getUsedBytes());
+    Assert.assertEquals(valueLength + currentQuotaUsage,
+        bucket.getUsedBytes());
     currentQuotaUsage += valueLength;
 
     // Case6: Do not specify the value Length, simulate HDFS api writing.
@@ -783,8 +798,11 @@ public abstract class TestOzoneRpcClientAbstract {
     // Overwrite the keyName6
     writeFile(bucket, keyName6, ONE, value, 0);
     volume = store.getVolume(volumeName);
+    bucket = volume.getBucket(bucketName);
     Assert.assertEquals(valueLength * 2 + currentQuotaUsage,
         volume.getUsedBytes());
+    Assert.assertEquals(valueLength * 2 + currentQuotaUsage,
+        bucket.getUsedBytes());
     currentQuotaUsage += valueLength * 2;
 
     // Case7: Do not specify the value Length, simulate HDFS api writing.
@@ -792,8 +810,11 @@ public abstract class TestOzoneRpcClientAbstract {
     String keyName7 = UUID.randomUUID().toString();
     writeFile(bucket, keyName7, THREE, value, 0);
     volume = store.getVolume(volumeName);
+    bucket = volume.getBucket(bucketName);
     Assert.assertEquals(valueLength * 3 + currentQuotaUsage,
         volume.getUsedBytes());
+    Assert.assertEquals(valueLength * 3 + currentQuotaUsage,
+        bucket.getUsedBytes());
     currentQuotaUsage += valueLength * 3;
 
     // Case8: Do not specify the value Length, simulate HDFS api writing.
@@ -804,23 +825,32 @@ public abstract class TestOzoneRpcClientAbstract {
     // Overwrite the keyName8
     writeFile(bucket, keyName8, THREE, value, 0);
     volume = store.getVolume(volumeName);
+    bucket = volume.getBucket(bucketName);
     Assert.assertEquals(valueLength * 3 * 2 + currentQuotaUsage,
         volume.getUsedBytes());
+    Assert.assertEquals(valueLength * 3 * 2 + currentQuotaUsage,
+        bucket.getUsedBytes());
     currentQuotaUsage += valueLength * 3 * 2;
 
     // Case9: Test volumeUsedBytes when delete key of ONE replications.
     bucket.deleteKey(keyName1);
     volume = store.getVolume(volumeName);
+    bucket = volume.getBucket(bucketName);
     Assert.assertEquals(currentQuotaUsage - valueLength,
         volume.getUsedBytes());
+    Assert.assertEquals(currentQuotaUsage - valueLength,
+        bucket.getUsedBytes());
     currentQuotaUsage -= valueLength;
 
     // Case10: Test volumeUsedBytes when delete key of THREE
     // replications.
     bucket.deleteKey(keyName3);
     volume = store.getVolume(volumeName);
+    bucket = volume.getBucket(bucketName);
     Assert.assertEquals(currentQuotaUsage - valueLength * 3,
         volume.getUsedBytes());
+    Assert.assertEquals(currentQuotaUsage - valueLength * 3,
+        bucket.getUsedBytes());
     currentQuotaUsage -= valueLength * 3;
 
     // Case11: Test volumeUsedBytes when Test Delete keys. At this
@@ -834,7 +864,9 @@ public abstract class TestOzoneRpcClientAbstract {
     keyList.add(keyName8);
     bucket.deleteKeys(keyList);
     volume = store.getVolume(volumeName);
+    bucket = volume.getBucket(bucketName);
     Assert.assertEquals(0, volume.getUsedBytes());
+    Assert.assertEquals(0, bucket.getUsedBytes());
   }
 
   @Test
@@ -949,10 +981,14 @@ public abstract class TestOzoneRpcClientAbstract {
 
     Assert.assertEquals(valueLength, store.getVolume(volumeName)
         .getUsedBytes());
+    Assert.assertEquals(valueLength, store.getVolume(volumeName)
+        .getBucket(bucketName).getUsedBytes());
 
     // Abort uploaded partKey and the usedBytes of volume should be 0.
     bucket.abortMultipartUpload(keyName, uploadID);
     Assert.assertEquals(0, store.getVolume(volumeName).getUsedBytes());
+    Assert.assertEquals(0, store.getVolume(volumeName)
+        .getBucket(bucketName).getUsedBytes());
   }
 
   @Test

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -499,6 +499,7 @@ message BucketInfo {
     optional uint64 modificationTime = 11;
     optional string sourceVolume = 12;
     optional string sourceBucket = 13;
+    optional uint64 usedBytes = 14;
 }
 
 enum StorageTypeProto {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -565,4 +565,19 @@ public abstract class OMKeyRequest extends OMClientRequest {
         new CacheKey<>(omMetadataManager.getVolumeKey(volume)))
         .getCacheValue();
   }
+
+  /**
+   * Return bucket info for the specified bucket.
+   * @param omMetadataManager
+   * @param volume
+   * @param bucket
+   * @return OmVolumeArgs
+   * @throws IOException
+   */
+  protected OmBucketInfo getBucketInfo(OMMetadataManager omMetadataManager,
+      String volume, String bucket) {
+    return omMetadataManager.getBucketTable().getCacheValue(
+        new CacheKey<>(omMetadataManager.getBucketKey(volume, bucket)))
+        .getCacheValue();
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.ResolvedBucket;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
@@ -156,6 +157,8 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
 
       long quotaReleased = 0;
       OmVolumeArgs omVolumeArgs = getVolumeInfo(omMetadataManager, volumeName);
+      OmBucketInfo omBucketInfo =
+          getBucketInfo(omMetadataManager, volumeName, bucketName);
 
       // Mark all keys which can be deleted, in cache as deleted.
       for (OmKeyInfo omKeyInfo : omKeyInfoList) {
@@ -173,13 +176,14 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
       }
       // update usedBytes atomically.
       omVolumeArgs.getUsedBytes().add(-quotaReleased);
+      omBucketInfo.getUsedBytes().add(-quotaReleased);
 
       omClientResponse = new OMKeysDeleteResponse(omResponse
           .setDeleteKeysResponse(DeleteKeysResponse.newBuilder()
               .setStatus(deleteStatus).setUnDeletedKeys(unDeletedKeys))
           .setStatus(deleteStatus ? OK : PARTIAL_DELETE)
           .setSuccess(deleteStatus).build(), omKeyInfoList, trxnLogIndex,
-          ozoneManager.isRatisEnabled(), omVolumeArgs);
+          ozoneManager.isRatisEnabled(), omVolumeArgs, omBucketInfo);
 
       result = Result.SUCCESS;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponse.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.response.file;
 
 import javax.annotation.Nonnull;
 
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.response.key.OMKeyCreateResponse;
@@ -35,9 +36,10 @@ public class OMFileCreateResponse extends OMKeyCreateResponse {
 
   public OMFileCreateResponse(@Nonnull OMResponse omResponse,
       @Nonnull OmKeyInfo omKeyInfo, @Nonnull List<OmKeyInfo> parentKeyInfos,
-      long openKeySessionID, OmVolumeArgs omVolumeArgs) {
+      long openKeySessionID, @Nonnull OmVolumeArgs omVolumeArgs,
+      @Nonnull OmBucketInfo omBucketInfo) {
     super(omResponse, omKeyInfo, parentKeyInfos, openKeySessionID,
-        omVolumeArgs);
+        omVolumeArgs, omBucketInfo);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMAllocateBlockResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMAllocateBlockResponse.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.om.response.key;
 
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
@@ -41,13 +42,16 @@ public class OMAllocateBlockResponse extends OMClientResponse {
   private OmKeyInfo omKeyInfo;
   private long clientID;
   private OmVolumeArgs omVolumeArgs;
+  private OmBucketInfo omBucketInfo;
 
   public OMAllocateBlockResponse(@Nonnull OMResponse omResponse,
-      @Nonnull OmKeyInfo omKeyInfo, long clientID, OmVolumeArgs omVolumeArgs) {
+      @Nonnull OmKeyInfo omKeyInfo, long clientID,
+      @Nonnull OmVolumeArgs omVolumeArgs, @Nonnull OmBucketInfo omBucketInfo) {
     super(omResponse);
     this.omKeyInfo = omKeyInfo;
     this.clientID = clientID;
     this.omVolumeArgs = omVolumeArgs;
+    this.omBucketInfo = omBucketInfo;
   }
 
   /**
@@ -72,5 +76,10 @@ public class OMAllocateBlockResponse extends OMClientResponse {
     omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
         omMetadataManager.getVolumeKey(omVolumeArgs.getVolume()),
         omVolumeArgs);
+    // update bucket usedBytes.
+    omMetadataManager.getBucketTable().putWithBatch(batchOperation,
+        omMetadataManager.getBucketKey(omVolumeArgs.getVolume(),
+            omBucketInfo.getBucketName()),
+        omBucketInfo);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMAllocateBlockResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMAllocateBlockResponse.java
@@ -79,7 +79,6 @@ public class OMAllocateBlockResponse extends OMClientResponse {
     // update bucket usedBytes.
     omMetadataManager.getBucketTable().putWithBatch(batchOperation,
         omMetadataManager.getBucketKey(omVolumeArgs.getVolume(),
-            omBucketInfo.getBucketName()),
-        omBucketInfo);
+            omBucketInfo.getBucketName()), omBucketInfo);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
@@ -83,8 +83,7 @@ public class OMKeyCommitResponse extends OMClientResponse {
     // update bucket usedBytes.
     omMetadataManager.getBucketTable().putWithBatch(batchOperation,
         omMetadataManager.getBucketKey(omVolumeArgs.getVolume(),
-            omBucketInfo.getBucketName()),
-        omBucketInfo);
+            omBucketInfo.getBucketName()), omBucketInfo);
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponse.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.om.response.key;
 
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
@@ -42,15 +43,17 @@ public class OMKeyCommitResponse extends OMClientResponse {
   private String ozoneKeyName;
   private String openKeyName;
   private OmVolumeArgs omVolumeArgs;
+  private OmBucketInfo omBucketInfo;
 
   public OMKeyCommitResponse(@Nonnull OMResponse omResponse,
       @Nonnull OmKeyInfo omKeyInfo, String ozoneKeyName, String openKeyName,
-      OmVolumeArgs omVolumeArgs) {
+      @Nonnull OmVolumeArgs omVolumeArgs, @Nonnull OmBucketInfo omBucketInfo) {
     super(omResponse);
     this.omKeyInfo = omKeyInfo;
     this.ozoneKeyName = ozoneKeyName;
     this.openKeyName = openKeyName;
     this.omVolumeArgs = omVolumeArgs;
+    this.omBucketInfo = omBucketInfo;
   }
 
   /**
@@ -77,6 +80,11 @@ public class OMKeyCommitResponse extends OMClientResponse {
     omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
         omMetadataManager.getVolumeKey(omVolumeArgs.getVolume()),
         omVolumeArgs);
+    // update bucket usedBytes.
+    omMetadataManager.getBucketTable().putWithBatch(batchOperation,
+        omMetadataManager.getBucketKey(omVolumeArgs.getVolume(),
+            omBucketInfo.getBucketName()),
+        omBucketInfo);
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCreateResponse.java
@@ -23,6 +23,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
@@ -47,15 +48,18 @@ public class OMKeyCreateResponse extends OMClientResponse {
   private long openKeySessionID;
   private List<OmKeyInfo> parentKeyInfos;
   private OmVolumeArgs omVolumeArgs;
+  private OmBucketInfo omBucketInfo;
 
   public OMKeyCreateResponse(@Nonnull OMResponse omResponse,
       @Nonnull OmKeyInfo omKeyInfo, List<OmKeyInfo> parentKeyInfos,
-      long openKeySessionID, OmVolumeArgs omVolumeArgs) {
+      long openKeySessionID, @Nonnull OmVolumeArgs omVolumeArgs,
+      @Nonnull OmBucketInfo omBucketInfo) {
     super(omResponse);
     this.omKeyInfo = omKeyInfo;
     this.openKeySessionID = openKeySessionID;
     this.parentKeyInfos = parentKeyInfos;
     this.omVolumeArgs = omVolumeArgs;
+    this.omBucketInfo = omBucketInfo;
   }
 
   /**
@@ -99,6 +103,11 @@ public class OMKeyCreateResponse extends OMClientResponse {
     omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
         omMetadataManager.getVolumeKey(omVolumeArgs.getVolume()),
         omVolumeArgs);
+    // update bucket usedBytes.
+    omMetadataManager.getBucketTable().putWithBatch(batchOperation,
+        omMetadataManager.getBucketKey(omVolumeArgs.getVolume(),
+            omBucketInfo.getBucketName()),
+        omBucketInfo);
   }
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCreateResponse.java
@@ -106,8 +106,7 @@ public class OMKeyCreateResponse extends OMClientResponse {
     // update bucket usedBytes.
     omMetadataManager.getBucketTable().putWithBatch(batchOperation,
         omMetadataManager.getBucketKey(omVolumeArgs.getVolume(),
-            omBucketInfo.getBucketName()),
-        omBucketInfo);
+            omBucketInfo.getBucketName()), omBucketInfo);
   }
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponse.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.response.key;
 
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
@@ -46,14 +47,16 @@ public class OMKeyDeleteResponse extends OMClientResponse {
   private OmKeyInfo omKeyInfo;
   private boolean isRatisEnabled;
   private OmVolumeArgs omVolumeArgs;
+  private OmBucketInfo omBucketInfo;
 
   public OMKeyDeleteResponse(@Nonnull OMResponse omResponse,
       @Nonnull OmKeyInfo omKeyInfo, boolean isRatisEnabled,
-      @Nonnull OmVolumeArgs omVolumeArgs) {
+      @Nonnull OmVolumeArgs omVolumeArgs, @Nonnull OmBucketInfo omBucketInfo) {
     super(omResponse);
     this.omKeyInfo = omKeyInfo;
     this.isRatisEnabled = isRatisEnabled;
     this.omVolumeArgs = omVolumeArgs;
+    this.omBucketInfo = omBucketInfo;
   }
 
   /**
@@ -98,6 +101,11 @@ public class OMKeyDeleteResponse extends OMClientResponse {
       omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
           omMetadataManager.getVolumeKey(omVolumeArgs.getVolume()),
           omVolumeArgs);
+      // update bucket usedBytes.
+      omMetadataManager.getBucketTable().putWithBatch(batchOperation,
+          omMetadataManager.getBucketKey(omVolumeArgs.getVolume(),
+              omBucketInfo.getBucketName()),
+          omBucketInfo);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponse.java
@@ -104,8 +104,7 @@ public class OMKeyDeleteResponse extends OMClientResponse {
       // update bucket usedBytes.
       omMetadataManager.getBucketTable().putWithBatch(batchOperation,
           omMetadataManager.getBucketKey(omVolumeArgs.getVolume(),
-              omBucketInfo.getBucketName()),
-          omBucketInfo);
+              omBucketInfo.getBucketName()), omBucketInfo);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponse.java
@@ -120,7 +120,6 @@ public class OMKeysDeleteResponse extends OMClientResponse {
     // update bucket usedBytes.
     omMetadataManager.getBucketTable().putWithBatch(batchOperation,
         omMetadataManager.getBucketKey(omVolumeArgs.getVolume(),
-            omBucketInfo.getBucketName()),
-        omBucketInfo);
+            omBucketInfo.getBucketName()), omBucketInfo);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponse.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.om.response.key;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
@@ -45,15 +46,18 @@ public class OMKeysDeleteResponse extends OMClientResponse {
   private boolean isRatisEnabled;
   private long trxnLogIndex;
   private OmVolumeArgs omVolumeArgs;
+  private OmBucketInfo omBucketInfo;
 
   public OMKeysDeleteResponse(@Nonnull OMResponse omResponse,
       @Nonnull List<OmKeyInfo> keyDeleteList, long trxnLogIndex,
-      boolean isRatisEnabled, OmVolumeArgs omVolumeArgs) {
+      boolean isRatisEnabled, @Nonnull OmVolumeArgs omVolumeArgs,
+      @Nonnull OmBucketInfo omBucketInfo) {
     super(omResponse);
     this.omKeyInfoList = keyDeleteList;
     this.isRatisEnabled = isRatisEnabled;
     this.trxnLogIndex = trxnLogIndex;
     this.omVolumeArgs = omVolumeArgs;
+    this.omBucketInfo = omBucketInfo;
   }
 
   /**
@@ -113,5 +117,10 @@ public class OMKeysDeleteResponse extends OMClientResponse {
     omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
         omMetadataManager.getVolumeKey(omVolumeArgs.getVolume()),
         omVolumeArgs);
+    // update bucket usedBytes.
+    omMetadataManager.getBucketTable().putWithBatch(batchOperation,
+        omMetadataManager.getBucketKey(omVolumeArgs.getVolume(),
+            omBucketInfo.getBucketName()),
+        omBucketInfo);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponse.java
@@ -111,8 +111,7 @@ public class S3MultipartUploadAbortResponse extends OMClientResponse {
       // update bucket usedBytes.
       omMetadataManager.getBucketTable().putWithBatch(batchOperation,
           omMetadataManager.getBucketKey(omVolumeArgs.getVolume(),
-              omBucketInfo.getBucketName()),
-          omBucketInfo);
+              omBucketInfo.getBucketName()), omBucketInfo);
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponse.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.response.s3.multipart;
 
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
@@ -52,15 +53,18 @@ public class S3MultipartUploadAbortResponse extends OMClientResponse {
   private OmMultipartKeyInfo omMultipartKeyInfo;
   private boolean isRatisEnabled;
   private OmVolumeArgs omVolumeArgs;
+  private OmBucketInfo omBucketInfo;
 
   public S3MultipartUploadAbortResponse(@Nonnull OMResponse omResponse,
       String multipartKey, @Nonnull OmMultipartKeyInfo omMultipartKeyInfo,
-      boolean isRatisEnabled, @Nonnull OmVolumeArgs omVolumeArgs) {
+      boolean isRatisEnabled, @Nonnull OmVolumeArgs omVolumeArgs,
+      @Nonnull OmBucketInfo omBucketInfo) {
     super(omResponse);
     this.multipartKey = multipartKey;
     this.omMultipartKeyInfo = omMultipartKeyInfo;
     this.isRatisEnabled = isRatisEnabled;
     this.omVolumeArgs = omVolumeArgs;
+    this.omBucketInfo = omBucketInfo;
   }
 
   /**
@@ -104,6 +108,11 @@ public class S3MultipartUploadAbortResponse extends OMClientResponse {
       omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
           omMetadataManager.getVolumeKey(omVolumeArgs.getVolume()),
           omVolumeArgs);
+      // update bucket usedBytes.
+      omMetadataManager.getBucketTable().putWithBatch(batchOperation,
+          omMetadataManager.getBucketKey(omVolumeArgs.getVolume(),
+              omBucketInfo.getBucketName()),
+          omBucketInfo);
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.response.s3.multipart;
 
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
@@ -58,6 +59,7 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
   private OmKeyInfo openPartKeyInfoToBeDeleted;
   private boolean isRatisEnabled;
   private OmVolumeArgs omVolumeArgs;
+  private OmBucketInfo omBucketInfo;
 
   /**
    * Regular response.
@@ -76,7 +78,8 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
       @Nullable OmMultipartKeyInfo omMultipartKeyInfo,
       @Nullable OzoneManagerProtocolProtos.PartKeyInfo oldPartKeyInfo,
       @Nullable OmKeyInfo openPartKeyInfoToBeDeleted,
-      boolean isRatisEnabled, OmVolumeArgs omVolumeArgs) {
+      boolean isRatisEnabled, @Nonnull OmVolumeArgs omVolumeArgs,
+      @Nonnull OmBucketInfo omBucketInfo) {
     super(omResponse);
     this.multipartKey = multipartKey;
     this.openKey = openKey;
@@ -85,6 +88,7 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
     this.openPartKeyInfoToBeDeleted = openPartKeyInfoToBeDeleted;
     this.isRatisEnabled = isRatisEnabled;
     this.omVolumeArgs = omVolumeArgs;
+    this.omBucketInfo = omBucketInfo;
   }
 
   @Override
@@ -151,6 +155,11 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
     omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
         omMetadataManager.getVolumeKey(omVolumeArgs.getVolume()),
         omVolumeArgs);
+    // update bucket usedBytes.
+    omMetadataManager.getBucketTable().putWithBatch(batchOperation,
+        omMetadataManager.getBucketKey(omVolumeArgs.getVolume(),
+            omBucketInfo.getBucketName()),
+        omBucketInfo);
   }
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
@@ -158,8 +158,7 @@ public class S3MultipartUploadCommitPartResponse extends OMClientResponse {
     // update bucket usedBytes.
     omMetadataManager.getBucketTable().putWithBatch(batchOperation,
         omMetadataManager.getBucketKey(omVolumeArgs.getVolume(),
-            omBucketInfo.getBucketName()),
-        omBucketInfo);
+            omBucketInfo.getBucketName()), omBucketInfo);
   }
 }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponse.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.util.Time;
 import org.junit.Assert;
@@ -26,10 +27,8 @@ import org.junit.Test;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .AllocateBlockResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .OMResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AllocateBlockResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 
 /**
  * Tests OMAllocateBlockResponse.
@@ -44,6 +43,9 @@ public class TestOMAllocateBlockResponse extends TestOMKeyResponse {
     OmVolumeArgs omVolumeArgs = OmVolumeArgs.newBuilder()
         .setOwnerName(keyName).setAdminName(keyName)
         .setVolume(volumeName).setCreationTime(Time.now()).build();
+    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName).setBucketName(bucketName)
+        .setCreationTime(Time.now()).build();
 
     OMResponse omResponse = OMResponse.newBuilder()
         .setAllocateBlockResponse(
@@ -53,7 +55,7 @@ public class TestOMAllocateBlockResponse extends TestOMKeyResponse {
         .build();
     OMAllocateBlockResponse omAllocateBlockResponse =
         new OMAllocateBlockResponse(omResponse, omKeyInfo, clientID,
-            omVolumeArgs);
+            omVolumeArgs, omBucketInfo);
 
     String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,
         keyName, clientID);
@@ -75,6 +77,9 @@ public class TestOMAllocateBlockResponse extends TestOMKeyResponse {
     OmVolumeArgs omVolumeArgs = OmVolumeArgs.newBuilder()
         .setOwnerName(keyName).setAdminName(keyName)
         .setVolume(volumeName).setCreationTime(Time.now()).build();
+    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName).setBucketName(bucketName)
+        .setCreationTime(Time.now()).build();
 
     OMResponse omResponse = OMResponse.newBuilder()
         .setAllocateBlockResponse(
@@ -84,7 +89,7 @@ public class TestOMAllocateBlockResponse extends TestOMKeyResponse {
         .build();
     OMAllocateBlockResponse omAllocateBlockResponse =
         new OMAllocateBlockResponse(omResponse, omKeyInfo, clientID,
-            omVolumeArgs);
+            omVolumeArgs, omBucketInfo);
 
     // Before calling addToDBBatch
     String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.util.Time;
 import org.junit.Assert;
@@ -40,6 +41,9 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
     OmVolumeArgs omVolumeArgs = OmVolumeArgs.newBuilder()
         .setOwnerName(keyName).setAdminName(keyName)
         .setVolume(volumeName).setCreationTime(Time.now()).build();
+    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName).setBucketName(bucketName)
+        .setCreationTime(Time.now()).build();
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
         OzoneManagerProtocolProtos.OMResponse.newBuilder().setCommitKeyResponse(
@@ -60,7 +64,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
     String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
         keyName);
     OMKeyCommitResponse omKeyCommitResponse = new OMKeyCommitResponse(
-        omResponse, omKeyInfo, ozoneKey, openKey, omVolumeArgs);
+        omResponse, omKeyInfo, ozoneKey, openKey, omVolumeArgs, omBucketInfo);
 
     omKeyCommitResponse.addToDBBatch(omMetadataManager, batchOperation);
 
@@ -81,6 +85,9 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
     OmVolumeArgs omVolumeArgs = OmVolumeArgs.newBuilder()
         .setOwnerName(keyName).setAdminName(keyName)
         .setVolume(volumeName).setCreationTime(Time.now()).build();
+    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName).setBucketName(bucketName)
+        .setCreationTime(Time.now()).build();
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
         OzoneManagerProtocolProtos.OMResponse.newBuilder().setCommitKeyResponse(
@@ -95,7 +102,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
         keyName);
 
     OMKeyCommitResponse omKeyCommitResponse = new OMKeyCommitResponse(
-        omResponse, omKeyInfo, ozoneKey, openKey, omVolumeArgs);
+        omResponse, omKeyInfo, ozoneKey, openKey, omVolumeArgs, omBucketInfo);
 
     // As during commit Key, entry will be already there in openKeyTable.
     // Adding it here.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.util.Time;
 import org.junit.Assert;
@@ -46,6 +47,9 @@ public class TestOMKeyCreateResponse extends TestOMKeyResponse {
     OmVolumeArgs omVolumeArgs = OmVolumeArgs.newBuilder()
         .setOwnerName(keyName).setAdminName(keyName)
         .setVolume(volumeName).setCreationTime(Time.now()).build();
+    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName).setBucketName(bucketName)
+        .setCreationTime(Time.now()).build();
 
     OMResponse omResponse = OMResponse.newBuilder().setCreateKeyResponse(
                 CreateKeyResponse.getDefaultInstance())
@@ -55,7 +59,7 @@ public class TestOMKeyCreateResponse extends TestOMKeyResponse {
 
     OMKeyCreateResponse omKeyCreateResponse =
         new OMKeyCreateResponse(omResponse, omKeyInfo, null, clientID,
-            omVolumeArgs);
+            omVolumeArgs, omBucketInfo);
 
     String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,
         keyName, clientID);
@@ -76,6 +80,9 @@ public class TestOMKeyCreateResponse extends TestOMKeyResponse {
     OmVolumeArgs omVolumeArgs = OmVolumeArgs.newBuilder()
         .setOwnerName(keyName).setAdminName(keyName)
         .setVolume(volumeName).setCreationTime(Time.now()).build();
+    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName).setBucketName(bucketName)
+        .setCreationTime(Time.now()).build();
 
     OMResponse omResponse = OMResponse.newBuilder().setCreateKeyResponse(
         CreateKeyResponse.getDefaultInstance())
@@ -85,7 +92,7 @@ public class TestOMKeyCreateResponse extends TestOMKeyResponse {
 
     OMKeyCreateResponse omKeyCreateResponse =
         new OMKeyCreateResponse(omResponse, omKeyInfo, null, clientID,
-            omVolumeArgs);
+            omVolumeArgs, omBucketInfo);
 
     // Before calling addToDBBatch
     String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.om.response.key;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.util.Time;
@@ -47,6 +48,9 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
     OmVolumeArgs omVolumeArgs = OmVolumeArgs.newBuilder()
         .setOwnerName(keyName).setAdminName(keyName)
         .setVolume(volumeName).setCreationTime(Time.now()).build();
+    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName).setBucketName(bucketName)
+        .setCreationTime(Time.now()).build();
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
         OzoneManagerProtocolProtos.OMResponse.newBuilder().setDeleteKeyResponse(
@@ -56,7 +60,7 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
             .build();
 
     OMKeyDeleteResponse omKeyDeleteResponse = new OMKeyDeleteResponse(
-        omResponse, omKeyInfo, true, omVolumeArgs);
+        omResponse, omKeyInfo, true, omVolumeArgs, omBucketInfo);
 
     String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
         keyName);
@@ -86,6 +90,9 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
     OmVolumeArgs omVolumeArgs = OmVolumeArgs.newBuilder()
         .setOwnerName(keyName).setAdminName(keyName)
         .setVolume(volumeName).setCreationTime(Time.now()).build();
+    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName).setBucketName(bucketName)
+        .setCreationTime(Time.now()).build();
 
     // Add block to key.
     List<OmKeyLocationInfo> omKeyLocationInfoList = new ArrayList<>();
@@ -121,7 +128,7 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
             .build();
 
     OMKeyDeleteResponse omKeyDeleteResponse = new OMKeyDeleteResponse(
-        omResponse, omKeyInfo, true, omVolumeArgs);
+        omResponse, omKeyInfo, true, omVolumeArgs, omBucketInfo);
 
     Assert.assertTrue(omMetadataManager.getKeyTable().isExist(ozoneKey));
     omKeyDeleteResponse.addToDBBatch(omMetadataManager, batchOperation);
@@ -144,6 +151,9 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
     OmVolumeArgs omVolumeArgs = OmVolumeArgs.newBuilder()
         .setOwnerName(keyName).setAdminName(keyName)
         .setVolume(volumeName).setCreationTime(Time.now()).build();
+    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName).setBucketName(bucketName)
+        .setCreationTime(Time.now()).build();
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
         OzoneManagerProtocolProtos.OMResponse.newBuilder().setDeleteKeyResponse(
@@ -153,7 +163,7 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
             .build();
 
     OMKeyDeleteResponse omKeyDeleteResponse = new OMKeyDeleteResponse(
-        omResponse, omKeyInfo, true, omVolumeArgs);
+        omResponse, omKeyInfo, true, omVolumeArgs, omBucketInfo);
 
     String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
         keyName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponse.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
@@ -79,10 +80,13 @@ public class TestOMKeysDeleteResponse extends TestOMKeyResponse {
     OmVolumeArgs omVolumeArgs = OmVolumeArgs.newBuilder()
         .setOwnerName(keyName).setAdminName(keyName)
         .setVolume(volumeName).setCreationTime(Time.now()).build();
+    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName).setBucketName(bucketName)
+        .setCreationTime(Time.now()).build();
 
     OMClientResponse omKeysDeleteResponse = new OMKeysDeleteResponse(
         omResponse, omKeyInfoList, 10L, true,
-        omVolumeArgs);
+        omVolumeArgs, omBucketInfo);
 
     omKeysDeleteResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
 
@@ -114,10 +118,13 @@ public class TestOMKeysDeleteResponse extends TestOMKeyResponse {
     OmVolumeArgs omVolumeArgs = OmVolumeArgs.newBuilder()
         .setOwnerName(keyName).setAdminName(keyName)
         .setVolume(volumeName).setCreationTime(Time.now()).build();
+    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName).setBucketName(bucketName)
+        .setCreationTime(Time.now()).build();
 
     OMClientResponse omKeysDeleteResponse = new OMKeysDeleteResponse(
         omResponse, omKeyInfoList, 10L, true,
-        omVolumeArgs);
+        omVolumeArgs, omBucketInfo);
 
     omKeysDeleteResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.UUID;
 
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.junit.Before;
 import org.junit.Rule;
@@ -109,7 +110,8 @@ public class TestS3MultipartResponse {
 
   public S3MultipartUploadAbortResponse createS3AbortMPUResponse(
       String multipartKey, long timeStamp,
-      OmMultipartKeyInfo omMultipartKeyInfo, OmVolumeArgs omVolumeArgs) {
+      OmMultipartKeyInfo omMultipartKeyInfo, OmVolumeArgs omVolumeArgs,
+      OmBucketInfo omBucketInfo) {
     OMResponse omResponse = OMResponse.newBuilder()
         .setCmdType(OzoneManagerProtocolProtos.Type.AbortMultiPartUpload)
         .setStatus(OzoneManagerProtocolProtos.Status.OK)
@@ -118,7 +120,7 @@ public class TestS3MultipartResponse {
             MultipartUploadAbortResponse.newBuilder().build()).build();
 
     return new S3MultipartUploadAbortResponse(omResponse, multipartKey,
-        omMultipartKeyInfo, true, omVolumeArgs);
+        omMultipartKeyInfo, true, omVolumeArgs, omBucketInfo);
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponse.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.response.s3.multipart;
 
 import java.util.UUID;
 
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.junit.Assert;
@@ -50,6 +51,9 @@ public class TestS3MultipartUploadAbortResponse
     OmVolumeArgs omVolumeArgs = OmVolumeArgs.newBuilder()
         .setOwnerName(keyName).setAdminName(keyName)
         .setVolume(volumeName).setCreationTime(Time.now()).build();
+    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName).setBucketName(bucketName)
+        .setCreationTime(Time.now()).build();
     S3InitiateMultipartUploadResponse s3InitiateMultipartUploadResponse =
         createS3InitiateMPUResponse(volumeName, bucketName, keyName,
             multipartUploadID);
@@ -60,7 +64,7 @@ public class TestS3MultipartUploadAbortResponse
     S3MultipartUploadAbortResponse s3MultipartUploadAbortResponse =
         createS3AbortMPUResponse(multipartKey, Time.now(),
             s3InitiateMultipartUploadResponse.getOmMultipartKeyInfo(),
-            omVolumeArgs);
+            omVolumeArgs, omBucketInfo);
 
     s3MultipartUploadAbortResponse.addToDBBatch(omMetadataManager,
         batchOperation);
@@ -88,6 +92,9 @@ public class TestS3MultipartUploadAbortResponse
     OmVolumeArgs omVolumeArgs = OmVolumeArgs.newBuilder()
         .setOwnerName(keyName).setAdminName(keyName)
         .setVolume(volumeName).setCreationTime(Time.now()).build();
+    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName).setBucketName(bucketName)
+        .setCreationTime(Time.now()).build();
 
     S3InitiateMultipartUploadResponse s3InitiateMultipartUploadResponse =
         createS3InitiateMPUResponse(volumeName, bucketName, keyName,
@@ -117,7 +124,7 @@ public class TestS3MultipartUploadAbortResponse
     S3MultipartUploadAbortResponse s3MultipartUploadAbortResponse =
         createS3AbortMPUResponse(multipartKey, timeStamp,
             s3InitiateMultipartUploadResponse.getOmMultipartKeyInfo(),
-            omVolumeArgs);
+            omVolumeArgs, omBucketInfo);
 
     s3MultipartUploadAbortResponse.addToDBBatch(omMetadataManager,
         batchOperation);


### PR DESCRIPTION
## What changes were proposed in this pull request?

In addition, the current Quota setting does not take effect. HDDS-541 gives all the work needed to perfect Quota.
This PR is a subtask of HDDS-541.
First, we increase usedBytes of Bucket. Later, we will judge whether the Bucket can be written based on this when we write the key.
Volume has implemented increase usedBytes when write, and this is based on HDDS-4053.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4254

## How was this patch tested?

added UT
