### PR TITLE
HDDS-4297. Allow multiple transactions per container to be sent for deletion by SCM.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DatanodeDeletedBlockTransactions.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DatanodeDeletedBlockTransactions.java
@@ -82,30 +82,20 @@ public class DatanodeDeletedBlockTransactions {
   }
 
   private boolean addTransactionToDN(UUID dnID, DeletedBlocksTransaction tx) {
-    if (transactions.containsKey(dnID)) {
-      List<DeletedBlocksTransaction> txs = transactions.get(dnID);
-      if (txs != null && txs.size() < maximumAllowedTXNum) {
-        boolean hasContained = false;
-        for (DeletedBlocksTransaction t : txs) {
-          if (t.getContainerID() == tx.getContainerID()) {
-            hasContained = true;
-            break;
-          }
-        }
-
-        if (!hasContained) {
-          txs.add(tx);
-          currentTXNum++;
-          return true;
-        }
-      }
-    } else {
+    List<DeletedBlocksTransaction> txs = transactions.get(dnID);
+    if (txs == null || txs.size() < maximumAllowedTXNum) {
       currentTXNum++;
-      transactions.put(dnID, tx);
+      if (txs == null) {
+        transactions.put(dnID, tx);
+      } else {
+        txs.add(tx);
+      }
+      if (SCMBlockDeletingService.LOG.isDebugEnabled()) {
+        SCMBlockDeletingService.LOG
+            .debug("Transaction added: {} <- TX({})", dnID, tx.getTxID());
+      }
       return true;
     }
-    SCMBlockDeletingService.LOG
-        .debug("Transaction added: {} <- TX({})", dnID, tx.getTxID());
     return false;
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -375,30 +375,27 @@ public class TestDeletedBlockLog {
         transactions.getDatanodeTransactions(dnId1.getUuid()).size());
 
     int size = transactions.getDatanodeTransactions(dnId2.getUuid()).size();
-    // add duplicated container in dnID2, this should be failed.
+    // add two transactions for same container in dnID2
     DeletedBlocksTransaction.Builder builder =
         DeletedBlocksTransaction.newBuilder();
     builder.setTxID(11);
     builder.setContainerID(containerID);
     builder.setCount(0);
-    transactions.addTransaction(builder.build(),
-        null);
+    Assert.assertTrue(transactions.addTransaction(builder.build(), null));
 
-    // The number of TX in dnID2 should not be changed.
-    Assert.assertEquals(size,
+    // Total number of transactions reaches the maximum value
+    Assert.assertEquals(size + 1,
         transactions.getDatanodeTransactions(dnId2.getUuid()).size());
+    Assert.assertTrue(transactions.isFull());
 
-    // Add new TX in dnID2, then dnID2 will reach maximum value.
     containerID = RandomUtils.nextLong();
     builder = DeletedBlocksTransaction.newBuilder();
     builder.setTxID(12);
     builder.setContainerID(containerID);
     builder.setCount(0);
     mockContainerInfo(containerID, dnId2);
-    transactions.addTransaction(builder.build(),
-        null);
-    // Since all node are full, then transactions is full.
-    Assert.assertTrue(transactions.isFull());
+    // No more txns can be added as maximum number of transactions are reached
+    Assert.assertFalse(transactions.addTransaction(builder.build(), null));
   }
 
   private void mockContainerInfo(long containerID, DatanodeDetails dd)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently SCM Block Deleting Service allows only one transaction per container to be sent for deletion to the datanode. This can slow down deletion if there are multiple delete transactions for a container.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4297

## How was this patch tested?

UT