### PR TITLE
HDDS-3959. Avoid HddsProtos.PipelineID#toString

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
@@ -17,11 +17,9 @@
 package org.apache.hadoop.ozone.container.common.statemachine.commandhandler;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.protocol.proto.
-    StorageContainerDatanodeProtocolProtos.ClosePipelineCommandProto;
 import org.apache.hadoop.hdds.protocol.proto.
     StorageContainerDatanodeProtocolProtos.SCMCommandProto;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.ozone.container.common.statemachine
     .SCMConnectionManager;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
@@ -68,17 +66,16 @@ public class ClosePipelineCommandHandler implements CommandHandler {
     invocationCount.incrementAndGet();
     final long startTime = Time.monotonicNow();
     final DatanodeDetails dn = context.getParent().getDatanodeDetails();
-    final ClosePipelineCommandProto closeCommand =
-        ((ClosePipelineCommand)command).getProto();
-    final HddsProtos.PipelineID pipelineID = closeCommand.getPipelineID();
+    ClosePipelineCommand closePipelineCommand = (ClosePipelineCommand) command;
+    final PipelineID pipelineID = closePipelineCommand.getPipelineID();
 
     try {
       XceiverServerSpi server = ozoneContainer.getWriteChannel();
-      server.removeGroup(pipelineID);
-      LOG.info("Close Pipeline #{} command on datanode #{}.", pipelineID,
+      server.removeGroup(pipelineID.getProtobuf());
+      LOG.info("Close Pipeline {} command on datanode {}.", pipelineID,
           dn.getUuidString());
     } catch (IOException e) {
-      LOG.error("Can't close pipeline #{}", pipelineID, e);
+      LOG.error("Can't close pipeline {}", pipelineID, e);
     } finally {
       long endTime = Time.monotonicNow();
       totalTime += endTime - startTime;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CreatePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CreatePipelineCommandHandler.java
@@ -19,12 +19,10 @@ package org.apache.hadoop.ozone.container.common.statemachine.commandhandler;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CreatePipelineCommandProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
@@ -79,23 +77,19 @@ public class CreatePipelineCommandHandler implements CommandHandler {
     final long startTime = Time.monotonicNow();
     final DatanodeDetails dn = context.getParent()
         .getDatanodeDetails();
-    final CreatePipelineCommandProto createCommand =
-        ((CreatePipelineCommand)command).getProto();
-    final HddsProtos.PipelineID pipelineID = createCommand.getPipelineID();
-    final List<DatanodeDetails> peers =
-        createCommand.getDatanodeList().stream()
-            .map(DatanodeDetails::getFromProtoBuf)
-            .collect(Collectors.toList());
+    final CreatePipelineCommand createCommand = (CreatePipelineCommand) command;
+    final PipelineID pipelineID = createCommand.getPipelineID();
+    final HddsProtos.PipelineID pipelineIdProto = pipelineID.getProtobuf();
+    final List<DatanodeDetails> peers = createCommand.getNodeList();
     final List<Integer> priorityList = createCommand.getPriorityList();
 
     try {
       XceiverServerSpi server = ozoneContainer.getWriteChannel();
-      if (!server.isExist(pipelineID)) {
-        final RaftGroupId groupId = RaftGroupId.valueOf(
-            PipelineID.getFromProtobuf(pipelineID).getId());
+      if (!server.isExist(pipelineIdProto)) {
+        final RaftGroupId groupId = RaftGroupId.valueOf(pipelineID.getId());
         final RaftGroup group =
             RatisHelper.newRaftGroup(groupId, peers, priorityList);
-        server.addGroup(pipelineID, peers, priorityList);
+        server.addGroup(pipelineIdProto, peers, priorityList);
         peers.stream().filter(
             d -> !d.getUuid().equals(dn.getUuid()))
             .forEach(d -> {
@@ -109,11 +103,13 @@ public class CreatePipelineCommandHandler implements CommandHandler {
                 LOG.warn("Add group failed for {}", d, ioe);
               }
             });
-        LOG.info("Created Pipeline {} {} #{}.",
-            createCommand.getType(), createCommand.getFactor(), pipelineID);
+        LOG.info("Created Pipeline {} {} {}.",
+            createCommand.getReplicationType(), createCommand.getFactor(),
+            pipelineID);
       }
     } catch (IOException e) {
-      LOG.error("Can't create pipeline {} {} #{}", createCommand.getType(),
+      LOG.error("Can't create pipeline {} {} {}",
+          createCommand.getReplicationType(),
           createCommand.getFactor(), pipelineID, e);
     } finally {
       long endTime = Time.monotonicNow();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/CreatePipelineCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/CreatePipelineCommand.java
@@ -139,4 +139,20 @@ public class CreatePipelineCommand
   public PipelineID getPipelineID() {
     return pipelineID;
   }
+
+  public List<DatanodeDetails> getNodeList() {
+    return nodelist;
+  }
+
+  public List<Integer> getPriorityList() {
+    return priorityList;
+  }
+
+  public ReplicationType getReplicationType() {
+    return type;
+  }
+
+  public ReplicationFactor getFactor() {
+    return factor;
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change `CreatePipelineCommandHandler` and `ClosePipelineCommandHandler` to use the non-proto `PipelineID` object for logging.  This lets us avoid printing multi-line messages, mostly caused by `uuid128` structure.

Also tweak logic a bit to avoid unnecessary back and forth proto conversion for getting the node list in pipeline creation.

https://issues.apache.org/jira/browse/HDDS-3959

## How was this patch tested?

Ran `ozone` docker compose cluster, closed one pipeline manually, verified log messages:

```
datanode_1  | 2020-10-27 09:58:13,533 [Command processor thread] INFO commandhandler.CreatePipelineCommandHandler: Created Pipeline RATIS THREE PipelineID=658bfc91-c07c-405f-94ab-7b7a87c9dd2c.
...
datanode_2  | 2020-10-27 10:02:00,686 [Command processor thread] INFO commandhandler.ClosePipelineCommandHandler: Close Pipeline PipelineID=658bfc91-c07c-405f-94ab-7b7a87c9dd2c command on datanode fea867c0-2e70-45ec-8491-be7f952d91a4.
```