### PR TITLE
HDDS-4324. DatanodeAdminMonitor no longers needs maintenance end time to be passed

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitor.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
  */
 public interface DatanodeAdminMonitor extends Runnable {
 
-  void startMonitoring(DatanodeDetails dn, int endInHours);
+  void startMonitoring(DatanodeDetails dn);
   void stopMonitoring(DatanodeDetails dn);
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorImpl.java
@@ -87,12 +87,9 @@ public class DatanodeAdminMonitorImpl implements DatanodeAdminMonitor {
    * queued and added to the workflow after a defined interval.
    *
    * @param dn         The datanode to move into an admin state
-   * @param endInHours For nodes going into maintenance, the number of hours
-   *                   from now for maintenance to automatically end. Ignored
-   *                   for decommissioning nodes.
    */
   @Override
-  public synchronized void startMonitoring(DatanodeDetails dn, int endInHours) {
+  public synchronized void startMonitoring(DatanodeDetails dn) {
     cancelledNodes.remove(dn);
     pendingNodes.add(dn);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -245,7 +245,7 @@ public class NodeDecommissionManager {
     NodeOperationalState opState = getNodeStatus(dn).getOperationalState();
     if (opState == NodeOperationalState.DECOMMISSIONING
         || opState == NodeOperationalState.ENTERING_MAINTENANCE) {
-      monitor.startMonitoring(dn, 0);
+      monitor.startMonitoring(dn);
     }
   }
 
@@ -257,7 +257,7 @@ public class NodeDecommissionManager {
       LOG.info("Starting Decommission for node {}", dn);
       nodeManager.setNodeOperationalState(
           dn, NodeOperationalState.DECOMMISSIONING);
-      monitor.startMonitoring(dn, 0);
+      monitor.startMonitoring(dn);
     } else if (nodeStatus.isDecommission()) {
       LOG.info("Start Decommission called on node {} in state {}. Nothing to "+
           "do.", dn, opState);
@@ -339,7 +339,7 @@ public class NodeDecommissionManager {
     if (opState == NodeOperationalState.IN_SERVICE) {
       nodeManager.setNodeOperationalState(
           dn, NodeOperationalState.ENTERING_MAINTENANCE, maintenanceEnd);
-      monitor.startMonitoring(dn, endInHours);
+      monitor.startMonitoring(dn);
       LOG.info("Starting Maintenance for node {}", dn);
     } else if (nodeStatus.isMaintenance()) {
       LOG.info("Starting Maintenance called on node {} with state {}. "+

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
@@ -85,14 +85,14 @@ public class TestDatanodeAdminMonitor {
   @Test
   public void testNodeCanBeQueuedAndCancelled() {
     DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
-    monitor.startMonitoring(dn, 0);
+    monitor.startMonitoring(dn);
     assertEquals(1, monitor.getPendingCount());
 
     monitor.stopMonitoring(dn);
     assertEquals(0, monitor.getPendingCount());
     assertEquals(1, monitor.getCancelledCount());
 
-    monitor.startMonitoring(dn, 0);
+    monitor.startMonitoring(dn);
     assertEquals(1, monitor.getPendingCount());
     assertEquals(0, monitor.getCancelledCount());
   }
@@ -112,7 +112,7 @@ public class TestDatanodeAdminMonitor {
     // Ensure the node has some pipelines
     nodeManager.setPipelines(dn1, 2);
     // Add the node to the monitor
-    monitor.startMonitoring(dn1, 0);
+    monitor.startMonitoring(dn1);
     monitor.run();
     // Ensure a StartAdmin event was fired
     eventQueue.processAll(20000);
@@ -152,7 +152,7 @@ public class TestDatanodeAdminMonitor {
     // Add the node to the monitor. By default we have zero pipelines and
     // zero containers in the test setup, so the node should immediately
     // transition to COMPLETED state
-    monitor.startMonitoring(dn1, 0);
+    monitor.startMonitoring(dn1);
     monitor.run();
     assertEquals(0, monitor.getTrackedNodeCount());
     NodeStatus newStatus = nodeManager.getNodeStatus(dn1);
@@ -179,7 +179,7 @@ public class TestDatanodeAdminMonitor {
 
     // Run the monitor for the first time and the node will transition to
     // REPLICATE_CONTAINERS as there are no pipelines to close.
-    monitor.startMonitoring(dn1, 0);
+    monitor.startMonitoring(dn1);
     monitor.run();
     DatanodeDetails node = getFirstTrackedNode();
     assertEquals(1, monitor.getTrackedNodeCount());
@@ -225,7 +225,7 @@ public class TestDatanodeAdminMonitor {
 
     // Add the node to the monitor, it should have 3 under-replicated containers
     // after the first run
-    monitor.startMonitoring(dn1, 0);
+    monitor.startMonitoring(dn1);
     monitor.run();
     assertEquals(1, monitor.getTrackedNodeCount());
     DatanodeDetails node = getFirstTrackedNode();
@@ -258,7 +258,7 @@ public class TestDatanodeAdminMonitor {
 
     // Add the node to the monitor, it should have 3 under-replicated containers
     // after the first run
-    monitor.startMonitoring(dn1, 0);
+    monitor.startMonitoring(dn1);
     monitor.run();
     assertEquals(1, monitor.getTrackedNodeCount());
     DatanodeDetails node = getFirstTrackedNode();
@@ -286,7 +286,7 @@ public class TestDatanodeAdminMonitor {
 
     // Add the node to the monitor, it should transiting to
     // IN_MAINTENANCE as there are no containers to replicate.
-    monitor.startMonitoring(dn1, 1);
+    monitor.startMonitoring(dn1);
     monitor.run();
     assertEquals(1, monitor.getTrackedNodeCount());
     DatanodeDetails node = getFirstTrackedNode();
@@ -317,7 +317,7 @@ public class TestDatanodeAdminMonitor {
     // Ensure the node has some pipelines
     nodeManager.setPipelines(dn1, 2);
     // Add the node to the monitor
-    monitor.startMonitoring(dn1, 1);
+    monitor.startMonitoring(dn1);
     monitor.run();
     DatanodeDetails node = getFirstTrackedNode();
     assertEquals(1, monitor.getTrackedNodeCount());
@@ -351,7 +351,7 @@ public class TestDatanodeAdminMonitor {
     // Add the node to the monitor, it should transiting to
     // REPLICATE_CONTAINERS as the containers are under-replicated for
     // maintenance.
-    monitor.startMonitoring(dn1, 1);
+    monitor.startMonitoring(dn1);
     monitor.run();
     assertEquals(1, monitor.getTrackedNodeCount());
     DatanodeDetails node = getFirstTrackedNode();
@@ -375,7 +375,7 @@ public class TestDatanodeAdminMonitor {
 
     // Add the node to the monitor, it should transiting to
     // AWAIT_MAINTENANCE_END as there are no under-replicated containers.
-    monitor.startMonitoring(dn1, 1);
+    monitor.startMonitoring(dn1);
     monitor.run();
     assertEquals(1, monitor.getTrackedNodeCount());
     DatanodeDetails node = getFirstTrackedNode();
@@ -402,7 +402,7 @@ public class TestDatanodeAdminMonitor {
 
     // Add the node to the monitor, it should transiting to
     // AWAIT_MAINTENANCE_END as there are no under-replicated containers.
-    monitor.startMonitoring(dn1, 1);
+    monitor.startMonitoring(dn1);
     monitor.run();
     assertEquals(1, monitor.getTrackedNodeCount());
     DatanodeDetails node = getFirstTrackedNode();


### PR DESCRIPTION
## What changes were proposed in this pull request?

An earlier change moved the maintenance endtime into the NodeStatus object. However when adding a node to the decommission monitor the end time must still be passed. This value is never used.

This Jira will remove the endInHours field from the interface:

```
public interface DatanodeAdminMonitor extends Runnable {

  void startMonitoring(DatanodeDetails dn, int endInHours);
  void stopMonitoring(DatanodeDetails dn);
}
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4324

## How was this patch tested?

Existing tests
