### PR TITLE
HDDS-4362. Change hadoop32 test to use 3.2 image

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/.env
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 HDDS_VERSION=@hdds.version@
-HADOOP_IMAGE=apache/hadoop
-HADOOP_VERSION=3
+HADOOP_IMAGE=flokkr/hadoop
+HADOOP_VERSION=3.2.1
 OZONE_RUNNER_VERSION=@docker.ozone-runner.version@
 HADOOP_OPTS=

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/.env
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 HDDS_VERSION=${hdds.version}
-HADOOP_VERSION=3
+HADOOP_IMAGE=flokkr/hadoop
+HADOOP_VERSION=3.2.1
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
 HADOOP_OPTS=

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
     volumes:
       - ../..:/opt/hadoop
   kms:
-    image: apache/hadoop:${HADOOP_VERSION}
+    image: ${HADOOP_IMAGE}:${HADOOP_VERSION}
     networks:
       - ozone
     ports:
@@ -100,7 +100,7 @@ services:
       HADOOP_OPTS: ${HADOOP_OPTS}
     command: ["/opt/hadoop/bin/ozone","scm"]
   rm:
-    image: apache/hadoop:${HADOOP_VERSION}
+    image: ${HADOOP_IMAGE}:${HADOOP_VERSION}
     hostname: rm
     networks:
       - ozone
@@ -115,7 +115,7 @@ services:
       KERBEROS_KEYTABS: rm HTTP hadoop
     command: ["yarn", "resourcemanager"]
   nm:
-    image: apache/hadoop:${HADOOP_VERSION}
+    image: ${HADOOP_IMAGE}:${HADOOP_VERSION}
     hostname: nm
     networks:
       - ozone
@@ -129,7 +129,7 @@ services:
       KERBEROS_KEYTABS: nm HTTP
     command: ["yarn","nodemanager"]
   jhs:
-    image: apache/hadoop:${HADOOP_VERSION}
+    image: ${HADOOP_IMAGE}:${HADOOP_VERSION}
     container_name: jhs
     hostname: jhs
     networks:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/test.sh
@@ -35,6 +35,7 @@ export OZONE_DIR=/opt/ozone
 # shellcheck source=/dev/null
 source "$COMPOSE_DIR/../testlib.sh"
 
+execute_command_in_container rm sudo yum install -y krb5-workstation
 execute_robot_test rm kinit-hadoop.robot
 
 for scheme in o3fs ofs; do


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ozone-mr/hadoop32` and `ozonesecure-mr` acceptance tests use "latest" `hadoop:3` docker image, which is currently Hadoop 3.2.  If it gets updated to Hadoop 3.3, Ozone acceptance test will be broken.  This PR changes to a specific 3.2-based image, similar to how `ozone-mr/hadoop31` uses 3.1-based image.

https://issues.apache.org/jira/browse/HDDS-4362

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/1294092363