### PR TITLE
HDDS-4343: ReplicationManager.handleOverReplicatedContainer() does not handle unhealthyReplicas properly.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -746,8 +746,9 @@ public class ReplicationManager
         if (excess > 0) {
           sendDeleteCommand(container, r.getDatanodeDetails(), true);
           excess -= 1;
+        } else {
+          break;
         }
-        break;
       }
       // After removing all unhealthy replicas, if the container is still over
       // replicated then we need to check if it is already mis-replicated.


### PR DESCRIPTION
What changes were proposed in this pull request?

ReplicationManager.handleOverReplicatedContainer() does not handle unhealthyReplicas properly

```
      // If there are unhealthy replicas, then we should remove them even if it
      // makes the container violate the placement policy, as excess unhealthy
      // containers are not really useful. It will be corrected later as a
      // mis-replicated container will be seen as under-replicated.
      for (ContainerReplica r : unhealthyReplicas) {
        if (excess > 0) {
          sendDeleteCommand(container, r.getDatanodeDetails(), true);
          excess -= 1;
        }
        break;
      }
      // After removing all unhealthy replicas, if the container is still over
      // replicated then we need to check if it is already mis-replicated.
      // If it is, we do no harm by removing excess replicas. However, if it is
      // not mis-replicated, then we can only remove replicas if they don't
      // make the container become mis-replicated.
```

From the comment, it wants to remove all unhealthy replicas until excess reach 0 ? It should be

```
      for (ContainerReplica r : unhealthyReplicas) {
        if (excess > 0) {
          sendDeleteCommand(container, r.getDatanodeDetails(), true);
          excess -= 1;
        } else {
          break;
        }
      }
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4343#


## How was this patch tested?

CI