### PR TITLE
HDDS-4319. Compile error with Java 11

### DIFF
--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -168,9 +168,13 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         </executions>
       </plugin>
       <plugin>
+        <!--
+        https://github.com/mojohaus/aspectj-maven-plugin/issues/24#issuecomment-419077658
         <groupId>org.codehaus.mojo</groupId>
+        -->
+        <groupId>com.github.m50d</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
-        <version>1.10</version>
+        <version>1.11.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>


### PR DESCRIPTION
## What changes were proposed in this pull request?

AspectJ-Maven-Plugin is [not compatible with Java 9](https://github.com/mojohaus/aspectj-maven-plugin/issues/24) or later as of the current version (1.11).  There is a snapshot build that can be used [for the time being](https://github.com/mojohaus/aspectj-maven-plugin/issues/24#issuecomment-419077658).

https://issues.apache.org/jira/browse/HDDS-4319

## How was this patch tested?

Compiled locally with Java 11.  

https://github.com/adoroszlai/hadoop-ozone/runs/1221457072