### PR TITLE
HDDS-4365: SCMBlockLocationFailoverProxyProvider should use ScmBlockLocationProtocolPB.class in RPC.setProtocolEngine

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
@@ -22,7 +22,6 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
-import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocolPB.ScmBlockLocationProtocolPB;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 import org.apache.hadoop.io.retry.FailoverProxyProvider;
@@ -80,7 +79,7 @@ public class SCMBlockLocationFailoverProxyProvider implements
 
   public SCMBlockLocationFailoverProxyProvider(ConfigurationSource conf) {
     this.conf = conf;
-    this.scmVersion = RPC.getProtocolVersion(ScmBlockLocationProtocol.class);
+    this.scmVersion = RPC.getProtocolVersion(ScmBlockLocationProtocolPB.class);
     this.scmServiceId = conf.getTrimmed(OZONE_SCM_SERVICE_IDS_KEY);
     this.scmProxies = new HashMap<>();
     this.scmProxyInfoMap = new HashMap<>();
@@ -257,7 +256,7 @@ public class SCMBlockLocationFailoverProxyProvider implements
       InetSocketAddress scmAddress) throws IOException {
     Configuration hadoopConf =
         LegacyHadoopConfigurationSource.asHadoopConfiguration(conf);
-    RPC.setProtocolEngine(hadoopConf, ScmBlockLocationProtocol.class,
+    RPC.setProtocolEngine(hadoopConf, ScmBlockLocationProtocolPB.class,
         ProtobufRpcEngine.class);
     return RPC.getProxy(ScmBlockLocationProtocolPB.class, scmVersion,
         scmAddress, UserGroupInformation.getCurrentUser(), hadoopConf,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -67,7 +67,6 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocolPB.ScmBlockLocationProtocolClientSideTranslatorPB;
-import org.apache.hadoop.hdds.scm.protocolPB.ScmBlockLocationProtocolPB;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolPB;
 import org.apache.hadoop.hdds.scm.proxy.SCMBlockLocationFailoverProxyProvider;
@@ -805,8 +804,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    */
   private static ScmBlockLocationProtocol getScmBlockClient(
       OzoneConfiguration conf) throws IOException {
-    RPC.setProtocolEngine(conf, ScmBlockLocationProtocolPB.class,
-        ProtobufRpcEngine.class);
     ScmBlockLocationProtocolClientSideTranslatorPB scmBlockLocationClient =
         new ScmBlockLocationProtocolClientSideTranslatorPB(
             new SCMBlockLocationFailoverProxyProvider(conf));


### PR DESCRIPTION
## What changes were proposed in this pull request?

In SCMBlockLocationFailoverProxyProvider, currently it is
```
private ScmBlockLocationProtocolPB createSCMProxy(
    InetSocketAddress scmAddress) throws IOException {
  ...
  RPC.setProtocolEngine(hadoopConf, ScmBlockLocationProtocol.class,
      ProtobufRpcEngine.class);
  ...
```

it should be 
```
private ScmBlockLocationProtocolPB createSCMProxy(
    InetSocketAddress scmAddress) throws IOException {
  ...
  RPC.setProtocolEngine(hadoopConf, ScmBlockLocationProtocolPB.class,
      ProtobufRpcEngine.class);
  ...
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4365

## How was this patch tested?

CI
