### PR TITLE
HDDS-4263. ReplicatiomManager shouldn't retain one healthy replica per origin node Id.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -24,12 +24,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -624,17 +622,8 @@ public class ReplicationManager
               " is {}, but found {}.", id, replicationFactor,
           replicationFactor + excess);
 
-      final Map<UUID, ContainerReplica> uniqueReplicas =
-          new LinkedHashMap<>();
-
-      replicas.stream()
-          .filter(r -> compareState(container.getState(), r.getState()))
-          .forEach(r -> uniqueReplicas
-              .putIfAbsent(r.getOriginDatanodeId(), r));
-
       // Retain one healthy replica per origin node Id.
       final List<ContainerReplica> eligibleReplicas = new ArrayList<>(replicas);
-      eligibleReplicas.removeAll(uniqueReplicas.values());
 
       final List<ContainerReplica> unhealthyReplicas = eligibleReplicas
           .stream()

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -629,7 +629,7 @@ public class ReplicationManager
       final Map<UUID, ContainerReplica> uniqueReplicas =
           new LinkedHashMap<>();
 
-      if (container.getState() == LifeCycleState.CLOSED) {
+      if (container.getState() != LifeCycleState.CLOSED) {
         replicas.stream()
             .filter(r -> compareState(container.getState(), r.getState()))
             .forEach(r -> uniqueReplicas

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
@@ -817,7 +817,7 @@ public class TestReplicationManager {
     final ContainerReplica replicaFour = getReplicas(
         id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
     final ContainerReplica replicaFive = getReplicas(
-        id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
+        id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
 
     containerStateManager.loadContainer(container);
     containerStateManager.updateContainerReplica(id, replicaOne);


### PR DESCRIPTION
## What changes were proposed in this pull request?

ReplicatiomManager shouldn't retain one healthy replica per origin node Id.

## What is the link to the Apache JIRA

HDDS-4263

## How was this patch tested?

Make the replicas over replicated, and wait the replicationManager reduce it to the replicationFactor.
