### PR TITLE
HDDS-4299. Display Ratis version with ozone version

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/RatisVersionInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/RatisVersionInfo.java
@@ -41,7 +41,7 @@ public class RatisVersionInfo {
         RATIS_VERSION_PROPERTIES)) {
       info.load(is);
     } catch (IOException ex) {
-      LoggerFactory.getLogger(getClass()).warn("Could not read '" +
+      LoggerFactory.getLogger(getClass()).warn("Could not read " +
           RATIS_VERSION_PROPERTIES, ex);
     }
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/RatisVersionInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/RatisVersionInfo.java
@@ -21,40 +21,29 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-import org.apache.hadoop.hdds.annotation.InterfaceAudience;
-import org.apache.hadoop.hdds.annotation.InterfaceStability;
-import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.util.ThreadUtil;
 
 import org.slf4j.LoggerFactory;
 
 /**
- * This class returns build information about Hadoop components.
+ * This class returns build information about Ratis projects.
  */
-@InterfaceAudience.Public
-@InterfaceStability.Stable
-public class VersionInfo {
+public class RatisVersionInfo {
+
+  private static final String RATIS_VERSION_PROPERTIES =
+      "ratis-version.properties";
 
   private final Properties info = new Properties();
 
-  public VersionInfo(String component) {
-    String versionInfoFile = component + "-version-info.properties";
-    InputStream is = null;
-    try {
-      is = ThreadUtil.getResourceAsStream(
+  public RatisVersionInfo() {
+    try (InputStream is = ThreadUtil.getResourceAsStream(
         getClass().getClassLoader(),
-        versionInfoFile);
+        RATIS_VERSION_PROPERTIES)) {
       info.load(is);
     } catch (IOException ex) {
       LoggerFactory.getLogger(getClass()).warn("Could not read '" +
-          versionInfoFile + "', " + ex.toString(), ex);
-    } finally {
-      IOUtils.closeStream(is);
+          RATIS_VERSION_PROPERTIES, ex);
     }
-  }
-
-  public String getRelease() {
-    return info.getProperty("release", "Unknown");
   }
 
   public String getVersion() {
@@ -65,34 +54,8 @@ public class VersionInfo {
     return info.getProperty("revision", "Unknown");
   }
 
-  public String getBranch() {
-    return info.getProperty("branch", "Unknown");
-  }
-
-  public String getDate() {
-    return info.getProperty("date", "Unknown");
-  }
-
-  public String getUser() {
-    return info.getProperty("user", "Unknown");
-  }
-
-  public String getUrl() {
-    return info.getProperty("url", "Unknown");
-  }
-
-  public String getSrcChecksum() {
-    return info.getProperty("srcChecksum", "Unknown");
-  }
-
-  public String getProtocVersion() {
-    return info.getProperty("protocVersion", "Unknown");
-  }
-
   public String getBuildVersion() {
     return getVersion() +
-        " from " + getRevision() +
-        " by " + getUser() +
-        " source checksum " + getSrcChecksum();
+        " from " + getRevision();
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/OzoneVersionInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/OzoneVersionInfo.java
@@ -20,10 +20,12 @@ package org.apache.hadoop.ozone.util;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
+import org.apache.hadoop.hdds.utils.HddsVersionInfo;
+import org.apache.hadoop.hdds.utils.RatisVersionInfo;
+import org.apache.hadoop.hdds.utils.VersionInfo;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.util.ClassUtil;
-import org.apache.hadoop.hdds.utils.HddsVersionInfo;
-import org.apache.hadoop.hdds.utils.VersionInfo;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +40,9 @@ public final class OzoneVersionInfo {
 
   public static final VersionInfo OZONE_VERSION_INFO =
       new VersionInfo(OzoneConsts.OZONE);
+
+  public static final RatisVersionInfo RATIS_VERSION_INFO =
+      new RatisVersionInfo();
 
   private OzoneVersionInfo() {}
 
@@ -69,8 +74,10 @@ public final class OzoneVersionInfo {
     System.out.println(
         "Compiled with protoc " + OZONE_VERSION_INFO.getProtocVersion());
     System.out.println(
-        "From source with checksum " + OZONE_VERSION_INFO.getSrcChecksum()
-            + "\n");
+        "From source with checksum " + OZONE_VERSION_INFO.getSrcChecksum());
+    System.out.println(
+        "With Apache Ratis: " + RATIS_VERSION_INFO.getBuildVersion());
+    System.out.println();
     LOG.debug("This command was run using " +
         ClassUtil.findContainingJar(OzoneVersionInfo.class));
     HddsVersionInfo.main(args);


### PR DESCRIPTION
## What changes were proposed in this pull request?

During the development Ozone uses snapshot releases from Ratis. It can be useful to print out the exact version of the used Ratis as part of the output of "ozone version".

Ratis versions are part of the jar files since RATIS-1050

It can make the testing easier, as it's easier to check which Ratis version is used.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4299

## How was this patch tested?

```
 ./bin/ozone version
                  //////////////
               ////////////////////
            ////////     ////////////////
           //////      ////////////////
          /////      ////////////////  /
         /////            ////////   ///
         ////           ////////    /////
        /////         ////////////////
        /////       ////////////////   //
         ////     ///////////////   /////
         /////  ///////////////     ////
          /////       //////      /////
           //////   //////       /////
             ///////////     ////////
               //////  ////////////
               ///   //////////
              /    1.1.0-SNAPSHOT(Denali)

Source code repository git@github.com:apache/hadoop-ozone.git -r b2c6c3b61572bfd9b765f106ab2cf501db55e5e8
Compiled by elek on 2020-10-01T10:35Z
Compiled with protoc 2.5.0
From source with checksum ff92fd89808d10a6ee1dc21db8276427
With Apache Ratis: 1.1.0-11689cd-SNAPSHOT from 11689cd536b05bde323c9c6c6b57a8e82a60b680

Using HDDS 1.1.0-SNAPSHOT
Source code repository git@github.com:apache/hadoop-ozone.git -r b2c6c3b61572bfd9b765f106ab2cf501db55e5e8
Compiled by elek on 2020-10-01T10:34Z
Compiled with protoc 2.5.0
From source with checksum d0e6e752e4d52fb0f05063e16ade73d7
```