### PR TITLE
HDDS-4288. the icon of hadoop-ozone is bigger than ever

### DIFF
--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/navbar.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/navbar.html
@@ -23,8 +23,8 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a href="{{ "index.html" | relLangURL }}" class="navbar-left" style="height: 50px; padding: 5px 10px 5px 0px;">
-        <img src="{{ "ozone-logo-small.png" | relURL }}" style="width: 40px; padding: 0px;"/>
+      <a href="{{ "index.html" | relLangURL }}" class="navbar-left ozone-logo">
+        <img src="{{ "ozone-logo-small.png" | relURL }}"/>
       </a>
       <a class="navbar-brand hidden-xs" href="{{ "index.html" | relLangURL }}">
         Apache Hadoop Ozone/HDDS documentation

--- a/hadoop-hdds/docs/themes/ozonedoc/static/css/ozonedoc.css
+++ b/hadoop-hdds/docs/themes/ozonedoc/static/css/ozonedoc.css
@@ -54,6 +54,16 @@ a:hover {
   border: 0;
 }
 
+A.ozone-logo {
+  height: 50px;
+  padding: 5px 10px 5px 0px;
+}
+
+.ozone-logo img {
+  width: 40px;
+  padding: 0px;
+}
+
 /*
  * Sidebar
  */
@@ -62,6 +72,7 @@ a:hover {
 .sidebar {
   display: none;
 }
+
 @media (min-width: 768px) {
   .sidebar {
     position: fixed;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Logo is too big on [doc snapshot](https://ci-hadoop.apache.org/view/Hadoop%20Ozone/job/ozone-doc-master/lastSuccessfulBuild/artifact/hadoop-hdds/docs/public/index.html) (generated by the Jenkins):

![image](https://user-images.githubusercontent.com/170549/94560414-eb243000-0262-11eb-9667-1652787200f7.png)

INFRA is migrated to a new jenkins and the new Jenkins adds a more secure HTTP headers:

```
< Content-Security-Policy: sandbox; default-src 'none'; img-src 'self'; style-src 'self';
< X-WebKit-CSP: sandbox; default-src 'none'; img-src 'self'; style-src 'self';
```

IMHO the inline styles which are used in the current code are disabled:

```
<a href="{{ "index.html" | relLangURL }}" class="navbar-left" style="height: 50px; padding: 5px 10px 5px 0px;">
```

While it's not a production issue, we can move the custom styles to the css, to make it compatible with the jenkins.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4288

## How was this patch tested?

  1. If you remove inline `style` attributes , and do a `hugo serve` in `hadoop-hdds/docs`, you can see that the logo is too big.
  2. When you apply the patches (css based styles) the logo is fine, again.

It is supposed to be compatible with the Jenkins as all the other css based styles are working.