### PR TITLE
HDDS-4258.Set GDPR to a Security submenu in EN and CN document

### DIFF
--- a/hadoop-hdds/docs/content/security/GDPR.md
+++ b/hadoop-hdds/docs/content/security/GDPR.md
@@ -6,7 +6,7 @@ summary: GDPR in Ozone
 icon: user
 menu:
    main:
-      parent: Features
+      parent: Security
 summary: Support to implement the "Right to be Forgotten" requirement of GDPR
 ---
 <!---

--- a/hadoop-hdds/docs/content/security/GDPR.zh.md
+++ b/hadoop-hdds/docs/content/security/GDPR.zh.md
@@ -3,6 +3,9 @@ title: "Ozone 中的 GDPR"
 date: "2019-September-17"
 weight: 5
 summary: Ozone 中的 GDPR
+menu:
+   main:
+      parent: 安全
 icon: user
 ---
 <!---


### PR DESCRIPTION
## What changes were proposed in this pull request?

Setting GDPR to security submenu for EN & CN pages.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4258

## How was this patch tested?

Locally with 'hugo serve', see attached screenshot:

<img width="1387" alt="Screenshot 2020-10-27 at 07 18 01" src="https://user-images.githubusercontent.com/47358141/97264554-7aead900-1825-11eb-9a6e-01e940783511.png">

