### PR TITLE
HDDS-4328. Provide fallback cache restore key

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           path: ~/.m2/repository
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-repo-
       - name: Setup java
         uses: actions/setup-java@v1
         with:
@@ -182,6 +183,7 @@ jobs:
         with:
           path: ~/.m2/repository
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-repo-
       - name: Cache for npm dependencies
         uses: actions/cache@v2
         with:
@@ -311,6 +313,7 @@ jobs:
         with:
           path: ~/.m2/repository
           key: maven-repo-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-repo-
       - name: Cache for npm dependencies
         uses: actions/cache@v2
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <protobuf.version>2.5.0</protobuf.version>
 
     <findbugs.version>3.0.0</findbugs.version>
-    <spotbugs.version>3.1.12</spotbugs.version>
+    <spotbugs.version>4.1.3</spotbugs.version>
     <dnsjava.version>2.1.7</dnsjava.version>
 
     <guava.version>28.2-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <protobuf.version>2.5.0</protobuf.version>
 
     <findbugs.version>3.0.0</findbugs.version>
-    <spotbugs.version>4.1.3</spotbugs.version>
+    <spotbugs.version>3.1.12</spotbugs.version>
     <dnsjava.version>2.1.7</dnsjava.version>
 
     <guava.version>28.2-jre</guava.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Specify fallback cache restore key (`restore-keys`) for GitHub Actions CI workflow.

Maven dependency cache hit or miss in GitHub Actions workflow is based on the
hash of all POM files. If any POM is changed, all dependencies need to be
downloaded from scratch.  The fallback key allows it to use one of the previous
caches, potentially avoiding most of the downloads ([doc](https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key)).

https://issues.apache.org/jira/browse/HDDS-4328

## How was this patch tested?

Regular CI in two steps.

Initial [commit](https://github.com/adoroszlai/hadoop-ozone/commit/582d89af0009e909fbcbaf82e359d0068924de79):

```
    key: maven-repo-91e13458cfebf5c61e6f829853e6d98af55898ed81a5ad0b4e855c96fc0fe0ce
    restore-keys: maven-repo-
Cache not found for input keys: maven-repo-91e13458cfebf5c61e6f829853e6d98af55898ed81a5ad0b4e855c96fc0fe0ce, maven-repo-

...

Post job cleanup.
Cache saved successfully
```

Next [commit](https://github.com/adoroszlai/hadoop-ozone/commit/45730362fab01d9a0ed4bcf62b1f6ac8dec5c965), with POM changes:

```
    key: maven-repo-5fb5c783db98f682a1b3f4926097ed49d2297d6ee0118ace1d994e545b0259bd
    restore-keys: maven-repo-

...

Cache restored from key: maven-repo-91e13458cfebf5c61e6f829853e6d98af55898ed81a5ad0b4e855c96fc0fe0ce
```

The second commit encountered cache miss, but restored from previous version.