### PR TITLE
Fix inconsistency recon config keys starting with recon and not ozone

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2322,7 +2322,7 @@
   </description>
 </property>
   <property>
-    <name>recon.om.connection.request.timeout</name>
+    <name>ozone.recon.om.connection.request.timeout</name>
     <value>5000</value>
     <tag>OZONE, RECON, OM</tag>
     <description>
@@ -2331,7 +2331,7 @@
     </description>
   </property>
   <property>
-    <name>recon.om.connection.timeout</name>
+    <name>ozone.recon.om.connection.timeout</name>
     <value>5s</value>
     <tag>OZONE, RECON, OM</tag>
     <description>
@@ -2340,7 +2340,7 @@
     </description>
   </property>
   <property>
-    <name>recon.om.socket.timeout</name>
+    <name>ozone.recon.om.socket.timeout</name>
     <value>5s</value>
     <tag>OZONE, RECON, OM</tag>
     <description>
@@ -2349,7 +2349,7 @@
     </description>
   </property>
   <property>
-    <name>recon.om.snapshot.task.initial.delay</name>
+    <name>ozone.recon.om.snapshot.task.initial.delay</name>
     <value>1m</value>
     <tag>OZONE, RECON, OM</tag>
     <description>
@@ -2357,7 +2357,7 @@
     </description>
   </property>
   <property>
-    <name>recon.om.snapshot.task.interval.delay</name>
+    <name>ozone.recon.om.snapshot.task.interval.delay</name>
     <value>10m</value>
     <tag>OZONE, RECON, OM</tag>
     <description>
@@ -2365,7 +2365,7 @@
     </description>
   </property>
   <property>
-    <name>recon.om.snapshot.task.flush.param</name>
+    <name>ozone.recon.om.snapshot.task.flush.param</name>
     <value>false</value>
     <tag>OZONE, RECON, OM</tag>
     <description>

--- a/hadoop-hdds/docs/content/feature/Recon.md
+++ b/hadoop-hdds/docs/content/feature/Recon.md
@@ -44,4 +44,4 @@ ozone.recon.http-address | 0.0.0.0:9888 | The address and the base port where th
 ozone.recon.address | 0.0.0.0:9891 | RPC address of the Recon.
 ozone.recon.db.dir | none | Directory where the Recon Server stores its metadata.
 ozone.recon.om.db.dir | none | Directory where the Recon Server stores its OM snapshot DB.
-recon.om.snapshot.task.interval.delay | 10m | Interval in MINUTES by Recon to request OM DB Snapshot.
+ozone.recon.om.snapshot.task.interval.delay | 10m | Interval in MINUTES by Recon to request OM DB Snapshot.

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-config
@@ -29,6 +29,6 @@ OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
 OZONE-SITE.XML_ozone.scm.client.address=scm
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 OZONE-SITE.XML_ozone.recon.address=recon:9891
-OZONE-SITE.XML_recon.om.snapshot.task.interval.delay=1m
+OZONE-SITE.XML_ozone.recon.om.snapshot.task.interval.delay=1m
 
 no_proxy=om,scm,s3g,recon,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-om-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-om-ha/docker-config
@@ -41,9 +41,9 @@ OZONE-SITE.XML_ozone.scm.client.address=scm
 OZONE-SITE.XML_hdds.block.token.enabled=true
 OZONE-SITE.XML_ozone.replication=3
 
-OZONE-SITE.XML_recon.om.snapshot.task.interval.delay=1m
+OZONE-SITE.XML_ozone.recon.om.snapshot.task.interval.delay=1m
 OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
-OZONE-SITE.XML_recon.om.snapshot.task.initial.delay=20s
+OZONE-SITE.XML_ozone.recon.om.snapshot.task.initial.delay=20s
 OZONE-SITE.XML_ozone.recon.address=recon:9891
 
 OZONE-SITE.XML_ozone.security.enabled=true

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -30,9 +30,9 @@ OZONE-SITE.XML_ozone.scm.client.address=scm
 OZONE-SITE.XML_hdds.block.token.enabled=true
 OZONE-SITE.XML_ozone.replication=3
 
