### PR TITLE
HDDS-4287: Exclude protobuff classes from ozone-filesystem-hadoop3 jars

### DIFF
--- a/hadoop-ozone/ozonefs-shaded/pom.xml
+++ b/hadoop-ozone/ozonefs-shaded/pom.xml
@@ -59,6 +59,10 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Excluded the protobuf classes from hadoop-ozone-filesystem-hadoop3/2. We already kept the dependency on hadoop anyway and hadoop provides protobuf jars. So, we just excluded the protobuff classes. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4287