### PR TITLE
HDDS-4301. SCM CA certificate does not encode KeyUsage extension properly

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificates/utils/CertificateSignRequest.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificates/utils/CertificateSignRequest.java
@@ -265,7 +265,7 @@ public final class CertificateSignRequest {
       }
       KeyUsage keyUsage = new KeyUsage(keyUsageFlag);
       return new Extension(Extension.keyUsage, true,
-          new DEROctetString(keyUsage));
+          keyUsage.getEncoded());
     }
 
     private Optional<Extension> getSubjectAltNameExtension() throws

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificates/utils/SelfSignedCertificate.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificates/utils/SelfSignedCertificate.java
@@ -145,8 +145,7 @@ public final class SelfSignedCertificate {
           new BasicConstraints(true));
       int keyUsageFlag = KeyUsage.keyCertSign | KeyUsage.cRLSign;
       KeyUsage keyUsage = new KeyUsage(keyUsageFlag);
-      builder.addExtension(Extension.keyUsage, false,
-          new DEROctetString(keyUsage));
+      builder.addExtension(Extension.keyUsage, true, keyUsage);
       if (altNames != null && altNames.size() >= 1) {
         builder.addExtension(new Extension(Extension.subjectAlternativeName,
             false, new GeneralNames(altNames.toArray(

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificates/utils/SelfSignedCertificate.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificates/utils/SelfSignedCertificate.java
@@ -42,7 +42,6 @@ import org.apache.logging.log4j.util.Strings;
 import org.bouncycastle.asn1.ASN1EncodableVector;
 import org.bouncycastle.asn1.ASN1Object;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.DERTaggedObject;
 import org.bouncycastle.asn1.DERUTF8String;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the encoding of KeyUsage in the CSR to ensure it can be used in FIPS environment. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4301

## How was this patch tested?

FIPS enabled secure ozone cluster and verify that the CA certificate can be properly generated and used. 