-OZONE-SITE.XML_recon.om.snapshot.task.interval.delay=1m
+OZONE-SITE.XML_ozone.recon.om.snapshot.task.interval.delay=1m
 OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
-OZONE-SITE.XML_recon.om.snapshot.task.initial.delay=20s
+OZONE-SITE.XML_ozone.recon.om.snapshot.task.initial.delay=20s
 OZONE-SITE.XML_ozone.recon.address=recon:9891
 
 OZONE-SITE.XML_ozone.security.enabled=true

--- a/hadoop-ozone/dist/src/main/compose/upgrade/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/docker-config
@@ -29,6 +29,6 @@ OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
 OZONE-SITE.XML_ozone.scm.client.address=scm
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 OZONE-SITE.XML_ozone.recon.address=recon:9891
-OZONE-SITE.XML_recon.om.snapshot.task.interval.delay=1m
+OZONE-SITE.XML_ozone.recon.om.snapshot.task.interval.delay=1m
 
 no_proxy=om,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -68,8 +68,8 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS_NATIVE,
         OzoneConfigKeys.OZONE_S3_AUTHINFO_MAX_LIFETIME_KEY,
         ReconServerConfigKeys.OZONE_RECON_SCM_DB_DIR,
-        ReconServerConfigKeys.RECON_METRICS_HTTP_CONNECTION_TIMEOUT,
-        ReconServerConfigKeys.RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT,
+        ReconServerConfigKeys.OZONE_RECON_METRICS_HTTP_CONNECTION_TIMEOUT,
+        ReconServerConfigKeys.OZONE_RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT,
         OMConfigKeys.OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_KEY
         // TODO HDDS-2856
     ));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -69,7 +69,8 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         OzoneConfigKeys.OZONE_S3_AUTHINFO_MAX_LIFETIME_KEY,
         ReconServerConfigKeys.OZONE_RECON_SCM_DB_DIR,
         ReconServerConfigKeys.OZONE_RECON_METRICS_HTTP_CONNECTION_TIMEOUT,
-        ReconServerConfigKeys.OZONE_RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT,
+        ReconServerConfigKeys
+            .OZONE_RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT,
         OMConfigKeys.OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_KEY
         // TODO HDDS-2856
     ));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -71,6 +71,12 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         ReconServerConfigKeys.OZONE_RECON_METRICS_HTTP_CONNECTION_TIMEOUT,
         ReconServerConfigKeys
             .OZONE_RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT,
+        ReconServerConfigKeys.RECON_OM_SOCKET_TIMEOUT,
+        ReconServerConfigKeys.RECON_OM_CONNECTION_TIMEOUT,
+        ReconServerConfigKeys.RECON_OM_CONNECTION_REQUEST_TIMEOUT,
+        ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY,
+        ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_INTERVAL_DELAY,
+        ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM,
         OMConfigKeys.OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_KEY
         // TODO HDDS-2856
     ));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
@@ -89,14 +89,24 @@ public class TestReconWithOzoneManager {
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
     int socketTimeout = (int) conf.getTimeDuration(
-        OZONE_RECON_OM_SOCKET_TIMEOUT, OZONE_RECON_OM_SOCKET_TIMEOUT_DEFAULT,
+        OZONE_RECON_OM_SOCKET_TIMEOUT,
+        conf.get(
+            ReconServerConfigKeys.RECON_OM_SOCKET_TIMEOUT,
+            OZONE_RECON_OM_SOCKET_TIMEOUT_DEFAULT),
         TimeUnit.MILLISECONDS);
     int connectionTimeout = (int) conf.getTimeDuration(
         OZONE_RECON_OM_CONNECTION_TIMEOUT,
-        OZONE_RECON_OM_CONNECTION_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS);
+        conf.get(
+            ReconServerConfigKeys.RECON_OM_CONNECTION_TIMEOUT,
+            OZONE_RECON_OM_CONNECTION_TIMEOUT_DEFAULT),
+        TimeUnit.MILLISECONDS);
     int connectionRequestTimeout = (int)conf.getTimeDuration(
         OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT,
-        OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS);
+        conf.get(
+            ReconServerConfigKeys.RECON_OM_CONNECTION_REQUEST_TIMEOUT,
+            OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT),
+        TimeUnit.MILLISECONDS
+    );
     RequestConfig config = RequestConfig.custom()
         .setConnectTimeout(socketTimeout)
         .setConnectionRequestTimeout(connectionTimeout)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
