### PR TITLE
HDDS-4359. Expose VolumeIOStats in DN JMX

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -400,12 +400,18 @@ public class HddsVolume
     if (volumeInfo != null) {
       volumeInfo.shutdownUsageThread();
     }
+    if (volumeIOStats != null) {
+      volumeIOStats.unregister();
+    }
   }
 
   public void shutdown() {
     this.state = VolumeState.NON_EXISTENT;
     if (volumeInfo != null) {
       volumeInfo.shutdownUsageThread();
+    }
+    if (volumeIOStats != null) {
+      volumeIOStats.unregister();
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -165,7 +165,7 @@ public class HddsVolume
       this.state = VolumeState.NOT_INITIALIZED;
       this.clusterID = b.clusterID;
       this.datanodeUuid = b.datanodeUuid;
-      this.volumeIOStats = new VolumeIOStats();
+      this.volumeIOStats = new VolumeIOStats(b.volumeRootStr);
 
       volumeInfo = new VolumeInfo.Builder(b.volumeRootStr, b.conf)
           .storageType(b.storageType)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
@@ -36,12 +36,15 @@ public class VolumeIOStats {
   private @Metric MutableCounterLong writeOpCount;
   private @Metric MutableCounterLong readTime;
   private @Metric MutableCounterLong writeTime;
-  private MetricsRegistry registry;
 
+  @Deprecated
   public VolumeIOStats() {
     init();
   }
 
+  /**
+   * @param identifier Usually path to volume root, e.g. /data/hdds
+   */
   public VolumeIOStats(String identifier) {
     this.sourceName += '-' + identifier;
     init();
@@ -50,7 +53,6 @@ public class VolumeIOStats {
   public void init() {
     MetricsSystem ms = DefaultMetricsSystem.instance();
     ms.register(sourceName, "Volume I/O Statistics", this);
-    this.registry = new MetricsRegistry(sourceName);
   }
 
   public void unregister() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.metrics2.lib.MutableCounterLong;
  * This class is used to track Volume IO stats for each HDDS Volume.
  */
 public class VolumeIOStats {
-  private String sourceName = VolumeIOStats.class.getSimpleName();
+  public String sourceName = VolumeIOStats.class.getSimpleName();
 
   private @Metric MutableCounterLong readBytes;
   private @Metric MutableCounterLong readOpCount;
@@ -42,7 +42,7 @@ public class VolumeIOStats {
   }
 
   /**
-   * @param identifier Usually path to volume root, e.g. /data/hdds
+   * @param identifier Typically, path to volume root. e.g. /data/hdds
    */
   public VolumeIOStats(String identifier) {
     this.sourceName += '-' + identifier;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
@@ -18,27 +18,41 @@
 
 package org.apache.hadoop.ozone.container.common.volume;
 
-import java.util.concurrent.atomic.AtomicLong;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.annotation.Metric;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.MetricsRegistry;
+import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 
 /**
  * This class is used to track Volume IO stats for each HDDS Volume.
  */
 public class VolumeIOStats {
+  private String name = VolumeIOStats.class.getSimpleName();
 
-  private final AtomicLong readBytes;
-  private final AtomicLong readOpCount;
-  private final AtomicLong writeBytes;
-  private final AtomicLong writeOpCount;
-  private final AtomicLong readTime;
-  private final AtomicLong writeTime;
+  private @Metric MutableCounterLong readBytes;
+  private @Metric MutableCounterLong readOpCount;
+  private @Metric MutableCounterLong writeBytes;
+  private @Metric MutableCounterLong writeOpCount;
+  private @Metric MutableCounterLong readTime;
+  private @Metric MutableCounterLong writeTime;
+  private MetricsRegistry registry;
 
   public VolumeIOStats() {
-    readBytes = new AtomicLong(0);
-    readOpCount = new AtomicLong(0);
-    writeBytes = new AtomicLong(0);
-    writeOpCount = new AtomicLong(0);
-    readTime = new AtomicLong(0);
-    writeTime = new AtomicLong(0);
+    init();
+  }
+
+  public VolumeIOStats(String identifier) {
+    this.name += '-' + identifier;
+    init();
+  }
+
+  public void init() {
+    DefaultMetricsSystem.initialize(name);
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    ms.register(name, "Volume I/O Statistics", this);
+
+    this.registry = new MetricsRegistry(name);
   }
 
   /**
@@ -46,14 +60,14 @@ public class VolumeIOStats {
    * @param bytesRead
    */
   public void incReadBytes(long bytesRead) {
-    readBytes.addAndGet(bytesRead);
+    readBytes.incr(bytesRead);
   }
 
   /**
    * Increment the read operations performed on the volume.
    */
   public void incReadOpCount() {
-    readOpCount.incrementAndGet();
+    readOpCount.incr();
   }
 
   /**
@@ -61,14 +75,14 @@ public class VolumeIOStats {
    * @param bytesWritten
    */
   public void incWriteBytes(long bytesWritten) {
-    writeBytes.addAndGet(bytesWritten);
+    writeBytes.incr(bytesWritten);
   }
 
   /**
    * Increment the write operations performed on the volume.
    */
   public void incWriteOpCount() {
-    writeOpCount.incrementAndGet();
+    writeOpCount.incr();
   }
 
   /**
@@ -76,7 +90,7 @@ public class VolumeIOStats {
    * @param time
    */
   public void incReadTime(long time) {
-    readTime.addAndGet(time);
+    readTime.incr(time);
   }
 
   /**
@@ -84,7 +98,7 @@ public class VolumeIOStats {
    * @param time
    */
   public void incWriteTime(long time) {
-    writeTime.addAndGet(time);
+    writeTime.incr(time);
   }
 
   /**
@@ -92,7 +106,7 @@ public class VolumeIOStats {
    * @return long
    */
   public long getReadBytes() {
-    return readBytes.get();
+    return readBytes.value();
   }
 
   /**
@@ -100,7 +114,7 @@ public class VolumeIOStats {
    * @return long
    */
   public long getWriteBytes() {
-    return writeBytes.get();
+    return writeBytes.value();
   }
 
   /**
@@ -108,7 +122,7 @@ public class VolumeIOStats {
    * @return long
    */
   public long getReadOpCount() {
-    return readOpCount.get();
+    return readOpCount.value();
   }
 
   /**
@@ -116,7 +130,7 @@ public class VolumeIOStats {
    * @return long
    */
   public long getWriteOpCount() {
-    return writeOpCount.get();
+    return writeOpCount.value();
   }
 
   /**
@@ -124,7 +138,7 @@ public class VolumeIOStats {
    * @return long
    */
   public long getReadTime() {
-    return readTime.get();
+    return readTime.value();
   }
 
   /**
@@ -132,7 +146,7 @@ public class VolumeIOStats {
    * @return long
    */
   public long getWriteTime() {
-    return writeTime.get();
+    return writeTime.value();
   }
 
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.metrics2.lib.MutableCounterLong;
  * This class is used to track Volume IO stats for each HDDS Volume.
  */
 public class VolumeIOStats {
-  public String sourceName = VolumeIOStats.class.getSimpleName();
+  private String metricsSourceName = VolumeIOStats.class.getSimpleName();
 
   private @Metric MutableCounterLong readBytes;
   private @Metric MutableCounterLong readOpCount;
@@ -45,18 +45,22 @@ public class VolumeIOStats {
    * @param identifier Typically, path to volume root. e.g. /data/hdds
    */
   public VolumeIOStats(String identifier) {
-    this.sourceName += '-' + identifier;
+    this.metricsSourceName += '-' + identifier;
     init();
   }
 
   public void init() {
     MetricsSystem ms = DefaultMetricsSystem.instance();
-    ms.register(sourceName, "Volume I/O Statistics", this);
+    ms.register(metricsSourceName, "Volume I/O Statistics", this);
   }
 
   public void unregister() {
     MetricsSystem ms = DefaultMetricsSystem.instance();
-    ms.unregisterSource(sourceName);
+    ms.unregisterSource(metricsSourceName);
+  }
+
+  public String getMetricsSourceName() {
+    return metricsSourceName;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.container.common.volume;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
-import org.apache.hadoop.metrics2.lib.MetricsRegistry;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 
 /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
@@ -48,10 +48,8 @@ public class VolumeIOStats {
   }
 
   public void init() {
-    DefaultMetricsSystem.initialize(sourceName);
     MetricsSystem ms = DefaultMetricsSystem.instance();
     ms.register(sourceName, "Volume I/O Statistics", this);
-
     this.registry = new MetricsRegistry(sourceName);
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.metrics2.lib.MutableCounterLong;
  * This class is used to track Volume IO stats for each HDDS Volume.
  */
 public class VolumeIOStats {
-  private String name = VolumeIOStats.class.getSimpleName();
+  private String sourceName = VolumeIOStats.class.getSimpleName();
 
   private @Metric MutableCounterLong readBytes;
   private @Metric MutableCounterLong readOpCount;
@@ -43,16 +43,21 @@ public class VolumeIOStats {
   }
 
   public VolumeIOStats(String identifier) {
-    this.name += '-' + identifier;
+    this.sourceName += '-' + identifier;
     init();
   }
 
   public void init() {
-    DefaultMetricsSystem.initialize(name);
+    DefaultMetricsSystem.initialize(sourceName);
     MetricsSystem ms = DefaultMetricsSystem.instance();
-    ms.register(name, "Volume I/O Statistics", this);
+    ms.register(sourceName, "Volume I/O Statistics", this);
 
-    this.registry = new MetricsRegistry(name);
+    this.registry = new MetricsRegistry(sourceName);
+  }
+
+  public void unregister() {
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    ms.unregisterSource(sourceName);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestContainerMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestContainerMetrics.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.container.metrics;
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.assertQuantileGauges;
+import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 
 import com.google.common.collect.Maps;
@@ -48,6 +49,7 @@ import org.apache.hadoop.ozone.container.common.interfaces.Handler;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.common.transport.server.XceiverServerGrpc;
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
@@ -171,6 +173,18 @@ public class TestContainerMetrics {
       String sec = interval + "s";
       Thread.sleep((interval + 1) * 1000);
       assertQuantileGauges("WriteChunkNanos" + sec, containerMetrics);
+
+      // Check VolumeIOStats metrics
+      HddsVolume hddsVolume = volumeSet.getVolumesList().get(0);
+      MetricsRecordBuilder volumeIOMetrics =
+          getMetrics(hddsVolume.getVolumeIOStats().sourceName);
+      assertCounter("ReadBytes", 1024L, volumeIOMetrics);
+      assertCounter("ReadOpCount", 1L, volumeIOMetrics);
+      assertCounter("WriteBytes", 1024L, volumeIOMetrics);
+      assertCounter("WriteOpCount", 1L, volumeIOMetrics);
+      // ReadTime and WriteTime vary from run to run, only checking non-zero
+      Assert.assertNotEquals(0L, getLongCounter("ReadTime", volumeIOMetrics));
+      Assert.assertNotEquals(0L, getLongCounter("WriteTime", volumeIOMetrics));
     } finally {
       if (client != null) {
         client.close();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestContainerMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestContainerMetrics.java
@@ -177,7 +177,7 @@ public class TestContainerMetrics {
       // Check VolumeIOStats metrics
       HddsVolume hddsVolume = volumeSet.getVolumesList().get(0);
       MetricsRecordBuilder volumeIOMetrics =
-          getMetrics(hddsVolume.getVolumeIOStats().sourceName);
+          getMetrics(hddsVolume.getVolumeIOStats().getMetricsSourceName());
       assertCounter("ReadBytes", 1024L, volumeIOMetrics);
       assertCounter("ReadOpCount", 1L, volumeIOMetrics);
       assertCounter("WriteBytes", 1024L, volumeIOMetrics);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-4359

## How was this patch tested?

Checked manually in DN JMX (initial):

e.g. http://127.0.0.1:9882/jmx?qry=Hadoop:service=HddsDatanode,name=VolumeIOStats-/data/hdds

```json
{
  "beans" : [ {
    "name" : "Hadoop:service=HddsDatanode,name=VolumeIOStats-/data/hdds",
    "modelerType" : "VolumeIOStats-/data/hdds",
    "tag.Hostname" : "38d7022a0825",
    "ReadBytes" : 0,
    "ReadOpCount" : 0,
    "WriteBytes" : 0,
    "WriteOpCount" : 0,
    "ReadTime" : 0,
    "WriteTime" : 0
  } ]
}
```

(a short while) after executing `ozone fs -put README.md ofs://om/vol1/buck1/`:

```json
    "name" : "Hadoop:service=HddsDatanode,name=VolumeIOStats-/data/hdds",
    "modelerType" : "VolumeIOStats-/data/hdds",
    "tag.Hostname" : "38d7022a0825",
    "ReadBytes" : 0,
    "ReadOpCount" : 0,
    "WriteBytes" : 3841,
    "WriteOpCount" : 1,
    "ReadTime" : 0,
    "WriteTime" : 1
```