### PR TITLE
HDDS-4312. findbugs check succeeds despite compile error

### DIFF
--- a/hadoop-ozone/dev-support/checks/findbugs.sh
+++ b/hadoop-ozone/dev-support/checks/findbugs.sh
@@ -26,6 +26,7 @@ fi
 
 #shellcheck disable=SC2086
 mvn ${MAVEN_OPTIONS} compile spotbugs:spotbugs
+rc=$?
 
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/findbugs"}
 mkdir -p "$REPORT_DIR"
@@ -42,3 +43,5 @@ wc -l "$REPORT_FILE" | awk '{print $1}'> "$REPORT_DIR/failures"
 if [[ -s "${REPORT_FILE}" ]]; then
    exit 1
 fi
+
+exit ${rc}

--- a/hadoop-ozone/dev-support/checks/findbugs.sh
+++ b/hadoop-ozone/dev-support/checks/findbugs.sh
@@ -20,12 +20,12 @@ MAVEN_OPTIONS='-B -fae -Dskip.npx -Dskip.installnpx'
 
 if ! type unionBugs >/dev/null 2>&1 || ! type convertXmlToText >/dev/null 2>&1; then
   #shellcheck disable=SC2086
-  mvn ${MAVEN_OPTIONS} compile spotbugs:check
+  mvn ${MAVEN_OPTIONS} test-compile spotbugs:check
   exit $?
 fi
 
 #shellcheck disable=SC2086
-mvn ${MAVEN_OPTIONS} compile spotbugs:spotbugs
+mvn ${MAVEN_OPTIONS} test-compile spotbugs:spotbugs
 rc=$?
 
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/findbugs"}

--- a/hadoop-ozone/interface-storage/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-ozone/interface-storage/dev-support/findbugsExcludeFile.xml
@@ -1,0 +1,21 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<FindBugsFilter>
+  <Match>
+    <Package name="org.apache.hadoop.ozone.storage.proto"/>
+  </Match>
+</FindBugsFilter>

--- a/hadoop-ozone/interface-storage/pom.xml
+++ b/hadoop-ozone/interface-storage/pom.xml
@@ -91,6 +91,13 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>${basedir}/dev-support/findbugsExcludeFile.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Make findbugs check correctly report compilation failure via exit code
2. Compile test classes, required by `test-jar` dependency
3. Exclude Protobuf generated classes in new `hadoop-ozone/interface-storage` module

https://issues.apache.org/jira/browse/HDDS-4312

## How was this patch tested?

1. Verified that findbugs check can [now fail](https://github.com/adoroszlai/hadoop-ozone/runs/1215266036#step:3:866) (without fixes 2 and 3)
2. Verified that the check proceeds beyond compilation, and [finds actual findbugs violations](https://github.com/adoroszlai/hadoop-ozone/runs/1215409391#step:3:1808) (without fix 3)
3. Verified that findbugs check [passes](https://github.com/adoroszlai/hadoop-ozone/runs/1215527172#step:3:1803) (with all 3 fixes)