@@ -18,12 +18,12 @@ package org.apache.hadoop.ozone.recon;
 
 import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_OK;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_CONNECTION_REQUEST_TIMEOUT;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_CONNECTION_TIMEOUT;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_CONNECTION_TIMEOUT_DEFAULT;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_SOCKET_TIMEOUT;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_SOCKET_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_CONNECTION_TIMEOUT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_CONNECTION_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SOCKET_TIMEOUT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SOCKET_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl.OmSnapshotTaskName.OmDeltaRequest;
 import static org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl.OmSnapshotTaskName.OmSnapshotRequest;
 
@@ -89,14 +89,14 @@ public class TestReconWithOzoneManager {
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
     int socketTimeout = (int) conf.getTimeDuration(
-        RECON_OM_SOCKET_TIMEOUT, RECON_OM_SOCKET_TIMEOUT_DEFAULT,
+        OZONE_RECON_OM_SOCKET_TIMEOUT, OZONE_RECON_OM_SOCKET_TIMEOUT_DEFAULT,
         TimeUnit.MILLISECONDS);
     int connectionTimeout = (int) conf.getTimeDuration(
-        RECON_OM_CONNECTION_TIMEOUT,
-        RECON_OM_CONNECTION_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS);
+        OZONE_RECON_OM_CONNECTION_TIMEOUT,
+        OZONE_RECON_OM_CONNECTION_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS);
     int connectionRequestTimeout = (int)conf.getTimeDuration(
-        RECON_OM_CONNECTION_REQUEST_TIMEOUT,
-        RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS);
+        OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT,
+        OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS);
     RequestConfig config = RequestConfig.custom()
         .setConnectTimeout(socketTimeout)
         .setConnectionRequestTimeout(connectionTimeout)

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
@@ -63,28 +63,46 @@ public final class  ReconServerConfigKeys {
   public static final String OZONE_RECON_OM_SOCKET_TIMEOUT =
       "ozone.recon.om.socket.timeout";
   public static final String OZONE_RECON_OM_SOCKET_TIMEOUT_DEFAULT = "5s";
+  @Deprecated
+  public static final String RECON_OM_SOCKET_TIMEOUT =
+      "recon.om.socket.timeout";
 
   public static final String OZONE_RECON_OM_CONNECTION_TIMEOUT =
       "ozone.recon.om.connection.timeout";
   public static final String OZONE_RECON_OM_CONNECTION_TIMEOUT_DEFAULT = "5s";
+  @Deprecated
+  public static final String RECON_OM_CONNECTION_TIMEOUT =
+      "recon.om.connection.timeout";
 
   public static final String OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT =
       "ozone.recon.om.connection.request.timeout";
-
-  public static final String OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT = "5s";
+  public static final String OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT =
+      "5s";
+  @Deprecated
+  public static final String RECON_OM_CONNECTION_REQUEST_TIMEOUT =
+      "recon.om.connection.request.timeout";
 
   public static final String OZONE_RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY =
       "ozone.recon.om.snapshot.task.initial.delay";
   public static final String
       OZONE_RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY_DEFAULT = "1m";
+  @Deprecated
+  public static final String RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY =
+      "recon.om.snapshot.task.initial.delay";
 
   public static final String OZONE_RECON_OM_SNAPSHOT_TASK_INTERVAL_DELAY =
       "ozone.recon.om.snapshot.task.interval.delay";
   public static final String OZONE_RECON_OM_SNAPSHOT_TASK_INTERVAL_DEFAULT
       = "10m";
+  @Deprecated
+  public static final String RECON_OM_SNAPSHOT_TASK_INTERVAL_DELAY =
+      "recon.om.snapshot.task.interval.delay";
 
   public static final String OZONE_RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM =
       "ozone.recon.om.snapshot.task.flush.param";
+  @Deprecated
+  public static final String RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM =
+      "recon.om.snapshot.task.flush.param";
 
   public static final String OZONE_RECON_TASK_THREAD_COUNT_KEY =
       "ozone.recon.task.thread.count";

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.hdds.annotation.InterfaceStability;
  */
 @InterfaceAudience.Public
 @InterfaceStability.Unstable
-public final class ReconServerConfigKeys {
+public final class  ReconServerConfigKeys {
 
   public static final String OZONE_RECON_HTTP_ENABLED_KEY =
       "ozone.recon.http.enabled";
@@ -60,31 +60,31 @@ public final class ReconServerConfigKeys {
 
   public static final String RECON_STORAGE_DIR = "recon";
 
-  public static final String RECON_OM_SOCKET_TIMEOUT =
-      "recon.om.socket.timeout";
-  public static final String RECON_OM_SOCKET_TIMEOUT_DEFAULT = "5s";
+  public static final String OZONE_RECON_OM_SOCKET_TIMEOUT =
+      "ozone.recon.om.socket.timeout";
+  public static final String OZONE_RECON_OM_SOCKET_TIMEOUT_DEFAULT = "5s";
 
-  public static final String RECON_OM_CONNECTION_TIMEOUT =
-      "recon.om.connection.timeout";
-  public static final String RECON_OM_CONNECTION_TIMEOUT_DEFAULT = "5s";
+  public static final String OZONE_RECON_OM_CONNECTION_TIMEOUT =
+      "ozone.recon.om.connection.timeout";
+  public static final String OZONE_RECON_OM_CONNECTION_TIMEOUT_DEFAULT = "5s";
 
-  public static final String RECON_OM_CONNECTION_REQUEST_TIMEOUT =
-      "recon.om.connection.request.timeout";
+  public static final String OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT =
+      "ozone.recon.om.connection.request.timeout";
 
-  public static final String RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT = "5s";
+  public static final String OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT = "5s";
 
-  public static final String RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY =
-      "recon.om.snapshot.task.initial.delay";
+  public static final String OZONE_RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY =
+      "ozone.recon.om.snapshot.task.initial.delay";
   public static final String
-      RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY_DEFAULT = "1m";
+      OZONE_RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY_DEFAULT = "1m";
 
-  public static final String RECON_OM_SNAPSHOT_TASK_INTERVAL =
-      "recon.om.snapshot.task.interval.delay";
-  public static final String RECON_OM_SNAPSHOT_TASK_INTERVAL_DEFAULT
+  public static final String OZONE_RECON_OM_SNAPSHOT_TASK_INTERVAL_DELAY =
+      "ozone.recon.om.snapshot.task.interval.delay";
+  public static final String OZONE_RECON_OM_SNAPSHOT_TASK_INTERVAL_DEFAULT
       = "10m";
 
-  public static final String RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM =
-      "recon.om.snapshot.task.flush.param";
+  public static final String OZONE_RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM =
+      "ozone.recon.om.snapshot.task.flush.param";
 
   public static final String OZONE_RECON_TASK_THREAD_COUNT_KEY =
       "ozone.recon.task.thread.count";
@@ -96,17 +96,19 @@ public final class ReconServerConfigKeys {
   public static final String OZONE_RECON_HTTP_AUTH_TYPE =
       OZONE_RECON_HTTP_AUTH_CONFIG_PREFIX + "type";
 
-  public static final String RECON_METRICS_HTTP_CONNECTION_TIMEOUT =
+  public static final String OZONE_RECON_METRICS_HTTP_CONNECTION_TIMEOUT =
       "ozone.recon.metrics.http.connection.timeout";
 
-  public static final String RECON_METRICS_HTTP_CONNECTION_TIMEOUT_DEFAULT =
+  public static final String
+      OZONE_RECON_METRICS_HTTP_CONNECTION_TIMEOUT_DEFAULT =
       "10s";
 
-  public static final String RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT =
+  public static final String
+      OZONE_RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT =
       "ozone.recon.metrics.http.connection.request.timeout";
 
   public static final String
-      RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT_DEFAULT = "10s";
+      OZONE_RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT_DEFAULT = "10s";
 
   /**
    * Private constructor for utility class.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -61,15 +61,15 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OM_DB_CHECKPOINT_HTTP_EN
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_AUTH_TYPE;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_OM_SNAPSHOT_DB;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_DB_DIR;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_CONNECTION_REQUEST_TIMEOUT;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_CONNECTION_TIMEOUT;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_CONNECTION_TIMEOUT_DEFAULT;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY_DEFAULT;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_INTERVAL;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_INTERVAL_DEFAULT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_CONNECTION_TIMEOUT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_CONNECTION_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY_DEFAULT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_TASK_INTERVAL_DELAY;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_TASK_INTERVAL_DEFAULT;
 import static org.apache.ratis.proto.RaftProtos.RaftPeerRole.LEADER;
 import org.hadoop.ozone.recon.schema.tables.daos.ReconTaskStatusDao;
 import org.hadoop.ozone.recon.schema.tables.pojos.ReconTaskStatus;
@@ -121,11 +121,11 @@ public class OzoneManagerServiceProviderImpl
       OzoneManagerProtocol ozoneManagerClient) {
 
     int connectionTimeout = (int) configuration.getTimeDuration(
-        RECON_OM_CONNECTION_TIMEOUT,
-        RECON_OM_CONNECTION_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS);
+        OZONE_RECON_OM_CONNECTION_TIMEOUT,
+        OZONE_RECON_OM_CONNECTION_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS);
     int connectionRequestTimeout = (int)configuration.getTimeDuration(
-        RECON_OM_CONNECTION_REQUEST_TIMEOUT,
-        RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS);
+        OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT,
+        OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS);
 
     connectionFactory =
         URLConnectionFactory.newDefaultURLConnectionFactory(connectionTimeout,
@@ -151,7 +151,7 @@ public class OzoneManagerServiceProviderImpl
     }
 
     boolean flushParam = configuration.getBoolean(
-        RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM, false);
+        OZONE_RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM, false);
 
     if (flushParam) {
       omDBSnapshotUrl += "?" + OZONE_DB_CHECKPOINT_REQUEST_FLUSH + "=true";
@@ -205,12 +205,12 @@ public class OzoneManagerServiceProviderImpl
     }
     reconTaskController.start();
     long initialDelay = configuration.getTimeDuration(
-        RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY,
-        RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY_DEFAULT,
+        OZONE_RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY,
+        OZONE_RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY_DEFAULT,
         TimeUnit.MILLISECONDS);
     long interval = configuration.getTimeDuration(
-        RECON_OM_SNAPSHOT_TASK_INTERVAL,
-        RECON_OM_SNAPSHOT_TASK_INTERVAL_DEFAULT,
+        OZONE_RECON_OM_SNAPSHOT_TASK_INTERVAL_DELAY,
+        OZONE_RECON_OM_SNAPSHOT_TASK_INTERVAL_DEFAULT,
         TimeUnit.MILLISECONDS);
     scheduler.scheduleWithFixedDelay(() -> {
       try {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.ozone.om.helpers.DBUpdates;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DBUpdatesRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServicePort.Type;
+import org.apache.hadoop.ozone.recon.ReconServerConfigKeys;
 import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.metrics.OzoneManagerSyncMetrics;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
@@ -122,10 +123,17 @@ public class OzoneManagerServiceProviderImpl
 
     int connectionTimeout = (int) configuration.getTimeDuration(
         OZONE_RECON_OM_CONNECTION_TIMEOUT,
-        OZONE_RECON_OM_CONNECTION_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS);
+        configuration.get(
+            ReconServerConfigKeys.RECON_OM_CONNECTION_TIMEOUT,
+            OZONE_RECON_OM_CONNECTION_TIMEOUT_DEFAULT),
+        TimeUnit.MILLISECONDS);
     int connectionRequestTimeout = (int)configuration.getTimeDuration(
         OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT,
-        OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS);
+        configuration.get(
+            ReconServerConfigKeys.RECON_OM_CONNECTION_REQUEST_TIMEOUT,
+            OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT),
+        TimeUnit.MILLISECONDS
+    );
 
     connectionFactory =
         URLConnectionFactory.newDefaultURLConnectionFactory(connectionTimeout,
@@ -151,7 +159,11 @@ public class OzoneManagerServiceProviderImpl
     }
 
     boolean flushParam = configuration.getBoolean(
-        OZONE_RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM, false);
+        OZONE_RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM,
+        configuration.getBoolean(
+            ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM,
+            false)
+    );
 
     if (flushParam) {
       omDBSnapshotUrl += "?" + OZONE_DB_CHECKPOINT_REQUEST_FLUSH + "=true";
@@ -206,11 +218,15 @@ public class OzoneManagerServiceProviderImpl
     reconTaskController.start();
     long initialDelay = configuration.getTimeDuration(
         OZONE_RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY,
-        OZONE_RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY_DEFAULT,
+        configuration.get(
+            ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY,
+            OZONE_RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY_DEFAULT),
         TimeUnit.MILLISECONDS);
     long interval = configuration.getTimeDuration(
         OZONE_RECON_OM_SNAPSHOT_TASK_INTERVAL_DELAY,
-        OZONE_RECON_OM_SNAPSHOT_TASK_INTERVAL_DEFAULT,
+        configuration.get(
+            ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_INTERVAL_DELAY,
+            OZONE_RECON_OM_SNAPSHOT_TASK_INTERVAL_DEFAULT),
         TimeUnit.MILLISECONDS);
     scheduler.scheduleWithFixedDelay(() -> {
       try {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/PrometheusServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/PrometheusServiceProviderImpl.java
@@ -65,8 +65,8 @@ public class PrometheusServiceProviderImpl
 
     int connectionTimeout = (int) configuration.getTimeDuration(
         OZONE_RECON_METRICS_HTTP_CONNECTION_TIMEOUT,
-        OZONE_RECON_METRICS_HTTP_CONNECTION_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS
-    );
+        OZONE_RECON_METRICS_HTTP_CONNECTION_TIMEOUT_DEFAULT,
+        TimeUnit.MILLISECONDS);
     int connectionRequestTimeout = (int) configuration.getTimeDuration(
         OZONE_RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT,
         OZONE_RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT_DEFAULT,

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/PrometheusServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/PrometheusServiceProviderImpl.java
@@ -65,7 +65,8 @@ public class PrometheusServiceProviderImpl
 
     int connectionTimeout = (int) configuration.getTimeDuration(
         OZONE_RECON_METRICS_HTTP_CONNECTION_TIMEOUT,
-        OZONE_RECON_METRICS_HTTP_CONNECTION_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS);
+        OZONE_RECON_METRICS_HTTP_CONNECTION_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS
+    );
     int connectionRequestTimeout = (int) configuration.getTimeDuration(
         OZONE_RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT,
         OZONE_RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT_DEFAULT,

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/PrometheusServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/PrometheusServiceProviderImpl.java
@@ -38,10 +38,10 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT_DEFAULT;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_METRICS_HTTP_CONNECTION_TIMEOUT;
-import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_METRICS_HTTP_CONNECTION_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_METRICS_HTTP_CONNECTION_TIMEOUT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_METRICS_HTTP_CONNECTION_TIMEOUT_DEFAULT;
 
 /**
  * Implementation of the Prometheus Metrics Service provider.
@@ -64,11 +64,11 @@ public class PrometheusServiceProviderImpl
                                        ReconUtils reconUtils) {
 
     int connectionTimeout = (int) configuration.getTimeDuration(
-        RECON_METRICS_HTTP_CONNECTION_TIMEOUT,
-        RECON_METRICS_HTTP_CONNECTION_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS);
+        OZONE_RECON_METRICS_HTTP_CONNECTION_TIMEOUT,
+        OZONE_RECON_METRICS_HTTP_CONNECTION_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS);
     int connectionRequestTimeout = (int) configuration.getTimeDuration(
-        RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT,
-        RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT_DEFAULT,
+        OZONE_RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT,
+        OZONE_RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT_DEFAULT,
         TimeUnit.MILLISECONDS);
 
     connectionFactory =


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix recon configs inconsistent

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4309

## How was this patch tested?

Build up project, launch dockers, and new default parameters were present but not old ones anymore.

On recon container:
```
> ozone getconf confKey recon.om.socket.timeout
Configuration recon.om.socket.timeout is missing.
> ozone getconf confKey ozone.recon.om.socket.timeout
5s
```
