### PR TITLE
HDDS-4269. Ozone DataNode thinks a volume is failed if an unexpected file is in the HDDS root directory.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/HddsVolumeUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/HddsVolumeUtil.java
@@ -213,7 +213,9 @@ public final class HddsVolumeUtil {
       // The hdds root dir should always have 2 files. One is Version file
       // and other is SCM directory.
       logger.error("The hdds root dir {} should always have 2 files. " +
-              "One is Version file and other is SCM directory.",
+              "One is Version file and other is SCM directory. " +
+              "Please remove any other extra files from the directory " +
+              "so that DataNode startup can proceed.",
               hddsRoot.getAbsolutePath());
       return false;
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/HddsVolumeUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/HddsVolumeUtil.java
@@ -212,6 +212,9 @@ public final class HddsVolumeUtil {
     } else {
       // The hdds root dir should always have 2 files. One is Version file
       // and other is SCM directory.
+      logger.error("The hdds root dir {} should always have 2 files. " +
+              "One is Version file and other is SCM directory.",
+              hddsRoot.getAbsolutePath());
       return false;
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding a log makes it easy to track the problem.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4269

## How was this patch tested?
Test on local.