### PR TITLE
HDDS-4274. Change the log level of the SCM Delete block to improve performance.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -218,7 +218,7 @@ public class SCMBlockProtocolServer implements
   @Override
   public List<DeleteBlockGroupResult> deleteKeyBlocks(
       List<BlockGroup> keyBlocksInfoList) throws IOException {
-    LOG.info("SCM is informed by OM to delete {} blocks", keyBlocksInfoList
+    LOG.debug("SCM is informed by OM to delete {} blocks", keyBlocksInfoList
         .size());
     List<DeleteBlockGroupResult> results = new ArrayList<>();
     Map<String, String> auditMap = Maps.newHashMap();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -218,8 +218,10 @@ public class SCMBlockProtocolServer implements
   @Override
   public List<DeleteBlockGroupResult> deleteKeyBlocks(
       List<BlockGroup> keyBlocksInfoList) throws IOException {
-    LOG.debug("SCM is informed by OM to delete {} blocks", keyBlocksInfoList
-        .size());
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("SCM is informed by OM to delete {} blocks",
+          keyBlocksInfoList.size());
+    }
     List<DeleteBlockGroupResult> results = new ArrayList<>();
     Map<String, String> auditMap = Maps.newHashMap();
     for (BlockGroup keyBlocks : keyBlocksInfoList) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are scenarios in which the DELETE operation is very frequent. Now that info level logs in SCM are affecting performance, we should change this to Debug

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4274

## How was this patch tested?

 no need add ut.