### PR TITLE
HDDS-4306. Ozone checkstyle rule can't be imported to IntelliJ.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/CommitWatcher.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/CommitWatcher.java
@@ -115,7 +115,7 @@ public class CommitWatcher {
 
   public void updateCommitInfoMap(long index, List<ChunkBuffer> buffers) {
     commitIndex2flushedDataMap.computeIfAbsent(index, k -> new LinkedList<>())
-      .addAll(buffers);
+        .addAll(buffers);
   }
 
   int getCommitInfoMapSize() {

--- a/hadoop-hdds/dev-support/checkstyle/checkstyle.xml
+++ b/hadoop-hdds/dev-support/checkstyle/checkstyle.xml
@@ -71,6 +71,7 @@
     <!--<module name="FileLength">-->
     <module name="FileTabCharacter"/>
 
+    <module name="LineLength"/>
     <module name="TreeWalker">
 
         <module name="SuppressWarningsHolder"/>
@@ -129,7 +130,6 @@
 
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
-        <module name="LineLength"/>
         <module name="MethodLength"/>
         <module name="ParameterNumber">
           <property name="ignoreOverriddenMethods" value="true"/>

--- a/hadoop-hdds/dev-support/checkstyle/checkstyle.xml
+++ b/hadoop-hdds/dev-support/checkstyle/checkstyle.xml
@@ -71,7 +71,9 @@
     <!--<module name="FileLength">-->
     <module name="FileTabCharacter"/>
 
-    <module name="LineLength"/>
+    <module name="LineLength">
+        <property name="fileExtensions" value="java"/>
+    </module>
     <module name="TreeWalker">
 
         <module name="SuppressWarningsHolder"/>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -273,8 +273,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     SetVolumePropertyRequest.Builder req =
         SetVolumePropertyRequest.newBuilder();
     req.setVolumeName(volume)
-       .setQuotaInBytes(quotaInBytes)
-       .setQuotaInCounts(quotaInCounts);
+        .setQuotaInBytes(quotaInBytes)
+        .setQuotaInCounts(quotaInCounts);
 
     OMRequest omRequest = createOMRequest(Type.SetVolumeProperty)
         .setSetVolumePropertyRequest(req)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetOwnerRequest.java
@@ -133,7 +133,7 @@ public class OMVolumeSetOwnerRequest extends OMVolumeRequest {
         omResponse.setStatus(OzoneManagerProtocolProtos.Status.OK)
           .setMessage(
             "Volume '" + volume + "' owner is already '" + newOwner + "'.")
-          .setSuccess(false);
+            .setSuccess(false);
         omResponse.setSetVolumePropertyResponse(
             SetVolumePropertyResponse.newBuilder().setResponse(false).build());
         omClientResponse = new OMVolumeSetOwnerResponse(omResponse.build());

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerKeyMapperTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerKeyMapperTask.java
@@ -291,7 +291,7 @@ public class TestContainerKeyMapperTask {
     when(tableMock.getName()).thenReturn("keyTable");
     when(omMetadataManagerMock.getKeyTable()).thenReturn(tableMock);
     when(omServiceProviderMock.getOMMetadataManagerInstance())
-      .thenReturn(omMetadataManagerMock);
+        .thenReturn(omMetadataManagerMock);
     return omServiceProviderMock;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -221,8 +221,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
     <make-maven-plugin.version>1.0-beta-1</make-maven-plugin.version>
     <native-maven-plugin.version>1.0-alpha-8</native-maven-plugin.version>
-    <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
-    <checkstyle.version>8.19</checkstyle.version>
+    <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
+    <checkstyle.version>8.29</checkstyle.version>
     <surefire.fork.timeout>1200</surefire.fork.timeout>
     <aws-java-sdk.version>1.11.615</aws-java-sdk.version>
     <hsqldb.version>2.3.4</hsqldb.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

CheckStyle: Move LineLength Check parent from TreeWalker to Checker, otherwise fail to import to latest IntelliJ

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4306

## How was this patch tested?

Import to IntelliJ checkstyle plugin and verify there is no syntax error. 