### PR TITLE
HDDS-3727. Volume space: check quotaUsageInBytes when write key.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
@@ -229,7 +229,9 @@ public class OMException extends IOException {
 
     NOT_SUPPORTED_OPERATION,
 
-    PARTIAL_RENAME
+    PARTIAL_RENAME,
+
+    QUOTA_EXCEEDED
 
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -818,11 +818,11 @@ public class TestRootedOzoneFileSystem {
     VolumeArgs volumeArgs = new VolumeArgs.Builder()
         .setAcls(Collections.singletonList(aclWorldAccess))
         .setQuotaInCounts(1000)
-        .setQuotaInBytes("1MB").build();
+        .setQuotaInBytes("1TB").build();
     // Sanity check
     Assert.assertNull(volumeArgs.getOwner());
     Assert.assertNull(volumeArgs.getAdmin());
-    Assert.assertEquals("1MB", volumeArgs.getQuotaInBytes());
+    Assert.assertEquals("1TB", volumeArgs.getQuotaInBytes());
     Assert.assertEquals(1000, volumeArgs.getQuotaInCounts());
     Assert.assertEquals(0, volumeArgs.getMetadata().size());
     Assert.assertEquals(1, volumeArgs.getAcls().size());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -755,7 +755,7 @@ public abstract class TestOzoneRpcClientAbstract {
     try {
       OzoneOutputStream out = bucket.createKey(UUID.randomUUID().toString(),
           valueLength, STAND_ALONE, ONE, new HashMap<>());
-      for(int i=0; i <= blockSize/value.length(); i++) {
+      for (int i = 0; i <= blockSize / value.length(); i++) {
         out.write(value.getBytes());
       }
       out.close();
@@ -773,7 +773,7 @@ public abstract class TestOzoneRpcClientAbstract {
     try {
       OzoneOutputStream out = bucket.createKey(UUID.randomUUID().toString(),
           valueLength, STAND_ALONE, ONE, new HashMap<>());
-      for(int i=0; i <= (4 * blockSize)/value.length(); i++) {
+      for (int i = 0; i <= (4 * blockSize) / value.length(); i++) {
         out.write(value.getBytes());
       }
       out.close();
@@ -781,8 +781,7 @@ public abstract class TestOzoneRpcClientAbstract {
       countException++;
       GenericTestUtils.assertExceptionContains("QUOTA_EXCEEDED", ex);
     }
-    // AllocateBlock failed, volume usedBytes should be 4 * blockSize + 1 *
-    // blockSize = 5 * blockSize.
+    // AllocateBlock failed, volume usedBytes should be (4 + 1) * blockSize
     Assert.assertEquals(5 * blockSize,
         store.getVolume(volumeName).getUsedBytes());
 

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -314,6 +314,8 @@ enum Status {
 
     PARTIAL_RENAME = 65;
 
+    QUOTA_EXCEEDED = 66;
+
 }
 
 /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -283,9 +283,7 @@ public class OMFileCreateRequest extends OMKeyRequest {
       long preAllocatedSpace = newLocationList.size()
           * ozoneManager.getScmBlockSize()
           * omKeyInfo.getFactor().getNumber();
-      if (omVolumeArgs.getQuotaInBytes() > OzoneConsts.QUOTA_RESET) {
-        checkVolumeQuotaInBytes(omVolumeArgs, preAllocatedSpace);
-      }
+      checkVolumeQuotaInBytes(omVolumeArgs, preAllocatedSpace);
 
       // Add to cache entry can be done outside of lock for this openKey.
       // Even if bucket gets deleted, when commitKey we shall identify if

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -192,7 +192,6 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
             KEY_NOT_FOUND);
       }
 
-
       List<OmKeyLocationInfo> newLocationList = Collections.singletonList(
           OmKeyLocationInfo.getFromProtobuf(blockLocation));
       omVolumeArgs = getVolumeInfo(omMetadataManager, volumeName);
@@ -201,9 +200,7 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
       long preAllocatedSpace = newLocationList.size()
           * ozoneManager.getScmBlockSize()
           * openKeyInfo.getFactor().getNumber();
-      if (omVolumeArgs.getQuotaInBytes() > OzoneConsts.QUOTA_RESET) {
-        checkVolumeQuotaInBytes(omVolumeArgs, preAllocatedSpace);
-      }
+      checkVolumeQuotaInBytes(omVolumeArgs, preAllocatedSpace);
       // Append new block
       openKeyInfo.appendNewBlocks(newLocationList, false);
 
@@ -232,18 +229,6 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
     } catch (IOException ex) {
       omMetrics.incNumBlockAllocateCallFails();
       exception = ex;
-      if (exception.toString().contains(
-          OMException.ResultCodes.QUOTA_EXCEEDED.toString())) {
-        long keyAllocatedSpace = openKeyInfo.getLatestVersionLocations()
-            .getLocationListCount() * ozoneManager.getScmBlockSize()
-            * openKeyInfo.getFactor().getNumber();
-        // Update usedBytes atomically. ErrorOMResponse does not persist the DB,
-        // so we update the cache first. The next time another key is written,
-        // volume Args will be persisted to the DB.
-        // TODO: There is a delay in updating DB in this way, and if necessary
-        //  we can modify the ErrorOMResponse to avoid it.
-        omVolumeArgs.getUsedBytes().add(-keyAllocatedSpace);
-      }
       omClientResponse = new OMAllocateBlockResponse(createErrorOMResponse(
           omResponse, exception));
       LOG.error("Allocate Block failed. Volume:{}, Bucket:{}, OpenKey:{}. " +
@@ -258,5 +243,4 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
 
     return omClientResponse;
   }
-
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -29,6 +29,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
@@ -286,17 +287,8 @@ public class OMKeyCreateRequest extends OMKeyRequest {
           .collect(Collectors.toList());
       omKeyInfo.appendNewBlocks(newLocationList, false);
 
-      // Add to cache entry can be done outside of lock for this openKey.
-      // Even if bucket gets deleted, when commitKey we shall identify if
-      // bucket gets deleted.
-      omMetadataManager.getOpenKeyTable().addCacheEntry(
-          new CacheKey<>(dbOpenKeyName),
-          new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
-
-      long scmBlockSize = ozoneManager.getScmBlockSize();
       omVolumeArgs = getVolumeInfo(omMetadataManager, volumeName);
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
-
       // Here we refer to the implementation of HDFS:
       // If the key size is 600MB, when createKey, keyLocationInfo in
       // keyLocationList is 3, and  the every pre-allocated block length is
@@ -304,11 +296,23 @@ public class OMKeyCreateRequest extends OMKeyRequest {
       // ize is 256MB * 3 * 3. We will allocate more 256MB * 3 * 3 - 600mb * 3
       // = 504MB in advance, and we  will subtract this part when we finally
       // commitKey.
-      long preAllocatedSpace = newLocationList.size() * scmBlockSize
+      long preAllocatedSpace = newLocationList.size()
+          * ozoneManager.getScmBlockSize()
           * omKeyInfo.getFactor().getNumber();
+      // check volume quota
+      if (omVolumeArgs.getQuotaInBytes() > OzoneConsts.QUOTA_RESET) {
+        checkVolumeQuotaInBytes(omVolumeArgs, preAllocatedSpace);
+      }
+
+      // Add to cache entry can be done outside of lock for this openKey.
+      // Even if bucket gets deleted, when commitKey we shall identify if
+      // bucket gets deleted.
+      omMetadataManager.getOpenKeyTable().addCacheEntry(
+          new CacheKey<>(dbOpenKeyName),
+          new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
+
       omVolumeArgs.getUsedBytes().add(preAllocatedSpace);
       omBucketInfo.getUsedBytes().add(preAllocatedSpace);
-
 
       // Prepare response
       omResponse.setCreateKeyResponse(CreateKeyResponse.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -29,7 +29,6 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneAcl;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
@@ -300,9 +299,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
           * ozoneManager.getScmBlockSize()
           * omKeyInfo.getFactor().getNumber();
       // check volume quota
-      if (omVolumeArgs.getQuotaInBytes() > OzoneConsts.QUOTA_RESET) {
-        checkVolumeQuotaInBytes(omVolumeArgs, preAllocatedSpace);
-      }
+      checkVolumeQuotaInBytes(omVolumeArgs, preAllocatedSpace);
 
       // Add to cache entry can be done outside of lock for this openKey.
       // Even if bucket gets deleted, when commitKey we shall identify if

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -534,6 +534,26 @@ public abstract class OMKeyRequest extends OMClientRequest {
   }
 
   /**
+   * Check volume quota in bytes.
+   * @param omVolumeArgs
+   * @param allocateSize
+   * @throws IOException
+   */
+  protected void checkVolumeQuotaInBytes(OmVolumeArgs omVolumeArgs,
+      long allocateSize) throws IOException {
+    long usedBytes = omVolumeArgs.getUsedBytes().sum();
+    long quotaInBytes = omVolumeArgs.getQuotaInBytes();
+    if (quotaInBytes - usedBytes < allocateSize) {
+      throw new OMException("The DiskSpace quota of volume:"
+          + omVolumeArgs.getVolume() + "exceeded: quotaInBytes: "
+          + quotaInBytes + " Bytes but diskspace consumed: " + (usedBytes
+          + allocateSize) + " Bytes.",
+          OMException.ResultCodes.QUOTA_EXCEEDED);
+    }
+
+  }
+
+  /**
    * Check directory exists. If exists return true, else false.
    * @param volumeName
    * @param bucketName

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -33,6 +33,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.PrefixManager;
 import org.apache.hadoop.ozone.om.ResolvedBucket;
 import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
@@ -541,16 +542,17 @@ public abstract class OMKeyRequest extends OMClientRequest {
    */
   protected void checkVolumeQuotaInBytes(OmVolumeArgs omVolumeArgs,
       long allocateSize) throws IOException {
-    long usedBytes = omVolumeArgs.getUsedBytes().sum();
-    long quotaInBytes = omVolumeArgs.getQuotaInBytes();
-    if (quotaInBytes - usedBytes < allocateSize) {
-      throw new OMException("The DiskSpace quota of volume:"
-          + omVolumeArgs.getVolume() + "exceeded: quotaInBytes: "
-          + quotaInBytes + " Bytes but diskspace consumed: " + (usedBytes
-          + allocateSize) + " Bytes.",
-          OMException.ResultCodes.QUOTA_EXCEEDED);
+    if (omVolumeArgs.getQuotaInBytes() > OzoneConsts.QUOTA_RESET) {
+      long usedBytes = omVolumeArgs.getUsedBytes().sum();
+      long quotaInBytes = omVolumeArgs.getQuotaInBytes();
+      if (quotaInBytes - usedBytes < allocateSize) {
+        throw new OMException("The DiskSpace quota of volume:"
+            + omVolumeArgs.getVolume() + "exceeded: quotaInBytes: "
+            + quotaInBytes + " Bytes but diskspace consumed: " + (usedBytes
+            + allocateSize) + " Bytes.",
+            OMException.ResultCodes.QUOTA_EXCEEDED);
+      }
     }
-
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -283,6 +283,7 @@ public final class TestOMRequestUtils {
     OmVolumeArgs omVolumeArgs =
         OmVolumeArgs.newBuilder().setCreationTime(Time.now())
             .setVolume(volumeName).setAdminName(ownerName)
+            .setQuotaInBytes(Long.MAX_VALUE)
             .setOwnerName(ownerName).build();
     omMetadataManager.getVolumeTable().put(
         omMetadataManager.getVolumeKey(volumeName), omVolumeArgs);


### PR DESCRIPTION
## What changes were proposed in this pull request?

In addition, the current Quota setting does not take effect. HDDS-541 gives all the work needed to perfect Quota.
This PR is a subtask of HDDS-541.

Volume has implemented increase usedBytes when write, and this PR is based on #1296.
In this PR we judge whether the Volume can be written when we write the key if the volume space quota enable.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3727

## How was this patch tested?

UT added.
