### PR TITLE
HDDS-4292. Ozone Client not working with Hadoop Version < 3.2

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/failover/TestOMFailovers.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/failover/TestOMFailovers.java
@@ -119,12 +119,11 @@ public class TestOMFailovers {
     }
 
     @Override
-    protected void createOMProxyIfNeeded(ProxyInfo proxyInfo,
-        String nodeId) {
-      if (proxyInfo.proxy == null) {
-        proxyInfo.proxy = new MockOzoneManagerProtocol(nodeId,
-            testException);
-      }
+    protected ProxyInfo createOMProxy(String nodeId) {
+      ProxyInfo proxyInfo = new ProxyInfo<>(new MockOzoneManagerProtocol(nodeId,
+          testException), nodeId);
+      getOMProxyMap().put(nodeId, proxyInfo);
+      return proxyInfo;
     }
 
     @Override
@@ -137,7 +136,7 @@ public class TestOMFailovers {
 
       for (int i = 1; i <= 3; i++) {
         String nodeId = "om" + i;
-        omProxies.put(nodeId, new ProxyInfo<>(null, nodeId));
+        omProxies.put(nodeId, null);
         omProxyInfos.put(nodeId, null);
         omNodeIDList.add(nodeId);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The ozone client is not working with Hadoop Version < 3.2.
The issue is due to not properly initialization of the proxy object.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4292
## How was this patch tested?

Tested the fix on a cluster with Hadoop version 3.0
