### PR TITLE
HDDS-4264. Uniform naming conventions of Ozone Shell Options.

### DIFF
--- a/hadoop-hdds/docs/content/tools/TestTools.md
+++ b/hadoop-hdds/docs/content/tools/TestTools.md
@@ -87,7 +87,7 @@ bin/ozone freon --help
 For example:
 
 ```
-ozone freon randomkeys --numOfVolumes=10 --numOfBuckets 10 --numOfKeys 10  --replicationType=RATIS --factor=THREE
+ozone freon randomkeys --num-of-volumes=10 --num-of-buckets 10 --num-of-keys 10  --replication-type=RATIS --factor=THREE
 ```
 
 ```

--- a/hadoop-hdds/docs/content/tools/TestTools.zh.md
+++ b/hadoop-hdds/docs/content/tools/TestTools.zh.md
@@ -88,7 +88,7 @@ bin/ozone freon --help
 例如：
 
 ```
-ozone freon randomkeys --numOfVolumes=10 --numOfBuckets 10 --numOfKeys 10  --replicationType=RATIS --factor=THREE
+ozone freon randomkeys --num-of-volumes=10 --num-of-buckets 10 --num-of-keys 10  --replication-type=RATIS --factor=THREE
 ```
 
 ```

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/CreatePipelineSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/CreatePipelineSubcommand.java
@@ -38,15 +38,17 @@ import java.io.IOException;
 public class CreatePipelineSubcommand extends ScmSubcommand {
 
   @CommandLine.Option(
-      names = {"-t", "--replication-type"},
-      description = "Replication type (STAND_ALONE, RATIS)",
+      names = {"-t", "--replication-type", "--replicationType"},
+      description = "Replication type (STAND_ALONE, RATIS). Full name" +
+          " --replicationType will be removed in later versions.",
       defaultValue = "STAND_ALONE"
   )
   private HddsProtos.ReplicationType type;
 
   @CommandLine.Option(
-      names = {"-f", "--replicationFactor"},
-      description = "Replication factor (ONE, THREE)",
+      names = {"-f", "--replication-factor", "--replicationFactor"},
+      description = "Replication factor (ONE, THREE). Full name" +
+          " --replicationFactor will be removed in later versions.",
       defaultValue = "ONE"
   )
   private HddsProtos.ReplicationFactor factor;

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/CreatePipelineSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/CreatePipelineSubcommand.java
@@ -38,7 +38,7 @@ import java.io.IOException;
 public class CreatePipelineSubcommand extends ScmSubcommand {
 
   @CommandLine.Option(
-      names = {"-t", "--replicationType"},
+      names = {"-t", "--replication-type"},
       description = "Replication type (STAND_ALONE, RATIS)",
       defaultValue = "STAND_ALONE"
   )

--- a/hadoop-ozone/dist/src/main/k8s/definitions/ozone/freon/freon.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/definitions/ozone/freon/freon.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
         - name: freon
           image: "@docker.image@"
-          args: ["ozone","freon", "rk", "--factor=THREE", "--replicationType=RATIS"]
+          args: ["ozone","freon", "rk", "--factor=THREE", "--replication-type=RATIS"]
           envFrom:
             - configMapRef:
                 name: config

--- a/hadoop-ozone/dist/src/main/k8s/examples/getting-started/freon/freon-deployment.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/getting-started/freon/freon-deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - freon
         - rk
         - --factor=THREE
-        - --replicationType=RATIS
+        - --replication-type=RATIS
         envFrom:
         - configMapRef:
             name: config

--- a/hadoop-ozone/dist/src/main/k8s/examples/minikube/freon/freon-deployment.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/minikube/freon/freon-deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - freon
         - rk
         - --factor=THREE
-        - --replicationType=RATIS
+        - --replication-type=RATIS
         envFrom:
         - configMapRef:
             name: config

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/freon/freon-deployment.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone-dev/freon/freon-deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - freon
         - rk
         - --factor=THREE
-        - --replicationType=RATIS
+        - --replication-type=RATIS
         envFrom:
         - configMapRef:
             name: config

--- a/hadoop-ozone/dist/src/main/k8s/examples/ozone/freon/freon-deployment.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/examples/ozone/freon/freon-deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - freon
         - rk
         - --factor=THREE
-        - --replicationType=RATIS
+        - --replication-type=RATIS
         envFrom:
         - configMapRef:
             name: config

--- a/hadoop-ozone/dist/src/main/smoketest/auditparser/auditparser.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/auditparser/auditparser.robot
@@ -33,7 +33,7 @@ Set username
 
 *** Test Cases ***
 Initiating freon to generate data
-    ${result} =        Execute              ozone freon randomkeys --numOfVolumes 5 --numOfBuckets 5 --numOfKeys 5 --numOfThreads 1
+    ${result} =        Execute              ozone freon randomkeys --num-of-volumes 5 --num-of-buckets 5 --num-of-keys 5 --num-of-threads 1
                        Wait Until Keyword Succeeds      3min       10sec     Should contain   ${result}   Number of Keys added: 125
                        Should Not Contain               ${result}  ERROR
 

--- a/hadoop-ozone/dist/src/main/smoketest/basic/basic.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/basic.robot
@@ -32,6 +32,6 @@ Check webui static resources
 
 Start freon testing
     Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
-    ${result} =        Execute              ozone freon randomkeys --numOfVolumes 5 --numOfBuckets 5 --numOfKeys 5 --numOfThreads 1 --replicationType RATIS --factor THREE --validateWrites
+    ${result} =        Execute              ozone freon randomkeys --num-of-volumes 5 --num-of-buckets 5 --num-of-keys 5 --num-of-threads 1 --replication-type RATIS --factor THREE --validate-writes
                        Wait Until Keyword Succeeds      3min       10sec     Should contain   ${result}   Number of Keys added: 125
                        Should Contain                   ${result}  Status: Success

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -37,7 +37,7 @@ Test ozone shell
                     Should contain      ${result}       creationTime
     ${result} =     Execute             ozone sh volume list | jq -r '. | select(.name=="${volume}")'
                     Should contain      ${result}       creationTime
-# TODO: Disable updating the owner, acls should be used to give access to other user.        
+# TODO: Disable updating the owner, acls should be used to give access to other user.
                     Execute             ozone sh volume setquota ${protocol}${server}/${volume} --space-quota 10TB --count-quota 100
 #    ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.volumeName=="${volume}") | .owner | .name'
 #                    Should Be Equal     ${result}       bill

--- a/hadoop-ozone/dist/src/main/smoketest/freon/freon.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/freon/freon.robot
@@ -21,7 +21,7 @@ Test Timeout        5 minutes
 
 *** Test Cases ***
 Freon Randomkey Generator
-    ${result} =        Execute              ozone freon rk ${OM_HA_PARAM} --numOfVolumes=1 --numOfBuckets=1 --numOfKeys=1 --numOfThreads=1
+    ${result} =        Execute              ozone freon rk ${OM_HA_PARAM} --num-of-volumes=1 --num-of-buckets=1 --num-of-keys=1 --num-of-threads=1
                        Wait Until Keyword Succeeds      3min       10sec     Should contain   ${result}   Number of Keys added: 1
 
 Freon Ozone Key Generator

--- a/hadoop-ozone/dist/src/main/smoketest/recon/recon-api.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/recon/recon-api.robot
@@ -37,7 +37,7 @@ Check if Recon picks up container from OM
 *** Test Cases ***
 Generate Freon data
     Run Keyword if      '${SECURITY_ENABLED}' == 'true'     Kinit test user     testuser     testuser.keytab
-                        Execute                             ozone freon rk --replicationType=RATIS --numOfVolumes 1 --numOfBuckets 1 --numOfKeys 10 --keySize 1025
+                        Execute                             ozone freon rk --replication-type=RATIS --num-of-volumes 1 --num-of-buckets 1 --num-of-keys 10 --key-size 1025
 
 Check if Recon picks up OM data
     Wait Until Keyword Succeeds     90sec      10sec        Check if Recon picks up container from OM

--- a/hadoop-ozone/dist/src/main/smoketest/spnego/web.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/spnego/web.robot
@@ -51,7 +51,7 @@ Verify SPNEGO enabled URL
 *** Test Cases ***
 Generate Freon data
     Run Keyword if      '${SECURITY_ENABLED}' == 'true'     Kinit test user     testuser     testuser.keytab
-                        Execute                             ozone freon rk --replicationType=RATIS --numOfVolumes 1 --numOfBuckets 1 --numOfKeys 2 --keySize 1025
+                        Execute                             ozone freon rk --replication-type=RATIS --num-of-volumes 1 --num-of-buckets 1 --num-of-keys 2 --key-size 1025
 
 Test OM portal
     Verify SPNEGO enabled URL       ${OM_URL}

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
@@ -52,36 +52,36 @@ public class TestMiniChaosOzoneCluster extends GenericCli {
   static final Logger LOG =
       LoggerFactory.getLogger(TestMiniChaosOzoneCluster.class);
 
-  @Option(names = {"-d", "--numDatanodes"},
+  @Option(names = {"-d", "--num-datanodes"},
       description = "num of datanodes")
   private static int numDatanodes = 20;
 
-  @Option(names = {"-o", "--numOzoneManager"},
+  @Option(names = {"-o", "--num-ozone-manager"},
       description = "num of ozoneManagers")
   private static int numOzoneManagers = 1;
 
-  @Option(names = {"-s", "--failureService"},
+  @Option(names = {"-s", "--failure-service"},
       description = "service (datanode or ozoneManager) to test chaos on",
       defaultValue = "datanode")
   private static String failureService = "datanode";
 
-  @Option(names = {"-t", "--numThreads"},
+  @Option(names = {"-t", "--num-threads"},
       description = "num of IO threads")
   private static int numThreads = 5;
 
-  @Option(names = {"-b", "--numBuffers"},
+  @Option(names = {"-b", "--num-buffers"},
       description = "num of IO buffers")
   private static int numBuffers = 16;
 
-  @Option(names = {"-m", "--numMinutes"},
+  @Option(names = {"-m", "--num-minutes"},
       description = "total run time")
   private static int numMinutes = 1440; // 1 day by default
 
-  @Option(names = {"-v", "--numDataVolume"},
+  @Option(names = {"-v", "--num-data-volume"},
       description = "number of datanode volumes to create")
   private static int numDataVolumes = 3;
 
-  @Option(names = {"-i", "--failureInterval"},
+  @Option(names = {"-i", "--failure-interval"},
       description = "time between failure events in seconds")
   private static int failureInterval = 300; // 5 minute period between failures.
 

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/TestMiniChaosOzoneCluster.java
@@ -52,37 +52,45 @@ public class TestMiniChaosOzoneCluster extends GenericCli {
   static final Logger LOG =
       LoggerFactory.getLogger(TestMiniChaosOzoneCluster.class);
 
-  @Option(names = {"-d", "--num-datanodes"},
-      description = "num of datanodes")
+  @Option(names = {"-d", "--num-datanodes", "--numDatanodes"},
+      description = "num of datanodes. Full name --numDatanodes will be" +
+          " removed in later versions.")
   private static int numDatanodes = 20;
 
-  @Option(names = {"-o", "--num-ozone-manager"},
-      description = "num of ozoneManagers")
+  @Option(names = {"-o", "--num-ozone-manager", "--numOzoneManager"},
+      description = "num of ozoneManagers. Full name --numOzoneManager will" +
+          " be removed in later versions.")
   private static int numOzoneManagers = 1;
 
-  @Option(names = {"-s", "--failure-service"},
-      description = "service (datanode or ozoneManager) to test chaos on",
+  @Option(names = {"-s", "--failure-service", "--failureService"},
+      description = "service (datanode or ozoneManager) to test chaos on. " +
+          "Full --failureService name will be removed in later versions.",
       defaultValue = "datanode")
   private static String failureService = "datanode";
 
-  @Option(names = {"-t", "--num-threads"},
-      description = "num of IO threads")
+  @Option(names = {"-t", "--num-threads", "--numThreads"},
+      description = "num of IO threads. Full name --numThreads will be" +
+          " removed in later versions.")
   private static int numThreads = 5;
 
-  @Option(names = {"-b", "--num-buffers"},
-      description = "num of IO buffers")
+  @Option(names = {"-b", "--num-buffers", "--numBuffers"},
+      description = "num of IO buffers. Full name --numBuffers will be" +
+          " removed in later versions.")
   private static int numBuffers = 16;
 
-  @Option(names = {"-m", "--num-minutes"},
-      description = "total run time")
+  @Option(names = {"-m", "--num-minutes", "--numMinutes"},
+      description = "total run time. Full name --numMinutes will be " +
+          "removed in later versions.")
   private static int numMinutes = 1440; // 1 day by default
 
-  @Option(names = {"-v", "--num-data-volume"},
-      description = "number of datanode volumes to create")
+  @Option(names = {"-v", "--num-data-volume", "--numDataVolume"},
+      description = "number of datanode volumes to create. Full name " +
+          "--numDataVolume will be removed in later versions.")
   private static int numDataVolumes = 3;
 
-  @Option(names = {"-i", "--failure-interval"},
-      description = "time between failure events in seconds")
+  @Option(names = {"-i", "--failure-interval", "--failureInterval"},
+      description = "time between failure events in seconds. Full name " +
+          "--failureInterval will be removed in later versions.")
   private static int failureInterval = 300; // 5 minute period between failures.
 
   private static MiniOzoneChaosCluster cluster;

--- a/hadoop-ozone/fault-injection-test/network-tests/src/test/blockade/ozone/client.py
+++ b/hadoop-ozone/fault-injection-test/network-tests/src/test/blockade/ozone/client.py
@@ -66,10 +66,10 @@ class OzoneClient:
         """
         command = [Command.freon,
                    " rk",
-                   " --numOfVolumes " + str(num_volumes),
-                   " --numOfBuckets " + str(num_buckets),
-                   " --numOfKeys " + str(num_keys),
-                   " --keySize " + str(key_size),
-                   " --replicationType " + replication_type,
+                   " --num-of-volumes " + str(num_volumes),
+                   " --num-of-buckets " + str(num_buckets),
+                   " --num-of-keys " + str(num_keys),
+                   " --key-size " + str(key_size),
+                   " --replication-type " + replication_type,
                    " --factor " + replication_factor]
         return util.run_docker_command(command, self.cluster.client)

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
@@ -59,12 +59,12 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
       defaultValue = "5")
   private int depth;
 
-  @Option(names = {"-c", "--fileCount"},
+  @Option(names = {"-c", "--file-count"},
       description = "Number of files to be written in each directory",
       defaultValue = "2")
   private int fileCount;
 
-  @Option(names = {"-g", "--fileSize"},
+  @Option(names = {"-g", "--file-size"},
       description = "Generated data size(in bytes) of each file to be " +
               "written in each directory",
       defaultValue = "4096")
@@ -81,7 +81,7 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
       defaultValue = "10")
   private int span;
 
-  @Option(names = {"-l", "--nameLen"},
+  @Option(names = {"-l", "--name-len"},
       description =
           "Length of the random name of directory you want to create.",
       defaultValue = "10")

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
@@ -59,14 +59,16 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
       defaultValue = "5")
   private int depth;
 
-  @Option(names = {"-c", "--file-count"},
-      description = "Number of files to be written in each directory",
+  @Option(names = {"-c", "--file-count", "--fileCount"},
+      description = "Number of files to be written in each directory. Full" +
+          " name --fileCount will be removed in later versions.",
       defaultValue = "2")
   private int fileCount;
 
-  @Option(names = {"-g", "--file-size"},
+  @Option(names = {"-g", "--file-size", "--fileSize"},
       description = "Generated data size(in bytes) of each file to be " +
-              "written in each directory",
+          "written in each directory. Full name --fileSize will be removed " +
+          "in later versions.",
       defaultValue = "4096")
   private int fileSizeInBytes;
 
@@ -81,9 +83,10 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
       defaultValue = "10")
   private int span;
 
-  @Option(names = {"-l", "--name-len"},
+  @Option(names = {"-l", "--name-len", "--nameLen"},
       description =
-          "Length of the random name of directory you want to create.",
+          "Length of the random name of directory you want to create. Full " +
+              "name --nameLen will be removed in later versions.",
       defaultValue = "10")
   private int length;
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopNestedDirGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopNestedDirGenerator.java
@@ -62,9 +62,10 @@ public class HadoopNestedDirGenerator extends BaseFreonGenerator
       defaultValue = "10")
   private int span;
 
-  @Option(names = {"-l", "--name-len"},
+  @Option(names = {"-l", "--name-len", "--nameLen"},
       description =
-          "Length of the random name of directory you want to create.",
+          "Length of the random name of directory you want to create. Full " +
+              "name --nameLen will be removed in later versions.",
       defaultValue = "10")
   private int length;
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopNestedDirGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopNestedDirGenerator.java
@@ -62,7 +62,7 @@ public class HadoopNestedDirGenerator extends BaseFreonGenerator
       defaultValue = "10")
   private int span;
 
-  @Option(names = {"-l", "--nameLen"},
+  @Option(names = {"-l", "--name-len"},
       description =
           "Length of the random name of directory you want to create.",
       defaultValue = "10")

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -113,44 +113,51 @@ public final class RandomKeyGenerator implements Callable<Void> {
   private volatile boolean completed = false;
   private volatile Throwable exception;
 
-  @Option(names = "--num-of-threads",
-      description = "number of threads to be launched for the run",
+  @Option(names = {"--num-of-threads", "--numOfThreads"},
+      description = "number of threads to be launched for the run. Full name " +
+          "--numOfThreads will be removed in later versions.",
       defaultValue = "10")
   private int numOfThreads = 10;
 
-  @Option(names = "--num-of-volumes",
-      description = "specifies number of Volumes to be created in offline mode",
+  @Option(names = {"--num-of-volumes", "--numOfVolumes"},
+      description = "specifies number of Volumes to be created in offline " +
+          "mode. Full name --numOfVolumes will be removed in later versions.",
       defaultValue = "10")
   private int numOfVolumes = 10;
 
-  @Option(names = "--num-of-buckets",
-      description = "specifies number of Buckets to be created per Volume",
+  @Option(names = {"--num-of-buckets", "--numOfBuckets"},
+      description = "specifies number of Buckets to be created per Volume. " +
+          "Full name --numOfBuckets will be removed in later versions.",
       defaultValue = "1000")
   private int numOfBuckets = 1000;
 
   @Option(
-      names = "--num-of-keys",
-      description = "specifies number of Keys to be created per Bucket",
+      names = {"--num-of-keys", "--numOfKeys"},
+      description = "specifies number of Keys to be created per Bucket. Full" +
+          " name --numOfKeys will be removed in later versions.",
       defaultValue = "500000"
   )
   private int numOfKeys = 500000;
 
   @Option(
-      names = "--key-size",
-      description = "Specifies the size of Key in bytes to be created",
+      names = {"--key-size", "--keySize"},
+      description = "Specifies the size of Key in bytes to be created. Full" +
+          " name --keySize will be removed in later versions.",
       defaultValue = "10240"
   )
   private long keySize = 10240;
 
   @Option(
-      names = "--validate-writes",
-      description = "Specifies whether to validate keys after writing"
+      names = {"--validate-writes", "--validateWrites"},
+      description = "Specifies whether to validate keys after writing. Full" +
+          " name --validateWrites will be removed in later versions."
   )
   private boolean validateWrites = false;
 
   @Option(
-      names = "--buffer-size",
-      description = "Specifies the buffer size while writing",
+      names = {"--buffer-size", "--bufferSize"},
+      description = "Specifies the buffer size while writing. Full name " +
+          "--bufferSize will be removed in later versions.",
       defaultValue = "4096"
   )
   private int bufferSize = 4096;
@@ -162,8 +169,9 @@ public final class RandomKeyGenerator implements Callable<Void> {
   private String jsonDir;
 
   @Option(
-      names = "--replication-type",
-      description = "Replication type (STAND_ALONE, RATIS)",
+      names = {"--replication-type", "--replicationType"},
+      description = "Replication type (STAND_ALONE, RATIS). Full name " +
+          "--replicationType will be removed in later versions.",
       defaultValue = "STAND_ALONE"
   )
   private ReplicationType type = ReplicationType.STAND_ALONE;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -113,43 +113,43 @@ public final class RandomKeyGenerator implements Callable<Void> {
   private volatile boolean completed = false;
   private volatile Throwable exception;
 
-  @Option(names = "--numOfThreads",
+  @Option(names = "--num-of-threads",
       description = "number of threads to be launched for the run",
       defaultValue = "10")
   private int numOfThreads = 10;
 
-  @Option(names = "--numOfVolumes",
+  @Option(names = "--num-of-volumes",
       description = "specifies number of Volumes to be created in offline mode",
       defaultValue = "10")
   private int numOfVolumes = 10;
 
-  @Option(names = "--numOfBuckets",
+  @Option(names = "--num-of-buckets",
       description = "specifies number of Buckets to be created per Volume",
       defaultValue = "1000")
   private int numOfBuckets = 1000;
 
   @Option(
-      names = "--numOfKeys",
+      names = "--num-of-keys",
       description = "specifies number of Keys to be created per Bucket",
       defaultValue = "500000"
   )
   private int numOfKeys = 500000;
 
   @Option(
-      names = "--keySize",
+      names = "--key-size",
       description = "Specifies the size of Key in bytes to be created",
       defaultValue = "10240"
   )
   private long keySize = 10240;
 
   @Option(
-      names = "--validateWrites",
+      names = "--validate-writes",
       description = "Specifies whether to validate keys after writing"
   )
   private boolean validateWrites = false;
 
   @Option(
-      names = "--bufferSize",
+      names = "--buffer-size",
       description = "Specifies the buffer size while writing",
       defaultValue = "4096"
   )
@@ -162,7 +162,7 @@ public final class RandomKeyGenerator implements Callable<Void> {
   private String jsonDir;
 
   @Option(
-      names = "--replicationType",
+      names = "--replication-type",
       description = "Replication type (STAND_ALONE, RATIS)",
       defaultValue = "STAND_ALONE"
   )


### PR DESCRIPTION
## What changes were proposed in this pull request?

Current Shell command of Ozone, some use hump connection, some use '-' connection. We need to unify the naming conventions.
See the usage [documentation of Picocli](https://picocli.info/#command-methods), which use '-' connection more often. 
![image](https://user-images.githubusercontent.com/13825159/94270584-da2da300-ff72-11ea-90cf-c57b79d13d06.png)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4264

## How was this patch tested?
UT has been fixed.
