### PR TITLE
HDDS-4271. Avoid logging chunk content in Ozone Insight

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
@@ -77,7 +77,7 @@ public final class ContainerUtils {
       ContainerCommandRequestProto request) {
     String logInfo = "Operation: {} , Trace ID: {} , Message: {} , " +
         "Result: {} , StorageContainerException Occurred.";
-    log.info(logInfo, request.getCmdType().name(), request.getTraceID(),
+    log.info(logInfo, request.getCmdType(), request.getTraceID(),
         ex.getMessage(), ex.getResult().getValueDescriptor().getName(), ex);
     return getContainerCommandResponse(request, ex.getResult(), ex.getMessage())
         .build();
@@ -105,7 +105,6 @@ public final class ContainerUtils {
    * Verifies that this is indeed a new container.
    *
    * @param containerFile - Container File to verify
-   * @throws FileAlreadyExistsException
    */
   public static void verifyIsNewContainer(File containerFile) throws
       FileAlreadyExistsException {
@@ -129,7 +128,7 @@ public final class ContainerUtils {
    *
    * @throws IOException when read/write error occurs
    */
-  public synchronized static void writeDatanodeDetailsTo(
+  public static synchronized void writeDatanodeDetailsTo(
       DatanodeDetails datanodeDetails, File path) throws IOException {
     if (path.exists()) {
       if (!path.delete() || !path.createNewFile()) {
@@ -151,7 +150,7 @@ public final class ContainerUtils {
    * @return {@link DatanodeDetails}
    * @throws IOException If the id file is malformed or other I/O exceptions
    */
-  public synchronized static DatanodeDetails readDatanodeDetailsFrom(File path)
+  public static synchronized DatanodeDetails readDatanodeDetailsFrom(File path)
       throws IOException {
     if (!path.exists()) {
       throw new IOException("Datanode ID file not found.");
@@ -159,7 +158,7 @@ public final class ContainerUtils {
     try {
       return DatanodeIdYaml.readDatanodeIdFile(path);
     } catch (IOException e) {
-      LOG.warn("Error loading DatanodeDetails yaml from " +
+      LOG.warn("Error loading DatanodeDetails yaml from {}",
           path.getAbsolutePath(), e);
       // Try to load as protobuf before giving up
       try (FileInputStream in = new FileInputStream(path)) {
@@ -175,8 +174,6 @@ public final class ContainerUtils {
   /**
    * Verify that the checksum stored in containerData is equal to the
    * computed checksum.
-   * @param containerData
-   * @throws IOException
    */
   public static void verifyChecksum(ContainerData containerData)
       throws IOException {
@@ -200,7 +197,6 @@ public final class ContainerUtils {
    * Return the SHA-256 checksum of the containerData.
    * @param containerDataYamlStr ContainerData as a Yaml String
    * @return Checksum of the container data
-   * @throws StorageContainerException
    */
   public static String getChecksum(String containerDataYamlStr)
       throws StorageContainerException {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -123,7 +123,9 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
     this.dispatcher =
         new OzoneProtocolMessageDispatcher<>("DatanodeClient",
             protocolMetrics,
-            LOG);
+            LOG,
+            ContainerUtils::processForDebug,
+            ContainerUtils::processForDebug);
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneProtocolMessageDispatcher.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneProtocolMessageDispatcher.java
@@ -37,12 +37,12 @@ import java.util.function.UnaryOperator;
  */
 public class OzoneProtocolMessageDispatcher<REQUEST, RESPONSE, TYPE> {
 
-  private String serviceName;
+  private final String serviceName;
 
   private final ProtocolMessageMetrics<TYPE>
       protocolMessageMetrics;
 
-  private Logger logger;
+  private final Logger logger;
   private final UnaryOperator<REQUEST> requestPreprocessor;
   private final UnaryOperator<RESPONSE> responsePreprocessor;
 
@@ -75,11 +75,11 @@ public class OzoneProtocolMessageDispatcher<REQUEST, RESPONSE, TYPE> {
         logger.trace(
             "[service={}] [type={}] request is received: <json>{}</json>",
             serviceName,
-            type.toString(),
+            type,
             escapeNewLines(requestPreprocessor.apply(request)));
       } else if (logger.isDebugEnabled()) {
         logger.debug("{} {} request is received",
-            serviceName, type.toString());
+            serviceName, type);
       }
 
       long startTime = System.nanoTime();
@@ -93,7 +93,7 @@ public class OzoneProtocolMessageDispatcher<REQUEST, RESPONSE, TYPE> {
             "[service={}] [type={}] request is processed. Response: "
                 + "<json>{}</json>",
             serviceName,
-            type.toString(),
+            type,
             escapeNewLines(responsePreprocessor.apply(response)));
       }
       return response;


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-2660 added an insight point for the datanode dispatcher.  At trace level it logs all chunk content, which can be huge and contain control characters.  This PR removes chunk data from such log messages.

https://issues.apache.org/jira/browse/HDDS-4271

## How was this patch tested?

Started Ozone Insight (for all 3 datanodes in separate windows):

```
ozone insight logs -v datanode.dispatcher -f datanode=ozone_datanode_1
```

Ran test:

```
ozone freon ockg -n1 -t1 -p warmup
ozone sh key put /vol1/bucket1/passwd /etc/passwd
ozone sh key get /vol1/bucket1/passwd /tmp/passwd
diff -q /etc/passwd /tmp/passwd
```

Output for `ozone freon ockg -n1 -t1 -p warmup`:

```
[DATANODE] ... [TRACE|org.apache.hadoop.ozone.container.common.impl.HddsDispatcher|OzoneProtocolMessageDispatcher] [service=DatanodeClient] [type=WriteChunk] request is received:
cmdType: WriteChunk
traceID: ""
containerID: 1
datanodeUuid: "833184d2-c6db-409a-934e-df7699b97061"
pipelineID: "d8e8bf6c-6eca-4941-a4a6-3b0b997fbf4f"
writeChunk {
  blockID {
    containerID: 1
    localID: 104959326432133120
    blockCommitSequenceId: 0
  }
  chunkData {
    chunkName: "104959326432133120_chunk_1"
    offset: 0
    len: 10240
    checksumData {
      type: CRC32
      bytesPerChecksum: 1048576
      checksums: "327275221253"
    }
  }
  data: "<redacted>"
}

[DATANODE] ... [TRACE|org.apache.hadoop.ozone.container.common.impl.HddsDispatcher|HddsDispatcher] Command WriteChunk, trace ID:
[DATANODE] ... [TRACE|org.apache.hadoop.ozone.container.common.impl.HddsDispatcher|OzoneProtocolMessageDispatcher] [service=DatanodeClient] [type=WriteChunk] request is processed. Response:
cmdType: WriteChunk
traceID: ""
result: SUCCESS
message: ""
```

Output for `ozone sh key get /vol1/bucket1/passwd /tmp/passwd`:

```
[DATANODE] ... [TRACE|org.apache.hadoop.ozone.container.common.impl.HddsDispatcher|OzoneProtocolMessageDispatcher] [service=DatanodeClient] [type=ReadChunk] request is received:
cmdType: ReadChunk
traceID: ""
containerID: 1
datanodeUuid: "833184d2-c6db-409a-934e-df7699b97061"
readChunk {
  blockID {
    containerID: 1
    localID: 104959326926798849
    blockCommitSequenceId: 6
  }
  chunkData {
    chunkName: "104959326926798849_chunk_1"
    offset: 0
    len: 671
    checksumData {
      type: CRC32
      bytesPerChecksum: 1048576
      checksums: "362232235315"
    }
  }
}

[DATANODE] ... [TRACE|org.apache.hadoop.ozone.container.common.impl.HddsDispatcher|HddsDispatcher] Command ReadChunk, trace ID:
[DATANODE] ... [TRACE|org.apache.hadoop.ozone.container.common.impl.HddsDispatcher|OzoneProtocolMessageDispatcher] [service=DatanodeClient] [type=ReadChunk] request is processed. Response:
cmdType: ReadChunk
traceID: ""
result: SUCCESS
readChunk {
  blockID {
    containerID: 1
    localID: 104959326926798849
    blockCommitSequenceId: 6
  }
  chunkData {
    chunkName: "104959326926798849_chunk_1"
    offset: 0
    len: 671
    checksumData {
      type: CRC32
      bytesPerChecksum: 1048576
      checksums: "362232235315"
    }
  }
  data: "<redacted>"
}
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/282279336