### PR TITLE
HDDS-4325. Incompatible return codes from Ozone getconf -confKey

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/basic/getconf.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/getconf.robot
@@ -14,20 +14,33 @@
 # limitations under the License.
 
 *** Settings ***
-Documentation       Smoketest ozone cluster startup
-Library             OperatingSystem
-Resource            ../commonlib.robot
+Documentation       Test 'ozone getconf' command
+Resource            ../lib/os.robot
 Test Timeout        5 minutes
 
 *** Test Cases ***
-Ozone getconf OM
-    ${result} =        Execute              ozone getconf ozonemanagers
-                       Should contain   ${result}   om
+Get OM
+    ${result} =      Execute                ozone getconf ozonemanagers
+                     Should contain   ${result}   om
+    ${result} =      Execute                ozone getconf -ozonemanagers
+                     Should contain   ${result}   om
 
-Ozone getconf SCM
-    ${result} =        Execute              ozone getconf storagecontainermanagers
-                       Should contain   ${result}   scm
+Get SCM
+    ${result} =      Execute                ozone getconf storagecontainermanagers
+                     Should contain   ${result}   scm
+    ${result} =      Execute                ozone getconf -storagecontainermanagers
+                     Should contain   ${result}   scm
 
-Ozone getconf configration keys
-    ${result} =        Execute              ozone getconf confKey endpoint.token
-                       Should contain   ${result}   Configuration endpoint.token is missing
+Get existing config key
+    ${result} =      Execute                ozone getconf confKey ozone.om.address
+                     Should contain    ${result}   om
+                     Should not contain   ${result}   is missing
+    ${result} =      Execute                ozone getconf -confKey ozone.om.address
+                     Should contain    ${result}   om
+                     Should not contain   ${result}   is missing
+
+Get undefined config key
+    ${result} =      Execute and checkrc    ozone getconf confKey no-such-config-key    255
+                     Should contain   ${result}   Configuration no-such-config-key is missing
+    ${result} =      Execute and checkrc    ozone getconf -confKey no-such-config-key    255
+                     Should contain   ${result}   Configuration no-such-config-key is missing

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/conf/PrintConfKeyCommandHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/conf/PrintConfKeyCommandHandler.java
@@ -44,7 +44,8 @@ public class PrintConfKeyCommandHandler implements Callable<Void> {
     if (value != null) {
       tool.printOut(value);
     } else {
-      tool.printError("Configuration " + confKey + " is missing.");
+      throw new IllegalArgumentException(
+          "Configuration " + confKey + " is missing.");
     }
     return null;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make `ozone getconf -confKey` return error (255) instead of success (0) for missing key, to be compatible with Ozone 1.0.

https://issues.apache.org/jira/browse/HDDS-4325

## How was this patch tested?

Manually verified that output and exit codes with patch:

```
$ ozone getconf -confKey asdf; echo $?
Configuration asdf is missing.
255
$ ozone getconf -confKey ozone.om.address; echo $?
om
0
```

match 1.0.0:

```
$ ozone getconf -confKey asdf; echo $?
Configuration asdf is missing.
255
$ ozone getconf -confKey ozone.om.address; echo $?
om
0
```

Added check for exit code in acceptance test case for missing key.  Also added test case for existing key.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/295406415